### PR TITLE
Call on_call_media_event() callback asynchronously to avoid deadlock

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -443,6 +443,7 @@ struct pjsua_data
     /* Control: */
     pj_caching_pool	 cp;	    /**< Global pool factory.		*/
     pj_pool_t		*pool;	    /**< pjsua's private pool.		*/
+    pj_pool_t		*timer_pool;/**< pjsua's timer pool.		*/
     pj_mutex_t		*mutex;	    /**< Mutex protection for this data	*/
     unsigned		 mutex_nesting_level; /**< Mutex nesting level.	*/
     pj_thread_t		*mutex_owner; /**< Mutex owner.			*/

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -425,6 +425,15 @@ typedef struct pjsua_timer_list
 } pjsua_timer_list;
 
 
+typedef struct pjsua_event_list 
+{
+    PJ_DECL_LIST_MEMBER(struct pjsua_event_list);
+    pjmedia_event       event;
+    pjsua_call_id	call_id;
+    unsigned           	med_idx;
+} pjsua_event_list;
+
+
 /**
  * Global pjsua application data.
  */
@@ -536,8 +545,9 @@ struct pjsua_data
     pjsua_vid_win	 win[PJSUA_MAX_VID_WINS]; /**< Array of windows	*/
 #endif
 
-    /* Timer entry list */
+    /* Timer entry and event list */
     pjsua_timer_list	 timer_list;
+    pjsua_event_list	 event_list;
     pj_mutex_t          *timer_mutex;
 };
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -936,12 +936,13 @@ PJ_DEF(pj_status_t) pjsua_create(void)
     /* Init caching pool. */
     pj_caching_pool_init(&pjsua_var.cp, NULL, 0);
 
-    /* Create memory pool for application. */
+    /* Create memory pools for application and internal use. */
     pjsua_var.pool = pjsua_pool_create("pjsua", 1000, 1000);
-    if (pjsua_var.pool == NULL) {
+    pjsua_var.timer_pool = pjsua_pool_create("pjsua_timer", 500, 500);
+    if (pjsua_var.pool == NULL || pjsua_var.timer_pool == NULL) {
 	pj_log_pop_indent();
 	status = PJ_ENOMEM;
-	pjsua_perror(THIS_FILE, "Unable to create pjsua pool", status);
+	pjsua_perror(THIS_FILE, "Unable to create pjsua/timer pool", status);
 	pj_shutdown();
 	return status;
     }
@@ -2042,7 +2043,11 @@ PJ_DEF(pj_status_t) pjsua_destroy2(unsigned flags)
         pjsua_var.timer_mutex = NULL;
     }
 
-    /* Destroy pool and pool factory. */
+    /* Destroy pools and pool factory. */
+    if (pjsua_var.timer_pool) {
+	pj_pool_release(pjsua_var.timer_pool);
+	pjsua_var.timer_pool = NULL;
+    }
     if (pjsua_var.pool) {
 	pj_pool_release(pjsua_var.pool);
 	pjsua_var.pool = NULL;
@@ -3332,7 +3337,7 @@ PJ_DEF(pj_status_t) pjsua_schedule_timer2( void (*cb)(void *user_data),
     pj_mutex_lock(pjsua_var.timer_mutex);
 
     if (pj_list_empty(&pjsua_var.timer_list)) {
-        tmr = PJ_POOL_ALLOC_T(pjsua_var.pool, pjsua_timer_list);
+        tmr = PJ_POOL_ALLOC_T(pjsua_var.timer_pool, pjsua_timer_list);
     } else {
         tmr = pjsua_var.timer_list.next;
         pj_list_erase(tmr);

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -969,8 +969,9 @@ PJ_DEF(pj_status_t) pjsua_create(void)
 	return status;
     }
 
-    /* Init timer entry list */
+    /* Init timer entry and event list */
     pj_list_init(&pjsua_var.timer_list);
+    pj_list_init(&pjsua_var.event_list);
 
     /* Create timer mutex */
     status = pj_mutex_create_recursive(pjsua_var.pool, "pjsua_timer", 

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1513,6 +1513,20 @@ pj_status_t on_media_event(pjmedia_event *event, void *user_data)
     return status;
 }
 
+/* Call on_call_media_event() callback using timer */
+void call_med_event_cb(void *user_data)
+{
+    pjsua_event_list *eve = (pjsua_event_list *)user_data;
+    
+    (*pjsua_var.ua_cfg.cb.on_call_media_event)(eve->call_id,
+					       eve->med_idx,
+					       &eve->event);
+
+    pj_mutex_lock(pjsua_var.timer_mutex);
+    pj_list_push_back(&pjsua_var.event_list, eve);
+    pj_mutex_unlock(pjsua_var.timer_mutex);
+}
+
 /* Callback to receive media events of a call */
 pj_status_t call_media_on_event(pjmedia_event *event,
                                 void *user_data)
@@ -1624,14 +1638,27 @@ pj_status_t call_media_on_event(pjmedia_event *event,
     }
 
     if (pjsua_var.ua_cfg.cb.on_call_media_event) {
-	if (call) {
-	    (*pjsua_var.ua_cfg.cb.on_call_media_event)(call->index,
-						       call_med->idx, event);
-	} else {
+	pjsua_event_list *eve = NULL;
+ 
+    	pj_mutex_lock(pjsua_var.timer_mutex);
+
+    	if (pj_list_empty(&pjsua_var.event_list)) {
+            eve = PJ_POOL_ALLOC_T(pjsua_var.pool, pjsua_event_list);
+    	} else {
+            eve = pjsua_var.event_list.next;
+            pj_list_erase(eve);
+    	}
+    	
+    	if (call) {
+    	    eve->call_id = call->index;
+    	    eve->med_idx = call_med->idx;
+    	} else {
 	    /* Also deliver non call events such as audio device error */
-	    (*pjsua_var.ua_cfg.cb.on_call_media_event)(PJSUA_INVALID_ID,
-						       0, event);
-	}
+    	    eve->call_id = PJSUA_INVALID_ID;
+    	    eve->med_idx = 0;
+    	}
+    	pj_memcpy(&eve->event, event, sizeof(pjmedia_event));
+    	pjsua_schedule_timer2(&call_med_event_cb, eve, 1);
     }
 
     return status;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1514,7 +1514,7 @@ pj_status_t on_media_event(pjmedia_event *event, void *user_data)
 }
 
 /* Call on_call_media_event() callback using timer */
-void call_med_event_cb(void *user_data)
+static void call_med_event_cb(void *user_data)
 {
     pjsua_event_list *eve = (pjsua_event_list *)user_data;
     

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1643,7 +1643,7 @@ pj_status_t call_media_on_event(pjmedia_event *event,
     	pj_mutex_lock(pjsua_var.timer_mutex);
 
     	if (pj_list_empty(&pjsua_var.event_list)) {
-            eve = PJ_POOL_ALLOC_T(pjsua_var.pool, pjsua_event_list);
+            eve = PJ_POOL_ALLOC_T(pjsua_var.timer_pool, pjsua_event_list);
     	} else {
             eve = pjsua_var.event_list.next;
             pj_list_erase(eve);

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1648,6 +1648,8 @@ pj_status_t call_media_on_event(pjmedia_event *event,
             eve = pjsua_var.event_list.next;
             pj_list_erase(eve);
     	}
+
+    	pj_mutex_unlock(pjsua_var.timer_mutex);
     	
     	if (call) {
     	    eve->call_id = call->index;


### PR DESCRIPTION
This is to prevent issues such as #2414 and #2440 .
