### PR TITLE
Fix short noise at the beginning of call when audio device started later.

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1428,6 +1428,24 @@
 
 
 /**
+ * Reset jitter buffer and return silent audio on stream playback start
+ * (first get_frame()). This is useful to avoid possible noise that may be
+ * introduced by discard algorithm and neutralize latency when audio device
+ * is started later than the stream.
+ *
+ * Set this to N>0 to allow N silent audio frames returned on stream playback
+ * start, this will allow about N frames to be buffered in the jitter buffer
+ * before the playback is started (prefetching effect).
+ * Set this to zero to disable this feature.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_STREAM_SOFT_START
+#   define PJMEDIA_STREAM_SOFT_START		    1
+#endif
+
+
+/**
  * Video stream will discard old picture from the jitter buffer as soon as
  * new picture is received, to reduce latency.
  *


### PR DESCRIPTION
Reported that short clicking noise right was heard on callee's side after the call is connected after implementing iOS 13 support as outlined in issue #1941.

After investigation, the click noise seems to be caused by JB discard to adjust latency as the provided log shows a regular interval of missing frames and the codec PLC may not perform well (in maintaining audio signal continuation in back-to-back frames generated by decoder-PLC-decoder). And some tests showed that resetting jitter buffer does solve the clicking noise issue.

The patch introduces a new feature in stream to automatically reset jitter buffer in the beginning of stream playback (stream's `get_frame()`) and return silent audio frames to allow a short prefetching effect to avoid empty frame returned by just resetted jitter buffer in the next immediate `get_frame()`.

Thanks to Marcus Froeschl for the report.