### PR TITLE
Call in early state gets disconnected on IP change

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1019,6 +1019,17 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #   define PJSIP_TSX_1XX_RETRANS_DELAY	60
 #endif
 
+/**
+ * Terminate INVITE transaction when TCP/TLS transport is disconnected.
+ * This setting does not apply for disconnection during sending. For initial
+ * INVITE, terminating the transaction will cause call to be disconnected.
+ *
+ * Default: 1 (yes)
+ */
+#ifndef PJSIP_STOP_INVITE_TSX_ON_TP_DOWN
+#   define PJSIP_STOP_INVITE_TSX_ON_TP_DOWN	1
+#endif
+
 #define PJSIP_MAX_TSX_KEY_LEN		(PJSIP_MAX_URL_SIZE*2)
 
 /* User agent. */

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -1141,8 +1141,9 @@ static void tsx_timer_callback( pj_timer_heap_t *theap, pj_timer_entry *entry)
 	    {
 		/* Transport disconnected (while idle/not-sending) */
 		stop_tsx = PJ_FALSE;
-		PJ_LOG(5,(tsx->obj_name, "Transport error",
-			 (entry==&tsx->retransmit_timer ? "Retransmit":"Timeout")));
+		PJ_LOG(5,(tsx->obj_name,
+		          "INVITE transaction configured to not be terminated"
+			  " on transport disconnected event"));
 	    }
 
 	    pj_grp_lock_acquire(tsx->grp_lock);

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -1117,6 +1117,7 @@ static pj_status_t tsx_shutdown( pjsip_transaction *tsx )
 static void tsx_timer_callback( pj_timer_heap_t *theap, pj_timer_entry *entry)
 {
     pjsip_transaction *tsx = (pjsip_transaction*) entry->user_data;
+    int entry_id = entry->id;
 
     PJ_UNUSED_ARG(theap);
 
@@ -1125,8 +1126,8 @@ static void tsx_timer_callback( pj_timer_heap_t *theap, pj_timer_entry *entry)
         return;
     }
 
-    if (entry->id == TRANSPORT_ERR_TIMER ||
-	entry->id == TRANSPORT_DOWN_TIMER)
+    if (entry_id == TRANSPORT_ERR_TIMER ||
+	entry_id == TRANSPORT_DOWN_TIMER)
     {
 	/* Posted transport error event */
 	entry->id = 0;
@@ -1137,7 +1138,7 @@ static void tsx_timer_callback( pj_timer_heap_t *theap, pj_timer_entry *entry)
 
 	    if (PJSIP_STOP_INVITE_TSX_ON_TP_DOWN==0 &&
 		tsx->method.id==PJSIP_INVITE_METHOD &&
-		entry->id == TRANSPORT_DOWN_TIMER)
+		entry_id == TRANSPORT_DOWN_TIMER)
 	    {
 		/* Transport disconnected (while idle/not-sending) */
 		stop_tsx = PJ_FALSE;


### PR DESCRIPTION
Add configurable setting for INVITE transaction to terminate or maintain the transaction on transport down (such as in IP change scenario). Currently a transport failure (either error or down) will terminate all transactions using that transport. And when the transaction is terminated, the INVITE session will be terminated too. While some applications prefer to be able to leave the call remaining active.

Caveat:
Some servers such as Kamailio, FreeSwitch may still try to route the response via the old/down transport instead of the new one (used by re-REGISTER).