### PR TITLE
Increment outgoing RTP timestamp on inactive or receive only audio stream

### DIFF
--- a/pjmedia/src/pjmedia/rtp.c
+++ b/pjmedia/src/pjmedia/rtp.c
@@ -113,6 +113,11 @@ PJ_DEF(pj_status_t) pjmedia_rtp_session_init2(
 	ses->peer_ssrc = settings.peer_ssrc;
     }
 
+    PJ_LOG(5, (THIS_FILE,
+	       "pjmedia_rtp_session_init2: ses=%p, seq=%d, ts=%d, peer_ssrc=%d",
+	       ses, pj_ntohs(ses->out_hdr.seq), pj_ntohl(ses->out_hdr.ts),
+	       ses->has_peer_ssrc? ses->peer_ssrc : 0));
+
     return PJ_SUCCESS;
 }
 

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -514,9 +514,14 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
 	    call_med->strm.a.conf_slot = PJSUA_INVALID_ID;
 	}
 
-	if ((call_med->dir & PJMEDIA_DIR_ENCODING) &&
-	    (pjmedia_stream_get_stat(strm, &stat) == PJ_SUCCESS) &&
-	    stat.tx.pkt)
+	/* Don't check for direction and transmitted packets count as we
+	 * assume that RTP timestamp remains increasing when outgoing
+	 * direction is disabled/paused.
+	 */
+	//if ((call_med->dir & PJMEDIA_DIR_ENCODING) &&
+	//    (pjmedia_stream_get_stat(strm, &stat) == PJ_SUCCESS) &&
+	//    stat.tx.pkt)
+	if (pjmedia_stream_get_stat(strm, &stat) == PJ_SUCCESS)
 	{
 	    /* Save RTP timestamp & sequence, so when media session is
 	     * restarted, those values will be restored as the initial


### PR DESCRIPTION
When an active stream is set to inactive, RTP timestamp increment will be stopped too, so when the stream is reactivated, the outgoing RTP timestamp will start from the last RTP timestamp before stream deactivated. Some app expect the RTP timestamp to keep increasing linearly with wall clock when stream is inactive, so this PR will try to address that.

Thanks to Schuster Harald for the report.

#### Caveat
SDP re-offer/answer is kind of complex scenario, i.e: RFC3264 section 8.3 describes that SDP re-offer/answer may modify any media parameters such as direction, codec, SRTP settings, even media type (audio, video, etc), so after SDP re-offer/answer, basically we deal with a completely different streams. For example, if clockrate is changed in SDP re-offer/answer (either in order to deactivate or reactivate a stream, due to codec or media type change), the RTP timestamp unit will be different, which may cause RTP timestamp contiguous-ness becoming meaningless and RTP timestamp of the new stream should not be seen as a continuation of the old stream.

Also, this may not work in all cases, e.g:
- when G722 is chosen in SDP re-offer/answer due to clockrate bug (RFC defines G722 to use 8000Hz clockrate, while it should be 16000Hz)
- stream deactivation is done by setting port to zero.
