### PR TITLE
More consistent configure script library detection message

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -7595,8 +7595,8 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
    ac_openh264_cflags="-DPJMEDIA_HAS_OPENH264_CODEC=1 $OPENH264_CFLAGS"
 		  		   ac_openh264_ldflags="$OPENH264_LDFLAGS $OPENH264_LIBS"
-		  		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
+		  		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
 else
 
@@ -7681,8 +7681,8 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
    ac_vpx_cflags="-DPJMEDIA_HAS_VPX_CODEC=1 $VPX_CFLAGS"
 		  		   ac_vpx_ldflags="$VPX_LDFLAGS $VPX_LIBS"
-		  		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
+		  		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
 else
 
@@ -7844,8 +7844,8 @@ ippStaticInit();
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -7971,8 +7971,8 @@ extern USC_Fxns USC_G729AFP_Fxns;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -8933,8 +8933,8 @@ if ac_fn_c_try_link "$LINENO"; then :
 
 				   $as_echo "#define PJMEDIA_HAS_BCG729 1" >>confdefs.h
 
-		  		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
+		  		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
 else
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -1286,7 +1286,7 @@ AC_ARG_ENABLE(openh264,
 					         )],
 		  		 [ ac_openh264_cflags="-DPJMEDIA_HAS_OPENH264_CODEC=1 $OPENH264_CFLAGS"
 		  		   ac_openh264_ldflags="$OPENH264_LDFLAGS $OPENH264_LIBS"
-		  		   AC_MSG_RESULT(ok)
+		  		   AC_MSG_RESULT(yes)
 		  		  ],
 		  		 [
 				   LIBS="$SAVED_LIBS"
@@ -1351,7 +1351,7 @@ AC_ARG_ENABLE(vpx,
 					         )],
 		  		 [ ac_vpx_cflags="-DPJMEDIA_HAS_VPX_CODEC=1 $VPX_CFLAGS"
 		  		   ac_vpx_ldflags="$VPX_LDFLAGS $VPX_LIBS"
-		  		   AC_MSG_RESULT(ok)
+		  		   AC_MSG_RESULT(yes)
 		  		  ],
 		  		 [
 				   LIBS="$SAVED_LIBS"
@@ -1484,7 +1484,7 @@ if test "x$enable_ipp" != "xno"; then
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <ippcore.h>
 					   ]],
 					   [ippStaticInit();])],
-		  [AC_MSG_RESULT(ok)],
+		  [AC_MSG_RESULT(yes)],
 		  [AC_MSG_FAILURE([Error: unable to recognize your IPP installation. Make sure the paths and ARCH suffix are set correctly, run with --help for more info])])
 
 	CFLAGS="$SAVED_CFLAGS"
@@ -1574,7 +1574,7 @@ if test "x$enable_ipp" != "xno"; then
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <usc.h>
 					   ]],
 					   [extern USC_Fxns USC_G729AFP_Fxns;])],
-		  [AC_MSG_RESULT(ok)],
+		  [AC_MSG_RESULT(yes)],
 		  [AC_MSG_FAILURE(no)])
 
 	CFLAGS="$SAVED_CFLAGS"
@@ -2010,7 +2010,7 @@ AC_ARG_ENABLE(bcg729,
 					         )],
 		  		 [ 
 				   AC_DEFINE(PJMEDIA_HAS_BCG729,1)
-		  		   AC_MSG_RESULT(ok)
+		  		   AC_MSG_RESULT(yes)
 		  		  ],
 		  		 [
 				   [ac_no_bcg729=1]


### PR DESCRIPTION
Patch by Alexander Traud:
"
When an external library was found, the script configure prints "yes". However in five cases, the script prints "ok".
"

The patch is to make the message more consistent by changing all to "yes" when a library is found.
