### PR TITLE
Transaction module shutdown may leak resources when there is any transaction with pending transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+pjlib/include/pj/config_site.h
+lib/
+bin/
+output/
+
+# VS stuff
+*.ncb
+*.suo
+.vs/
+**/build/**/*.vcproj.*.user
+UpgradeLog.htm
+
+# GNU stuff
+config.log
+config.status
+build.mak
+user.mak
+cc-auto.mak
+os-auto.mak
+m_auto.h
+os_auto.h
+config_auto.h
+sip_autoconf.h
+*.depend
+
+# SWIG Java/Android stuff
+pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/*.java
+pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/PjCamera*.java
+pjsip-apps/src/swig/java/android/app/src/main/jniLibs/
+
+# SWIG CSharp/Xamarin stuff
+pjsip-apps/src/swig/csharp/pjsua2xamarin/
+
+# SWIG Python stuff
+pjsip-apps/src/swig/python/build/
+pjsip-apps/src/swig/python/pjsua2.py
+pjsip-apps/src/swig/python/pjsua2_wrap.*
+

--- a/pjsip/src/test/tsx_basic_test.c
+++ b/pjsip/src/test/tsx_basic_test.c
@@ -274,13 +274,9 @@ int tsx_destroy_test()
 	    "resolve and destroy, wait",
 	    &tsx_create_and_send_req,
 	    "sip:user@somehost",
-	    3000, /* Wait for DNS timeout, dec ref to the group lock is done in DNS+send callback */
+	    1,
 	    15000
 	},
-#if 0
-	/* These tests rely on TCP connect timeout (so group lock reference count becomes 0 and group lock objects destroys are initiated).
-	 * Unfortunately TCP connect timeout may take longer in some OS, e.g: Linux, MacOS, so let's disable this test for now.
-	 */
 	{
 	    "tcp connect and destroy",
 	    &tsx_create_and_send_req,
@@ -289,13 +285,12 @@ int tsx_destroy_test()
 	    1000
 	},
 	{
-	    "tcp connect and destroy",
+	    "tcp connect and destroy 2",
 	    &tsx_create_and_send_req,
 	    "sip:user@10.125.36.63:58517;transport=tcp",
-	    22000, /* Wait for TCP connect timeout, dec ref to the group lock is done in send callback */
+	    1,
 	    60000
 	},
-#endif
     };
     int rc;
     unsigned i;


### PR DESCRIPTION
Currently when transaction module is shutdown, any transactions with pending transport (e.g: sending in progress) will be terminated and destroyed but its sending counter (transaction group lock ref counter) may never reach zero, so there will be leak due to unfreed tsx group lock and unreleased tsx memory pool.

This is because the sending counter will be decreased only by send_msg_callback() with condition that transaction module is not shutdown. This pull request will change the transaction destroy behavior that sending counter will be decreased when tsx state shifting to terminated, also revert back latest changes in tsx destroy test in pjsip-test.