### PR TITLE
Github action/CI for windows.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,370 +1,63 @@
 name: C/C++ CI
-
 on: [push, pull_request]
-
 jobs:
   build-ubuntu-default:
-  # checking pure lib source distribution with plain configure & make
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
+    - uses: actions/checkout@master
+    - name: set config site
+      run:
+        echo "" > pjlib/include/pj/config_site.h
+      shell: powershell
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.0
+      with:
+        vs-version: 14.0
+    - name: MSBuild
+      working-directory: .
+      run: msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32
+      shell: cmd
 
-  build-ubuntu-default-full-bundle-1:
-  # full bundle: enable all codecs + AEC + DTLS
-  # full bundle 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
-    runs-on: ubuntu-latest
+  build-windows-default-full-bundle-1:
+    runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y swig sip-tester libopencore-amrnb-dev
+    - uses: actions/checkout@master
+    - name: get openssl
+      run: Invoke-WebRequest -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1e-dev.zip" -OutFile ".\openssl.zip"
+      shell: powershell
+    - name: expand openssl
+      run: Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+      shell: powershell
+    - name: check openssl folder
+      run: |
+        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include"
+        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib"
+      shell: powershell
     - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
-    - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
+      run:
+        cd pjlib/include/pj; cp config_site_test.h config_site.h; Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
+      shell: powershell
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.0
+      with:
+        vs-version: 14.0
+    - name: check VsDevCmd.bat
+      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      shell: cmd
+    - name: MSBuild
+      working-directory: .
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        dir D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
+        dir D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
+        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
+        set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32 /p:UseEnv=true
+      shell: cmd
     - name: unit tests
-      run: make pjlib-test pjlib-util-test pjmedia-test pjsua-test
-
-  build-ubuntu-default-full-bundle-2:
-  # full bundle 2: running pjnath test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y libopencore-amrnb-dev
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: unit tests
-      run: make pjnath-test
-
-  build-ubuntu-default-full-bundle-3:
-  # full bundle 3: running pjsip test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y libopencore-amrnb-dev
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: unit tests
-      run: make pjsip-test
-
-  build-ubuntu-no-tls:
-  # no TLS
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y swig
-    - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-ssl
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-
-  # build-ubuntu-openssl
-  # TLS: with OpenSSL (same as build-ubuntu-default)
-
-  build-ubuntu-gnu-tls:
-  # TLS: with GnuTLS
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get update && sudo apt-get install -y --fix-missing swig libgnutls28-dev
-    - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=/usr/
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-
-  build-ubuntu-video-openh264-1:
-  # video: video enabled with vpx and openh264
-  # video 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y swig nasm sip-tester libvpx-dev libopencore-amrnb-dev
-    - name: get openh264
-      run: git clone --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
-    - name: build openh264
-      run: cd openh264 && make && sudo make install && sudo ldconfig
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: CFLAGS="-fPIC -DHAS_VID_CODEC_TEST=0" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-    - name: unit tests
-      run: make pjlib-test pjlib-util-test pjmedia-test pjsua-test
-
-  build-ubuntu-video-openh264-2:
-  # video 2: running pjnath test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y nasm libvpx-dev libopencore-amrnb-dev
-    - name: get openh264
-      run: git clone --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
-    - name: build openh264
-      run: cd openh264 && make && sudo make install && sudo ldconfig
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: unit tests
-      run: make pjnath-test
-
-  build-ubuntu-video-openh264-3:
-  # video: 3: running pjsip test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y nasm libvpx-dev libopencore-amrnb-dev
-    - name: get openh264
-      run: git clone --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
-    - name: build openh264
-      run: cd openh264 && make && sudo make install && sudo ldconfig
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-    - name: unit tests
-      run: make pjsip-test
-
-  build-ubuntu-video-ffmpeg:
-  # video enabled with vpx and ffmpeg and x264
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: sudo apt-get install -y swig nasm libx264-dev libvpx-dev
-    - name: get ffmpeg
-      run: git clone --single-branch --branch release/4.2 https://github.com/FFmpeg/FFmpeg.git
-    - name: configure ffmpeg
-      run: cd FFmpeg && ./configure --enable-shared --disable-static --enable-gpl --enable-libx264
-    - name: build ffmpeg
-      run: cd FFmpeg && make -j10 && sudo make install
-    - name: config site
-      run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n" > pjlib/include/pj/config_site.h
-    - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-
-  build-mac-default:
-  # checking pure lib source distribution with plain configure & make
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
-
-  build-mac-default-full-bundle-1:
-  # full bundle: enable all codecs + AEC + DTLS
-  # full bundle 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install opencore-amr
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: unit tests
-      run: make pjlib-test pjmedia-test pjlib-util-test pjsua-test
-
-  build-mac-default-full-bundle-2:
-  # full bundle 2: running pjnath test
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install opencore-amr
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
-    - name: make
-      run: make
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: unit tests
-      run: make pjnath-test
-
-  build-mac-default-full-bundle-3:
-  # full bundle 3: running pjsip test
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install opencore-amr
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
-    - name: make
-      run: make
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: unit tests
-      run: make pjsip-test
-
-  # build-ubuntu-no-tls:
-  # no TLS (same as build-mac-default)
-
-  build-mac-openssl:
-  # TLS: with OpenSSL
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-
-  build-mac-gnu-tls:
-  # TLS: with GnuTLS
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=/usr/local/
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-
-  build-mac-video-openh264-1:
-  # video: video enabled with vpx and openh264
-  # video 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install openh264 libvpx opencore-amr sipp 
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -DHAS_VID_CODEC_TEST=0 -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: unit tests
-      run: make pjlib-test pjmedia-test pjlib-util-test pjsua-test
-
-  build-mac-video-openh264-2:
-  # video 2: running pjnath test
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install openh264 libvpx opencore-amr
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
-    - name: make
-      run: make
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: unit tests
-      run: make pjnath-test
-
-  build-mac-video-openh264-3:
-  # video 3: running pjsip test
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install openh264 libvpx opencore-amr
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
-    - name: make
-      run: make
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: unit tests
-      run: make pjsip-test
-
-  build-mac-video-ffmpeg:
-  # video enabled with vpx and ffmpeg and x264
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install x264 libvpx nasm
-    - name: get ffmpeg
-      run: git clone --single-branch --branch release/4.2 https://github.com/FFmpeg/FFmpeg.git
-    - name: configure ffmpeg
-      run: cd FFmpeg && ./configure --enable-shared --disable-static --enable-gpl --enable-libx264
-    - name: build ffmpeg
-      run: cd FFmpeg && make -j10 && sudo make install
-    - name: config site
-      run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n" > pjlib/include/pj/config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
-
-  build-mac-video-vid-toolbox:
-  # video enabled with vpx and video toolbox
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
-      run: brew install libvpx
-    - name: config site
-      run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n#define PJMEDIA_HAS_VID_TOOLBOX_CODEC 1\n" > pjlib/include/pj/config_site.h
-    - name: configure
-      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
-    - name: make
-      run: make
-    - name: swig bindings
-      run: cd pjsip-apps/src/swig && make
+      run: |
+        $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin"
+        cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Debug.exe
+        cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Debug.exe
+        cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Debug.exe
+      shell: powershell

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,6 +2,372 @@ name: C/C++ CI
 on: [push, pull_request]
 jobs:
   build-ubuntu-default:
+  # checking pure lib source distribution with plain configure & make
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+
+  build-ubuntu-default-full-bundle-1:
+  # full bundle: enable all codecs + AEC + DTLS
+  # full bundle 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y swig sip-tester libopencore-amrnb-dev
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+    - name: configure
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+    - name: unit tests
+      run: make pjlib-test pjlib-util-test pjmedia-test pjsua-test
+
+  build-ubuntu-default-full-bundle-2:
+  # full bundle 2: running pjnath test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y libopencore-amrnb-dev
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: unit tests
+      run: make pjnath-test
+
+  build-ubuntu-default-full-bundle-3:
+  # full bundle 3: running pjsip test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y libopencore-amrnb-dev
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: unit tests
+      run: make pjsip-test
+
+  build-ubuntu-no-tls:
+  # no TLS
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y swig
+    - name: configure
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-ssl
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  # build-ubuntu-openssl
+  # TLS: with OpenSSL (same as build-ubuntu-default)
+
+  build-ubuntu-gnu-tls:
+  # TLS: with GnuTLS
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get update && sudo apt-get install -y --fix-missing swig libgnutls28-dev
+    - name: configure
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=/usr/
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  build-ubuntu-video-openh264-1:
+  # video: video enabled with vpx and openh264
+  # video 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y swig nasm sip-tester libvpx-dev libopencore-amrnb-dev
+    - name: get openh264
+      run: git clone --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
+    - name: build openh264
+      run: cd openh264 && make && sudo make install && sudo ldconfig
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+    - name: configure
+      run: CFLAGS="-fPIC -DHAS_VID_CODEC_TEST=0" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+    - name: unit tests
+      run: make pjlib-test pjlib-util-test pjmedia-test pjsua-test
+
+  build-ubuntu-video-openh264-2:
+  # video 2: running pjnath test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y nasm libvpx-dev libopencore-amrnb-dev
+    - name: get openh264
+      run: git clone --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
+    - name: build openh264
+      run: cd openh264 && make && sudo make install && sudo ldconfig
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: unit tests
+      run: make pjnath-test
+
+  build-ubuntu-video-openh264-3:
+  # video: 3: running pjsip test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y nasm libvpx-dev libopencore-amrnb-dev
+    - name: get openh264
+      run: git clone --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
+    - name: build openh264
+      run: cd openh264 && make && sudo make install && sudo ldconfig
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: unit tests
+      run: make pjsip-test
+
+  build-ubuntu-video-ffmpeg:
+  # video enabled with vpx and ffmpeg and x264
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get install -y swig nasm libx264-dev libvpx-dev
+    - name: get ffmpeg
+      run: git clone --single-branch --branch release/4.2 https://github.com/FFmpeg/FFmpeg.git
+    - name: configure ffmpeg
+      run: cd FFmpeg && ./configure --enable-shared --disable-static --enable-gpl --enable-libx264
+    - name: build ffmpeg
+      run: cd FFmpeg && make -j10 && sudo make install
+    - name: config site
+      run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n" > pjlib/include/pj/config_site.h
+    - name: configure
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  build-mac-default:
+  # checking pure lib source distribution with plain configure & make
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+
+  build-mac-default-full-bundle-1:
+  # full bundle: enable all codecs + AEC + DTLS
+  # full bundle 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install opencore-amr
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+    - name: disable firewall
+      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+    - name: unit tests
+      run: make pjlib-test pjmedia-test pjlib-util-test pjsua-test
+
+  build-mac-default-full-bundle-2:
+  # full bundle 2: running pjnath test
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install opencore-amr
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
+    - name: make
+      run: make
+    - name: disable firewall
+      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+    - name: unit tests
+      run: make pjnath-test
+
+  build-mac-default-full-bundle-3:
+  # full bundle 3: running pjsip test
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install opencore-amr
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
+    - name: make
+      run: make
+    - name: disable firewall
+      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+    - name: unit tests
+      run: make pjsip-test
+
+  # build-ubuntu-no-tls:
+  # no TLS (same as build-mac-default)
+
+  build-mac-openssl:
+  # TLS: with OpenSSL
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  build-mac-gnu-tls:
+  # TLS: with GnuTLS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=/usr/local/
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  build-mac-video-openh264-1:
+  # video: video enabled with vpx and openh264
+  # video 1: running pjlib, pjlib-util, pjmedia, and pjsua tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install openh264 libvpx opencore-amr sipp 
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -DHAS_VID_CODEC_TEST=0 -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+    - name: disable firewall
+      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+    - name: unit tests
+      run: make pjlib-test pjmedia-test pjlib-util-test pjsua-test
+
+  build-mac-video-openh264-2:
+  # video 2: running pjnath test
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install openh264 libvpx opencore-amr
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
+    - name: make
+      run: make
+    - name: disable firewall
+      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+    - name: unit tests
+      run: make pjnath-test
+
+  build-mac-video-openh264-3:
+  # video 3: running pjsip test
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install openh264 libvpx opencore-amr
+    - name: config site
+      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" ./configure
+    - name: make
+      run: make
+    - name: disable firewall
+      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+    - name: unit tests
+      run: make pjsip-test
+
+  build-mac-video-ffmpeg:
+  # video enabled with vpx and ffmpeg and x264
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install x264 libvpx nasm
+    - name: get ffmpeg
+      run: git clone --single-branch --branch release/4.2 https://github.com/FFmpeg/FFmpeg.git
+    - name: configure ffmpeg
+      run: cd FFmpeg && ./configure --enable-shared --disable-static --enable-gpl --enable-libx264
+    - name: build ffmpeg
+      run: cd FFmpeg && make -j10 && sudo make install
+    - name: config site
+      run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n" > pjlib/include/pj/config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  build-mac-video-vid-toolbox:
+  # video enabled with vpx and video toolbox
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install libvpx
+    - name: config site
+      run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n#define PJMEDIA_HAS_VID_TOOLBOX_CODEC 1\n" > pjlib/include/pj/config_site.h
+    - name: configure
+      run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl/lib" CXXFLAGS="-fPIC" ./configure
+    - name: make
+      run: make
+    - name: swig bindings
+      run: cd pjsip-apps/src/swig && make
+
+  build-windows-default:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -371,17 +371,34 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
-    - name: set config site
-      run:
-        echo "" > pjlib/include/pj/config_site.h
+    - name: get swig
+      run: Invoke-WebRequest -Uri "https://nchc.dl.sourceforge.net/project/swig/swigwin/swigwin-4.0.1/swigwin-4.0.1.zip"  -OutFile ".\swigwin.zip"
       shell: powershell
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
-      with:
-        vs-version: 14.0
+    - name: expand swig
+      run: |
+        Expand-Archive -LiteralPath .\swigwin.zip -DestinationPath .\swigwin\; pwd
+        cd swigwin\swigwin-4.0.1
+        Add-Content ..\..\swig_path.txt $pwd.Path
+      shell: powershell
+    - name: config site
+      run:
+        type nul > pjlib/include/pj/config_site.h
+      shell: cmd
     - name: MSBuild
-      working-directory: .
-      run: msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32
+      run: |
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32
+      shell: cmd
+    - name: build swig
+      run: |
+        set /P SWIG_PATH=<swig_path.txt
+        set PATH=%PATH%;%SWIG_PATH%
+        dir pjlib/include/pj/config_site.h
+        type pjlib/include/pj/config_site.h
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%JAVA_HOME%\include;%JAVA_HOME%\include\win32
+        cd pjsip-apps/build
+        msbuild swig_java_pjsua2.vcxproj /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32 /p:UseEnv=true
       shell: cmd
 
   build-windows-with-openssl-unit-test-1:
@@ -469,40 +486,6 @@ jobs:
         $env:PATH+=";$env:OPENSSL_DIR\bin"
         cd pjsip/bin; ./pjsip-test-i386-Win32-vc14-Release.exe
       shell: powershell
-
-  build-windows-swig:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: get swig
-      run: Invoke-WebRequest -Uri "https://nchc.dl.sourceforge.net/project/swig/swigwin/swigwin-4.0.1/swigwin-4.0.1.zip"  -OutFile ".\swigwin.zip"
-      shell: powershell
-    - name: expand swig
-      run: |
-        Expand-Archive -LiteralPath .\swigwin.zip -DestinationPath .\swigwin\; pwd
-        cd swigwin\swigwin-4.0.1
-        Add-Content ..\..\swig_path.txt $pwd.Path
-      shell: powershell
-    - name: set config site
-      run:
-        type nul > pjlib/include/pj/config_site.h
-      shell: cmd
-    - name: MSBuild
-      run: |
-        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32
-      shell: cmd
-    - name: build swig
-      run: |
-        set /P SWIG_PATH=<swig_path.txt
-        set PATH=%PATH%;%SWIG_PATH%
-        dir pjlib/include/pj/config_site.h
-        type pjlib/include/pj/config_site.h
-        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;%JAVA_HOME%\include;%JAVA_HOME%\include\win32
-        cd pjsip-apps/build
-        msbuild swig_java_pjsua2.vcxproj /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32 /p:UseEnv=true
-      shell: cmd
 
   build-windows-gnu-tls:
     runs-on: windows-latest

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -392,31 +392,37 @@ jobs:
       run: Invoke-WebRequest -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1e-dev.zip" -OutFile ".\openssl.zip"
       shell: powershell
     - name: expand openssl
-      run: Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\;
+        cd openssl_build\openssl-1.1\x86
+        Add-Content ..\..\..\openssl_dir.txt $pwd.Path
       shell: powershell
     - name: check openssl folder
       run: |
-        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include"
-        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib"
-      shell: powershell
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        dir %OPENSSL_DIR%\include
+        dir %OPENSSL_DIR%\lib
+      shell: cmd
     - name: config site
       run:
         cd pjlib/include/pj; cp config_site_test.h config_site.h; Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
       shell: powershell
     - name: check VsDevCmd.bat
-      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      run: dir "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       shell: cmd
     - name: MSBuild
       working-directory: .
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
-        set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%OPENSSL_DIR%\include
+        set LIB=%LIB%;%OPENSSL_DIR%\lib
         msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
     - name: unit tests
       run: |
-        $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin"
+        $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
+        $env:PATH+=";$env:OPENSSL_DIR\bin"
         cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe
         cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Release.exe
         cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Release.exe
@@ -430,35 +436,75 @@ jobs:
       run: Invoke-WebRequest -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1e-dev.zip" -OutFile ".\openssl.zip"
       shell: powershell
     - name: expand openssl
-      run: Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+        cd openssl_build\openssl-1.1\x86
+        Add-Content ..\..\..\openssl_dir.txt $pwd.Path
       shell: powershell
     - name: check openssl folder
       run: |
-        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include"
-        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib"
-      shell: powershell
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        dir "%OPENSSL_DIR%\include"
+        dir "%OPENSSL_DIR%\lib"
+      shell: cmd
     - name: config site
       run:
         cd pjlib/include/pj; cp config_site_test.h config_site.h; Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
       shell: powershell
     - name: check VsDevCmd.bat
-      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      run: dir "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       shell: cmd
     - name: MSBuild
       working-directory: .
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
-        set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%OPENSSL_DIR%\include
+        set LIB=%LIB%;%OPENSSL_DIR%\lib
         msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
     - name: unit tests
       run: |
-        $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin"
+        $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
+        $env:PATH+=";$env:OPENSSL_DIR\bin"
         cd pjsip/bin; ./pjsip-test-i386-Win32-vc14-Release.exe
       shell: powershell
 
-  build-windows-with-gnu-tls:
+  build-windows-swig:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: get swig
+      run: Invoke-WebRequest -Uri "https://nchc.dl.sourceforge.net/project/swig/swigwin/swigwin-4.0.1/swigwin-4.0.1.zip"  -OutFile ".\swigwin.zip"
+      shell: powershell
+    - name: expand swig
+      run: |
+        Expand-Archive -LiteralPath .\swigwin.zip -DestinationPath .\swigwin\; pwd
+        cd swigwin\swigwin-4.0.1
+        Add-Content ..\..\swig_path.txt $pwd.Path
+      shell: powershell
+    - name: set config site
+      run:
+        type nul > pjlib/include/pj/config_site.h
+      shell: cmd
+    - name: MSBuild
+      run: |
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32
+      shell: cmd
+    - name: build swig
+      run: |
+        set /P SWIG_PATH=<swig_path.txt
+        set PATH=%PATH%;%SWIG_PATH%
+        dir pjlib/include/pj/config_site.h
+        type pjlib/include/pj/config_site.h
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%JAVA_HOME%\include;%JAVA_HOME%\include\win32
+        cd pjsip-apps/build
+        msbuild swig_java_pjsua2.vcxproj /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32 /p:UseEnv=true
+      shell: cmd
+
+  build-windows-gnu-tls:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
@@ -466,13 +512,17 @@ jobs:
       run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/gnutls/releases/download/gnutls_3_6_11/libgnutls_gnutls_3_6_11_msvc14.zip" -Outfile ".\libgnutls.zip"
       shell: powershell
     - name: expand gnutls
-      run: Expand-Archive -LiteralPath .\libgnutls.zip -DestinationPath .\libgnutls_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\libgnutls.zip -DestinationPath .\libgnutls_build\; pwd
+        cd libgnutls_build
+        Add-Content ..\libgnutls_dir.txt $pwd.Path
       shell: powershell
     - name: check gnutls folder
       run: |
-        dir "D:\a\pjproject\pjproject\libgnutls_build\include"
-        dir "D:\a\pjproject\pjproject\libgnutls_build\lib\x86"
-      shell: powershell
+        set /P LIBGNUTLS_DIR=<libgnutls_dir.txt
+        dir "%LIBGNUTLS_DIR%\include"
+        dir "%LIBGNUTLS_DIR%\lib\x86"
+      shell: cmd
     - name: config site
       run: |
         echo "" > pjlib\include\pj\config_site.h
@@ -480,14 +530,15 @@ jobs:
         Add-Content config_site.h "#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_GNUTLS"
       shell: powershell
     - name: check VsDevCmd.bat
-      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      run: dir "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       shell: cmd
     - name: MSBuild
       working-directory: .
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\libgnutls_build\include
-        set LIB=%LIB%;D:\a\pjproject\pjproject\libgnutls_build\lib\x86
+        set /P LIBGNUTLS_DIR=<gnutls_dir.txt
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%LIBGNUTLS_DIR%\include
+        set LIB=%LIB%;%LIBGNUTLS_DIR%\lib\x86
         msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
 
@@ -499,35 +550,47 @@ jobs:
       run: Invoke-WebRequest -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1e-dev.zip" -OutFile ".\openssl.zip"
       shell: powershell
     - name: expand openssl
-      run: Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+        cd openssl_build\openssl-1.1\x86
+        Add-Content ..\..\..\openssl_dir.txt $pwd.Path
       shell: powershell
     - name: check openssl folder
       run: |
-        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include"
-        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib"
-      shell: powershell
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        dir "%OPENSSL_DIR%\include"
+        dir "%OPENSSL_DIR%\lib"
+      shell: cmd
     - name: get libvpx
       run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/libvpx/releases/download/v1.8.2/libvpx_v1.8.2_msvc14.zip" -Outfile "libvpx.zip"
       shell: powershell
     - name: expand libvpx
-      run: Expand-Archive -LiteralPath .\libvpx.zip -DestinationPath .\libvpx_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\libvpx.zip -DestinationPath .\libvpx_build\; pwd
+        cd libvpx_build
+        Add-Content ..\libvpx_dir.txt $pwd.Path
       shell: powershell
     - name: check libvpx folder
       run: |
-        dir "D:\a\pjproject\pjproject\libvpx_build\include"
-        dir "D:\a\pjproject\pjproject\libvpx_build\lib\x86"
-      shell: powershell
+        set /P LIBVPX_DIR=<libvpx_dir.txt
+        dir "%LIBVPX_DIR%\include"
+        dir "%LIBVPX_DIR%\lib\x86"
+      shell: cmd
     - name: get libsdl
       run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/SDL/releases/download/release-2.0.9/libsdl_release-2.0.9_msvc14.zip" -Outfile ".\libsdl.zip"
       shell: powershell
     - name: expand libsdl
-      run: Expand-Archive -LiteralPath .\libsdl.zip -DestinationPath .\libsdl_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\libsdl.zip -DestinationPath .\libsdl_build\; pwd
+        cd libsdl_build
+        Add-Content ..\libsdl_dir.txt $pwd.Path
       shell: powershell
     - name: check libsdl folder
       run: |
-        dir "D:\a\pjproject\pjproject\libsdl_build\include\SDL"
-        dir "D:\a\pjproject\pjproject\libsdl_build\lib\x86"
-      shell: powershell
+        set /P LIBSDL_DIR=<libsdl_dir.txt
+        dir "%LIBSDL_DIR%\include\SDL"
+        dir "%LIBSDL_DIR%\lib\x86"
+      shell: cmd
     - name: config site
       run: |
         cd pjlib/include/pj; cp config_site_test.h config_site.h
@@ -539,19 +602,25 @@ jobs:
         Add-Content config_site.h "#define PJMEDIA_HAS_VPX_CODEC 1"
       shell: powershell
     - name: check VsDevCmd.bat
-      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      run: dir "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       shell: cmd
     - name: MSBuild
       working-directory: .
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include;D:\a\pjproject\pjproject\libsdl_build\include\SDL;D:\a\pjproject\pjproject\libvpx_build\include
-        set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib;D:\a\pjproject\pjproject\libvpx_build\lib\x86;D:\a\pjproject\pjproject\libsdl_build\lib\x86
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        set /P LIBVPX_DIR=<libvpx_dir.txt
+        set /P LIBSDL_DIR=<libsdl_dir.txt
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%OPENSSL_DIR%\include;%LIBVPX_DIR%\include;%LIBSDL_DIR%\include\SDL
+        set LIB=%LIB%;%OPENSSL_DIR%\lib;%LIBVPX_DIR%\lib\x86;%LIBSDL_DIR%\lib\x86
         msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
     - name: unit tests
       run: |
-        $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin;D:\a\pjproject\pjproject\libvpx_build\bin\x86;D:\a\pjproject\pjproject\libsdl_build\bin\x86;"
+        $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
+        $env:LIBVPX_DIR = Get-Content .\libvpx_dir.txt
+        $env:LIBSDL_DIR = Get-Content .\libsdl_dir.txt
+        $env:PATH+=";$env:OPENSSL_DIR\bin;$env:LIBVPX_DIR\bin\x86;$env:LIBSDL_DIR\bin\x86;"
         cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe
         cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Release.exe
         cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Release.exe
@@ -565,35 +634,47 @@ jobs:
       run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/FFmpeg/releases/download/4.3.r96746/libffmpeg_4.3.r96746_msvc14_x86.zip" -Outfile "libffmpeg.zip"
       shell: powershell
     - name: expand ffmpeg
-      run: Expand-Archive -LiteralPath .\libffmpeg.zip -DestinationPath .\libffmpeg_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\libffmpeg.zip -DestinationPath .\libffmpeg_build\; pwd
+        cd libffmpeg_build
+        Add-Content ..\libffmpeg_dir.txt $pwd.Path
       shell: powershell
     - name: check ffmpeg folder
       run: |
-        dir "D:\a\pjproject\pjproject\libffmpeg_build\include"
-        dir "D:\a\pjproject\pjproject\libffmpeg_build\lib\x86"
-      shell: powershell
+        set /P LIBFFMPEG_DIR=<libffmpeg_dir.txt
+        dir "%LIBFFMPEG_DIR%\include"
+        dir "%LIBFFMPEG_DIR%\lib\x86"
+      shell: cmd
     - name: get libx264
       run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/x264/releases/download/0.159.r2991/libx264_0.159.r2991_msvc14.zip" -Outfile ".\libx264.zip"
       shell: powershell
     - name: expand libx264
-      run: Expand-Archive -LiteralPath .\libx264.zip -DestinationPath .\libx264_build\; pwd
-      shell: powershell
-    - name: check ffmpeg folder
       run: |
-        dir "D:\a\pjproject\pjproject\libx264_build\include"
-        dir "D:\a\pjproject\pjproject\libx264_build\lib\x86"
+        Expand-Archive -LiteralPath .\libx264.zip -DestinationPath .\libx264_build\; pwd
+        cd libx264_build
+        Add-Content ..\libx264_dir.txt $pwd.Path
       shell: powershell
+    - name: check libx264 folder
+      run: |
+        set /P LIBX264_DIR=<libx264_dir.txt
+        dir "%LIBX264_DIR%\include"
+        dir "%LIBX264_DIR%\lib\x86"
+      shell: cmd
     - name: get libsdl
       run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/SDL/releases/download/release-2.0.9/libsdl_release-2.0.9_msvc14.zip" -Outfile ".\libsdl.zip"
       shell: powershell
     - name: expand libsdl
-      run: Expand-Archive -LiteralPath .\libsdl.zip -DestinationPath .\libsdl_build\; pwd
+      run: |
+        Expand-Archive -LiteralPath .\libsdl.zip -DestinationPath .\libsdl_build\; pwd
+        cd libsdl_build
+        Add-Content ..\libsdl_dir.txt $pwd.Path
       shell: powershell
     - name: check libsdl folder
       run: |
-        dir "D:\a\pjproject\pjproject\libsdl_build\include\SDL"
-        dir "D:\a\pjproject\pjproject\libsdl_build\lib\x86"
-      shell: powershell
+        set /P LIBSDL_DIR=<libsdl_dir.txt
+        dir "%LIBSDL_DIR%\include\SDL"
+        dir "%LIBSDL_DIR%\lib\x86"
+      shell: cmd
     - name: config site
       run: |
         echo "" > pjlib\include\pj\config_site.h
@@ -604,13 +685,16 @@ jobs:
         Add-Content config_site.h "#define PJMEDIA_VIDEO_DEV_HAS_SDL 1"
       shell: powershell
     - name: check VsDevCmd.bat
-      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      run: dir "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       shell: cmd
     - name: MSBuild
       working-directory: .
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\libffpmeg_build\include;D:\a\pjproject\pjproject\libx264_build\include;D:\a\pjproject\pjproject\libsdl_build\include\SDL
-        set LIB=%LIB%;D:\a\pjproject\pjproject\libffpmeg_build\lib\x86;D:\a\pjproject\pjproject\libx264_build\lib\x86;D:\a\pjproject\pjproject\libsdl_build\lib\x86
+        set /P LIBFFMPEG_DIR=<libffmpeg_dir.txt
+        set /P LIBX264_DIR=<libx264_dir.txt
+        set /P LIBSDL_DIR=<libsdl_dir.txt
+        call "%PROGRAMFILES(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%LIBFFMPEG_DIR%\include;%LIBX264_DIR%\include;%LIBSDL_DIR%\include\SDL
+        set LIB=%LIB%;%LIBFFMPEG_DIR%\lib\x86;%LIBX264_DIR%\lib\x86;%LIBSDL_DIR%\lib\x86
         msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -381,10 +381,10 @@ jobs:
         vs-version: 14.0
     - name: MSBuild
       working-directory: .
-      run: msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32
+      run: msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32
       shell: cmd
 
-  build-windows-default-full-bundle-1:
+  build-windows-with-openssl-unit-test-1:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
@@ -403,10 +403,6 @@ jobs:
       run:
         cd pjlib/include/pj; cp config_site_test.h config_site.h; Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
       shell: powershell
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
-      with:
-        vs-version: 14.0
     - name: check VsDevCmd.bat
       run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       shell: cmd
@@ -414,16 +410,207 @@ jobs:
       working-directory: .
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-        dir D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
-        dir D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
         set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
         set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
-        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Debug /p:Platform=win32 /p:UseEnv=true
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
     - name: unit tests
       run: |
         $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin"
-        cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Debug.exe
-        cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Debug.exe
-        cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Debug.exe
+        cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe
+        cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Release.exe
+        cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Release.exe
       shell: powershell
+
+  build-windows-with-openssl-unit-test-2:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: get openssl
+      run: Invoke-WebRequest -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1e-dev.zip" -OutFile ".\openssl.zip"
+      shell: powershell
+    - name: expand openssl
+      run: Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+      shell: powershell
+    - name: check openssl folder
+      run: |
+        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include"
+        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib"
+      shell: powershell
+    - name: config site
+      run:
+        cd pjlib/include/pj; cp config_site_test.h config_site.h; Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
+      shell: powershell
+    - name: check VsDevCmd.bat
+      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      shell: cmd
+    - name: MSBuild
+      working-directory: .
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include
+        set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
+      shell: cmd
+    - name: unit tests
+      run: |
+        $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin"
+        cd pjsip/bin; ./pjsip-test-i386-Win32-vc14-Release.exe
+      shell: powershell
+
+  build-windows-with-gnu-tls:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: get gnutls
+      run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/gnutls/releases/download/gnutls_3_6_11/libgnutls_gnutls_3_6_11_msvc14.zip" -Outfile ".\libgnutls.zip"
+      shell: powershell
+    - name: expand gnutls
+      run: Expand-Archive -LiteralPath .\libgnutls.zip -DestinationPath .\libgnutls_build\; pwd
+      shell: powershell
+    - name: check gnutls folder
+      run: |
+        dir "D:\a\pjproject\pjproject\libgnutls_build\include"
+        dir "D:\a\pjproject\pjproject\libgnutls_build\lib\x86"
+      shell: powershell
+    - name: config site
+      run: |
+        echo "" > pjlib\include\pj\config_site.h
+        Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
+        Add-Content config_site.h "#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_GNUTLS"
+      shell: powershell
+    - name: check VsDevCmd.bat
+      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      shell: cmd
+    - name: MSBuild
+      working-directory: .
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\libgnutls_build\include
+        set LIB=%LIB%;D:\a\pjproject\pjproject\libgnutls_build\lib\x86
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
+      shell: cmd
+
+  build-windows-with-video-libvpx-unit-test-1:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: get openssl
+      run: Invoke-WebRequest -Uri "https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1e-dev.zip" -OutFile ".\openssl.zip"
+      shell: powershell
+    - name: expand openssl
+      run: Expand-Archive -LiteralPath .\openssl.zip -DestinationPath .\openssl_build\; pwd
+      shell: powershell
+    - name: check openssl folder
+      run: |
+        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include"
+        dir "D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib"
+      shell: powershell
+    - name: get libvpx
+      run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/libvpx/releases/download/v1.8.2/libvpx_v1.8.2_msvc14.zip" -Outfile "libvpx.zip"
+      shell: powershell
+    - name: expand libvpx
+      run: Expand-Archive -LiteralPath .\libvpx.zip -DestinationPath .\libvpx_build\; pwd
+      shell: powershell
+    - name: check libvpx folder
+      run: |
+        dir "D:\a\pjproject\pjproject\libvpx_build\include"
+        dir "D:\a\pjproject\pjproject\libvpx_build\lib\x86"
+      shell: powershell
+    - name: get libsdl
+      run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/SDL/releases/download/release-2.0.9/libsdl_release-2.0.9_msvc14.zip" -Outfile ".\libsdl.zip"
+      shell: powershell
+    - name: expand libsdl
+      run: Expand-Archive -LiteralPath .\libsdl.zip -DestinationPath .\libsdl_build\; pwd
+      shell: powershell
+    - name: check libsdl folder
+      run: |
+        dir "D:\a\pjproject\pjproject\libsdl_build\include\SDL"
+        dir "D:\a\pjproject\pjproject\libsdl_build\lib\x86"
+      shell: powershell
+    - name: config site
+      run: |
+        cd pjlib/include/pj; cp config_site_test.h config_site.h
+        Add-Content config_site.h "#define PJ_HAS_SSL_SOCK 1"
+        Add-Content config_site.h "#define PJMEDIA_HAS_VIDEO 1"
+        Add-Content config_site.h "#define PJMEDIA_VIDEO_DEV_HAS_DSHOW 1"
+        Add-Content config_site.h "#define PJMEDIA_HAS_LIBYUV 1"
+        Add-Content config_site.h "#define PJMEDIA_VIDEO_DEV_HAS_SDL 1"
+        Add-Content config_site.h "#define PJMEDIA_HAS_VPX_CODEC 1"
+      shell: powershell
+    - name: check VsDevCmd.bat
+      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      shell: cmd
+    - name: MSBuild
+      working-directory: .
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\include;D:\a\pjproject\pjproject\libsdl_build\include\SDL;D:\a\pjproject\pjproject\libvpx_build\include
+        set LIB=%LIB%;D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\lib;D:\a\pjproject\pjproject\libvpx_build\lib\x86;D:\a\pjproject\pjproject\libsdl_build\lib\x86
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
+      shell: cmd
+    - name: unit tests
+      run: |
+        $env:PATH+=";D:\a\pjproject\pjproject\openssl_build\openssl-1.1\x86\bin;D:\a\pjproject\pjproject\libvpx_build\bin\x86;D:\a\pjproject\pjproject\libsdl_build\bin\x86;"
+        cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe
+        cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Release.exe
+        cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Release.exe
+      shell: powershell
+
+  build-windows-video-ffmpeg:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: get ffmpeg
+      run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/FFmpeg/releases/download/4.3.r96746/libffmpeg_4.3.r96746_msvc14_x86.zip" -Outfile "libffmpeg.zip"
+      shell: powershell
+    - name: expand ffmpeg
+      run: Expand-Archive -LiteralPath .\libffmpeg.zip -DestinationPath .\libffmpeg_build\; pwd
+      shell: powershell
+    - name: check ffmpeg folder
+      run: |
+        dir "D:\a\pjproject\pjproject\libffmpeg_build\include"
+        dir "D:\a\pjproject\pjproject\libffmpeg_build\lib\x86"
+      shell: powershell
+    - name: get libx264
+      run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/x264/releases/download/0.159.r2991/libx264_0.159.r2991_msvc14.zip" -Outfile ".\libx264.zip"
+      shell: powershell
+    - name: expand libx264
+      run: Expand-Archive -LiteralPath .\libx264.zip -DestinationPath .\libx264_build\; pwd
+      shell: powershell
+    - name: check ffmpeg folder
+      run: |
+        dir "D:\a\pjproject\pjproject\libx264_build\include"
+        dir "D:\a\pjproject\pjproject\libx264_build\lib\x86"
+      shell: powershell
+    - name: get libsdl
+      run: Invoke-WebRequest -Uri "https://github.com/ShiftMediaProject/SDL/releases/download/release-2.0.9/libsdl_release-2.0.9_msvc14.zip" -Outfile ".\libsdl.zip"
+      shell: powershell
+    - name: expand libsdl
+      run: Expand-Archive -LiteralPath .\libsdl.zip -DestinationPath .\libsdl_build\; pwd
+      shell: powershell
+    - name: check libsdl folder
+      run: |
+        dir "D:\a\pjproject\pjproject\libsdl_build\include\SDL"
+        dir "D:\a\pjproject\pjproject\libsdl_build\lib\x86"
+      shell: powershell
+    - name: config site
+      run: |
+        echo "" > pjlib\include\pj\config_site.h
+        Add-Content config_site.h "#define PJMEDIA_HAS_VIDEO 1"
+        Add-Content config_site.h "#define PJMEDIA_HAS_FFMPEG 1"
+        Add-Content config_site.h "#define PJMEDIA_HAS_FFMPEG_VID_CODEC 1"
+        Add-Content config_site.h "#define PJMEDIA_VIDEO_DEV_HAS_FFMPEG 1"
+        Add-Content config_site.h "#define PJMEDIA_VIDEO_DEV_HAS_SDL 1"
+      shell: powershell
+    - name: check VsDevCmd.bat
+      run: dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      shell: cmd
+    - name: MSBuild
+      working-directory: .
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;D:\a\pjproject\pjproject\libffpmeg_build\include;D:\a\pjproject\pjproject\libx264_build\include;D:\a\pjproject\pjproject\libsdl_build\include\SDL
+        set LIB=%LIB%;D:\a\pjproject\pjproject\libffpmeg_build\lib\x86;D:\a\pjproject\pjproject\libx264_build\lib\x86;D:\a\pjproject\pjproject\libsdl_build\lib\x86
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v142 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
+      shell: cmd

--- a/pjsip-apps/build/swig_java_pjsua2.vcxproj
+++ b/pjsip-apps/build/swig_java_pjsua2.vcxproj
@@ -23,7 +23,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{63AC6D7A-5D97-40C2-9AF2-E13AA1F9567C}</ProjectGuid>
     <TargetName>pjsua2</TargetName>
-    <OutDir>..\src\swig\java\output\</OutDir>
     <RootNamespace>swig_java_pjsua2</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -75,6 +74,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.25431.1</_ProjectFileVersion>
+    <OutDir>..\src\swig\java\output\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
@@ -191,7 +191,7 @@
 %40echo on
 %40echo Building pjsua2.dll to $(OutputDir)
 mkdir $(OutDir)org\pjsip\pjsua2
-swig -c++ -java  -package org.pjsip.pjsua2 -I$(SolutionDir)pjsip\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
+swig -c++ -java  -package org.pjsip.pjsua2 -I$(ProjectDir)..\..\pjsip\include -I$(ProjectDir)..\..\pjlib\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
 javac -d $(OutDir) $(OutDir)org\pjsip\pjsua2\*.java
 %40echo Building sample app
 javac -d $(OutDir) -classpath $(OutDir) ..\src\swig\java\android\app\src\main\java\org\pjsip\pjsua2\app\MyApp.java
@@ -216,7 +216,7 @@ javac -d $(OutDir) -classpath $(OutDir) $(OutDir)..\sample.java
 %40echo on
 %40echo Building pjsua2.dll to $(OutDir)
 mkdir $(OutDir)org\pjsip\pjsua2
-swig -c++ -java  -package org.pjsip.pjsua2 -I$(SolutionDir)pjsip\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
+swig -c++ -java  -package org.pjsip.pjsua2 -I$(ProjectDir)..\..\pjsip\include -I$(ProjectDir)..\..\pjlib\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
 javac -d $(OutDir) $(OutDir)org\pjsip\pjsua2\*.java
 %40echo Building sample app
 javac -d $(OutDir) -classpath $(OutDir) ..\src\swig\java\android\app\src\main\java\org\pjsip\pjsua2\app\MyApp.java
@@ -241,7 +241,7 @@ javac -d $(OutDir) -classpath $(OutDir) $(OutDir)..\sample.java
 %40echo on
 %40echo Building pjsua2.dll to $(OutDir)
 mkdir $(OutDir)org\pjsip\pjsua2
-swig -c++ -java  -package org.pjsip.pjsua2 -I$(SolutionDir)pjsip\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
+swig -c++ -java  -package org.pjsip.pjsua2 -I$(ProjectDir)..\..\pjsip\include -I$(ProjectDir)..\..\pjlib\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
 javac -d $(OutDir) $(OutDir)org\pjsip\pjsua2\*.java
 %40echo Building sample app
 javac -d $(OutDir) -classpath $(OutDir) ..\src\swig\java\android\app\src\main\java\org\pjsip\pjsua2\app\MyApp.java
@@ -266,7 +266,7 @@ javac -d $(OutDir) -classpath $(OutDir) $(OutDir)..\sample.java
 %40echo on
 %40echo Building pjsua2.dll to $(OutDir)
 mkdir $(OutDir)org\pjsip\pjsua2
-swig -c++ -java  -package org.pjsip.pjsua2 -I$(SolutionDir)pjsip\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
+swig -c++ -java  -package org.pjsip.pjsua2 -I$(ProjectDir)..\..\pjsip\include -I$(ProjectDir)..\..\pjlib\include -outdir $(OutDir)org\pjsip\pjsua2 -o $(OutDir)pjsua2_wrap.cpp %(FullPath)
 javac -d $(OutDir) $(OutDir)org\pjsip\pjsua2\*.java
 %40echo Building sample app
 javac -d $(OutDir) -classpath $(OutDir) ..\src\swig\java\android\app\src\main\java\org\pjsip\pjsua2\app\MyApp.java

--- a/pjsip-apps/src/pjsua/winrt/cli/uwp/pjsua_cli_uwp.csproj
+++ b/pjsip-apps/src/pjsua/winrt/cli/uwp/pjsua_cli_uwp.csproj
@@ -146,7 +146,7 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Condition="'$(API_Family)'=='UWP'" Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/pjsip-apps/src/pjsua/winrt/cli/wp8/pjsua_cli_wp8.csproj
+++ b/pjsip-apps/src/pjsua/winrt/cli/wp8/pjsua_cli_wp8.csproj
@@ -154,8 +154,8 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
+  <Import Condition="'$(API_Family)'=='WinPhone8'" Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
+  <Import Condition="'$(API_Family)'=='WinPhone8'" Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/pjsip-apps/src/pjsua/winrt/gui/uwp/Voip/Voip.csproj
+++ b/pjsip-apps/src/pjsua/winrt/gui/uwp/Voip/Voip.csproj
@@ -153,7 +153,7 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Condition="'$(API_Family)'=='UWP'" Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/pjsip-apps/src/pjsua/winrt/gui/uwp/VoipTasks/VoipTasks.csproj
+++ b/pjsip-apps/src/pjsua/winrt/gui/uwp/VoipTasks/VoipTasks.csproj
@@ -133,7 +133,7 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Condition="'$(API_Family)'=='UWP'" Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/pjsua/tools/cmp_wav.vcxproj
+++ b/tests/pjsua/tools/cmp_wav.vcxproj
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="cmp_wav.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9102D366-6707-4789-938B-A373675F5B4C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>cmp_wav</RootNamespace>    
+    <OutDir>.\</OutDir>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../../pjsip/include;../../../pjlib/include;../../../pjlib-util/include;../../../pjmedia/include;../../../pjnath/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;dsound.lib;dxguid.lib;netapi32.lib;mswsock.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;ole32.lib;user32.lib;gdi32.lib;advapi32.lib;libpjproject-i386-Win32-vc14-Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmtd.lib</IgnoreSpecificDefaultLibraries>
+      <OutputFile>$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../../../pjsip/include;../../../pjlib/include;../../../pjlib-util/include;../../../pjmedia/include;../../../pjnath/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;dsound.lib;dxguid.lib;netapi32.lib;mswsock.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;ole32.lib;user32.lib;gdi32.lib;advapi32.lib;libpjproject-i386-Win32-vc14-Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
+      <OutputFile>$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>../../../pjsip/include;../../../pjlib/include;../../../pjlib-util/include;../../../pjmedia/include;../../../pjnath/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;dsound.lib;dxguid.lib;netapi32.lib;mswsock.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;ole32.lib;user32.lib;gdi32.lib;advapi32.lib;libpjproject-i386-Win32-vc14-Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
+      <OutputFile>$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>../../../pjsip/include;../../../pjlib/include;../../../pjlib-util/include;../../../pjmedia/include;../../../pjnath/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;dsound.lib;dxguid.lib;netapi32.lib;mswsock.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;ole32.lib;user32.lib;gdi32.lib;advapi32.lib;libpjproject-i386-Win32-vc14-Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
+      <OutputFile>$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Some notes for windows CI.
* Issue with building third party library (e.g: OpenSSL, openh264, etc). Simplest way is to download the  library header and binary from web (zip). This [site](https://shiftmediaproject.github.io/1-projects/) provide some supporting library which we can use (e.g: SDL, opus, gnuTLS, libvpx, ffmpeg). Build test and run using SDL. Others will follow.
* On windows machine, the Github action allowed to use powershell which allows us with some enhance tools. (e.g: download files and unzip). This is useful to download and use the third party library.
* Instead of ```make```, we use ```msbuild``` to build the project and use the existing solution+projects files. To use third party, we need to specify the correct path to be used. 
* Consider uploading Sipp binary (zip), to be used by python unit test. Currently, there's only (.exe) available to download.