### PR TITLE
Fix leak of ioqueue resource (PJ_ETOOMANY)

### DIFF
--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -339,19 +339,19 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
      * an fd that is higher than FD_SETSIZE.
      */
     if (sizeof(fd_set) < FD_SETSIZE && sock >= FD_SETSIZE) {
-    PJ_LOG(1, ("pjlib", "Failed to register socket to ioqueue because "
-		   	    "socket fd is too big (fd=%d/FD_SETSIZE=%d)",
-		   	    sock, FD_SETSIZE));
-    	return PJ_ETOOBIG;
+	PJ_LOG(1, ("pjlib", "Failed to register socket to ioqueue because "
+			    "socket fd is too big (fd=%d/FD_SETSIZE=%d)",
+		   sock, FD_SETSIZE));
+	return PJ_ETOOBIG;
     }
 
     pj_lock_acquire(ioqueue->lock);
 
     if (ioqueue->count >= ioqueue->max) {
-        PJ_LOG(1, ("pjlib", "Failed to register socket %d to ioqueue because "
-                   "current key count %d reaches max key count %d (PJ_ETOOMANY)",
-                   sock, ioqueue->count, ioqueue->max));
-        rc = PJ_ETOOMANY;
+	PJ_LOG(1, ("pjlib", "Failed to register socket %d to ioqueue because "
+			    "current key count %d reaches max key count %d (PJ_ETOOMANY)",
+		   sock, ioqueue->count, ioqueue->max));
+	rc = PJ_ETOOMANY;
 	goto on_return;
     }
 
@@ -365,7 +365,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
 
     pj_assert(!pj_list_empty(&ioqueue->free_list));
     if (pj_list_empty(&ioqueue->free_list)) {
-        PJ_LOG(1, ("pjlib", "Failed to get free list of ioqueue key (PJ_ETOOMANY)"));
+	PJ_LOG(1, ("pjlib", "Failed to get free list of ioqueue key (PJ_ETOOMANY)"));
 	rc = PJ_ETOOMANY;
 	goto on_return;
     }

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -339,7 +339,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
      * an fd that is higher than FD_SETSIZE.
      */
     if (sizeof(fd_set) < FD_SETSIZE && sock >= FD_SETSIZE) {
-	PJ_LOG(4, ("pjlib", "Failed to register socket to ioqueue because "
+    PJ_LOG(1, ("pjlib", "Failed to register socket to ioqueue because "
 		   	    "socket fd is too big (fd=%d/FD_SETSIZE=%d)",
 		   	    sock, FD_SETSIZE));
     	return PJ_ETOOBIG;
@@ -348,6 +348,9 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
     pj_lock_acquire(ioqueue->lock);
 
     if (ioqueue->count >= ioqueue->max) {
+        PJ_LOG(1, ("pjlib", "Failed to register socket %d to ioqueue because "
+                   "current key count %d reaches max key count %d (PJ_ETOOMANY)",
+                   sock, ioqueue->count, ioqueue->max));
         rc = PJ_ETOOMANY;
 	goto on_return;
     }
@@ -362,6 +365,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
 
     pj_assert(!pj_list_empty(&ioqueue->free_list));
     if (pj_list_empty(&ioqueue->free_list)) {
+        PJ_LOG(1, ("pjlib", "Failed to get free list of ioqueue key (PJ_ETOOMANY)"));
 	rc = PJ_ETOOMANY;
 	goto on_return;
     }

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -974,7 +974,21 @@ static pj_bool_t is_transport_valid(pjsip_transport *tp, pjsip_tpmgr *tpmgr,
 				    const pjsip_transport_key *key,
 				    int key_len)
 {
-    return (pj_hash_get(tpmgr->table, key, key_len, NULL) == (void*)tp);
+    pj_bool_t result = PJ_FALSE;
+    if(pj_hash_get(tpmgr->table, key, key_len, NULL) == (void*)tp) {
+        result = PJ_TRUE;
+    } else {
+        /* If not found in hash table, then search in the tp_list */
+        transport *tp_iter = tpmgr->tp_list.next;
+        while (tp_iter != &tpmgr->tp_list) {
+            if (tp_iter->tp == tp) {
+                result = PJ_TRUE;
+                break;
+            }
+            tp_iter = tp_iter->next;
+        }
+    }
+    return result;
 }
 
 /*

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -975,18 +975,18 @@ static pj_bool_t is_transport_valid(pjsip_transport *tp, pjsip_tpmgr *tpmgr,
 				    int key_len)
 {
     pj_bool_t result = PJ_FALSE;
-    if(pj_hash_get(tpmgr->table, key, key_len, NULL) == (void*)tp) {
-        result = PJ_TRUE;
+    if (pj_hash_get(tpmgr->table, key, key_len, NULL) == (void *)tp) {
+	result = PJ_TRUE;
     } else {
-        /* If not found in hash table, then search in the tp_list */
-        transport *tp_iter = tpmgr->tp_list.next;
-        while (tp_iter != &tpmgr->tp_list) {
-            if (tp_iter->tp == tp) {
-                result = PJ_TRUE;
-                break;
-            }
-            tp_iter = tp_iter->next;
-        }
+	/* If not found in hash table, then search in the tp_list */
+	transport *tp_iter = tpmgr->tp_list.next;
+	while (tp_iter != &tpmgr->tp_list) {
+	    if (tp_iter->tp == tp) {
+		result = PJ_TRUE;
+		break;
+	    }
+	    tp_iter = tp_iter->next;
+	}
     }
     return result;
 }


### PR DESCRIPTION
Galaxy S7
Android 8
Pjsip 2.7.2

Scenario:

A pjsip tls transport is getting closed because for example of some network issue.
We create a new one, with the same remote address and tranport type because of register expire timeout.

Following happens in a rare case if that is happen very quickly in a row:

To create a new connection, [pjsip_transport_register()](https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1071) is called.
Because of that the "old closing" transport is still "valid" this transport still exist in the `pjsip_tpmgr::table`.  https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1092 will found the "old" tranport, move it to `pjsip_tpmgr::tp_list` https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1103 and delete https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1104 the "old" transport entry in the `pjsip_tpmgr::table`
This has the effect that the tranport will not get in the `PJSIP_TP_STATE_DESTROY` state to call [pj_ioqueue_unregister()](https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjlib/src/pj/ioqueue_select.c#L467) to unregister handle from ioqueue, because `istransportvalid()` https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L977 is false. This function is used in [pjsip_transport_dec_ref()](https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1018) to verify if the transport is valid https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1038. The [transport_idle_callback()](https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L1058) is never schedule.

I added in `istransportvalid()` when the transport is not found in `pjsip_tpmgr::table` it should verify if the transport is in `pjsip_tpmgr::tp_list`. This also effects [pjsip_transport_add_ref()](https://github.com/pjsip/pjproject/blob/63b8ea5c14bff15fd6b080cef632ebf203998a8f/pjsip/src/pjsip/sip_transport.c#L983). I'm not sure if this is a good idea but it looks more consistent.

It was not very helpful to see in the log that a transport get a PJ_ETOOMANY state without to see from where this comes. So I also added a log error to see from where PJ_ETOOMANY is coming. I see there are many places where PJ_ETOOMANY is set, so I think it should be a coding convention to log an error in the same place.

Btw. coding convention, I didn't find your format convention, so it might be broken. I will fix this if somebody can send me the formatting convention.