### PR TITLE
Add callbacks to receive RTP DTMF events

### DIFF
--- a/pjmedia/include/pjmedia/rtp.h
+++ b/pjmedia/include/pjmedia/rtp.h
@@ -155,6 +155,20 @@ struct pjmedia_rtp_dtmf_event
 };
 
 /**
+ * Mask for the E ("End") bit of telephony-events payload.
+ *
+ * @see pjmedia_rtp_dtmf_event
+ */
+#define PJMEDIA_RTP_DTMF_EVENT_END_MASK     0x80
+
+/**
+ * Mask for the Volume field of telephony-events payload.
+ *
+ * @see pjmedia_rtp_dtmf_event
+ */
+#define PJMEDIA_RTP_DTMF_EVENT_VOLUME_MASK  0x3F
+
+/**
  * @see pjmedia_rtp_dtmf_event
  */
 typedef struct pjmedia_rtp_dtmf_event pjmedia_rtp_dtmf_event;

--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -149,6 +149,37 @@ typedef struct pjmedia_stream_info
                                          SDES and BYE.                      */
 } pjmedia_stream_info;
 
+/**
+ * This enumeration defines flags used by #pjmedia_stream_dtmf_event.
+ */
+typedef enum pjmedia_stream_dtmf_event_flags {
+    /**
+     * The event was already indicated earlier. The new indication contains an
+     * updated event duration.
+     */
+    PJMEDIA_STREAM_DTMF_IS_UPDATE = (1 << 0),
+
+    /**
+     * The event has ended and the indication contains the final event
+     * duration.
+     * Note that end indications might get lost. Hence it is not guaranteed
+     * to receive an event with PJMEDIA_STREAM_DTMF_IS_END for every event.
+     */
+    PJMEDIA_STREAM_DTMF_IS_END = (1 << 1),
+} pjmedia_stream_dtmf_event_flags;
+
+/**
+ * This structure describes DTMF telephony-events indicated through
+ * #pjmedia_stream_set_dtmf_event_callback().
+ */
+typedef struct pjmedia_stream_dtmf_event {
+    int                 digit;      /**< DTMF digit as ASCII character.     */
+    pj_uint32_t         timestamp;  /**< RTP timestamp of the event.        */
+    pj_uint16_t         duration;   /**< Event duration, in milliseconds.   */
+    pj_uint16_t         flags;      /**< Event flags (see
+                                         #pjmedia_stream_dtmf_event_flags). */
+} pjmedia_stream_dtmf_event;
+
 
 /**
  * This function will initialize the stream info based on information
@@ -401,6 +432,8 @@ PJ_DECL(pj_status_t) pjmedia_stream_get_dtmf( pjmedia_stream *stream,
  * Set callback to be called upon receiving DTMF digits. If callback is
  * registered, the stream will not buffer incoming DTMF but rather call
  * the callback as soon as DTMF digit is received completely.
+ * This callback will not be called if another callback is set via
+ * #pjmedia_stream_set_dtmf_event_callback() as well.
  *
  * @param stream	The media stream.
  * @param cb		Callback to be called upon receiving DTMF digits.
@@ -417,6 +450,26 @@ pjmedia_stream_set_dtmf_callback(pjmedia_stream *stream,
 					    void *user_data, 
 					    int digit), 
 				 void *user_data);
+
+/**
+ * Set callback to be called upon receiving DTMF digits. If callback is
+ * registered, the stream will not buffer incoming DTMF but rather call
+ * the callback as soon as DTMF digit is received.
+ *
+ * @param stream	The media stream.
+ * @param cb		Callback to be called upon receiving DTMF digits.
+ *			See #pjmedia_stream_dtmf_event.
+ * @param user_data	User data to be returned back when the callback
+ *			is called.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_set_dtmf_event_callback(pjmedia_stream *stream,
+                                       void (*cb)(pjmedia_stream*,
+                                                  void *user_data,
+                                                  const pjmedia_stream_dtmf_event *event),
+                                       void *user_data);
 
 
 /**

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -739,10 +739,60 @@ struct OnDtmfDigitParam
     string		digit;
 
     /**
-     * DTMF signal duration which might be included when sending DTMF using 
-     * SIP INFO.
+     * DTMF signal duration. If the duration is unknown, this value is set to
+     * PJSUA_UNKNOWN_DTMF_DURATION.
      */
     unsigned		duration;
+};
+
+/**
+ * This structure contains parameters for Call::onDtmfEvent()
+ * callback.
+ */
+struct OnDtmfEventParam
+{
+    /**
+     * DTMF sending method.
+     */
+    pjsua_dtmf_method   method;
+
+    /**
+     * The timestamp identifying the begin of the event. Timestamp units are
+     * expressed in milliseconds.
+     * Note that this value should only be used to compare multiple events
+     * received via the same method relatively to each other, as the time-base
+     * is randomized.
+     */
+    unsigned            timestamp;
+
+    /**
+     * DTMF ASCII digit.
+     */
+    string              digit;
+
+    /**
+     * DTMF signal duration in milliseconds. Interpretation of the duration
+     * depends on the flag PJMEDIA_STREAM_DTMF_IS_END.
+     * depends on the method.
+     * If the method is PJSUA_DTMF_METHOD_SIP_INFO, this contains the total
+     * duration of the DTMF signal or PJSUA_UNKNOWN_DTMF_DURATION if no signal
+     * duration was indicated.
+     * If the method is PJSUA_DTMF_METHOD_RFC2833, this contains the total
+     * duration of the DTMF signal received up to this point in time.
+     */
+    unsigned            duration;
+
+    /**
+     * Flags indicating additional information about the DTMF event.
+     * If PJMEDIA_STREAM_DTMF_IS_UPDATE is set, the event was already
+     * indicated earlier. The new indication contains an updated event
+     * duration.
+     * If PJMEDIA_STREAM_DTMF_IS_END is set, the event has ended and this
+     * indication contains the final event duration. Note that end
+     * indications might get lost. Hence it is not guaranteed to receive
+     * an event with PJMEDIA_STREAM_DTMF_IS_END for every event.
+     */
+    unsigned            flags;
 };
 
 /**
@@ -1737,7 +1787,15 @@ public:
      */
     virtual void onDtmfDigit(OnDtmfDigitParam &prm)
     { PJ_UNUSED_ARG(prm); }
-    
+
+    /**
+     * Notify application upon incoming DTMF events.
+     *
+     * @param prm	Callback parameter.
+     */
+    virtual void onDtmfEvent(OnDtmfEventParam &prm)
+    { PJ_UNUSED_ARG(prm); }
+
     /**
      * Notify application on call being transferred (i.e. REFER is received).
      * Application can decide to accept/reject transfer request by setting

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1795,6 +1795,8 @@ private:
     static void on_dtmf_digit(pjsua_call_id call_id, int digit);
     static void on_dtmf_digit2(pjsua_call_id call_id, 
 			       const pjsua_dtmf_info *info);
+    static void on_dtmf_event(pjsua_call_id call_id,
+                              const pjsua_dtmf_event *event);
     static void on_call_transfer_request(pjsua_call_id call_id,
                                          const pj_str_t *dst,
                                          pjsip_status_code *code);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5589,7 +5589,9 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 	    pj_status_t status;
 	    pj_bool_t is_handled = PJ_FALSE;
 
-	    if (pjsua_var.ua_cfg.cb.on_dtmf_digit2) {
+	    if (pjsua_var.ua_cfg.cb.on_dtmf_digit2 ||
+                pjsua_var.ua_cfg.cb.on_dtmf_event)
+            {
 		pjsua_dtmf_info info;
 		pj_str_t delim, token, input;
 		pj_ssize_t found_idx;
@@ -5641,6 +5643,7 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 			        val_str.slen = input.slen - (p - input.ptr);
 			        info.duration = pj_strtoul(&val_str);
 			    } else {
+                                info.duration = PJSUA_UNKNOWN_DTMF_DURATION;
 				is_handled = PJ_FALSE;
 				PJ_LOG(2, (THIS_FILE, "Invalid dtmf-relay format"));
 			    }
@@ -5648,8 +5651,29 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 
 			if (is_handled) {
 			    info.method = PJSUA_DTMF_METHOD_SIP_INFO;
-			    (*pjsua_var.ua_cfg.cb.on_dtmf_digit2)(call->index,
-				&info);
+                            if (pjsua_var.ua_cfg.cb.on_dtmf_event) {
+		                pjsua_dtmf_event evt;
+                                pj_timestamp begin_of_time, timestamp;
+                                /* Use the current instant as the events start
+                                 * time.
+                                 */
+                                begin_of_time.u64 = 0;
+                                pj_get_timestamp(&timestamp);
+                                evt.method = info.method;
+                                evt.timestamp = pj_elapsed_msec(&begin_of_time,
+                                                                &timestamp);
+                                evt.digit = info.digit;
+                                evt.duration = info.duration;
+                                /* There is only one message indicating the full
+                                 * duration of the digit.
+                                 */
+                                evt.flags = PJMEDIA_STREAM_DTMF_IS_END;
+                                (*pjsua_var.ua_cfg.cb.on_dtmf_event)(call->index,
+                                                                     &evt);
+                            } else {
+			        (*pjsua_var.ua_cfg.cb.on_dtmf_digit2)(call->index,
+							              &info);
+                            }
 
 			    status = pjsip_endpt_create_response(tsx->endpt, rdata,
 				200, NULL, &tdata);


### PR DESCRIPTION
First attempt at implementing #2436.

## Goal

Enable the application to determine the actual duration of an DTMF event in real-time.

I'm not completely happy with the abstraction provided but that was the best I could come up with, without violating the design constraints:
- It is obviously not possible to indicate the correct event duration right away, since it is not known.
- Buffering the event until the full duration is known and only then indicating the event is not feasible since it can cause huge delays - especially for longer DTMF digits.
- Fully managing the events in pjmedia is surprisingly hard and error-prone:
  When does an event end? RTP packets indicating the end of an event might be dropped. Using just a naive timer to bail out if no "end" packet is received can easily lead to false-positives, if event packets extending the event are dropped.
  The current approach leaves these decisions to the application.

## Overview

RTP events are basically just forwarded to the application using a new callback. Minimal state information is tracked by pjmedia and indicated to the application using flags:
- Is this an update? Events are considered an update, if the event has been indicated previously and this is just an update to the duration.
- Is this the end of the event? This information is directly derived from the "E" flag of the RTP payload. Packets with the "E" flag are typically sent multiple times to counter packet loss. Only the first packet with the "E" flag set results in an event indication, duplicates are absorbed by pjmedia.

## Changes

- pjmedia:
  - Added `struct pjmedia_stream_dtmf_event` for holding DTMF event information.
  - Added `pjmedia_stream_set_dtmf_event_callback()` for registering a callback to receive DTMF event information.
  - Modified `handle_incoming_dtmf()` to invoke callback registered by `pjmedia_stream_set_dtmf_event_callback()`. If it was not registered, there is no change in behavior and the old callback is invoked.
- pjsua-lib:
  - Added macro `PJSUA_UNKNOWN_DTMF_DURATION` to indicate that an event's duration is unknown.
  - Added `struct pjsua_dtmf_event` for holding DTMF event information (basically an extension of `pjsua_dtmf_info`).
  - Added callback `on_dtmf_event()` to `struct pjsua_callback`.
  - Modified `pjsua_aud_channel_update()` to register DTMF callback using `pjmedia_stream_set_dtmf_event_callback()` instead of `pjmedia_stream_set_dtmf_callback()` if callback `on_dtmf_event()` is set.
  - DTMF digits received via SIP INFO are passed to `on_dtmf_event()` as well (if set).
- pjsua2-lib
  - Add `pj::Call::onDtmfEvent` and `struct OnDtmfEventParam`.

_Edit: Changed the names of various identifiers as discussed below._