### PR TITLE
Add option to enable/disable multiple telephone-event formats in generating SDP

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -864,6 +864,20 @@
 
 
 /**
+ * This macro declares whether PJMEDIA should generate multiple
+ * telephone-event formats in SDP offer, i.e: one for each audio codec
+ * clock rate (see also ticket #2088). If this macro is set to zero, only
+ * one telephone event format will be generated and it uses clock rate 8kHz
+ * (old behavior before ticket #2088).
+ *
+ * Default: 1 (yes)
+ */
+#ifndef PJMEDIA_TELEPHONE_EVENT_ALL_CLOCKRATES
+#   define PJMEDIA_TELEPHONE_EVENT_ALL_CLOCKRATES   1
+#endif
+
+
+/**
  * Maximum tones/digits that can be enqueued in the tone generator.
  */
 #ifndef PJMEDIA_TONEGEN_MAX_DIGITS

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -435,6 +435,12 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 	    PJMEDIA_RTP_PT_TELEPHONE_EVENTS != 0
     if (endpt->has_telephone_event) {
 	used_pt[used_pt_num++] = PJMEDIA_RTP_PT_TELEPHONE_EVENTS;
+
+#  if PJMEDIA_TELEPHONE_EVENT_ALL_CLOCKRATES==0
+	televent_num = 1;
+	televent_clockrates[0] = 8000;
+#  endif
+
     }
 #endif
 
@@ -587,7 +593,8 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 
 	/* List clock rate of audio codecs for generating telephone-event */
 #if defined(PJMEDIA_RTP_PT_TELEPHONE_EVENTS) && \
-	    PJMEDIA_RTP_PT_TELEPHONE_EVENTS != 0
+	    PJMEDIA_RTP_PT_TELEPHONE_EVENTS != 0 && \
+	    PJMEDIA_TELEPHONE_EVENT_ALL_CLOCKRATES != 0
 	if (endpt->has_telephone_event) {
 	    unsigned j;
 


### PR DESCRIPTION
Since #2088, PJMEDIA will always generate multiple telephone-event formats based on supported audio codecs, however some applications prefer old behavior and currently there is no option to do that. This PR adds macro setting `PJMEDIA_TELEPHONE_EVENT_ALL_CLOCKRATES`, app can set it to 0 disable #2088.