### PR TITLE
Fixed assertion for offer with multiple telephone events

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1172,6 +1172,12 @@ static pj_status_t match_offer(pj_pool_t *pool,
 		    if (!answer_with_multiple_codecs && found_matching_codec)
 			continue;
 		    is_codec = 1;
+		} else {
+		    if (!answer_with_multiple_codecs &&
+		        found_matching_telephone_event)
+		    {
+			continue;
+		    }
 		}
 		
 		/* Find paylaod in our initial SDP with matching 


### PR DESCRIPTION
Re #2088, if we accept offer containing multiple telephone events with the same clock rate, such as:
```
      m=audio 5078 RTP/AVP 0 101 96
      a=rtpmap:0 PCMU/8000/1
      a=rtpmap:101 telephone-event/8000
      a=fmtp:101 0-15
      a=rtpmap:96 telephone-event/8000
      a=fmtp:96 0-15
```
An assertion will be raised:
```
Assertion failed: (j != answer->desc.fmt_count), function match_offer, file ../src/pjmedia/sdp_neg.c, line 1362.
```
Thanks to Ryan Wallach for the report.
