### PR TITLE
Fix bugs in pjsip_inv_answer()

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2424,6 +2424,7 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
 					pjsip_tx_data **p_tdata )
 {
     pjsip_tx_data *last_res;
+    pjsip_tx_data *old_res;
     pj_status_t status;
 
     /* Verify arguments. */
@@ -2474,8 +2475,11 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
     cleanup_allow_sup_hdr(inv->options, last_res, NULL, NULL);
 
     /* Update last_answer */
-    pjsip_tx_data_dec_ref(inv->last_answer);
+    old_res = inv->last_answer;
     inv->last_answer = last_res;
+
+    /* Release old answer */
+    pjsip_tx_data_dec_ref(old_res);
 
     *p_tdata = last_res;
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2424,7 +2424,6 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
 					pjsip_tx_data **p_tdata )
 {
     pjsip_tx_data *last_res;
-    pjsip_tx_data *old_res;
     pj_status_t status;
 
     /* Verify arguments. */
@@ -2448,14 +2447,13 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
     status = pjsip_tx_data_clone(inv->last_answer, 0, &last_res);
     if (status != PJ_SUCCESS)
 	goto on_return;
-    old_res = inv->last_answer;
-    inv->last_answer = last_res;
-    pjsip_tx_data_dec_ref(old_res);
 
     /* Modify last response. */
     status = pjsip_dlg_modify_response(inv->dlg, last_res, st_code, st_text);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+	pjsip_tx_data_dec_ref(last_res);
 	goto on_return;
+    }
 
     /* For non-2xx final response, strip message body */
     if (st_code >= 300) {
@@ -2474,6 +2472,10 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
 
     /* Cleanup Allow & Supported headers from disabled extensions */
     cleanup_allow_sup_hdr(inv->options, last_res, NULL, NULL);
+
+    /* Update last_answer */
+    pjsip_tx_data_dec_ref(inv->last_answer);
+    inv->last_answer = last_res;
 
     *p_tdata = last_res;
 


### PR DESCRIPTION
Fixed bugs:
- `inv->last_answer` is updated too early, if the function fails normally `inv->last_answer` should not be updated.
- `last_res` is not released when `pjsip_dlg_modify_response()` fails.