### PR TITLE
Skip unsupported digest algorithm

### DIFF
--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -1042,7 +1042,7 @@ static pj_status_t process_auth( pj_pool_t *req_pool,
     pjsip_hdr *hdr;
     pj_status_t status;
 
-    /* See if we have sent authorization header for this realm */
+    /* See if we have sent authorization header for this realm (and scheme) */
     hdr = tdata->msg->hdr.next;
     while (hdr != &tdata->msg->hdr) {
 	if ((hchal->type == PJSIP_H_WWW_AUTHENTICATE &&
@@ -1052,7 +1052,8 @@ static pj_status_t process_auth( pj_pool_t *req_pool,
 	{
 	    sent_auth = (pjsip_authorization_hdr*) hdr;
 	    if (pj_stricmp(&hchal->challenge.common.realm,
-			   &sent_auth->credential.common.realm )==0)
+			   &sent_auth->credential.common.realm)==0 &&
+		pj_stricmp(&hchal->scheme, &sent_auth->scheme)==0)
 	    {
 		/* If this authorization has empty response, remove it. */
 		if (pj_stricmp(&sent_auth->scheme, &pjsip_DIGEST_STR)==0 &&

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -1194,6 +1194,10 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_reinit_req(	pjsip_auth_clt_sess *sess,
 	    break;
 
 	hchal = (const pjsip_www_authenticate_hdr*)hdr;
+	if (pj_stricmp(&hchal->challenge.digest.algorithm, &pjsip_MD5_STR)) {
+	    hdr = hdr->next;
+	    continue;
+	}
 	++chal_cnt;
 
 	/* Find authentication session for this realm, create a new one

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -1065,7 +1065,7 @@ static pj_status_t process_auth( pj_pool_t *req_pool,
 		} else
 		if (pj_stricmp(&sent_auth->scheme, &pjsip_DIGEST_STR)==0 &&
 		    pj_stricmp(&sent_auth->credential.digest.algorithm,
-		               &hchal->challenge.digest.algorithm)==0)
+		               &hchal->challenge.digest.algorithm)!=0)
 		{
 		    /* Same 'digest' scheme but different algo */
 		    hdr = hdr->next;

--- a/tests/pjsua/scripts-sipp/uas-auth-two-algo.py
+++ b/tests/pjsua/scripts-sipp/uas-auth-two-algo.py
@@ -1,0 +1,7 @@
+# $Id$
+#
+import inc_const as const
+
+PJSUA = ["--null-audio --max-calls=1 --id=sip:a@localhost --username=a --realm=* --registrar=$SIPP_URI"]
+
+PJSUA_EXPECTS = []

--- a/tests/pjsua/scripts-sipp/uas-auth-two-algo.py
+++ b/tests/pjsua/scripts-sipp/uas-auth-two-algo.py
@@ -4,4 +4,4 @@ import inc_const as const
 
 PJSUA = ["--null-audio --max-calls=1 --id=sip:a@localhost --username=a --realm=* --registrar=$SIPP_URI"]
 
-PJSUA_EXPECTS = []
+PJSUA_EXPECTS = [[0, "registration success", ""]]

--- a/tests/pjsua/scripts-sipp/uas-auth-two-algo.xml
+++ b/tests/pjsua/scripts-sipp/uas-auth-two-algo.xml
@@ -27,13 +27,37 @@
       [last_CSeq:]
       WWW-Authenticate: Digest realm="sip.linphone.org", nonce="PARV4gAAAADgw3asAADW8zsi5BEAAAAA", opaque="+GNywA==", algorithm=SHA-256, qop="auth"
       WWW-Authenticate: Digest realm="sip.linphone.org", nonce="PARV4gAAAADgw3asAADW8zsi5BEAAAAA", opaque="+GNywA==", algorithm=MD5, qop="auth"
+      WWW-Authenticate: Digest realm="sip.linphone.org", nonce="PARV4gAAAADgw3asAADW8zsi5BEAAAAA", opaque="+GNywA==", algorithm=MD2, qop="auth"
       Content-Length: 0
     ]]>
   </send>
 
   <recv request="REGISTER" crlf="true">
+    <action>
+      <ereg regexp=".*"
+            search_in="hdr"
+	    header="Authorization:"
+	    assign_to="have_auth" />
+    </action>
   </recv>
 
+  <nop next="resp_okay" test="have_auth" />
+  
+  <send next="end">
+    <![CDATA[
+      SIP/2.0 403 no auth
+      [last_Via:];received=1.1.1.1;rport=1111
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Contact:]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <label id="resp_okay" />
+  
   <send>
     <![CDATA[
       SIP/2.0 200 OK
@@ -47,6 +71,7 @@
     ]]>
   </send>
 
+  <label id="end" />
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/pjsua/scripts-sipp/uas-auth-two-algo.xml
+++ b/tests/pjsua/scripts-sipp/uas-auth-two-algo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Basic UAS responder">
+  <recv request="REGISTER" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 100 Trying
+      [last_Via:];received=1.1.1.1;rport=1111
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 401 Unauthorized
+      [last_Via:];received=1.1.1.1;rport=1111
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      WWW-Authenticate: Digest realm="sip.linphone.org", nonce="PARV4gAAAADgw3asAADW8zsi5BEAAAAA", opaque="+GNywA==", algorithm=SHA-256, qop="auth"
+      WWW-Authenticate: Digest realm="sip.linphone.org", nonce="PARV4gAAAADgw3asAADW8zsi5BEAAAAA", opaque="+GNywA==", algorithm=MD5, qop="auth"
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <recv request="REGISTER" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:];received=1.1.1.1;rport=1111
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Contact:]
+      Content-Length: 0
+    ]]>
+  </send>
+
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+


### PR DESCRIPTION
Report and patch by Alexander Traud:
" (some minor edits without altering its content)
See <https://stackoverflow.com/q/60683714>, found independently.

PJSIP does not support SHA-256 but only MD5 (and AKAv1-MD5; pjsip/sip_auth_client.c:respond_digest). However, the Backus-Naur-Form in RFC 3261 allows several WWW-Authenticate lines and the implementation has to pick its supported algorithm. RFC 3261 even known about unknown algorithms (token).

Currently, PJSIP 2.10, goes for the first WWW-Authenticate line only. If that is not supported, no progress (PJSIP_EINVALIDALGORITHM)

With RFC 7616, algorithms got added like SHA-256. Recently, the SIP service at sip.linphone.org added that. Give it a try and use my account "traud", password does not matter. You get two WWW-Authenticate lines, the first is SHA-256 and the second one is MD5.

I am *not* asking for supporting "SHA-256". I am asking for picking the right, your supported algorithm. This was required in RFC 3261 already. And actually my 12-year-old Nokia Mobile Phone picks MD5.

Note: pjsua command line tool faces the same issue.
"

This current patch has two limitations:
1. WWW-Authenticate without algorithm is ignored.
2. WWW-Authenticate with AKAv1-MD5 is ignored [1].
Both cases work(ed) further down in the stack in respond_digest(.).
