### PR TITLE
ice: rfc6544 support

### DIFF
--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -383,6 +383,15 @@
 #   define ICE_CONTROLLED_AGENT_WAIT_NOMINATION_TIMEOUT	10000
 #endif
 
+/**
+ * For TCP transport, this timer is time that a controlling agent must wait for
+ * incoming checks if the local candidate is of type "passive" or "s-o".
+ *
+ * Default: 10000 (milliseconds)
+ */
+#ifndef ICE_CONTROLLING_PASSIVE_TIMEOUT
+#   define ICE_CONTROLLING_PASSIVE_TIMEOUT	10000
+#endif
 
 /**
  * For controlling agent if it uses regular nomination, specify the delay to

--- a/pjnath/include/pjnath/ice_strans.h
+++ b/pjnath/include/pjnath/ice_strans.h
@@ -301,6 +301,13 @@ typedef struct pj_ice_strans_stun_cfg
      */
     pj_bool_t		 ignore_stun_error;
 
+    /**
+     * Type of connection to the STUN server.
+     *
+     * Default is PJ_STUN_TP_UDP.
+     */
+    pj_stun_tp_type conn_type;
+
 } pj_ice_strans_stun_cfg;
 
 
@@ -315,6 +322,13 @@ typedef struct pj_ice_strans_turn_cfg
      * Default value is pj_AF_INET() (IPv4)
      */
     int			 af;
+
+    /**
+     * If we want to use UDP or TCP as described by RFC 6544.
+     * This will discover candidates via TCP sockets. Then it will
+     * transfer messages on the transport via TCP.
+     */
+    pj_ice_tp_type protocol;
 
     /**
      * Optional TURN socket settings. The default values will be
@@ -394,6 +408,13 @@ typedef struct pj_ice_strans_cfg
      * The default value is pj_AF_INET() (IPv4).
      */
     int			 af;
+
+    /**
+     * If we want to use UDP or TCP as described by RFC 6544.
+     * This will discover candidates via TCP sockets. Then it will
+     * transfer messages on the transport via TCP.
+     */
+    pj_ice_tp_type protocol;
 
     /**
      * STUN configuration which contains the timer heap and

--- a/pjnath/include/pjnath/turn_sock.h
+++ b/pjnath/include/pjnath/turn_sock.h
@@ -623,6 +623,17 @@ PJ_DECL(pj_status_t) pj_turn_sock_bind_channel(pj_turn_sock *turn_sock,
 					       const pj_sockaddr_t *peer,
 					       unsigned addr_len);
 
+/**
+ *  Check if peer is a dataconn
+ *
+ * @param turn_sock    The turn sock
+ * @param peer         The peer addr to check
+ *
+ * @return true if dataconn else false
+ */
+PJ_DECL(pj_bool_t) pj_turn_sock_has_dataconn(pj_turn_sock *turn_sock,
+					     const pj_sockaddr_t *peer);
+
 
 /**
  * @}

--- a/pjnath/src/pjnath-test/concur_test.c
+++ b/pjnath/src/pjnath-test/concur_test.c
@@ -184,8 +184,9 @@ static int stun_destroy_test_session(struct stun_test_session *test_sess)
 	char name[10];
 	sprintf(name, "stun%02d", i);
 	status = pj_stun_sock_create(&test_sess->stun_cfg, name, pj_AF_INET(),
-	                             &stun_cb, NULL, test_sess,
-	                             &stun_sock[i]);
+				     PJ_STUN_TP_UDP,
+				     &stun_cb, NULL, test_sess,
+				     &stun_sock[i]);
 	if (status != PJ_SUCCESS) {
 	    PJ_PERROR(1,(THIS_FILE, status, "Error creating stun socket"));
 	    return -10;

--- a/pjnath/src/pjnath-test/sess_auth.c
+++ b/pjnath/src/pjnath-test/sess_auth.c
@@ -248,7 +248,8 @@ static int create_std_server(pj_stun_auth_type auth_type,
     pj_bzero(&sess_cb, sizeof(sess_cb));
     sess_cb.on_rx_request = &server_on_rx_request;
     sess_cb.on_send_msg = &server_send_msg;
-    status = pj_stun_session_create(&stun_cfg, "server", &sess_cb, PJ_FALSE, NULL, &server->sess);
+    status = pj_stun_session_create(&stun_cfg, "server", &sess_cb, PJ_FALSE,
+                                    NULL, &server->sess, PJ_STUN_TP_UDP);
     if (status != PJ_SUCCESS) {
 	destroy_server();
 	return -10;
@@ -489,7 +490,8 @@ static int run_client_test(const char *title,
     pj_bzero(&sess_cb, sizeof(sess_cb));
     sess_cb.on_request_complete = &client_on_request_complete;
     sess_cb.on_send_msg = &client_send_msg;
-    status = pj_stun_session_create(&stun_cfg, "client", &sess_cb, PJ_FALSE, NULL, &client->sess);
+    status = pj_stun_session_create(&stun_cfg, "client", &sess_cb, PJ_FALSE,
+                                    NULL, &client->sess, PJ_STUN_TP_UDP);
     if (status != PJ_SUCCESS) {
 	destroy_client_server();
 	return -200;
@@ -575,8 +577,12 @@ static int run_client_test(const char *title,
     }
 
     /* Send the request */
-    status = pj_stun_session_send_msg(client->sess, NULL, PJ_FALSE, PJ_TRUE, &server->addr,
-				      pj_sockaddr_get_len(&server->addr), tdata);
+    status = pj_stun_session_send_msg(client->sess, NULL, PJ_FALSE,
+				      (pj_stun_session_tp_type(client->sess) ==
+				       PJ_STUN_TP_UDP),
+				      &server->addr,
+				      pj_sockaddr_get_len(&server->addr),
+				      tdata);
     if (status != PJ_SUCCESS) {
 	destroy_client_server();
 	return -270;

--- a/pjnath/src/pjnath-test/stun_sock_test.c
+++ b/pjnath/src/pjnath-test/stun_sock_test.c
@@ -254,8 +254,9 @@ static pj_status_t create_client(pj_stun_config *cfg,
     pj_bzero(&cb, sizeof(cb));
     cb.on_status = &stun_sock_on_status;
     cb.on_rx_data = &stun_sock_on_rx_data;
-    status = pj_stun_sock_create(cfg, NULL, GET_AF(use_ipv6), &cb, &sock_cfg, 
-				 client, &client->sock);
+    status = pj_stun_sock_create(cfg, NULL, GET_AF(use_ipv6),
+				 PJ_STUN_TP_UDP,
+				 &cb, &sock_cfg, client, &client->sock);
     if (status != PJ_SUCCESS) {
 	app_perror("   pj_stun_sock_create()", status);
 	pj_pool_release(pool);
@@ -584,7 +585,7 @@ static int keep_alive_test(pj_stun_config *cfg, pj_bool_t use_ipv6)
 	PJ_LOG(3,(THIS_FILE, "     sending to %s", pj_sockaddr_print(&info.srv_addr, txt, sizeof(txt), 3)));
     }
     status = pj_stun_sock_sendto(client->sock, NULL, &ret, sizeof(ret),
-				 0, &info.srv_addr, 
+				 0, &info.srv_addr,
 				 pj_sockaddr_get_len(&info.srv_addr));
     if (status != PJ_SUCCESS && status != PJ_EPENDING) {
 	app_perror("    error: server sending data", status);

--- a/pjnath/src/pjnath/nat_detect.c
+++ b/pjnath/src/pjnath/nat_detect.c
@@ -329,7 +329,8 @@ PJ_DEF(pj_status_t) pj_stun_detect_nat_type2(const pj_sockaddr *server,
     sess_cb.on_request_complete = &on_request_complete;
     sess_cb.on_send_msg = &on_send_msg;
     status = pj_stun_session_create(stun_cfg, pool->obj_name, &sess_cb,
-				    PJ_FALSE, sess->grp_lock, &sess->stun_sess);
+				    PJ_FALSE, sess->grp_lock, &sess->stun_sess,
+				    PJ_STUN_TP_UDP);
     if (status != PJ_SUCCESS)
 	goto on_error;
 
@@ -875,7 +876,9 @@ static pj_status_t send_test(nat_detect_session *sess,
 
     /* Send the request */
     status = pj_stun_session_send_msg(sess->stun_sess, NULL, PJ_TRUE,
-				      PJ_TRUE, sess->cur_server, 
+				      (pj_stun_session_tp_type(sess->stun_sess) ==
+				       PJ_STUN_TP_UDP),
+				      sess->cur_server,
 				      pj_sockaddr_get_len(sess->cur_server),
 				      sess->result[test_id].tdata);
     if (status != PJ_SUCCESS)

--- a/pjnath/src/pjnath/stun_session.c
+++ b/pjnath/src/pjnath/stun_session.c
@@ -49,6 +49,8 @@ struct pj_stun_session
 
     pj_stun_tx_data	 pending_request_list;
     pj_stun_tx_data	 cached_response_list;
+
+    pj_stun_tp_type	 conn_type;
 };
 
 #define SNAME(s_)		    ((s_)->pool->obj_name)
@@ -524,7 +526,8 @@ PJ_DEF(pj_status_t) pj_stun_session_create( pj_stun_config *cfg,
 					    const pj_stun_session_cb *cb,
 					    pj_bool_t fingerprint,
 					    pj_grp_lock_t *grp_lock,
-					    pj_stun_session **p_sess)
+					    pj_stun_session **p_sess,
+					    pj_stun_tp_type conn_type)
 {
     pj_pool_t	*pool;
     pj_stun_session *sess;
@@ -545,6 +548,7 @@ PJ_DEF(pj_status_t) pj_stun_session_create( pj_stun_config *cfg,
     pj_memcpy(&sess->cb, cb, sizeof(*cb));
     sess->use_fingerprint = fingerprint;
     sess->log_flag = 0xFFFF;
+    sess->conn_type = conn_type;
 
     if (grp_lock) {
 	sess->grp_lock = grp_lock;
@@ -1010,7 +1014,7 @@ PJ_DEF(pj_status_t) pj_stun_session_send_msg( pj_stun_session *sess,
 					     (unsigned)tdata->pkt_size);
 	if (status != PJ_SUCCESS && status != PJ_EPENDING) {
 	    pj_stun_msg_destroy_tdata(sess, tdata);
-	    LOG_ERR_(sess, "Error sending STUN request", status);
+	    LOG_ERR_(sess, "Error sending STUN request (pj_stun_client_tsx_send_msg)", status);
 	    goto on_return;
 	}
 
@@ -1067,7 +1071,7 @@ PJ_DEF(pj_status_t) pj_stun_session_send_msg( pj_stun_session *sess,
 
 	if (status != PJ_SUCCESS && status != PJ_EPENDING) {
 	    pj_stun_msg_destroy_tdata(sess, tdata);
-	    LOG_ERR_(sess, "Error sending STUN request", status);
+	    LOG_ERR_(sess, "Error sending STUN request (pj_stun_session_send_msg)", status);
 	    goto on_return;
 	}
 
@@ -1538,3 +1542,12 @@ on_return:
     return status;
 }
 
+PJ_DECL(pj_stun_session_cb *) pj_stun_session_callback(pj_stun_session *sess)
+{
+    return sess ? &sess->cb : NULL;
+}
+
+PJ_DECL(pj_stun_tp_type) pj_stun_session_tp_type(pj_stun_session *sess)
+{
+    return sess ? sess->conn_type : PJ_STUN_TP_UDP;
+}

--- a/pjnath/src/pjnath/stun_transaction.c
+++ b/pjnath/src/pjnath/stun_transaction.c
@@ -396,6 +396,9 @@ static void retransmit_timer_callback(pj_timer_heap_t *timer_heap,
 PJ_DEF(pj_status_t) pj_stun_client_tsx_retransmit(pj_stun_client_tsx *tsx,
                                                   pj_bool_t mod_count)
 {
+    if (!tsx)
+	return PJ_EINVAL;
+
     if (tsx->destroy_timer.id != 0) {
 	return PJ_SUCCESS;
     }

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -311,7 +311,8 @@ PJ_DEF(pj_status_t) pj_turn_session_create( const pj_stun_config *cfg,
     stun_cb.on_request_complete = &stun_on_request_complete;
     stun_cb.on_rx_indication = &stun_on_rx_indication;
     status = pj_stun_session_create(&sess->stun_cfg, sess->obj_name, &stun_cb,
-				    PJ_FALSE, sess->grp_lock, &sess->stun);
+				    PJ_FALSE, sess->grp_lock, &sess->stun,
+				    conn_type);
     if (status != PJ_SUCCESS) {
 	do_destroy(sess);
 	return status;

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -894,12 +894,7 @@ static pj_bool_t on_data_sent(pj_turn_sock *turn_sock,
     }
 
     if (turn_sock->cb.on_data_sent) {
-	pj_ssize_t header_len, sent_size;
-
-        /* Remove the length of packet header from sent size. */
-	header_len = turn_sock->pkt_len - turn_sock->body_len;
-	sent_size = (sent > header_len)? (sent - header_len) : 0;
-	(*turn_sock->cb.on_data_sent)(turn_sock, sent_size);
+	(*turn_sock->cb.on_data_sent)(turn_sock, sent);
     }
 
     return PJ_TRUE;
@@ -1765,4 +1760,21 @@ static void turn_on_connection_bind_status(pj_turn_session *sess,
 	(*turn_sock->cb.on_connection_status)(turn_sock, status, conn_id,
 					      peer_addr, addr_len);
     }
+}
+
+pj_bool_t pj_turn_sock_has_dataconn(pj_turn_sock *turn_sock,
+				    const pj_sockaddr_t *peer)
+{
+    if (!turn_sock) return PJ_FALSE;
+
+    for (int i = 0; i < turn_sock->data_conn_cnt; ++i) {
+	tcp_data_conn_t* dataconn = &turn_sock->data_conn[i];
+	if (dataconn) {
+	    pj_sockaddr_t* conn_peer = &dataconn->peer_addr;
+	    if (pj_sockaddr_cmp(conn_peer, peer) == 0)
+		return PJ_TRUE;
+	}
+    }
+
+    return PJ_FALSE;
 }

--- a/pjnath/src/pjturn-client/client_main.c
+++ b/pjnath/src/pjturn-client/client_main.c
@@ -155,7 +155,7 @@ static int init()
 
 	name[strlen(name)-1] = '0'+i;
 	status = pj_stun_sock_create(&g.stun_config, name, pj_AF_INET(), 
-				     &stun_sock_cb, &ss_cfg,
+				     PJ_STUN_TP_UDP, &stun_sock_cb, &ss_cfg,
 				     &g.peer[i], &g.peer[i].stun_sock);
 	if (status != PJ_SUCCESS) {
 	    my_perror("pj_stun_sock_create()", status);

--- a/pjnath/src/pjturn-srv/allocation.c
+++ b/pjnath/src/pjturn-srv/allocation.c
@@ -338,7 +338,8 @@ PJ_DEF(pj_status_t) pj_turn_allocation_create(pj_turn_transport *transport,
     sess_cb.on_rx_request = &stun_on_rx_request;
     sess_cb.on_rx_indication = &stun_on_rx_indication;
     status = pj_stun_session_create(&srv->core.stun_cfg, alloc->obj_name,
-				    &sess_cb, PJ_FALSE, NULL, &alloc->sess);
+				    &sess_cb, PJ_FALSE, NULL, &alloc->sess,
+				    PJ_STUN_TP_UDP);
     if (status != PJ_SUCCESS) {
 	goto on_error;
     }

--- a/pjnath/src/pjturn-srv/server.c
+++ b/pjnath/src/pjturn-srv/server.c
@@ -156,7 +156,7 @@ PJ_DEF(pj_status_t) pj_turn_srv_create(pj_pool_factory *pf,
 
     status = pj_stun_session_create(&srv->core.stun_cfg, srv->obj_name,
 				    &sess_cb, PJ_FALSE, NULL,
-				    &srv->core.stun_sess);
+				    &srv->core.stun_sess, PJ_STUN_TP_UDP);
     if (status != PJ_SUCCESS) {
 	goto on_error;
     }

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1553,7 +1553,7 @@ static void resolve_stun_entry(pjsua_stun_resolve *sess)
 	stun_sock_cb.on_status = &test_stun_on_status;
 	sess->async_wait = PJ_FALSE;
 	status = pj_stun_sock_create(&pjsua_var.stun_cfg, "stunresolve",
-				     sess->af, &stun_sock_cb,
+				     sess->af, PJ_STUN_TP_UDP, &stun_sock_cb,
 				     NULL, sess, &sess->stun_sock);
 	if (status != PJ_SUCCESS) {
 	    char errmsg[PJ_ERR_MSG_SIZE];


### PR DESCRIPTION
This patch is an implementation proposal of the RFC 6544 into PJNATH.
This allow PJNATH to support TCP ICE candidates and open a direct TCP
connection between peers.

- BUG fix also the on_data_sent in turn_sock.c

Written by
Sébastien Blin <sebastien.blin@savoirfairelinux.com>
on behalf of Savoir-faire Linux.

Rebased for pjsip 2.10 by Peymane Marandi
<paymon@savoirfairelinux.com>
on behalf of Savoir-faire Linux.

--------------------------------------

Hi,

Since a long time, we have some patches for pjsip we use and a bit hard to maintain.

**The patch is far from finished/perfect, lot of dirty things/hacks, but is working** We use it since 1 year and a half on a lot of clients. The idea is to support ICE over TCP (RFC6544).

Ideally, if we can work together to merge this upstream, I think it will be great for both us and pjproject.

You already have my contributor agreement.

Best regards,
Sébastien