### PR TITLE
Update pjsua-test module call to wait for ICE & DTLS-SRTP nego before checking media

### DIFF
--- a/tests/pjsua/mod_call.py
+++ b/tests/pjsua/mod_call.py
@@ -33,6 +33,13 @@ def test_func(t):
         time.sleep(1)
     if caller.inst_param.have_reg:
         time.sleep(1)
+        
+    # Check if ICE is used
+    caller_use_ice = "--use-ice" in caller.inst_param.arg
+    callee_use_ice = "--use-ice" in callee.inst_param.arg
+
+    # Check if DTLS-SRTP is used
+    use_dtls_srtp = "--srtp-keying=1" in caller.inst_param.arg
 
     # Caller making call
     if caller.use_telnet:
@@ -75,6 +82,17 @@ def test_func(t):
     ##time.sleep(0.1)
     caller.sync_stdout()
     callee.sync_stdout()
+    
+    # Wait ICE nego before checking media
+    if caller_use_ice:
+        caller.expect("ICE negotiation success")
+    if callee_use_ice:
+        callee.expect("ICE negotiation success")
+        
+    # Wait DTLS-SRTP nego before checking media
+    if use_dtls_srtp:
+        caller.expect("SRTP started, keying=DTLS-SRTP")
+        callee.expect("SRTP started, keying=DTLS-SRTP")
 
     # Test that media is okay
     ##time.sleep(0.3)

--- a/tests/pjsua/mod_call.py
+++ b/tests/pjsua/mod_call.py
@@ -35,8 +35,7 @@ def test_func(t):
         time.sleep(1)
         
     # Check if ICE is used
-    caller_use_ice = "--use-ice" in caller.inst_param.arg
-    callee_use_ice = "--use-ice" in callee.inst_param.arg
+    use_ice = ("--use-ice" in caller.inst_param.arg) and ("--use-ice" in callee.inst_param.arg)
 
     # Check if DTLS-SRTP is used
     use_dtls_srtp = "--srtp-keying=1" in caller.inst_param.arg
@@ -84,9 +83,8 @@ def test_func(t):
     callee.sync_stdout()
     
     # Wait ICE nego before checking media
-    if caller_use_ice:
+    if use_ice:
         caller.expect("ICE negotiation success")
-    if callee_use_ice:
         callee.expect("ICE negotiation success")
         
     # Wait DTLS-SRTP nego before checking media

--- a/tests/pjsua/scripts-call/160_srtp_dtls.py
+++ b/tests/pjsua/scripts-call/160_srtp_dtls.py
@@ -1,0 +1,11 @@
+# $Id$
+#
+from inc_cfg import *
+
+test_param = TestParam(
+		"Callee=mandatory SRTP, caller=mandatory SRTP with DTLS keying",
+		[
+			InstanceParam("callee", "--null-audio --use-srtp=2 --srtp-secure=0 --max-calls=1"),
+			InstanceParam("caller", "--null-audio --use-srtp=2 --srtp-secure=0 --max-calls=1 --srtp-keying=1")
+		]
+		)

--- a/tests/pjsua/scripts-call/320_ice_dtls_srtp.py
+++ b/tests/pjsua/scripts-call/320_ice_dtls_srtp.py
@@ -1,0 +1,12 @@
+# $Id$
+#
+from inc_cfg import *
+
+# ICE mismatch
+test_param = TestParam(
+		"Callee=use ICE & SRTP, caller=use ICE & DTLS-SRTP",
+		[
+			InstanceParam("callee", "--null-audio --use-ice --max-calls=1 --use-srtp=2 --srtp-secure=0"),
+			InstanceParam("caller", "--null-audio --use-ice --max-calls=1 --use-srtp=2 --srtp-secure=0 --srtp-keying=1")
+		]
+		)


### PR DESCRIPTION
This should fix intermittent failure of some test scenario involving ICE, e.g: `tests/pjsua/scripts-call/305_ice_comp_*.py`.

Also add a couple of tests for DTLS-SRTP.