### PR TITLE
Potential deadlock when app invokes PJSUA API from format changed event callback

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -1527,7 +1527,8 @@ static pj_status_t get_frame(pjmedia_port *port,
 			stream->dec : stream->enc,
 		       "changed");
 
-	pjmedia_event_publish(NULL, port, &stream->fmt_event, 0);
+	pjmedia_event_publish(NULL, port, &stream->fmt_event,
+			      PJMEDIA_EVENT_PUBLISH_POST_EVENT);
 
 	stream->fmt_event.type = PJMEDIA_EVENT_NONE;
     }


### PR DESCRIPTION
The event is published under video conference's lock and PJSUA API usually acquires PJSUA lock. If at the same time another thread is invoking PJSUA API that accesses video conference, such as `pjsua_vid_preview_start()` or `pjsua_call_set_vid_strm()`, deadlock may occur.

Not really sure why the `PJMEDIA_EVENT_FMT_CHANGED` event is currently published synchronously. Perhaps it wants the renderer/video-conf (the component downstream) to readjust format info and any frame buffer size before the frame being fetched is sent to it, to avoid possible buffer overflow for example, so changing it to be published asynchronously is perhaps not a good idea.

However, after investigation, for H264 where format change event is usually occurred, video stream's format is initialized with the highest size possible based on profile level ID, and any downstream components (e.g: video conf, renderer) will also initialize its format (and frame buffer size) based on the video stream's format, and format changed event should only reduce the video size, so buffer overflow should not happen. Moreover, currently PJSUA seem to only reconnect video conf connections (which actually does not readjust buffer sizes) upon format changed event.

After some tests, publishing the event asynchronously do not seem to cause any problem (crash, bad video rendering, etc).