### PR TITLE
pjmedia: Populate missing info fields from pjmedia_conf_get_port_info

### DIFF
--- a/pjmedia/include/pjmedia/format.h
+++ b/pjmedia/include/pjmedia/format.h
@@ -227,6 +227,8 @@ typedef enum pjmedia_format_id
     PJMEDIA_FORMAT_MPEG2VIDEO = PJMEDIA_FORMAT_PACK('M', 'P', '2', 'V'),
     PJMEDIA_FORMAT_MPEG4    = PJMEDIA_FORMAT_PACK('M', 'P', 'G', '4'),
 
+    PJMEDIA_FORMAT_INVALID  = 0xFFFFFFFF
+
 } pjmedia_format_id;
 
 /**

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1278,6 +1278,12 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_port_info( pjmedia_conf *conf,
 
     info->slot = slot;
     info->name = conf_port->name;
+    if (conf_port->port) {
+        pjmedia_format_copy(&info->format, &conf_port->port->info.fmt);
+    } else {
+        pj_bzero(&info->format, sizeof(info->format));
+        info->format.id = (pj_uint32_t)-1;
+    }
     info->tx_setting = conf_port->tx_setting;
     info->rx_setting = conf_port->rx_setting;
     info->listener_cnt = conf_port->listener_cnt;

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1282,7 +1282,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_port_info( pjmedia_conf *conf,
         pjmedia_format_copy(&info->format, &conf_port->port->info.fmt);
     } else {
         pj_bzero(&info->format, sizeof(info->format));
-        info->format.id = (pj_uint32_t)-1;
+        info->format.id = PJMEDIA_FORMAT_INVALID;
     }
     info->tx_setting = conf_port->tx_setting;
     info->rx_setting = conf_port->rx_setting;

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -442,7 +442,8 @@ typedef enum pjmedia_format_id
   PJMEDIA_FORMAT_MJPEG = ((('G' << 24) | ('P' << 16)) | ('J' << 8)) | 'M',
   PJMEDIA_FORMAT_MPEG1VIDEO = ((('V' << 24) | ('1' << 16)) | ('P' << 8)) | 'M',
   PJMEDIA_FORMAT_MPEG2VIDEO = ((('V' << 24) | ('2' << 16)) | ('P' << 8)) | 'M',
-  PJMEDIA_FORMAT_MPEG4 = ((('4' << 24) | ('G' << 16)) | ('P' << 8)) | 'M'
+  PJMEDIA_FORMAT_MPEG4 = ((('4' << 24) | ('G' << 16)) | ('P' << 8)) | 'M',
+  PJMEDIA_FORMAT_INVALID = 0xFFFFFFFF
 } pjmedia_format_id;
 
 typedef enum pjmedia_vid_packing


### PR DESCRIPTION
`pjmedia_conf_get_port_info` failed to populate the `format` member in `pjmedia_conf_port_info`.