### PR TITLE
More pjsua-test work: retry telnet on fail and runall.py emits exit/error code

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,10 +12,12 @@ jobs:
     - name: install dependencies
       run: sudo apt-get install -y sip-tester
     - name: config site
-      run: echo "#define PJMEDIA_SRTP_HAS_DTLS 1" > pjlib/include/pj/config_site.h
+      run: |
+        echo "#define PJMEDIA_SRTP_HAS_DTLS 1" > pjlib/include/pj/config_site.h
+        echo "#define PJ_EXCLUDE_BENCHMARK_TESTS 1" > pjlib/include/pj/config_site.h
     - name: configure
       run: ./configure
     - name: make
       run: make
-    - name: unit test
-      run: make selftest
+    - name: pjsua test
+      run: make pjsua-test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,12 +12,10 @@ jobs:
     - name: install dependencies
       run: sudo apt-get install -y sip-tester
     - name: config site
-      run: |
-        echo "#define PJMEDIA_SRTP_HAS_DTLS 1" > pjlib/include/pj/config_site.h
-        echo "#define PJ_EXCLUDE_BENCHMARK_TESTS 1" > pjlib/include/pj/config_site.h
+      run: echo "#define PJMEDIA_SRTP_HAS_DTLS 1" > pjlib/include/pj/config_site.h
     - name: configure
       run: ./configure
     - name: make
       run: make
-    - name: pjsua test
-      run: make pjsua-test
+    - name: unit test
+      run: make selftest

--- a/tests/pjsua/runall.py
+++ b/tests/pjsua/runall.py
@@ -214,3 +214,4 @@ if fails_cnt == 0:
 else:
     print str(tests_cnt) + " tests completed, " +  str(fails_cnt) + " test(s) failed"
 
+sys.exit(fails_cnt)


### PR DESCRIPTION
- Currently telnet may be done before pjsua app completes its start-up and telnet is ready.
- pjsua-test will always be seen as successful because it does not return any error code.