### PR TITLE
Change struct member names s_addr and s6_addr since it may conflict with predefined macros

### DIFF
--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -544,7 +544,7 @@ static int a_parser_test(void)
     pkt.ans[0].type = PJ_DNS_TYPE_A;
     pkt.ans[0].dnsclass = 1;
     pkt.ans[0].ttl = 1;
-    pkt.ans[0].rdata.a.ip_addr.s_addr = 0x01020304;
+    pkt.ans[0].rdata.a.ip_addr.addr = 0x01020304;
 
     /* CNAME to confuse the parser */
     pkt.ans[1].name = pj_str("ahost");
@@ -558,7 +558,7 @@ static int a_parser_test(void)
     pkt.ans[2].type = PJ_DNS_TYPE_A;
     pkt.ans[2].dnsclass = 1;
     pkt.ans[2].ttl = 1;
-    pkt.ans[2].rdata.a.ip_addr.s_addr = 0x0203;
+    pkt.ans[2].rdata.a.ip_addr.addr = 0x0203;
 
 
     rc = pj_dns_parse_a_response(&pkt, &rec);
@@ -566,7 +566,7 @@ static int a_parser_test(void)
     pj_assert(pj_strcmp2(&rec.name, "ahost")==0);
     pj_assert(rec.alias.slen == 0);
     pj_assert(rec.addr_count == 1);
-    pj_assert(rec.addr[0].s_addr == 0x01020304);
+    pj_assert(rec.addr[0].addr == 0x01020304);
 
     /* Answer with the target corresponds to a CNAME entry, but not
      * as the first record, and with additions of some CNAME and A
@@ -585,7 +585,7 @@ static int a_parser_test(void)
     pkt.ans[0].type = PJ_DNS_TYPE_A;
     pkt.ans[0].dnsclass = 1;
     pkt.ans[0].ttl = 1;
-    pkt.ans[0].rdata.a.ip_addr.s_addr = 0x02020202;
+    pkt.ans[0].rdata.a.ip_addr.addr = 0x02020202;
 
     /* CNAME entry corresponding to the query */
     pkt.ans[1].name = pj_str("ahost");
@@ -606,14 +606,14 @@ static int a_parser_test(void)
     pkt.ans[3].type = PJ_DNS_TYPE_A;
     pkt.ans[3].dnsclass = 1;
     pkt.ans[3].ttl = 1;
-    pkt.ans[3].rdata.a.ip_addr.s_addr = 0x03030303;
+    pkt.ans[3].rdata.a.ip_addr.addr = 0x03030303;
 
     rc = pj_dns_parse_a_response(&pkt, &rec);
     pj_assert(rc == PJ_SUCCESS);
     pj_assert(pj_strcmp2(&rec.name, "ahost")==0);
     pj_assert(pj_strcmp2(&rec.alias, "ahostalias")==0);
     pj_assert(rec.addr_count == 1);
-    pj_assert(rec.addr[0].s_addr == 0x02020202);
+    pj_assert(rec.addr[0].addr == 0x02020202);
 
     /*
      * No query section.
@@ -655,7 +655,7 @@ static int a_parser_test(void)
     pkt.ans[0].type = PJ_DNS_TYPE_A;
     pkt.ans[0].dnsclass = 1;
     pkt.ans[0].ttl = 1;
-    pkt.ans[0].rdata.a.ip_addr.s_addr = 0x02020202;
+    pkt.ans[0].rdata.a.ip_addr.addr = 0x02020202;
 
     rc = pj_dns_parse_a_response(&pkt, &rec);
     pj_assert(rc == PJLIB_UTIL_EDNSNOANSWERREC);
@@ -706,7 +706,7 @@ static int a_parser_test(void)
     pkt.ans[1].type = PJ_DNS_TYPE_A;
     pkt.ans[1].dnsclass = 1;
     pkt.ans[1].ttl = 1;
-    pkt.ans[1].rdata.a.ip_addr.s_addr = 0x01020304;
+    pkt.ans[1].rdata.a.ip_addr.addr = 0x01020304;
 
     rc = pj_dns_parse_a_response(&pkt, &rec);
     pj_assert(rc == PJLIB_UTIL_EDNSNOANSWERREC);
@@ -746,7 +746,7 @@ static int addr_parser_test(void)
     pkt.ans[0].type = PJ_DNS_TYPE_A;
     pkt.ans[0].dnsclass = 1;
     pkt.ans[0].ttl = 1;
-    pkt.ans[0].rdata.a.ip_addr.s_addr = 0x01020304;
+    pkt.ans[0].rdata.a.ip_addr.addr = 0x01020304;
 
     /* CNAME to confuse the parser */
     pkt.ans[1].name = pj_str("ahost");
@@ -760,7 +760,7 @@ static int addr_parser_test(void)
     pkt.ans[2].type = PJ_DNS_TYPE_A;
     pkt.ans[2].dnsclass = 1;
     pkt.ans[2].ttl = 1;
-    pkt.ans[2].rdata.a.ip_addr.s_addr = 0x0203;
+    pkt.ans[2].rdata.a.ip_addr.addr = 0x0203;
 
     /* Additional RR corresponding to the query, DNS AAAA RR */
     pkt.ans[3].name = pj_str("ahost");
@@ -775,7 +775,7 @@ static int addr_parser_test(void)
     pj_assert(pj_strcmp2(&rec.name, "ahost")==0);
     pj_assert(rec.alias.slen == 0);
     pj_assert(rec.addr_count == 2);
-    pj_assert(rec.addr[0].af==pj_AF_INET() && rec.addr[0].ip.v4.s_addr == 0x01020304);
+    pj_assert(rec.addr[0].af==pj_AF_INET() && rec.addr[0].ip.v4.addr == 0x01020304);
     pj_assert(rec.addr[1].af==pj_AF_INET6() && rec.addr[1].ip.v6.u6_addr32[0] == 0x01020304);
 
     /* Answer with the target corresponds to a CNAME entry, but not
@@ -795,7 +795,7 @@ static int addr_parser_test(void)
     pkt.ans[0].type = PJ_DNS_TYPE_A;
     pkt.ans[0].dnsclass = 1;
     pkt.ans[0].ttl = 1;
-    pkt.ans[0].rdata.a.ip_addr.s_addr = 0x02020202;
+    pkt.ans[0].rdata.a.ip_addr.addr = 0x02020202;
 
     /* CNAME entry corresponding to the query */
     pkt.ans[1].name = pj_str("ahost");
@@ -816,14 +816,14 @@ static int addr_parser_test(void)
     pkt.ans[3].type = PJ_DNS_TYPE_A;
     pkt.ans[3].dnsclass = 1;
     pkt.ans[3].ttl = 1;
-    pkt.ans[3].rdata.a.ip_addr.s_addr = 0x03030303;
+    pkt.ans[3].rdata.a.ip_addr.addr = 0x03030303;
 
     rc = pj_dns_parse_addr_response(&pkt, &rec);
     pj_assert(rc == PJ_SUCCESS);
     pj_assert(pj_strcmp2(&rec.name, "ahost")==0);
     pj_assert(pj_strcmp2(&rec.alias, "ahostalias")==0);
     pj_assert(rec.addr_count == 1);
-    pj_assert(rec.addr[0].ip.v4.s_addr == 0x02020202);
+    pj_assert(rec.addr[0].ip.v4.addr == 0x02020202);
 
     /*
      * No query section.
@@ -865,7 +865,7 @@ static int addr_parser_test(void)
     pkt.ans[0].type = PJ_DNS_TYPE_A;
     pkt.ans[0].dnsclass = 1;
     pkt.ans[0].ttl = 1;
-    pkt.ans[0].rdata.a.ip_addr.s_addr = 0x02020202;
+    pkt.ans[0].rdata.a.ip_addr.addr = 0x02020202;
 
     rc = pj_dns_parse_addr_response(&pkt, &rec);
     pj_assert(rc == PJLIB_UTIL_EDNSNOANSWERREC);
@@ -916,7 +916,7 @@ static int addr_parser_test(void)
     pkt.ans[1].type = PJ_DNS_TYPE_A;
     pkt.ans[1].dnsclass = 1;
     pkt.ans[1].ttl = 1;
-    pkt.ans[1].rdata.a.ip_addr.s_addr = 0x01020304;
+    pkt.ans[1].rdata.a.ip_addr.addr = 0x01020304;
 
     rc = pj_dns_parse_addr_response(&pkt, &rec);
     pj_assert(rc == PJLIB_UTIL_EDNSNOANSWERREC);
@@ -942,7 +942,7 @@ static void dns_callback(void *user_data,
     PJ_ASSERT_ON_FAIL(resp, return);
     PJ_ASSERT_ON_FAIL(resp->hdr.anscount == 1, return);
     PJ_ASSERT_ON_FAIL(resp->ans[0].type == PJ_DNS_TYPE_A, return);
-    PJ_ASSERT_ON_FAIL(resp->ans[0].rdata.a.ip_addr.s_addr == IP_ADDR0, return);
+    PJ_ASSERT_ON_FAIL(resp->ans[0].rdata.a.ip_addr.addr == IP_ADDR0, return);
 
 }
 
@@ -970,7 +970,7 @@ static int simple_test(void)
     r->ans[0].type = PJ_DNS_TYPE_A;
     r->ans[0].dnsclass = 1;
     r->ans[0].name = name;
-    r->ans[0].rdata.a.ip_addr.s_addr = IP_ADDR0;
+    r->ans[0].rdata.a.ip_addr.addr = IP_ADDR0;
 
     g_server[1].action = ACTION_REPLY;
     r = &g_server[1].resp;
@@ -984,7 +984,7 @@ static int simple_test(void)
     r->ans[0].type = PJ_DNS_TYPE_A;
     r->ans[0].dnsclass = 1;
     r->ans[0].name = name;
-    r->ans[0].rdata.a.ip_addr.s_addr = IP_ADDR0;
+    r->ans[0].rdata.a.ip_addr.addr = IP_ADDR0;
 
     status = pj_dns_resolver_start_query(resolver, &name, PJ_DNS_TYPE_A, 0,
 					 &dns_callback, NULL, NULL);
@@ -1238,7 +1238,7 @@ static void action1_1(const pj_dns_parsed_packet *pkt,
 	res->ans[1].dnsclass = 1;
 	res->ans[1].ttl = 1;
 	res->ans[1].name = pj_str(alias);
-	res->ans[1].rdata.a.ip_addr.s_addr = IP_ADDR1;
+	res->ans[1].rdata.a.ip_addr.addr = IP_ADDR1;
 
     } else if (pkt->q[0].type == PJ_DNS_TYPE_AAAA) {
 	char *alias = "sipalias.somedomain.com";
@@ -1284,7 +1284,7 @@ static void srv_cb_1(void *user_data,
 
     /* IPv4 only */
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr_count == 1, return);
-    PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].ip.v4.s_addr == IP_ADDR1, return);
+    PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].ip.v4.addr == IP_ADDR1, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].port == PORT1, return);
 
     
@@ -1327,7 +1327,7 @@ static void srv_cb_1c(void *user_data,
     /* IPv4 and IPv6 */
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr_count == 2, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].af == pj_AF_INET() &&
-		      rec->entry[0].server.addr[0].ip.v4.s_addr == IP_ADDR1, return);
+		      rec->entry[0].server.addr[0].ip.v4.addr == IP_ADDR1, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[1].af == pj_AF_INET6() &&
 		      rec->entry[0].server.addr[1].ip.v6.u6_addr32[0] == IP_ADDR1, return);
 }
@@ -1526,7 +1526,7 @@ static void action2_1(const pj_dns_parsed_packet *pkt,
 	res->ans[1].dnsclass = 1;
 	res->ans[1].name = pj_str(alias);
 	res->ans[1].ttl = 1;
-	res->ans[1].rdata.a.ip_addr.s_addr = IP_ADDR2;
+	res->ans[1].rdata.a.ip_addr.addr = IP_ADDR2;
 
     } else if (pkt->q[0].type == PJ_DNS_TYPE_AAAA) {
 	char *alias = "sipalias01." TARGET;
@@ -1574,7 +1574,7 @@ static void srv_cb_2(void *user_data,
     /* IPv4 only */
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr_count == 1, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].af == pj_AF_INET() &&
-		      rec->entry[0].server.addr[0].ip.v4.s_addr == IP_ADDR2, return);
+		      rec->entry[0].server.addr[0].ip.v4.addr == IP_ADDR2, return);
 }
 
 static void srv_cb_2a(void *user_data,
@@ -1598,7 +1598,7 @@ static void srv_cb_2a(void *user_data,
     /* IPv4 and IPv6 */
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr_count == 2, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].af == pj_AF_INET() &&
-		      rec->entry[0].server.addr[0].ip.v4.s_addr == IP_ADDR2, return);
+		      rec->entry[0].server.addr[0].ip.v4.addr == IP_ADDR2, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[1].af == pj_AF_INET6() &&
 		      rec->entry[0].server.addr[1].ip.v6.u6_addr32[0] == IP_ADDR2, return);
 }
@@ -1778,7 +1778,7 @@ static void action3_1(const pj_dns_parsed_packet *pkt,
 	    res->ans[i].dnsclass = 1;
 	    res->ans[i].ttl = 1;
 	    res->ans[i].name = res->q[0].name;
-	    res->ans[i].rdata.a.ip_addr.s_addr = IP_ADDR3+i;
+	    res->ans[i].rdata.a.ip_addr.addr = IP_ADDR3+i;
 	}
     }
 
@@ -1810,7 +1810,7 @@ static void srv_cb_3(void *user_data,
 	pj_assert(rec->entry[i].server.addr_count == PJ_DNS_MAX_IP_IN_A_REC);
 
 	for (j=0; j<PJ_DNS_MAX_IP_IN_A_REC; ++j) {
-	    pj_assert(rec->entry[i].server.addr[j].ip.v4.s_addr == IP_ADDR3+j);
+	    pj_assert(rec->entry[i].server.addr[j].ip.v4.addr == IP_ADDR3+j);
 	}
     }
 

--- a/pjlib-util/src/pjlib-util/dns.c
+++ b/pjlib-util/src/pjlib-util/dns.c
@@ -603,7 +603,7 @@ static void copy_rr(pj_pool_t *pool, pj_dns_parsed_rr *dst,
 	apply_name_table(nametable_count, nametable, &src->rdata.srv.target, 
 			 pool, &dst->rdata.srv.target);
     } else if (src->type == PJ_DNS_TYPE_A) {
-	dst->rdata.a.ip_addr.s_addr =  src->rdata.a.ip_addr.s_addr;
+	dst->rdata.a.ip_addr.addr =  src->rdata.a.ip_addr.addr;
     } else if (src->type == PJ_DNS_TYPE_AAAA) {
 	pj_memcpy(&dst->rdata.aaaa.ip_addr, &src->rdata.aaaa.ip_addr,
 		  sizeof(pj_in6_addr));

--- a/pjlib-util/src/pjlib-util/http_client.c
+++ b/pjlib-util/src/pjlib-util/http_client.c
@@ -1034,7 +1034,7 @@ static pj_status_t start_http_req(pj_http_req *http_req,
 	if (status != PJ_SUCCESS ||
 	    !pj_sockaddr_has_addr(&http_req->addr) ||
 	    (http_req->param.addr_family==pj_AF_INET() &&
-	     http_req->addr.ipv4.sin_addr.s_addr==PJ_INADDR_NONE))
+	     http_req->addr.ipv4.sin_addr.addr==PJ_INADDR_NONE))
 	{
 	    goto on_return;
         }

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -1147,8 +1147,8 @@ PJ_DEF(pj_status_t) pj_dns_parse_a_response(const pj_dns_parsed_packet *pkt,
 	    pj_stricmp(&pkt->ans[i].name, resname)==0 &&
 	    rec->addr_count < PJ_DNS_MAX_IP_IN_A_REC)
 	{
-	    rec->addr[rec->addr_count++].s_addr =
-		pkt->ans[i].rdata.a.ip_addr.s_addr;
+	    rec->addr[rec->addr_count++].addr =
+		pkt->ans[i].rdata.a.ip_addr.addr;
 	}
     }
 

--- a/pjlib-util/src/pjlib-util/stun_simple_client.c
+++ b/pjlib-util/src/pjlib-util/stun_simple_client.c
@@ -322,7 +322,7 @@ PJ_DEF(pj_status_t) pjstun_get_mapped_addr2(pj_pool_factory *pf,
     for (i=0; i<sock_cnt && status==PJ_SUCCESS; ++i) {
 	if (srv_cnt == 1) {
 	    mapped_addr[i].sin_family = pj_AF_INET();
-	    mapped_addr[i].sin_addr.s_addr = rec[i].srv[0].mapped_addr;
+	    mapped_addr[i].sin_addr.addr = rec[i].srv[0].mapped_addr;
 	    mapped_addr[i].sin_port = (pj_uint16_t)rec[i].srv[0].mapped_port;
 
 	    if (rec[i].srv[0].mapped_addr == 0 || rec[i].srv[0].mapped_port == 0) {
@@ -333,7 +333,7 @@ PJ_DEF(pj_status_t) pjstun_get_mapped_addr2(pj_pool_factory *pf,
 	           rec[i].srv[0].mapped_port == rec[i].srv[1].mapped_port)
 	{
 	    mapped_addr[i].sin_family = pj_AF_INET();
-	    mapped_addr[i].sin_addr.s_addr = rec[i].srv[0].mapped_addr;
+	    mapped_addr[i].sin_addr.addr = rec[i].srv[0].mapped_addr;
 	    mapped_addr[i].sin_port = (pj_uint16_t)rec[i].srv[0].mapped_port;
 
 	    if (rec[i].srv[0].mapped_addr == 0 || rec[i].srv[0].mapped_port == 0) {

--- a/pjlib/include/pj++/sock.hpp
+++ b/pjlib/include/pj++/sock.hpp
@@ -60,7 +60,7 @@ public:
     //
     pj_uint32_t get_ip_address() const
     {
-	return pj_sockaddr_in_get_addr(this).s_addr;
+	return pj_sockaddr_in_get_addr(this).addr;
     }
 
     //
@@ -103,7 +103,7 @@ public:
     bool operator==(const Pj_Inet_Addr &rhs) const
     {
 	return sin_family == rhs.sin_family &&
-               sin_addr.s_addr == rhs.sin_addr.s_addr &&
+               sin_addr.addr == rhs.sin_addr.addr &&
                sin_port == rhs.sin_port;
     }
 

--- a/pjlib/include/pj/addr_resolv.h
+++ b/pjlib/include/pj/addr_resolv.h
@@ -54,7 +54,7 @@ PJ_BEGIN_DECL
  *   }
  *
  *   // process address...
- *   addr.sin_addr.s_addr = *(pj_uint32_t*)he.h_addr;
+ *   addr.sin_addr.addr = *(pj_uint32_t*)he.h_addr;
  *   ...
  * </pre>
  *

--- a/pjlib/include/pj/compat/socket.h
+++ b/pjlib/include/pj/compat/socket.h
@@ -61,7 +61,7 @@
  */
 #if defined(_MSC_VER) && defined(PJ_HAS_IPV6) && PJ_HAS_IPV6!=0
 #   ifndef s_addr
-#	define s_addr  S_un.S_addr
+#	define s_addr  S_un.addr
 #   endif
 
 #   if !defined(IPPROTO_IPV6) && (_WIN32_WINNT == 0x0500)
@@ -179,10 +179,12 @@
 
 /*
  * And undefine these..
+ * Note: unfortunately, this may cause build failure to anyone who
+ * uses these standard macros.
  */
-#undef s_addr
-#undef s6_addr
-#undef sin_zero
+// #undef s_addr
+// #undef s6_addr
+// #undef sin_zero
 
 /*
  * This will finally be obsoleted, since it should be declared in

--- a/pjlib/include/pj/compat/socket.h
+++ b/pjlib/include/pj/compat/socket.h
@@ -61,7 +61,7 @@
  */
 #if defined(_MSC_VER) && defined(PJ_HAS_IPV6) && PJ_HAS_IPV6!=0
 #   ifndef s_addr
-#	define s_addr  S_un.addr
+#	define s_addr  S_un.S_addr
 #   endif
 
 #   if !defined(IPPROTO_IPV6) && (_WIN32_WINNT == 0x0500)
@@ -179,8 +179,8 @@
 
 /*
  * And undefine these..
- * Note: unfortunately, this may cause build failure to anyone who
- * uses these standard macros.
+ * Note (see issue #2311): unfortunately, this may cause build failure
+ * to anyone who uses these standard macros.
  */
 // #undef s_addr
 // #undef s6_addr

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -484,15 +484,26 @@ typedef enum pj_socket_sd_type
  */
 #define PJ_INVALID_SOCKET   (-1)
 
-/* Must undefine s_addr because of pj_in_addr below */
-#undef s_addr
+/* Must undefine s_addr because of pj_in_addr below.
+ * Note: unfortunately, this may cause build failure to anyone who
+ * uses this macro.
+ */
+//#undef s_addr
+
+/* This macro is used only for backward compatibility in apps which
+ * access pj_in_addr.addr . If it causes any issue, comment this
+ * and access pj_in_addr.addr directly.
+ */
+#ifndef s_addr
+    #define s_addr addr
+#endif
 
 /**
  * This structure describes Internet address.
  */
 typedef struct pj_in_addr
 {
-    pj_uint32_t	s_addr;		/**< The 32bit IP address.	    */
+    pj_uint32_t	addr;		/**< The 32bit IP address.	    */
 } pj_in_addr;
 
 
@@ -535,8 +546,19 @@ struct pj_sockaddr_in
     char	sin_zero[PJ_SOCKADDR_IN_SIN_ZERO_LEN]; /**< Padding.*/
 };
 
+/* Must undefine s6_addr because of pj_in6_addr below.
+ * Note: unfortunately, this may cause build failure to anyone who
+ * uses this macro.
+ */
+//#undef s6_addr
 
-#undef s6_addr
+/* This macro is used only for backward compatibility in apps which
+ * access pj_in_addr.s6_addr . If it causes any issue, comment this
+ * and access pj_in6_addr.addr directly.
+ */
+#ifndef s6_addr
+    #define s6_addr addr
+#endif
 
 /**
  * This structure describes IPv6 address.
@@ -544,7 +566,7 @@ struct pj_sockaddr_in
 typedef union pj_in6_addr
 {
     /* This is the main entry */
-    pj_uint8_t  s6_addr[16];   /**< 8-bit array */
+    pj_uint8_t  addr[16];   /**< 8-bit array */
 
     /* While these are used for proper alignment */
     pj_uint32_t	u6_addr32[4];

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -543,7 +543,8 @@ struct pj_sockaddr_in
 #endif
     pj_uint16_t	sin_port;	/**< Transport layer port number.   */
     pj_in_addr	sin_addr;	/**< IP address.		    */
-    char	sin_zero[PJ_SOCKADDR_IN_SIN_ZERO_LEN]; /**< Padding.*/
+    char	sin_zero_pad[PJ_SOCKADDR_IN_SIN_ZERO_LEN];
+    				/**< Padding.			    */
 };
 
 /* Must undefine s6_addr because of pj_in6_addr below.

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -485,8 +485,8 @@ typedef enum pj_socket_sd_type
 #define PJ_INVALID_SOCKET   (-1)
 
 /* Must undefine s_addr because of pj_in_addr below.
- * Note: unfortunately, this may cause build failure to anyone who
- * uses this macro.
+ * Note (see issue #2311): unfortunately, this may cause build failure to
+ * anyone who uses this macro.
  */
 //#undef s_addr
 
@@ -547,8 +547,8 @@ struct pj_sockaddr_in
 };
 
 /* Must undefine s6_addr because of pj_in6_addr below.
- * Note: unfortunately, this may cause build failure to anyone who
- * uses this macro.
+ * Note (see issue #2311): unfortunately, this may cause build failure to
+ * anyone who uses this macro.
  */
 //#undef s6_addr
 

--- a/pjlib/src/pj/ip_helper_generic.c
+++ b/pjlib/src/pj/ip_helper_generic.c
@@ -120,7 +120,7 @@ static pj_status_t if_enum_by_af(int af,
 	 * which doesn't seem to have practical use.
 	 */
 	if (af==pj_AF_INET() &&
-	    (pj_ntohl(((pj_sockaddr_in*)ad)->sin_addr.s_addr) >> 24) == 0)
+	    (pj_ntohl(((pj_sockaddr_in*)ad)->sin_addr.addr) >> 24) == 0)
 	{
 	    TRACE_((THIS_FILE, "  address %s ignored (0.0.0.0/8 class)", 
 		    get_addr(ad), ad->sa_family));
@@ -219,7 +219,7 @@ static pj_status_t if_enum_by_af(int af,
 	 * which doesn't seem to have practical use.
 	 */
 	if (af==pj_AF_INET() &&
-	    (pj_ntohl(((pj_sockaddr_in*)ad)->sin_addr.s_addr) >> 24) == 0)
+	    (pj_ntohl(((pj_sockaddr_in*)ad)->sin_addr.addr) >> 24) == 0)
 	{
 	    TRACE_((THIS_FILE, "  address %s ignored (0.0.0.0/8 class)", 
 		    get_addr(ad), ad->sa_family));
@@ -313,7 +313,7 @@ static pj_status_t if_enum_by_af(int af, unsigned *p_cnt, pj_sockaddr ifs[])
 	 * which doesn't seem to have practical use.
 	 */
 	if (af==pj_AF_INET() &&
-	    (pj_ntohl(((pj_sockaddr_in*)ad)->sin_addr.s_addr) >> 24) == 0)
+	    (pj_ntohl(((pj_sockaddr_in*)ad)->sin_addr.addr) >> 24) == 0)
 	{
 	    TRACE_((THIS_FILE, "  address %s ignored (0.0.0.0/8 class)", 
 		    get_addr(ad), ad->sa_family));
@@ -410,9 +410,9 @@ PJ_DEF(pj_status_t) pj_enum_ip_route(unsigned *p_cnt,
     if (status != PJ_SUCCESS)
 	return status;
     
-    routes[0].ipv4.if_addr.s_addr = itf.ipv4.sin_addr.s_addr;
-    routes[0].ipv4.dst_addr.s_addr = 0;
-    routes[0].ipv4.mask.s_addr = 0;
+    routes[0].ipv4.if_addr.addr = itf.ipv4.sin_addr.addr;
+    routes[0].ipv4.dst_addr.addr = 0;
+    routes[0].ipv4.mask.addr = 0;
     *p_cnt = 1;
 
     return PJ_SUCCESS;

--- a/pjlib/src/pj/ip_helper_win32.c
+++ b/pjlib/src/pj/ip_helper_win32.c
@@ -255,7 +255,7 @@ static pj_status_t enum_ipv4_interface(unsigned *p_cnt,
 #endif
 
 	ifs[*p_cnt].ipv4.sin_family = PJ_AF_INET;
-	ifs[*p_cnt].ipv4.sin_addr.s_addr = pTab->table[i].dwAddr;
+	ifs[*p_cnt].ipv4.sin_addr.addr = pTab->table[i].dwAddr;
 	(*p_cnt)++;
     }
 
@@ -322,13 +322,13 @@ static pj_status_t enum_ipv4_ipv6_interface(int af,
 		    (const pj_sockaddr_in*)pAddr->lpSockaddr;
 
 		/* Ignore 0.0.0.0 address (interface is down?) */
-		if (addr_in->sin_addr.s_addr == 0)
+		if (addr_in->sin_addr.addr == 0)
 		    continue;
 
 		/* Ignore 0.0.0.0/8 address. This is a special address
 		 * which doesn't seem to have practical use.
 		 */
-		if ((pj_ntohl(addr_in->sin_addr.s_addr) >> 24) == 0)
+		if ((pj_ntohl(addr_in->sin_addr.addr) >> 24) == 0)
 		    continue;
 	    }
 
@@ -451,9 +451,9 @@ PJ_DEF(pj_status_t) pj_enum_ip_route(unsigned *p_cnt,
 	if (j==pIpTab->dwNumEntries)
 	    continue;	/* Interface not found */
 
-	routes[*p_cnt].ipv4.if_addr.s_addr = pIpTab->table[j].dwAddr;
-	routes[*p_cnt].ipv4.dst_addr.s_addr = prTab->table[i].dwForwardDest;
-	routes[*p_cnt].ipv4.mask.s_addr = prTab->table[i].dwForwardMask;
+	routes[*p_cnt].ipv4.if_addr.addr = pIpTab->table[j].dwAddr;
+	routes[*p_cnt].ipv4.dst_addr.addr = prTab->table[i].dwForwardDest;
+	routes[*p_cnt].ipv4.mask.addr = prTab->table[i].dwForwardMask;
 
 	(*p_cnt)++;
     }

--- a/pjlib/src/pj/os_symbian.h
+++ b/pjlib/src/pj/os_symbian.h
@@ -267,7 +267,7 @@ public:
 	{
 		pj_addr.addr.sa_family = PJ_AF_INET;
 	    PJ_ASSERT_RETURN(*addr_len>=(int)sizeof(pj_sockaddr_in), PJ_ETOOSMALL);
-	    pj_addr.ipv4.sin_addr.s_addr = pj_htonl(sym_addr.Address());
+	    pj_addr.ipv4.sin_addr.addr = pj_htonl(sym_addr.Address());
 	    pj_addr.ipv4.sin_port = pj_htons((pj_uint16_t) sym_addr.Port());
 	    *addr_len = sizeof(pj_sockaddr_in);
 	} else if (fam == PJ_AF_INET6) {
@@ -296,7 +296,7 @@ public:
     	if (pj_addr.addr.sa_family == PJ_AF_INET) {
     	    PJ_ASSERT_RETURN(addrlen >= (int)sizeof(pj_sockaddr_in), PJ_EINVAL);
 	    sym_addr.Init(KAfInet);
-    	    sym_addr.SetAddress((TUint32)pj_ntohl(pj_addr.ipv4.sin_addr.s_addr));
+    	    sym_addr.SetAddress((TUint32)pj_ntohl(pj_addr.ipv4.sin_addr.addr));
     	    sym_addr.SetPort(pj_ntohs(pj_addr.ipv4.sin_port));
     	} else if (pj_addr.addr.sa_family == PJ_AF_INET6) {
     	    TIp6Addr ip6;

--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -600,7 +600,7 @@ PJ_DEF(pj_status_t) pj_sock_bind_in( pj_sock_t sock,
 
     PJ_SOCKADDR_SET_LEN(&addr, sizeof(pj_sockaddr_in));
     addr.sin_family = PJ_AF_INET;
-    pj_bzero(addr.sin_zero, sizeof(addr.sin_zero));
+    pj_bzero(addr.sin_zero_pad, sizeof(addr.sin_zero_pad));
     addr.sin_addr.addr = pj_htonl(addr32);
     addr.sin_port = pj_htons(port);
 

--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -233,7 +233,7 @@ PJ_DEF(char*) pj_inet_ntoa(pj_in_addr inaddr)
     return inet_ntoa(*(struct in_addr*)&inaddr);
 #else
     struct in_addr addr;
-    //addr.s_addr = inaddr.s_addr;
+    //addr.addr = inaddr.addr;
     pj_memcpy(&addr, &inaddr, sizeof(addr));
     return inet_ntoa(addr);
 #endif
@@ -601,7 +601,7 @@ PJ_DEF(pj_status_t) pj_sock_bind_in( pj_sock_t sock,
     PJ_SOCKADDR_SET_LEN(&addr, sizeof(pj_sockaddr_in));
     addr.sin_family = PJ_AF_INET;
     pj_bzero(addr.sin_zero, sizeof(addr.sin_zero));
-    addr.sin_addr.s_addr = pj_htonl(addr32);
+    addr.sin_addr.addr = pj_htonl(addr32);
     addr.sin_port = pj_htons(port);
 
     return pj_sock_bind(sock, &addr, sizeof(pj_sockaddr_in));

--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -129,7 +129,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_set_str_addr( pj_sockaddr_in *addr,
 
     PJ_SOCKADDR_RESET_LEN(addr);
     addr->sin_family = PJ_AF_INET;
-    pj_bzero(addr->sin_zero, sizeof(addr->sin_zero));
+    pj_bzero(addr->sin_zero_pad, sizeof(addr->sin_zero_pad));
 
     if (str_addr && str_addr->slen) {
 	addr->sin_addr = pj_inet_addr(str_addr);
@@ -210,7 +210,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_init( pj_sockaddr_in *addr,
 
     PJ_SOCKADDR_RESET_LEN(addr);
     addr->sin_family = PJ_AF_INET;
-    pj_bzero(addr->sin_zero, sizeof(addr->sin_zero));
+    pj_bzero(addr->sin_zero_pad, sizeof(addr->sin_zero_pad));
     pj_sockaddr_in_set_port(addr, port);
     return pj_sockaddr_in_set_str_addr(addr, str_addr);
 }

--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -125,7 +125,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_set_str_addr( pj_sockaddr_in *addr,
     PJ_CHECK_STACK();
 
     PJ_ASSERT_RETURN(!str_addr || str_addr->slen < PJ_MAX_HOSTNAME, 
-                     (addr->sin_addr.s_addr=PJ_INADDR_NONE, PJ_EINVAL));
+                     (addr->sin_addr.addr=PJ_INADDR_NONE, PJ_EINVAL));
 
     PJ_SOCKADDR_RESET_LEN(addr);
     addr->sin_family = PJ_AF_INET;
@@ -133,7 +133,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_set_str_addr( pj_sockaddr_in *addr,
 
     if (str_addr && str_addr->slen) {
 	addr->sin_addr = pj_inet_addr(str_addr);
-	if (addr->sin_addr.s_addr == PJ_INADDR_NONE) {
+	if (addr->sin_addr.addr == PJ_INADDR_NONE) {
     	    pj_addrinfo ai;
 	    unsigned count = 1;
 	    pj_status_t status;
@@ -148,7 +148,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_set_str_addr( pj_sockaddr_in *addr,
 	}
 
     } else {
-	addr->sin_addr.s_addr = 0;
+	addr->sin_addr.addr = 0;
     }
 
     return PJ_SUCCESS;
@@ -206,7 +206,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_init( pj_sockaddr_in *addr,
 				         const pj_str_t *str_addr,
 					 pj_uint16_t port)
 {
-    PJ_ASSERT_RETURN(addr, (addr->sin_addr.s_addr=PJ_INADDR_NONE, PJ_EINVAL));
+    PJ_ASSERT_RETURN(addr, (addr->sin_addr.addr=PJ_INADDR_NONE, PJ_EINVAL));
 
     PJ_SOCKADDR_RESET_LEN(addr);
     addr->sin_family = PJ_AF_INET;
@@ -352,10 +352,10 @@ PJ_DEF(pj_bool_t) pj_sockaddr_has_addr(const pj_sockaddr_t *addr)
     } else if (a->addr.sa_family == PJ_AF_INET6) {
 	pj_uint8_t zero[24];
 	pj_bzero(zero, sizeof(zero));
-	return pj_memcmp(a->ipv6.sin6_addr.s6_addr, zero, 
+	return pj_memcmp(a->ipv6.sin6_addr.addr, zero, 
 			 sizeof(pj_in6_addr)) != 0;
     } else
-	return a->ipv4.sin_addr.s_addr != PJ_INADDR_ANY;
+	return a->ipv4.sin_addr.addr != PJ_INADDR_ANY;
 }
 
 /*
@@ -483,7 +483,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_set_port(pj_sockaddr *addr,
 PJ_DEF(pj_in_addr) pj_sockaddr_in_get_addr(const pj_sockaddr_in *addr)
 {
     pj_in_addr in_addr;
-    in_addr.s_addr = pj_ntohl(addr->sin_addr.s_addr);
+    in_addr.addr = pj_ntohl(addr->sin_addr.addr);
     return in_addr;
 }
 
@@ -493,7 +493,7 @@ PJ_DEF(pj_in_addr) pj_sockaddr_in_get_addr(const pj_sockaddr_in *addr)
 PJ_DEF(void) pj_sockaddr_in_set_addr(pj_sockaddr_in *addr,
 				     pj_uint32_t hostaddr)
 {
-    addr->sin_addr.s_addr = pj_htonl(hostaddr);
+    addr->sin_addr.addr = pj_htonl(hostaddr);
 }
 
 /*
@@ -932,7 +932,7 @@ PJ_DEF(pj_status_t) pj_gethostip(int af, pj_sockaddr *addr)
 	for (i=0; i<cand_cnt; ++i) {
 	    unsigned j;
 	    for (j=0; j<PJ_ARRAY_SIZE(spec_ipv4); ++j) {
-		    pj_uint32_t a = pj_ntohl(cand_addr[i].ipv4.sin_addr.s_addr);
+		    pj_uint32_t a = pj_ntohl(cand_addr[i].ipv4.sin_addr.addr);
 		    pj_uint32_t pa = spec_ipv4[j].addr;
 		    pj_uint32_t pm = spec_ipv4[j].mask;
 
@@ -946,7 +946,7 @@ PJ_DEF(pj_status_t) pj_gethostip(int af, pj_sockaddr *addr)
 	for (i=0; i<PJ_ARRAY_SIZE(spec_ipv6); ++i) {
 		unsigned j;
 		for (j=0; j<cand_cnt; ++j) {
-		    pj_uint8_t *a = cand_addr[j].ipv6.sin6_addr.s6_addr;
+		    pj_uint8_t *a = cand_addr[j].ipv6.sin6_addr.addr;
 		    pj_uint8_t am[16];
 		    pj_uint8_t *pa = spec_ipv6[i].addr;
 		    pj_uint8_t *pm = spec_ipv6[i].mask;
@@ -985,13 +985,13 @@ PJ_DEF(pj_status_t) pj_gethostip(int af, pj_sockaddr *addr)
     /* If else fails, returns loopback interface as the last resort */
     if (selected_cand == -1) {
 	if (af==PJ_AF_INET) {
-	    addr->ipv4.sin_addr.s_addr = pj_htonl (0x7f000001);
+	    addr->ipv4.sin_addr.addr = pj_htonl (0x7f000001);
 	} else {
-	    pj_in6_addr *s6_addr;
+	    pj_in6_addr *in6_addr;
 
-	    s6_addr = (pj_in6_addr*) pj_sockaddr_get_addr(addr);
-	    pj_bzero(s6_addr, sizeof(pj_in6_addr));
-	    s6_addr->s6_addr[15] = 1;
+	    in6_addr = (pj_in6_addr*) pj_sockaddr_get_addr(addr);
+	    pj_bzero(in6_addr, sizeof(pj_in6_addr));
+	    in6_addr->addr[15] = 1;
 	}
 	TRACE_((THIS_FILE, "Loopback IP %s returned",
 		pj_sockaddr_print(addr, strip, sizeof(strip), 3)));

--- a/pjlib/src/pj/sock_symbian.cpp
+++ b/pjlib/src/pj/sock_symbian.cpp
@@ -287,7 +287,7 @@ PJ_DEF(char*) pj_inet_ntoa(pj_in_addr inaddr)
     TBuf<PJ_INET_ADDRSTRLEN> str16(0);
 
     /* (Symbian IP address is in host byte order) */
-    TInetAddr temp_addr((TUint32)pj_ntohl(inaddr.s_addr), (TUint)0);
+    TInetAddr temp_addr((TUint32)pj_ntohl(inaddr.addr), (TUint)0);
     temp_addr.Output(str16);
  
     return pj_unicode_to_ansi((const wchar_t*)str16.PtrZ(), str16.Length(),
@@ -418,7 +418,7 @@ PJ_DEF(pj_status_t) pj_inet_ntop(int af, const void *src,
 	pj_memcpy(&inaddr, src, 4);
 
 	/* Symbian IP address is in host byte order */
-	TInetAddr temp_addr((TUint32)pj_ntohl(inaddr.s_addr), (TUint)0);
+	TInetAddr temp_addr((TUint32)pj_ntohl(inaddr.addr), (TUint)0);
 	temp_addr.Output(str16);
  
 	pj_unicode_to_ansi((const wchar_t*)str16.PtrZ(), str16.Length(),
@@ -568,7 +568,7 @@ PJ_DEF(pj_status_t) pj_sock_bind_in( pj_sock_t sock,
 
     pj_bzero(&addr, sizeof(addr));
     addr.sin_family = PJ_AF_INET;
-    addr.sin_addr.s_addr = pj_htonl(addr32);
+    addr.sin_addr.addr = pj_htonl(addr32);
     addr.sin_port = pj_htons(port);
 
     return pj_sock_bind(sock, &addr, sizeof(pj_sockaddr_in));

--- a/pjlib/src/pj/sock_uwp.cpp
+++ b/pjlib/src/pj/sock_uwp.cpp
@@ -1217,7 +1217,7 @@ PJ_DEF(pj_status_t) pj_sock_bind_in( pj_sock_t sock,
 
     pj_bzero(&addr, sizeof(addr));
     addr.sin_family = PJ_AF_INET;
-    addr.sin_addr.s_addr = pj_htonl(addr32);
+    addr.sin_addr.addr = pj_htonl(addr32);
     addr.sin_port = pj_htons(port);
 
     return pj_sock_bind(sock, &addr, sizeof(pj_sockaddr_in));

--- a/pjlib/src/pjlib-test/ioq_tcp.c
+++ b/pjlib/src/pjlib-test/ioq_tcp.c
@@ -823,7 +823,7 @@ static int compliance_test_2(pj_bool_t allow_concur)
 
 	    // Check addresses
 	    if (server[i].local_addr.sin_family != pj_AF_INET() ||
-		server[i].local_addr.sin_addr.s_addr == 0 ||
+		server[i].local_addr.sin_addr.addr == 0 ||
 		server[i].local_addr.sin_port == 0)
 	    {
 		app_perror("...ERROR address not set", rc);
@@ -832,7 +832,7 @@ static int compliance_test_2(pj_bool_t allow_concur)
 	    }
 
 	    if (server[i].rem_addr.sin_family != pj_AF_INET() ||
-		server[i].rem_addr.sin_addr.s_addr == 0 ||
+		server[i].rem_addr.sin_addr.addr == 0 ||
 		server[i].rem_addr.sin_port == 0)
 	    {
 		app_perror("...ERROR address not set", rc);

--- a/pjlib/src/pjlib-test/ioq_udp.c
+++ b/pjlib/src/pjlib-test/ioq_udp.c
@@ -116,7 +116,7 @@ static pj_ioqueue_callback test_cb =
 };
 
 #if defined(PJ_WIN32) || defined(PJ_WIN64)
-#  define S_ADDR S_un.S_addr
+#  define S_ADDR S_un.addr
 #else
 #  define S_ADDR s_addr
 #endif

--- a/pjlib/src/pjlib-test/ioq_udp.c
+++ b/pjlib/src/pjlib-test/ioq_udp.c
@@ -116,7 +116,7 @@ static pj_ioqueue_callback test_cb =
 };
 
 #if defined(PJ_WIN32) || defined(PJ_WIN64)
-#  define S_ADDR S_un.addr
+#  define S_ADDR S_un.S_addr
 #else
 #  define S_ADDR s_addr
 #endif

--- a/pjlib/src/pjlib-test/main_rtems.c
+++ b/pjlib/src/pjlib-test/main_rtems.c
@@ -237,7 +237,7 @@ send_udp(const char *target)
     rc = bind(sock, (struct sockaddr*)&addr, sizeof(addr));
     assert("bind error" && rc==0);
 
-    addr.sin_addr.s_addr = inet_addr(target);
+    addr.sin_addr.addr = inet_addr(target);
     addr.sin_port = htons(4444);
 
     while(1) {
@@ -264,7 +264,7 @@ static void test_sock(void)
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    addr.sin_addr.addr = inet_addr("127.0.0.1");
     addr.sin_port = htons(5000);
 
     rc = bind(sock, (struct sockaddr*)&addr, sizeof(addr));

--- a/pjlib/src/pjlib-test/sock.c
+++ b/pjlib/src/pjlib-test/sock.c
@@ -162,11 +162,11 @@ static int format_test(void)
 #endif	/* PJ_HAS_IPV6 */
 
     /* Test that pj_sockaddr_in_init() initialize the whole structure, 
-     * including sin_zero.
+     * including sin_zero_pad.
      */
     pj_sockaddr_in_init(&addr2, 0, 1000);
     pj_bzero(zero, sizeof(zero));
-    if (pj_memcmp(addr2.sin_zero, zero, sizeof(addr2.sin_zero)) != 0)
+    if (pj_memcmp(addr2.sin_zero_pad, zero, sizeof(addr2.sin_zero_pad)) != 0)
 	return -35;
 
     /* pj_gethostname() */

--- a/pjnath/src/pjnath-test/ice_test.c
+++ b/pjnath/src/pjnath-test/ice_test.c
@@ -132,7 +132,7 @@ static pj_bool_t enable_ipv6_test()
     pj_bool_t retval = PJ_TRUE;
     if (pj_gethostip(pj_AF_INET6(), &addr) == PJ_SUCCESS) {
 	const pj_in6_addr *a = &addr.ipv6.sin6_addr;
-	if (a->s6_addr[0] == 0xFE && (a->s6_addr[1] & 0xC0) == 0x80) {
+	if (a->addr[0] == 0xFE && (a->addr[1] & 0xC0) == 0x80) {
 	    retval = PJ_FALSE;
 	    PJ_LOG(3,(THIS_FILE, INDENT "Skipping IPv6 test due to link-local "
 		     "address"));

--- a/pjnath/src/pjnath-test/server.c
+++ b/pjnath/src/pjnath-test/server.c
@@ -97,7 +97,7 @@ pj_status_t create_test_server(pj_stun_config *stun_cfg,
 	 * error, so let's just hardcode it.
 	 */
 	pj_sockaddr_init(pj_AF_INET6(), &hostip, NULL, 0);
-	hostip.ipv6.sin6_addr.s6_addr[15] = 1;
+	hostip.ipv6.sin6_addr.addr[15] = 1;
     } else {
 	status = pj_gethostip(GET_AF(use_ipv6), &hostip);
 	if (status != PJ_SUCCESS)
@@ -699,7 +699,7 @@ static pj_bool_t turn_on_data_read(test_server *test_srv,
 	     * error, so let's just hardcode it.
 	     */
 	    pj_sockaddr_init(pj_AF_INET6(), &alloc->alloc_addr, NULL, 0);
-	    alloc->alloc_addr.ipv6.sin6_addr.s6_addr[15] = 1;
+	    alloc->alloc_addr.ipv6.sin6_addr.addr[15] = 1;
 	} else {
 	    status = pj_gethostip(GET_AF(use_ipv6), &alloc->alloc_addr);
 	    if (status != PJ_SUCCESS) {

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -249,7 +249,7 @@ PJ_DEF(void) pj_ice_calc_foundation(pj_pool_t *pool,
     pj_uint32_t val;
 
     if (base_addr->addr.sa_family == pj_AF_INET()) {
-	val = pj_ntohl(base_addr->ipv4.sin_addr.s_addr);
+	val = pj_ntohl(base_addr->ipv4.sin_addr.addr);
     } else {
 	val = pj_hash_calc(0, pj_sockaddr_get_addr(base_addr),
 			   pj_sockaddr_get_addr_len(base_addr));

--- a/pjnath/src/pjnath/ice_strans.c
+++ b/pjnath/src/pjnath/ice_strans.c
@@ -650,13 +650,13 @@ static pj_status_t add_stun_and_host(pj_ice_strans *ice_st,
 	    /* Ignore loopback addresses if cfg->stun.loop_addr is unset */
 	    if (stun_cfg->loop_addr==PJ_FALSE) {
 		if (stun_cfg->af == pj_AF_INET() && 
-		    (pj_ntohl(addr->ipv4.sin_addr.s_addr)>>24)==127)
+		    (pj_ntohl(addr->ipv4.sin_addr.addr)>>24)==127)
 		{
 		    continue;
 		}
 		else if (stun_cfg->af == pj_AF_INET6()) {
 		    pj_in6_addr in6addr = {{0}};
-		    in6addr.s6_addr[15] = 1;
+		    in6addr.addr[15] = 1;
 		    if (pj_memcmp(&in6addr, &addr->ipv6.sin6_addr,
 				  sizeof(in6addr))==0)
 		    {
@@ -670,7 +670,7 @@ static pj_status_t add_stun_and_host(pj_ice_strans *ice_st,
 	     */
 	    if (stun_cfg->af == pj_AF_INET6() && i != 0) {
 		const pj_in6_addr *a = &addr->ipv6.sin6_addr;
-		if (a->s6_addr[0] == 0xFE && (a->s6_addr[1] & 0xC0) == 0x80)
+		if (a->addr[0] == 0xFE && (a->addr[1] & 0xC0) == 0x80)
 		    continue;
 	    }
 

--- a/pjnath/src/pjnath/stun_msg.c
+++ b/pjnath/src/pjnath/stun_msg.c
@@ -956,7 +956,7 @@ static pj_status_t decode_xored_sockaddr_attr(pj_pool_t *pool,
 
     if (attr->sockaddr.addr.sa_family == pj_AF_INET()) {
 	attr->sockaddr.ipv4.sin_port ^= pj_htons(PJ_STUN_MAGIC >> 16);
-	attr->sockaddr.ipv4.sin_addr.s_addr ^= pj_htonl(PJ_STUN_MAGIC);
+	attr->sockaddr.ipv4.sin_addr.addr ^= pj_htonl(PJ_STUN_MAGIC);
     } else if (attr->sockaddr.addr.sa_family == pj_AF_INET6()) {
 	unsigned i;
 	pj_uint8_t *dst = (pj_uint8_t*) &attr->sockaddr.ipv6.sin6_addr;
@@ -1026,7 +1026,7 @@ static pj_status_t encode_sockaddr_attr(const void *a, pj_uint8_t *buf,
 	    pj_uint32_t addr;
 	    pj_uint16_t port;
 
-	    addr = ca->sockaddr.ipv4.sin_addr.s_addr;
+	    addr = ca->sockaddr.ipv4.sin_addr.addr;
 	    port = ca->sockaddr.ipv4.sin_port;
 
 	    port ^= pj_htons(PJ_STUN_MAGIC >> 16);

--- a/pjsip-apps/src/samples/invtester.c
+++ b/pjsip-apps/src/samples/invtester.c
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
 	pj_sockaddr_in addr;
 
 	addr.sin_family = pj_AF_INET();
-	addr.sin_addr.s_addr = 0;
+	addr.sin_addr.addr = 0;
 	addr.sin_port = pj_htons(PORT);
 
 	status = pjsip_udp_transport_start( sip_endpt, &addr, NULL, 1, NULL);

--- a/pjsip-apps/src/samples/pcaputil.c
+++ b/pjsip-apps/src/samples/pcaputil.c
@@ -479,14 +479,14 @@ int main(int argc, char *argv[])
 	    {
 		pj_str_t t = pj_str(pj_optarg);
 		pj_in_addr a = pj_inet_addr(&t);
-		filter.ip_src = a.s_addr;
+		filter.ip_src = a.addr;
 	    }
 	    break;
 	case OPT_DST_IP:
 	    {
 		pj_str_t t = pj_str(pj_optarg);
 		pj_in_addr a = pj_inet_addr(&t);
-		filter.ip_dst = a.s_addr;
+		filter.ip_dst = a.addr;
 	    }
 	    break;
 	case OPT_SRC_PORT:

--- a/pjsip-apps/src/samples/pjsip-perf.c
+++ b/pjsip-apps/src/samples/pjsip-perf.c
@@ -766,7 +766,7 @@ static pj_status_t init_sip()
 
 	pj_bzero(&addr, sizeof(addr));
 	addr.sin_family = pj_AF_INET();
-	addr.sin_addr.s_addr = 0;
+	addr.sin_addr.addr = 0;
 	addr.sin_port = pj_htons((pj_uint16_t)app.local_port);
 
 	if (app.local_addr.slen) {

--- a/pjsip-apps/src/samples/proxy.h
+++ b/pjsip-apps/src/samples/proxy.h
@@ -214,7 +214,7 @@ static pj_status_t init_stack(void)
 	pj_sockaddr_in addr;
 
 	addr.sin_family = pj_AF_INET();
-	addr.sin_addr.s_addr = 0;
+	addr.sin_addr.addr = 0;
 	addr.sin_port = pj_htons((pj_uint16_t)global.port);
 
 	status = pjsip_udp_transport_start( global.endpt, &addr, 
@@ -266,7 +266,7 @@ static pj_status_t init_proxy(void)
 	for (i=0; i<addr_cnt; ++i) {
 	    char addr[PJ_INET_ADDRSTRLEN];
 	    
-	    if (addr_list[i].ipv4.sin_addr.s_addr == pri_addr.ipv4.sin_addr.s_addr)
+	    if (addr_list[i].ipv4.sin_addr.addr == pri_addr.ipv4.sin_addr.addr)
 		continue;
 
 	    pj_inet_ntop(pj_AF_INET(), &addr_list[i].ipv4.sin_addr, addr,

--- a/pjsip-apps/src/samples/siprtp.c
+++ b/pjsip-apps/src/samples/siprtp.c
@@ -311,7 +311,7 @@ static pj_status_t init_sip()
 
 	pj_bzero(&addr, sizeof(addr));
 	addr.sin_family = pj_AF_INET();
-	addr.sin_addr.s_addr = 0;
+	addr.sin_addr.addr = 0;
 	addr.sin_port = pj_htons((pj_uint16_t)app.sip_port);
 
 	if (app.local_addr.slen) {

--- a/pjsip-apps/src/samples/sipstateless.c
+++ b/pjsip-apps/src/samples/sipstateless.c
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
 	pj_sockaddr_in addr;
 
 	addr.sin_family = pj_AF_INET();
-	addr.sin_addr.s_addr = 0;
+	addr.sin_addr.addr = 0;
 	addr.sin_port = pj_htons(5060);
 
 	status = pjsip_udp_transport_start( sip_endpt, &addr, NULL, 1, NULL);
@@ -215,7 +215,7 @@ int main(int argc, char *argv[])
 	pj_sockaddr_in addr;
 
 	addr.sin_family = pj_AF_INET();
-	addr.sin_addr.s_addr = 0;
+	addr.sin_addr.addr = 0;
 	addr.sin_port = pj_htons(5060);
 
 	status = pjsip_tcp_transport_start(sip_endpt, &addr, 1, NULL);

--- a/pjsip-apps/src/samples/streamutil.c
+++ b/pjsip-apps/src/samples/streamutil.c
@@ -250,8 +250,8 @@ static pj_status_t create_stream( pj_pool_t *pool,
 	    struct pj_ip_mreq imr;
 	
 	    pj_memset(&imr, 0, sizeof(struct pj_ip_mreq));
-	    imr.imr_multiaddr.s_addr = mcast_addr->sin_addr.s_addr;
-	    imr.imr_interface.s_addr = pj_htonl(PJ_INADDR_ANY);
+	    imr.imr_multiaddr.addr = mcast_addr->sin_addr.addr;
+	    imr.imr_interface.addr = pj_htonl(PJ_INADDR_ANY);
 	    status = pj_sock_setsockopt(si.rtp_sock, pj_SOL_IP(),
 	    				pj_IP_ADD_MEMBERSHIP(),
 				   	&imr, sizeof(struct pj_ip_mreq));
@@ -574,7 +574,7 @@ int main(int argc, char *argv[])
         || is_dtls_client || is_dtls_server
 #endif
        ) {
-	if (remote_addr.sin_addr.s_addr == 0) {
+	if (remote_addr.sin_addr.addr == 0) {
 	    printf("Error: remote address must be set\n");
 	    return 1;
 	}

--- a/pjsip-apps/src/samples/vid_streamutil.c
+++ b/pjsip-apps/src/samples/vid_streamutil.c
@@ -565,7 +565,7 @@ int main(int argc, char *argv[])
 
     /* Verify arguments. */
     if (dir & PJMEDIA_DIR_ENCODING) {
-	if (remote_addr.sin_addr.s_addr == 0) {
+	if (remote_addr.sin_addr.addr == 0) {
 	    printf("Error: remote address must be set\n");
 	    return 1;
 	}

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -279,7 +279,7 @@ static pj_status_t update_factory_addr(struct tcp_listener *listener,
 	status = pj_sockaddr_init(af, &tmp, &addr_name->host,
 				  (pj_uint16_t)addr_name->port);
 	if (status != PJ_SUCCESS || !pj_sockaddr_has_addr(&tmp) ||
-	    (af == pj_AF_INET() && tmp.ipv4.sin_addr.s_addr == PJ_INADDR_NONE))
+	    (af == pj_AF_INET() && tmp.ipv4.sin_addr.addr == PJ_INADDR_NONE))
 	{
 	    /* Invalid address */
 	    return PJ_EINVAL;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -371,7 +371,7 @@ static pj_status_t update_factory_addr(struct tls_listener *listener,
 	status = pj_sockaddr_init(af, &tmp, &addr_name->host,
 				  (pj_uint16_t)addr_name->port);
 	if (status != PJ_SUCCESS || !pj_sockaddr_has_addr(&tmp) ||
-	    (af == pj_AF_INET() && tmp.ipv4.sin_addr.s_addr == PJ_INADDR_NONE))
+	    (af == pj_AF_INET() && tmp.ipv4.sin_addr.addr == PJ_INADDR_NONE))
 	{
 	    /* Invalid address */
 	    return PJ_EINVAL;

--- a/pjsip/src/pjsip/sip_transport_udp.c
+++ b/pjsip/src/pjsip/sip_transport_udp.c
@@ -573,7 +573,7 @@ static pj_status_t get_published_name(pj_sock_t sock,
 	/* If bound address specifies "0.0.0.0", get the IP address
 	 * of local hostname.
 	 */
-	if (tmp_addr.ipv4.sin_addr.s_addr == PJ_INADDR_ANY) {
+	if (tmp_addr.ipv4.sin_addr.addr == PJ_INADDR_ANY) {
 	    pj_sockaddr hostip;
 
 	    status = pj_gethostip(pj_AF_INET(), &hostip);

--- a/pjsip/src/test/dns_test.c
+++ b/pjsip/src/test/dns_test.c
@@ -371,7 +371,7 @@ static int test_resolve(const char *title,
 	    pj_sockaddr_in *ra = (pj_sockaddr_in *)&ref->entry[i].addr;
 	    pj_sockaddr_in *rb = (pj_sockaddr_in *)&result.servers.entry[i].addr;
 
-	    if (ra->sin_addr.s_addr != rb->sin_addr.s_addr) {
+	    if (ra->sin_addr.addr != rb->sin_addr.addr) {
 		PJ_LOG(3,(THIS_FILE, "  test_resolve() error 20: IP address mismatch"));
 		return 20;
 	    }
@@ -451,7 +451,7 @@ static int round_robin_test(pj_pool_t *pool)
 	    a1 = pj_inet_addr(&tmp);
 	    a2 = (pj_sockaddr_in*) &result.servers.entry[0].addr;
 
-	    if (a1.s_addr == a2->sin_addr.s_addr) {
+	    if (a1.addr == a2->sin_addr.addr) {
 		server_hit[j].hits++;
 		break;
 	    }

--- a/pjsip/src/test/transport_test.c
+++ b/pjsip/src/test/transport_test.c
@@ -40,7 +40,7 @@ int generic_transport_test(pjsip_transport *tp)
 	if (pj_inet_pton(pj_AF_INET(), &tp->local_name.host,
 			 &addr) == PJ_SUCCESS)
 	{
-	    if (addr.s_addr==PJ_INADDR_ANY || addr.s_addr==PJ_INADDR_NONE) {
+	    if (addr.addr==PJ_INADDR_ANY || addr.addr==PJ_INADDR_NONE) {
 		PJ_LOG(3,(THIS_FILE, "   Error: invalid address name"));
 		return -420;
 	    }


### PR DESCRIPTION
Re: #2311
