### PR TITLE
Limit log printing if video conference is connected to a sink port that's not running

### DIFF
--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -778,16 +778,17 @@ static void on_clock_tick(const pj_timestamp *now, void *user_data)
 	}
 	status = pjmedia_port_put_frame(sink->port, &frame);
 	if (got_frame && status != PJ_SUCCESS) {
+	    sink->last_err_cnt++;
 	    if (sink->last_err != status ||
-	        sink->last_err_cnt > MAX_ERR_COUNT)
+	        sink->last_err_cnt % MAX_ERR_COUNT == 0)
 	    {
-	    	PJ_PERROR(5, (THIS_FILE, status,
-			      "Failed to put frame to port %d [%s]!",
-			      sink->idx, sink->port->info.name.ptr));
+		if (sink->last_err != status)
+		    sink->last_err_cnt = 1;
 		sink->last_err = status;
-		sink->last_err_cnt = 1;
-	    } else {
-	    	sink->last_err_cnt++;
+	    	PJ_PERROR(5, (THIS_FILE, status,
+			      "Failed (%d time(s)) to put frame to port %d"
+			      " [%s]!", sink->last_err_cnt,
+			      sink->idx, sink->port->info.name.ptr));
 	    }
 	} else {
 	    sink->last_err = status;

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -994,8 +994,6 @@ static pj_status_t setup_vid_capture(pjsua_call_media *call_med)
     /* Done */
     inc_vid_win(wid);
     call_med->strm.v.cap_win_id = wid;
-    PJ_LOG(4,(THIS_FILE, "Call %d: video capture set up with dev %d, wid=%d",
-	      call_med->call->index, call_med->strm.v.cap_dev, wid));
 
     PJSUA_UNLOCK();
 
@@ -1282,8 +1280,6 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
 	/* Decrement ref count of preview video window */
 	dec_vid_win(call_med->strm.v.cap_win_id);
 	call_med->strm.v.cap_win_id = PJSUA_INVALID_ID;
-	
-	PJ_LOG(4,(THIS_FILE, "Preview video window released"));
     }
 
     if (call_med->strm.v.rdr_win_id != PJSUA_INVALID_ID) {
@@ -1297,8 +1293,6 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
 	/* Decrement ref count of stream video window */
 	dec_vid_win(call_med->strm.v.rdr_win_id);
 	call_med->strm.v.rdr_win_id = PJSUA_INVALID_ID;
-
-	PJ_LOG(4,(THIS_FILE, "Stream video window released"));
     }
     PJSUA_UNLOCK();
 
@@ -1439,6 +1433,7 @@ PJ_DEF(pj_status_t) pjsua_vid_preview_stop(pjmedia_vid_dev_index id)
     wid = pjsua_vid_preview_get_win(id);
     if (wid == PJSUA_INVALID_ID) {
 	PJSUA_UNLOCK();
+	pj_log_pop_indent();
 	return PJ_ENOTFOUND;
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -994,6 +994,8 @@ static pj_status_t setup_vid_capture(pjsua_call_media *call_med)
     /* Done */
     inc_vid_win(wid);
     call_med->strm.v.cap_win_id = wid;
+    PJ_LOG(4,(THIS_FILE, "Call %d: video capture set up with dev %d, wid=%d",
+	      call_med->call->index, call_med->strm.v.cap_dev, wid));
 
     PJSUA_UNLOCK();
 
@@ -1280,6 +1282,8 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
 	/* Decrement ref count of preview video window */
 	dec_vid_win(call_med->strm.v.cap_win_id);
 	call_med->strm.v.cap_win_id = PJSUA_INVALID_ID;
+	
+	PJ_LOG(4,(THIS_FILE, "Preview video window released"));
     }
 
     if (call_med->strm.v.rdr_win_id != PJSUA_INVALID_ID) {
@@ -1293,6 +1297,8 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
 	/* Decrement ref count of stream video window */
 	dec_vid_win(call_med->strm.v.rdr_win_id);
 	call_med->strm.v.rdr_win_id = PJSUA_INVALID_ID;
+
+	PJ_LOG(4,(THIS_FILE, "Stream video window released"));
     }
     PJSUA_UNLOCK();
 
@@ -1433,7 +1439,6 @@ PJ_DEF(pj_status_t) pjsua_vid_preview_stop(pjmedia_vid_dev_index id)
     wid = pjsua_vid_preview_get_win(id);
     if (wid == PJSUA_INVALID_ID) {
 	PJSUA_UNLOCK();
-	pj_log_pop_indent();
 	return PJ_ENOTFOUND;
     }
 


### PR DESCRIPTION
Re: [r6138](https://github.com/pjsip/pjproject/commit/d5ec2f45920a852cd28ea44822d9320bc3caec84), but that revision was for the encoding direction.
