### PR TITLE
Avoid undefinition of standard macros s_addr and s6_addr

### DIFF
--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -37,6 +37,9 @@
 #define ACTION_IGNORE	-1
 #define ACTION_CB	-2
 
+#undef s6_addr32
+#define s6_addr32(addr, idx) *((pj_uint32_t *)(addr.s6_addr + idx*4))
+
 static struct server_t
 {
     pj_sock_t	     sock;
@@ -774,7 +777,7 @@ static int addr_parser_test(void)
     pkt.ans[3].type = PJ_DNS_TYPE_AAAA;
     pkt.ans[3].dnsclass = 1;
     pkt.ans[3].ttl = 1;
-    pkt.ans[3].rdata.aaaa.ip_addr.u6_addr32[0] = 0x01020304;
+    s6_addr32(pkt.ans[3].rdata.aaaa.ip_addr, 0) = 0x01020304;
 
 
     rc = pj_dns_parse_addr_response(&pkt, &rec);
@@ -783,7 +786,7 @@ static int addr_parser_test(void)
     pj_assert(rec.alias.slen == 0);
     pj_assert(rec.addr_count == 2);
     pj_assert(rec.addr[0].af==pj_AF_INET() && rec.addr[0].ip.v4.s_addr == 0x01020304);
-    pj_assert(rec.addr[1].af==pj_AF_INET6() && rec.addr[1].ip.v6.u6_addr32[0] == 0x01020304);
+    pj_assert(rec.addr[1].af==pj_AF_INET6() && s6_addr32(rec.addr[1].ip.v6, 0) == 0x01020304);
 
     /* Answer with the target corresponds to a CNAME entry, but not
      * as the first record, and with additions of some CNAME and A
@@ -1264,10 +1267,10 @@ static void action1_1(const pj_dns_parsed_packet *pkt,
 	res->ans[1].dnsclass = 1;
 	res->ans[1].ttl = 1;
 	res->ans[1].name = pj_str(alias);
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[0] = IP_ADDR1;
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[1] = IP_ADDR1;
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[2] = IP_ADDR1;
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[3] = IP_ADDR1;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 0) = IP_ADDR1;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 1) = IP_ADDR1;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 2) = IP_ADDR1;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 3) = IP_ADDR1;
     }
 
     *p_res = res;
@@ -1337,7 +1340,7 @@ static void srv_cb_1c(void *user_data,
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].af == pj_AF_INET() &&
 		      rec->entry[0].server.addr[0].ip.v4.s_addr == IP_ADDR1, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[1].af == pj_AF_INET6() &&
-		      rec->entry[0].server.addr[1].ip.v6.u6_addr32[0] == IP_ADDR1, return);
+		      s6_addr32(rec->entry[0].server.addr[1].ip.v6, 0) == IP_ADDR1, return);
 }
 
 
@@ -1363,7 +1366,7 @@ static void srv_cb_1d(void *user_data,
     /* IPv6 only */
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr_count == 1, return);
     PJ_ASSERT_ON_FAIL(rec->entry[0].server.addr[0].af == pj_AF_INET6() &&
-		      rec->entry[0].server.addr[0].ip.v6.u6_addr32[0] == IP_ADDR1, return);
+		      s6_addr32(rec->entry[0].server.addr[0].ip.v6, 0) == IP_ADDR1, return);
 }
 
 
@@ -1551,10 +1554,10 @@ static void action2_1(const pj_dns_parsed_packet *pkt,
 	res->ans[1].dnsclass = 1;
 	res->ans[1].ttl = 1;
 	res->ans[1].name = pj_str(alias);
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[0] = IP_ADDR2;
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[1] = IP_ADDR2;
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[2] = IP_ADDR2;
-	res->ans[1].rdata.aaaa.ip_addr.u6_addr32[3] = IP_ADDR2;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 0) = IP_ADDR2;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 1) = IP_ADDR2;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 2) = IP_ADDR2;
+	s6_addr32(res->ans[1].rdata.aaaa.ip_addr, 3) = IP_ADDR2;
     }
 
     *p_res = res;
@@ -1606,7 +1609,7 @@ static void srv_cb_2a(void *user_data,
     SRV_CB_CHECK(rec->entry[0].server.addr[0].af == pj_AF_INET() &&
 		 rec->entry[0].server.addr[0].ip.v4.s_addr == IP_ADDR2, -90);
     SRV_CB_CHECK(rec->entry[0].server.addr[1].af == pj_AF_INET6() &&
-		 rec->entry[0].server.addr[1].ip.v6.u6_addr32[0] == IP_ADDR2,
+		 s6_addr32(rec->entry[0].server.addr[1].ip.v6, 0) == IP_ADDR2,
 		 -100);
 
 on_return:
@@ -1631,7 +1634,7 @@ static void srv_cb_2b(void *user_data,
     /* IPv6 only */
     SRV_CB_CHECK(rec->entry[0].server.addr_count == 1, -80);
     SRV_CB_CHECK(rec->entry[0].server.addr[0].af == pj_AF_INET6() &&
-		 rec->entry[0].server.addr[0].ip.v6.u6_addr32[0] == IP_ADDR2,
+		 s6_addr32(rec->entry[0].server.addr[0].ip.v6, 0) == IP_ADDR2,
 		 -90);
 
 on_return:

--- a/pjlib/include/pj/compat/socket.h
+++ b/pjlib/include/pj/compat/socket.h
@@ -179,10 +179,12 @@
 
 /*
  * And undefine these..
+ * Note (see issue #2311): unfortunately, this may cause build failure
+ * to anyone who uses these standard macros.
  */
-#undef s_addr
-#undef s6_addr
-#undef sin_zero
+//#undef s_addr
+//#undef s6_addr
+//#undef sin_zero
 
 /*
  * This will finally be obsoleted, since it should be declared in

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -26,6 +26,7 @@
  */
 
 #include <pj/types.h>
+#include <pj/compat/socket.h>
 
 PJ_BEGIN_DECL 
 
@@ -501,7 +502,6 @@ typedef struct pj_in_addr
 } pj_in_addr;
 
 #else
-#include <pj/compat/socket.h>
 typedef struct in_addr pj_in_addr;
 #endif
 

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -484,6 +484,11 @@ typedef enum pj_socket_sd_type
  */
 #define PJ_INVALID_SOCKET   (-1)
 
+/* Undefining UNIX standard library macro such as s_addr is not
+ * recommended as it may cause build issues for anyone who uses
+ * the macro. See #2311 for more details.
+ */
+#if 0
 /* Must undefine s_addr because of pj_in_addr below */
 #undef s_addr
 
@@ -495,6 +500,10 @@ typedef struct pj_in_addr
     pj_uint32_t	s_addr;		/**< The 32bit IP address.	    */
 } pj_in_addr;
 
+#else
+#include <pj/compat/socket.h>
+typedef struct in_addr pj_in_addr;
+#endif
 
 /**
  * Maximum length of text representation of an IPv4 address.
@@ -532,10 +541,15 @@ struct pj_sockaddr_in
 #endif
     pj_uint16_t	sin_port;	/**< Transport layer port number.   */
     pj_in_addr	sin_addr;	/**< IP address.		    */
-    char	sin_zero[PJ_SOCKADDR_IN_SIN_ZERO_LEN]; /**< Padding.*/
+    char	sin_zero_pad[PJ_SOCKADDR_IN_SIN_ZERO_LEN]; /**< Padding.*/
 };
 
 
+/* Undefining C standard library macro such as s6_addr is not
+ * recommended as it may cause build issues for anyone who uses
+ * the macro. See #2311 for more details.
+ */
+#if 0
 #undef s6_addr
 
 /**
@@ -560,6 +574,9 @@ typedef union pj_in6_addr
 #endif
 
 } pj_in6_addr;
+#else
+typedef struct in6_addr pj_in6_addr;
+#endif
 
 
 /** Initializer value for pj_in6_addr. */
@@ -712,7 +729,7 @@ PJ_DECL(char*) pj_inet_ntoa(pj_in_addr inaddr);
  *
  * @return	nonzero if the address is valid, zero if not.
  */
-PJ_DECL(int) pj_inet_aton(const pj_str_t *cp, struct pj_in_addr *inp);
+PJ_DECL(int) pj_inet_aton(const pj_str_t *cp, pj_in_addr *inp);
 
 /**
  * This function converts an address in its standard text presentation form

--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -244,7 +244,7 @@ PJ_DEF(char*) pj_inet_ntoa(pj_in_addr inaddr)
  * numbers-and-dots notation into binary data and stores it in the structure
  * that inp points to. 
  */
-PJ_DEF(int) pj_inet_aton(const pj_str_t *cp, struct pj_in_addr *inp)
+PJ_DEF(int) pj_inet_aton(const pj_str_t *cp, pj_in_addr *inp)
 {
     char tempaddr[PJ_INET_ADDRSTRLEN];
 
@@ -600,7 +600,7 @@ PJ_DEF(pj_status_t) pj_sock_bind_in( pj_sock_t sock,
 
     PJ_SOCKADDR_SET_LEN(&addr, sizeof(pj_sockaddr_in));
     addr.sin_family = PJ_AF_INET;
-    pj_bzero(addr.sin_zero, sizeof(addr.sin_zero));
+    pj_bzero(addr.sin_zero_pad, sizeof(addr.sin_zero_pad));
     addr.sin_addr.s_addr = pj_htonl(addr32);
     addr.sin_port = pj_htons(port);
 

--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -129,7 +129,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_set_str_addr( pj_sockaddr_in *addr,
 
     PJ_SOCKADDR_RESET_LEN(addr);
     addr->sin_family = PJ_AF_INET;
-    pj_bzero(addr->sin_zero, sizeof(addr->sin_zero));
+    pj_bzero(addr->sin_zero_pad, sizeof(addr->sin_zero_pad));
 
     if (str_addr && str_addr->slen) {
 	addr->sin_addr = pj_inet_addr(str_addr);
@@ -210,7 +210,7 @@ PJ_DEF(pj_status_t) pj_sockaddr_in_init( pj_sockaddr_in *addr,
 
     PJ_SOCKADDR_RESET_LEN(addr);
     addr->sin_family = PJ_AF_INET;
-    pj_bzero(addr->sin_zero, sizeof(addr->sin_zero));
+    pj_bzero(addr->sin_zero_pad, sizeof(addr->sin_zero_pad));
     pj_sockaddr_in_set_port(addr, port);
     return pj_sockaddr_in_set_str_addr(addr, str_addr);
 }
@@ -987,11 +987,11 @@ PJ_DEF(pj_status_t) pj_gethostip(int af, pj_sockaddr *addr)
 	if (af==PJ_AF_INET) {
 	    addr->ipv4.sin_addr.s_addr = pj_htonl (0x7f000001);
 	} else {
-	    pj_in6_addr *s6_addr;
+	    pj_in6_addr *s6_addr_;
 
-	    s6_addr = (pj_in6_addr*) pj_sockaddr_get_addr(addr);
-	    pj_bzero(s6_addr, sizeof(pj_in6_addr));
-	    s6_addr->s6_addr[15] = 1;
+	    s6_addr_ = (pj_in6_addr*) pj_sockaddr_get_addr(addr);
+	    pj_bzero(s6_addr_, sizeof(pj_in6_addr));
+	    s6_addr_->s6_addr[15] = 1;
 	}
 	TRACE_((THIS_FILE, "Loopback IP %s returned",
 		pj_sockaddr_print(addr, strip, sizeof(strip), 3)));

--- a/pjlib/src/pj/sock_symbian.cpp
+++ b/pjlib/src/pj/sock_symbian.cpp
@@ -299,7 +299,7 @@ PJ_DEF(char*) pj_inet_ntoa(pj_in_addr inaddr)
  * numbers-and-dots notation into binary data and stores it in the structure
  * that inp points to. 
  */
-PJ_DEF(int) pj_inet_aton(const pj_str_t *cp, struct pj_in_addr *inp)
+PJ_DEF(int) pj_inet_aton(const pj_str_t *cp, pj_in_addr *inp)
 {
     enum { MAXIPLEN = PJ_INET_ADDRSTRLEN };
 

--- a/pjlib/src/pj/sock_uwp.cpp
+++ b/pjlib/src/pj/sock_uwp.cpp
@@ -933,7 +933,7 @@ PJ_DEF(char*) pj_inet_ntoa(pj_in_addr inaddr)
  * numbers-and-dots notation into binary data and stores it in the structure
  * that inp points to. 
  */
-PJ_DEF(int) pj_inet_aton(const pj_str_t *cp, struct pj_in_addr *inp)
+PJ_DEF(int) pj_inet_aton(const pj_str_t *cp, pj_in_addr *inp)
 {
     char tempaddr[PJ_INET_ADDRSTRLEN];
 

--- a/pjlib/src/pjlib-test/sock.c
+++ b/pjlib/src/pjlib-test/sock.c
@@ -162,11 +162,11 @@ static int format_test(void)
 #endif	/* PJ_HAS_IPV6 */
 
     /* Test that pj_sockaddr_in_init() initialize the whole structure, 
-     * including sin_zero.
+     * including sin_zero_pad.
      */
     pj_sockaddr_in_init(&addr2, 0, 1000);
     pj_bzero(zero, sizeof(zero));
-    if (pj_memcmp(addr2.sin_zero, zero, sizeof(addr2.sin_zero)) != 0)
+    if (pj_memcmp(addr2.sin_zero_pad, zero, sizeof(addr2.sin_zero_pad)) != 0)
 	return -35;
 
     /* pj_gethostname() */

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -28,7 +28,7 @@
 #include <pj/string.h>
 
 
-struct user
+struct tp_user
 {
     pj_bool_t		rx_disabled;	/**< Doesn't want to receive pkt?   */
     void	       *user_data;	/**< Only valid when attached	    */
@@ -47,7 +47,7 @@ struct transport_loop
 
     pj_pool_t	       *pool;		/**< Memory pool		    */
     unsigned		user_cnt;	/**< Number of attachments	    */
-    struct user		users[4];	/**< Array of users.		    */
+    struct tp_user	users[4];	/**< Array of users.		    */
     pj_bool_t		disable_rx;	/**< Disable RX.		    */
 
     pjmedia_loop_tp_setting setting;	/**< Setting.			    */

--- a/pjnath/src/pjnath/ice_strans.c
+++ b/pjnath/src/pjnath/ice_strans.c
@@ -655,7 +655,7 @@ static pj_status_t add_stun_and_host(pj_ice_strans *ice_st,
 		    continue;
 		}
 		else if (stun_cfg->af == pj_AF_INET6()) {
-		    pj_in6_addr in6addr = {{0}};
+		    pj_in6_addr in6addr = {{{0}}};
 		    in6addr.s6_addr[15] = 1;
 		    if (pj_memcmp(&in6addr, &addr->ipv6.sin6_addr,
 				  sizeof(in6addr))==0)

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -31,6 +31,9 @@ using namespace std;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+/* Avoid conflict with predefined standard macros. */
+#undef max
+#undef min
 
 MathStat::MathStat()
 : n(0), max(0), min(0), last(0), mean(0)

--- a/pjsip/src/test/transport_test.c
+++ b/pjsip/src/test/transport_test.c
@@ -35,7 +35,7 @@ int generic_transport_test(pjsip_transport *tp)
 
     /* Check that local address name is valid. */
     {
-	struct pj_in_addr addr;
+	pj_in_addr addr;
 
 	if (pj_inet_pton(pj_AF_INET(), &tp->local_name.host,
 			 &addr) == PJ_SUCCESS)


### PR DESCRIPTION
To fix #2311. 

There's a different approach suggested in PR #2313, but it has the drawbacks of rather major API break as well as portability issue .

Thanks to @traud for suggesting this approach instead.

Tested on Windows, Mac, Ubuntu, iOS, and Android (there is a possibility this change may break PJSIP build on some other platform, though).
Passes pjlib and pjlib-util-test.

Note: minor API break: `struct pj_in_addr` no longer exists.
