### PR TITLE
Race condition between transport destroy and acquire

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2411,7 +2411,7 @@ static void tsx_update_transport( pjsip_transaction *tsx,
 	pjsip_transport_add_ref(tp);
 	pjsip_transport_add_state_listener(tp, &tsx_tp_state_callback, tsx,
 					    &tsx->tp_st_key);
-        if (tp->is_shutdown) {
+	if (tp->is_shutdown || tp->is_destroying) {
 	    pjsip_transport_state_info info;
 
 	    pj_bzero(&info, sizeof(info));

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1401,8 +1401,8 @@ PJ_DEF(pj_status_t) pjsip_transport_shutdown2(pjsip_transport *tp,
     mgr = tp->tpmgr;
     pj_lock_acquire(mgr->lock);
 
-    /* Do nothing if transport is being shutdown already */
-    if (tp->is_shutdown) {
+    /* Do nothing if transport is being shutdown/destroyed already */
+    if (tp->is_shutdown || tp->is_destroying) {
 	pj_lock_release(mgr->lock);
 	pj_lock_release(tp->lock);
 	return PJ_SUCCESS;
@@ -2642,7 +2642,7 @@ PJ_DEF(pj_status_t) pjsip_transport_add_state_listener (
 
     PJ_ASSERT_RETURN(tp && cb && key, PJ_EINVAL);
 
-    if (tp->is_shutdown) {
+    if (tp->is_shutdown || tp->is_destroying) {
 	*key = NULL;
 	return PJ_EINVALIDOP;
     }


### PR DESCRIPTION
The race is between `transport_idle_callback()` and `pjsip_tpmgr_acquire_transport2()`:
- when `destroy` locks the transport manager mutex first, things seems to be okay, transport will never be acquired.
- when `acquire` locks the transport manager mutex first (and the transport is acquired successfully), but `destroy` will keep on going (as it does not re-check the transport ref count), this is the problem.

So the solution should be about:
- `transport_idle_callback()` must stop the `destroy` if the transport is re-acquired (i.e: transport `ref_cnt` is not zero).
- `pjsip_tpmgr_acquire_transport2()` must not return a transport that is being destroyed.

See also discussions in #2430.