### PR TITLE
Modify timer_id check on cancel()

### DIFF
--- a/pjlib/include/pj/timer.h
+++ b/pjlib/include/pj/timer.h
@@ -120,7 +120,10 @@ typedef struct pj_timer_entry
 
     /** 
      * Internal unique timer ID, which is assigned by the timer heap. 
-     * Application should not touch this ID.
+     * Positive values indicate that the timer entry is running, 
+     * while -1 means that it's not. Any other value may indicate that it 
+     * hasn't been properly initialised or is in a bad state.
+     * Application should not touch this ID. 
      */
     pj_timer_id_t _timer_id;
 

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -535,7 +535,7 @@ static int cancel( pj_timer_heap_t *ht,
     PJ_CHECK_STACK();
 
     // Check to see if the timer_id is out of range
-    if (entry->_timer_id < 1 || (pj_size_t)entry->_timer_id > ht->max_size) {
+    if (entry->_timer_id < 1 || (pj_size_t)entry->_timer_id >= ht->max_size) {
 	entry->_timer_id = -1;
     	return 0;
     }

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -535,7 +535,7 @@ static int cancel( pj_timer_heap_t *ht,
     PJ_CHECK_STACK();
 
     // Check to see if the timer_id is out of range
-    if (entry->_timer_id < 0 || (pj_size_t)entry->_timer_id > ht->max_size) {
+    if (entry->_timer_id < 1 || (pj_size_t)entry->_timer_id > ht->max_size) {
 	entry->_timer_id = -1;
     	return 0;
     }


### PR DESCRIPTION
The `_timer_id` field of `pj_timer_entry` is used to point to the entry on the timer heap. 
The value is determine by a freelist table and shouldn't be set by app thus the valid value should be > 0. On cancel() the `_timer_id` is considered valid if it is >=0. If the entry pas this check (`_timer_id == 0`), then this will affect up the next freelist index. 
```
static void push_freelist (pj_timer_heap_t *ht, pj_timer_id_t old_id)
{
    PJ_CHECK_STACK();
    // The freelist values in the <timer_ids_> are negative, so we need
    // to negate them to get the next freelist "pointer."
    ht->timer_ids[old_id] = -ht->timer_ids_freelist;
    ht->timer_ids_freelist = old_id;
}
```
The next entry to be scheduled will potentially have an invalid `_timer_id`.