### PR TITLE
Possible leak tdata when receiving 200 OK response after the invite session is destroyed.

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -503,6 +503,10 @@ static pj_status_t inv_send_ack(pjsip_inv_session *inv, pjsip_event *e)
     if (inv->state < PJSIP_INV_STATE_CONFIRMED) {
 	inv_set_state(inv, PJSIP_INV_STATE_CONFIRMED, &ack_e);
     } else if (inv->state == PJSIP_INV_STATE_DISCONNECTED) {
+        /* Avoid possible leaked tdata when invite session is already
+         * destroyed.
+         * https://github.com/pjsip/pjproject/pull/2432
+         */
         pjsip_tx_data_dec_ref(inv->last_ack);
         inv->last_ack = NULL;
     }

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -502,6 +502,9 @@ static pj_status_t inv_send_ack(pjsip_inv_session *inv, pjsip_event *e)
      */
     if (inv->state < PJSIP_INV_STATE_CONFIRMED) {
 	inv_set_state(inv, PJSIP_INV_STATE_CONFIRMED, &ack_e);
+    } else if (inv->state == PJSIP_INV_STATE_DISCONNECTED) {
+        pjsip_tx_data_dec_ref(inv->last_ack);
+        inv->last_ack = NULL;
     }
 
     return PJ_SUCCESS;

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -502,7 +502,7 @@ static pj_status_t inv_send_ack(pjsip_inv_session *inv, pjsip_event *e)
      */
     if (inv->state < PJSIP_INV_STATE_CONFIRMED) {
 	inv_set_state(inv, PJSIP_INV_STATE_CONFIRMED, &ack_e);
-    } else if (inv->state == PJSIP_INV_STATE_DISCONNECTED) {
+    } else if (inv->state == PJSIP_INV_STATE_DISCONNECTED && inv->last_ack) {
         /* Avoid possible leaked tdata when invite session is already
          * destroyed.
          * https://github.com/pjsip/pjproject/pull/2432

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -778,6 +778,9 @@ static void tcp_flush_pending_tx(struct tcp_transport *tcp)
         if (pending_tx->timeout.sec > 0 &&
             PJ_TIME_VAL_GT(now, pending_tx->timeout))
         {
+            pj_lock_release(tcp->base.lock);
+	    on_data_sent(tcp->asock, op_key, -PJ_ETIMEDOUT);
+            pj_lock_acquire(tcp->base.lock);
             continue;
         }
 

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -946,6 +946,9 @@ static void tls_flush_pending_tx(struct tls_transport *tls)
         if (pending_tx->timeout.sec > 0 &&
             PJ_TIME_VAL_GT(now, pending_tx->timeout))
         {
+            pj_lock_release(tls->base.lock);
+	    on_data_sent(tls->ssock, op_key, -PJ_ETIMEDOUT);
+            pj_lock_acquire(tls->base.lock);
             continue;
         }
 


### PR DESCRIPTION
Consider this scenario:
```
-------> INVITE [1]
<------  200 OK INVITE [2]
-------> ACK [3]
-------> BYE [4]
<------  200 OK BYE [5]
<------  200 OK INVITE [6]
-------> ACK [7]
Dialog destroyed [8]
```
On normal condition, tdata created to send ACK [3] will be released when INVITE session was destroyed [5]. 
However If a 200 OK INVITE response was received [6] before dialog is destroyed, then the tdata created to send ACK [7] will not be released. 