### PR TITLE
Update sip_msg.h

### DIFF
--- a/pjsip/include/pjsip/sip_msg.h
+++ b/pjsip/include/pjsip/sip_msg.h
@@ -1070,7 +1070,7 @@ typedef struct pjsip_generic_int_hdr
     /** Standard header field. */
     PJSIP_DECL_HDR_MEMBER(struct pjsip_generic_int_hdr);
     /** ivalue */
-    pj_int32_t ivalue;
+    pj_int64_t ivalue;
 } pjsip_generic_int_hdr;
 
 


### PR DESCRIPTION
Valid Expiry values are between 0 and 2**32-1 [RFC 3261 20.19].  Changing the ivalue of pjsip_generic_int_hdr to pj_int64_t will widen the variable to prevent overflowing and maintain the historical signed nature of the variable.