### PR TITLE
Handle case when provisional response is sent after a final one

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -305,6 +305,8 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
 
 	pjsua_call_answer2(call_id, &opt, app_config.auto_answer, NULL,
 			   NULL);
+	pjsua_call_answer2(call_id, &opt, 180, NULL,
+			   NULL);
     }
     
     if (app_config.auto_answer < 200) {

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -305,8 +305,6 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
 
 	pjsua_call_answer2(call_id, &opt, app_config.auto_answer, NULL,
 			   NULL);
-	pjsua_call_answer2(call_id, &opt, 180, NULL,
-			   NULL);
     }
     
     if (app_config.auto_answer < 200) {

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -811,8 +811,11 @@ PJ_DEF(pj_status_t) pjsip_100rel_tx_response(pjsip_inv_session *inv,
 	tx_data_list_t *tl;
 
 	/* Return error if final response has been sent. */
-	if (dd->inv->state >= PJSIP_INV_STATE_CONNECTING)
+	if (dd->inv->state >= PJSIP_INV_STATE_CONNECTING) {
+	    /* Release the cloned tdata. */
+	    pjsip_tx_data_dec_ref(tdata);
 	    return PJ_EINVALIDOP;
+	}
 	
 	/* Create UAS state if we don't have one */
 	if (dd->uas_state == NULL) {

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -809,6 +809,10 @@ PJ_DEF(pj_status_t) pjsip_100rel_tx_response(pjsip_inv_session *inv,
 	char rseq_str[32];
 	pj_str_t rseq;
 	tx_data_list_t *tl;
+
+	/* Return error if final response has been sent. */
+	if (dd->inv->state >= PJSIP_INV_STATE_CONNECTING)
+	    return PJ_EINVALIDOP;
 	
 	/* Create UAS state if we don't have one */
 	if (dd->uas_state == NULL) {

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -3273,12 +3273,11 @@ static pj_status_t tsx_on_state_completed_uas( pjsip_transaction *tsx,
 	}
 
     } else {
-	/* Ignore request to transmit. */
-	if (event->type == PJSIP_EVENT_TX_MSG && 
-	    event->body.tx_msg.tdata == tsx->last_tx)
-	{ 
+	PJ_ASSERT_RETURN(event->type == PJSIP_EVENT_TX_MSG, 
+			 PJ_EINVALIDOP);
+	/* Ignore request to transmit a new message. */
+	if (event->body.tx_msg.tdata != tsx->last_tx)
 	    return PJ_EINVALIDOP;
-	}
     }
 
     return PJ_SUCCESS;

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -3274,9 +3274,11 @@ static pj_status_t tsx_on_state_completed_uas( pjsip_transaction *tsx,
 
     } else {
 	/* Ignore request to transmit. */
-	PJ_ASSERT_RETURN(event->type == PJSIP_EVENT_TX_MSG && 
-			 event->body.tx_msg.tdata == tsx->last_tx, 
-			 PJ_EINVALIDOP);
+	if (event->type == PJSIP_EVENT_TX_MSG && 
+	    event->body.tx_msg.tdata == tsx->last_tx)
+	{ 
+	    return PJ_EINVALIDOP;
+	}
     }
 
     return PJ_SUCCESS;


### PR DESCRIPTION
If application tries to answer a call with a provisional response after sending a final one, such as:
```
pjsua_call_answer(200);
pjsua_call_answer(180);
```

it will cause an assertion/crash in PJSIP.

`pjsua_call_answer()` will call `pjsip_inv_send_msg()` which will then call `pjsip_dlg_send_response()` or `pjsip_100rel_tx_response()` depending whether 100rel is required.

If 100rel is required, PJSIP will crash in `on_retransmit()` of `sip_100rel`:
```
* thread #11, stop reason = EXC_BAD_ACCESS (code=1, address=0x20)
  * frame #0: 0x00000001002068e4 pjsua-x86_64-apple-darwin19.3.0`pjsip_tsx_retransmit_no_state(tsx=0x0000000000000000, tdata=0x00000001030ccea8) at sip_transaction.c:2282:30
    frame #1: 0x00000001001bde78 pjsua-x86_64-apple-darwin19.3.0`on_retransmit(timer_heap=0x000000010302ac78, entry=0x00000001021fe958) at sip_100rel.c:605:2
```
This is because `dd->inv->invite_tsx` is `NULL` after a final response is sent.

Otherwise, it will trigger an assertion in `sip_transaction.c`:
```
Assertion failed: (event->type == PJSIP_EVENT_TX_MSG &&
event->body.tx_msg.tdata == tsx->last_tx), function
tsx_on_state_completed_uas, file ../src/pjsip/sip_transaction.c, line
3279
```