### PR TITLE
Indicate that video format change is from decoding stream.

### DIFF
--- a/pjmedia/include/pjmedia/event.h
+++ b/pjmedia/include/pjmedia/event.h
@@ -125,6 +125,10 @@ typedef struct pjmedia_event_fmt_changed_data
 
     /** The new media format. */
     pjmedia_format	new_fmt;
+
+    /** Event publisher is decoding stream. */
+    pj_bool_t		is_dec_stream;
+
 } pjmedia_event_fmt_changed_data;
 
 /**

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2507,8 +2507,9 @@ public:
  */
 struct MediaFmtChangedEvent
 {
-    unsigned newWidth;      /**< The new width.     */
-    unsigned newHeight;     /**< The new height.    */
+    unsigned newWidth;		/**< The new width.			*/
+    unsigned newHeight;		/**< The new height.			*/
+    bool     isDecodingStream;	/**< Event publisher is decoding stream.*/
 };
 
 /**

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1568,6 +1568,7 @@ pj_status_t call_media_on_event(pjmedia_event *event,
 
 #if PJSUA_HAS_VIDEO
 	case PJMEDIA_EVENT_FMT_CHANGED:
+	    event->data.fmt_changed.is_dec_stream = PJ_FALSE;
 	    if (call_med->strm.v.rdr_win_id != PJSUA_INVALID_ID) {
 		pjsua_vid_win *w = &pjsua_var.win[call_med->strm.v.rdr_win_id];
 		if (event->epub == w->vp_rend) {
@@ -1606,6 +1607,9 @@ pj_status_t call_media_on_event(pjmedia_event *event,
 		    pjsua_vid_conf_disconnect(dec_pid, pi.listeners[i]);
 		    pjsua_vid_conf_connect(dec_pid, pi.listeners[i], NULL);
 		}
+		/* Check if event publisher is decoding stream. */
+		event->data.fmt_changed.is_dec_stream =
+						    (strm_dec == event->epub);
 	    }
 	    break;
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1884,6 +1884,7 @@ void MediaEvent::fromPj(const pjmedia_event &ev)
     if (type == PJMEDIA_EVENT_FMT_CHANGED) {
         data.fmtChanged.newWidth = ev.data.fmt_changed.new_fmt.det.vid.size.w;
         data.fmtChanged.newHeight = ev.data.fmt_changed.new_fmt.det.vid.size.h;
+	data.fmtChanged.isDecodingStream = ev.data.fmt_changed.is_dec_stream;
     } else if (type == PJMEDIA_EVENT_AUD_DEV_ERROR) {
 	data.audDevError.dir = ev.data.aud_dev_err.dir;
 	data.audDevError.id = ev.data.aud_dev_err.id;


### PR DESCRIPTION
Currently on_call_media_event() might be called multiple times from various video components although it is the same event.
This patch will add information to indicate that the event publisher is stream decoder. This is useful for app to identify the correct event to watch.