### PR TITLE
Fix sip transaction to send pending message

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -732,7 +732,11 @@ PJ_DEF(pj_status_t) pjsip_tx_data_clone(const pjsip_tx_data *src,
     if (src->msg->body)
 	msg->body = pjsip_msg_body_clone(dst->pool, src->msg->body);
 
-    dst->is_pending = src->is_pending;
+    /* We shouldn't copy is_pending since it's src's internal state,
+     * indicating that it's currently being sent by the transport.
+     * While the cloned tdata is of course not.
+     */
+    //dst->is_pending = src->is_pending;
 
     PJ_LOG(5,(THIS_FILE,
 	     "Tx data %s cloned",


### PR DESCRIPTION
Example scenario:
1. RX Invite
2. 100 initial answer
3. Answer with 200 while 2 is still pending.
4. After 100 completed, the 200/OK never got sent and the call just stalled.

After investigation, there are two identified problems:
* There is no mechanism to send any pending message in transport_callback(), unlike in send_msg_callback().
* In sip invite, pjsip_inv_answer() will call pjsip_tx_data_clone() of the last response. If the last response is still pending, the resulting cloned tdata will also be marked pending, which will never get cleared since it's not actually being sent (The discussion to clone field is_pending can be found in our internal discussion for [CR issue 38787003](https://cr.teluu.com/38787003/#msg15)). As a result, tsx_send_msg() will always fail with `"Unable to send %s: message is pending".` 
