### PR TITLE
Fixed assertion when receving an INVITE response during an UPDATE

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2061,6 +2061,15 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
 	{
 	    const pjmedia_sdp_session *reoffer_sdp = NULL;
 
+	    if (pjmedia_sdp_neg_get_state(inv->neg) !=
+	    	PJMEDIA_SDP_NEG_STATE_DONE)
+	    {
+	    	PJ_LOG(4,(inv->obj_name, "Ignoring %s response "
+		          "because SDP negotiation is in progress",
+		          (st_code/10==18? "early" : "final" )));
+	    	return PJ_EINVALIDOP;
+	    }
+
 	    PJ_LOG(4,(inv->obj_name, "Received %s response "
 		      "after SDP negotiation has been done in early "
 		      "media. Renegotiating SDP..",

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2064,10 +2064,10 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
 	    if (pjmedia_sdp_neg_get_state(inv->neg) !=
 	    	PJMEDIA_SDP_NEG_STATE_DONE)
 	    {
-	    	PJ_LOG(4,(inv->obj_name, "Ignoring %s response "
-		          "because SDP negotiation is in progress",
+	    	PJ_LOG(4,(inv->obj_name, "SDP negotiation in progress, "
+	    		  "message body in %s response is ignored",
 		          (st_code/10==18? "early" : "final" )));
-	    	return PJ_EINVALIDOP;
+	    	return PJ_SUCCESS;
 	    }
 
 	    PJ_LOG(4,(inv->obj_name, "Received %s response "

--- a/tests/pjsua/scripts-sipp/uas-answer-180-multiple-fmts-support-update.xml
+++ b/tests/pjsua/scripts-sipp/uas-answer-180-multiple-fmts-support-update.xml
@@ -81,33 +81,6 @@
   <send>
     <![CDATA[
 
-      SIP/2.0 183 Session Progress
-      Via[$6]
-      [last_From:]
-      [last_To:];tag=[call_number]
-      [last_Call-ID:]
-      CSeq[$7]
-      Contact: sip:sipp@[local_ip]:[local_port]
-      Content-Type: application/sdp
-      Content-Length: [len]
-      Allow: INVITE, UPDATE, ACK, BYE
-
-      v=0
-      o=- 3441953879 3441953879 IN IP4 192.168.0.15
-      s=pjmedia
-      c=IN IP4 192.168.0.15
-      t=0 0
-      m=audio 4004 RTP/AVP 0 111
-      a=rtpmap:0 PCMU/8000
-      a=rtpmap:111 telephone-event/8000
-      a=fmtp:111 0-15
-
-    ]]>
-  </send>
-
-  <send>
-    <![CDATA[
-
       SIP/2.0 200 OK
       [last_Via:]
       [last_From:]
@@ -131,6 +104,8 @@
 
     ]]>
   </send>
+
+  <pause milliseconds="2000"/>
 
   <send retrans="500">
     <![CDATA[

--- a/tests/pjsua/scripts-sipp/uas-answer-180-multiple-fmts-support-update.xml
+++ b/tests/pjsua/scripts-sipp/uas-answer-180-multiple-fmts-support-update.xml
@@ -81,6 +81,33 @@
   <send>
     <![CDATA[
 
+      SIP/2.0 183 Session Progress
+      Via[$6]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      CSeq[$7]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+      Allow: INVITE, UPDATE, ACK, BYE
+
+      v=0
+      o=- 3441953879 3441953879 IN IP4 192.168.0.15
+      s=pjmedia
+      c=IN IP4 192.168.0.15
+      t=0 0
+      m=audio 4004 RTP/AVP 0 111
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:111 telephone-event/8000
+      a=fmtp:111 0-15
+
+    ]]>
+  </send>
+
+  <send>
+    <![CDATA[
+
       SIP/2.0 200 OK
       [last_Via:]
       [last_From:]
@@ -104,8 +131,6 @@
 
     ]]>
   </send>
-
-  <pause milliseconds="2000"/>
 
   <send retrans="500">
     <![CDATA[


### PR DESCRIPTION
Fixed #2413 .

This issue happens because we're receiving a response to INVITE in the middle of UPDATE when dialog is in early state, i.e. as in [RFC 3311 call flow example](https://tools.ietf.org/html/rfc3311#section-8), but (9) occurs after (5) instead.

Since we have just sent an UPDATE, neg->state is at `PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER`, which causes the assertion `(neg->state == PJMEDIA_SDP_NEG_STATE_DONE)` when processing the INVITE response.

`
frame #4: 0x0000000100164243 pjsua-x86_64-apple-darwin19.3.0pjmedia_sdp_neg_modify_local_offer2.cold.1 + 35 frame #5: 0x0000000100091448 pjsua-x86_64-apple-darwin19.3.0pjmedia_sdp_neg_modify_local_offer2 + 632
frame #6: 0x000000010003ceb3 pjsua-x86_64-apple-darwin19.3.0inv_check_sdp_in_incoming_msg + 499 frame #7: 0x000000010003dde2 pjsua-x86_64-apple-darwin19.3.0inv_on_state_early + 274
`