### PR TITLE
the simpleua app segfaults because the memory pool for the pjmedia ev…

### DIFF
--- a/pjsip-apps/src/samples/simpleua.c
+++ b/pjsip-apps/src/samples/simpleua.c
@@ -408,6 +408,13 @@ int main(int argc, char *argv[])
 
 #endif	/* PJMEDIA_HAS_VIDEO */
     
+    pool = pj_pool_create( &cp.factory,	    /* pool factory	    */
+			   "simpleua",	 /* pool name.	    */
+			   4000,	    /* init size	    */
+			   4000,	    /* increment size	    */
+			   NULL		    /* callback on error    */
+			   );
+
     /* Create event manager */
     status = pjmedia_event_mgr_create(pool, 0, NULL);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, 1);

--- a/pjsip-apps/src/samples/simpleua.c
+++ b/pjsip-apps/src/samples/simpleua.c
@@ -364,6 +364,9 @@ int main(int argc, char *argv[])
 #endif
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, 1);
 
+    /* Create pool. */
+    pool = pjmedia_endpt_create_pool(g_med_endpt, "Media pool", 512, 512);	
+
     /* 
      * Add PCMA/PCMU codec to the media endpoint. 
      */
@@ -375,7 +378,6 @@ int main(int argc, char *argv[])
 
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
     /* Init video subsystem */
-    pool = pjmedia_endpt_create_pool(g_med_endpt, "Video subsystem", 512, 512);
     status = pjmedia_video_format_mgr_create(pool, 64, 0, NULL);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, 1);
     status = pjmedia_converter_mgr_create(pool, NULL);
@@ -408,13 +410,6 @@ int main(int argc, char *argv[])
 
 #endif	/* PJMEDIA_HAS_VIDEO */
     
-    pool = pj_pool_create( &cp.factory,	    /* pool factory	    */
-			   "simpleua",	 /* pool name.	    */
-			   4000,	    /* init size	    */
-			   4000,	    /* increment size	    */
-			   NULL		    /* callback on error    */
-			   );
-
     /* Create event manager */
     status = pjmedia_event_mgr_create(pool, 0, NULL);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, 1);


### PR DESCRIPTION
…ent manager is never created. This fixes issue #2391. I initially thought it was only segfaulting on macos, but I tested on debian as well, and it will segfaulted. It is just because the memory pull ws not being created, so when passed to `pj_event_mgr_create`, it crashed.