### PR TITLE
Fix build failure when using Android NDK r20

### DIFF
--- a/third_party/build/yuv/Makefile
+++ b/third_party/build/yuv/Makefile
@@ -71,7 +71,7 @@ export YUV_OBJS = \
 	video_common.o
 
 export YUV_CFLAGS = -fomit-frame-pointer $(_CFLAGS)
-export YUV_CXXFLAGS = $(YUV_CFLAGS)
+export YUV_CXXFLAGS = -fomit-frame-pointer $(_CXXFLAGS)
 
 
 export CC_OUT CC AR RANLIB HOST_MV HOST_RM HOST_RMDIR HOST_MKDIR OBJEXT LD LDOUT 


### PR DESCRIPTION
When building Android with NDK r20, libyuv will fail to build with many errors, such as:
```
In file included from ../../yuv/source/compare.cc:14:
In file included from ndk20/sources/cxx-stl/llvm-libc++/include/math.h:309:
In file included from ndk20/sources/cxx-stl/llvm-libc++/include/type_traits:406:
ndk20/sources/cxx-stl/llvm-libc++/include/cstddef:50:9: error:
      no member named 'ptrdiff_t' in the global namespace
using ::ptrdiff_t;
      ~~^
ndk20/sources/cxx-stl/llvm-libc++/include/cstddef:51:9: error:
      no member named 'size_t' in the global namespace
using ::size_t;
      ~~^
```
