### PR TITLE
Check current inv state before decreasing ref count

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -323,9 +323,19 @@ static void inv_set_state(pjsip_inv_session *inv, pjsip_inv_state state,
 	(*mod_inv.cb.on_state_changed)(inv, e);
     pjsip_inv_dec_ref(inv);
 
-    /* Only decrement when previous state is not already DISCONNECTED */
+    /* The above callback may change the state, so we need to be careful here
+     * and only decrement inv under the following conditions:
+     * 1. If the state parameter is DISCONNECTED, and previous state is not
+     *    already DISCONNECTED.
+     *    This is to make sure that dec_ref() is not called more than once.
+     * 2. If current state is PJSIP_INV_STATE_DISCONNECTED.
+     *    This is to make sure that dec_ref() is not called if user restarts
+     *    inv within the callback. Note that this check must be last since
+     *    inv may have already been destroyed.
+     */
     if (state == PJSIP_INV_STATE_DISCONNECTED &&
-	prev_state != PJSIP_INV_STATE_DISCONNECTED) 
+	prev_state != PJSIP_INV_STATE_DISCONNECTED &&
+	inv->state == PJSIP_INV_STATE_DISCONNECTED) 
     {
 	pjsip_inv_dec_ref(inv);
     }


### PR DESCRIPTION
Fixed #2443 .

The change in https://github.com/pjsip/pjproject/commit/d5a9caf6aac077c157fa6b20c770385c2355973d replaces: 
`if (inv->state == PJSIP_INV_STATE_DISCONNECTED`
with 
`if (state == PJSIP_INV_STATE_DISCONNECTED`
to prevent double destruction.

However, if sip inv is restarted inside the `on_state_changed()` callback, it will cause the invite session to still be destroyed.

So, we need to check both, the state parameter and the current invite state to be DISCONNECTED, in order to make sure we can handle both cases (double destroy and inv restart). Note that the checking of invite state needs to be last since the invite session can already be destroyed inside the callback.

