### PR TITLE
Update comment in configure-android

### DIFF
--- a/configure-android
+++ b/configure-android
@@ -115,7 +115,7 @@ if test "$1" = "--use-ndk-cflags"; then
         NDK_CC=$i
       fi
     fi
-    # Find g++ toolchain
+    # Find g++ or clang++ toolchain
     if test "x`echo $i | grep 'g++'`" != "x"; then
       NDK_CXX=$i
     fi


### PR DESCRIPTION
Since `grep 'g++'` command finds both g++ or clang++ just like expected, reflect it in the comment.