### PR TITLE
Add thread locking callback when using OpenSSL.

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -1024,6 +1024,15 @@
 #  define PJ_SSL_SOCK_MAX_CURVES   32
 #endif
 
+/**
+ * Use SSL backend thread locking.
+ *
+ * Default: 0 (No)
+ */
+#ifndef PJ_SSL_SOCK_USE_THREAD_LOCK
+#  define PJ_SSL_SOCK_USE_THREAD_LOCK   0
+#endif
+
 
 /**
  * Disable WSAECONNRESET error for UDP sockets on Win32 platforms. See

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -1025,12 +1025,15 @@
 #endif
 
 /**
- * Use SSL backend thread locking.
+ * Use OpenSSL thread locking callback. This is only applicable for OpenSSL
+ * version prior to 1.1.0
  *
- * Default: 0 (No)
+ * Default: 1 (enabled)
  */
-#ifndef PJ_SSL_SOCK_USE_THREAD_LOCK
-#  define PJ_SSL_SOCK_USE_THREAD_LOCK   0
+#ifndef PJ_SSL_SOCK_OSSL_USE_THREAD_CB
+#   define PJ_SSL_SOCK_OSSL_USE_THREAD_CB   1
+#else
+#   define PJ_SSL_SOCK_OSSL_USE_THREAD_CB   0
 #endif
 
 

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -524,8 +524,10 @@ static void release_thread_cb(void)
     if (lock_pool) {
         pj_pool_release(lock_pool);
         lock_pool = NULL;
+        pj_caching_pool_destroy(&cp);
     }
-    pj_caching_pool_destroy(&cp);
+    ossl_locks = NULL;
+    ossl_num_locks = 0;
 }
 
 static pj_status_t init_ossl_lock()

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -459,14 +459,14 @@ static int sslsock_idx;
     PJ_SSL_SOCK_OSSL_USE_THREAD_CB != 0 && OPENSSL_VERSION_NUMBER < 0x10100000L
 
 /* Thread lock pool.*/
-pj_caching_pool 	 cp;
-pj_pool_t 		*lock_pool;
+static pj_caching_pool 	 cp;
+static pj_pool_t 	*lock_pool;
 
 /* OpenSSL locking list. */
-pj_lock_t **ossl_locks;
+static pj_lock_t **ossl_locks;
 
 /* OpenSSL number locks. */
-unsigned ossl_num_locks;
+static unsigned ossl_num_locks;
 
 #if     OPENSSL_VERSION_NUMBER >= 0x10000000
 static void ossl_set_thread_id(CRYPTO_THREADID *id)
@@ -504,7 +504,7 @@ static void ossl_lock(int mode, int id, const char *file, int line)
     }
 }
 
-static void release_thread_cb()
+static void release_thread_cb(void)
 {
     unsigned i = 0;
 
@@ -574,7 +574,7 @@ static pj_status_t init_ossl_lock()
 #endif
 
 /* Initialize OpenSSL */
-static pj_status_t init_openssl()
+static pj_status_t init_openssl(void)
 {
     pj_status_t status;
 
@@ -717,8 +717,9 @@ static pj_status_t init_openssl()
 }
 
 /* Shutdown OpenSSL */
-static void shutdown_openssl()
+static void shutdown_openssl(void)
 {
+    PJ_UNUSED_ARG(openssl_init_count);
 }
 
 /* SSL password callback. */

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -575,9 +575,8 @@ static pj_status_t init_ossl_lock()
         CRYPTO_set_locking_callback(ossl_lock);
         status = pj_atexit(&release_thread_cb);
         if (status != PJ_SUCCESS) {
-            PJ_PERROR(1, (THIS_FILE, status,
-                  "Cannot set OpenSSL lock thread callback unrelease method"));
-            release_thread_cb();
+            PJ_PERROR(1, (THIS_FILE, status, "Warning! Unable to set OpenSSL "
+                          "lock thread callback unrelease method."));
         }
     } else {
         status = PJ_ENOMEM;


### PR DESCRIPTION
It is reported that while using PJSIP with 8 worker threads and 1.0.2 openssl with FIPS enabled,
during runtime FIPS Random is stalled with a error message 'Selftest failed'.
```
SSL ECDH initialized (automatic), faster PFS ciphers enabled
SSL SSL_ERROR_SSL (Handshake): Level: 0 err: <755437702> <FIPS routines-FIPS_drbg_generate-selftest failed> len: 0
SSL SSL_ERROR_SSL (Handshake): Level: 1 err: <336285997> <SSL routines-ssl_get_new_session-ssl session id callback failed> len: 0
Handshake failed in accepting 136.243.39.78:53371: Unknown OpenSSL error 134
```
Once this happens, no further openssl function will work due to the protection in FIPS container.
Based on [this](https://www.openssl.org/docs/man1.0.2/man3/CRYPTO_set_locking_callback.html)
on multiple thread application, locking function need to be set otherwise random crash will happen. 

Thanks to Peter Koletzki for the report.

Notes:
- There is dynamic lock mechanism which is not included on this patch. From the docs:
```
Also, dynamic locks are currently not used internally by OpenSSL, but may do so in the future.
```