### PR TITLE
Stereo port fix

### DIFF
--- a/pjmedia/include/pjmedia/stereo.h
+++ b/pjmedia/include/pjmedia/stereo.h
@@ -93,6 +93,7 @@ PJ_INLINE(pj_status_t) pjmedia_convert_channel_nto1(pj_int16_t mono[],
 	    for(j = 0; j < channel_count; ++j)
 		tmp += multi[i+j];
 
+	    tmp = tmp / (int)channel_count;
 	    if (tmp > 32767) tmp = 32767;
 	    else if (tmp < -32768) tmp = -32768;
 	    *mono = (pj_int16_t) tmp;

--- a/pjmedia/include/pjmedia/stereo.h
+++ b/pjmedia/include/pjmedia/stereo.h
@@ -129,7 +129,6 @@ PJ_INLINE(pj_status_t) pjmedia_convert_channel_1ton(pj_int16_t multi[],
 
     PJ_ASSERT_RETURN(mono && multi && channel_count && samples_per_frame, 
 		     PJ_EINVAL);
-    PJ_ASSERT_RETURN(options == 0, PJ_EINVAL);
 
     PJ_UNUSED_ARG(options);
 

--- a/pjmedia/src/pjmedia/stereo_port.c
+++ b/pjmedia/src/pjmedia/stereo_port.c
@@ -183,12 +183,10 @@ static pj_status_t stereo_get_frame(pjmedia_port *this_port,
     if (status != PJ_SUCCESS)
 	return status;
 
+    // If downstream provides non PCM frames, skip conversion and return silence
+    // For example, empty ConfBridge gives PJMEDIA_FRAME_TYPE_NONE
     if (tmp_frame.type != PJMEDIA_FRAME_TYPE_AUDIO) {
-	frame->type = tmp_frame.type;
-	frame->timestamp = tmp_frame.timestamp;
-	frame->size = tmp_frame.size;
-	if (tmp_frame.size && tmp_frame.buf == sport->get_buf)
-	    pj_memcpy(frame->buf, tmp_frame.buf, tmp_frame.size);
+	pj_bzero(frame->buf, frame->size);
 	return PJ_SUCCESS;
     }
 

--- a/pjmedia/src/pjmedia/stereo_port.c
+++ b/pjmedia/src/pjmedia/stereo_port.c
@@ -196,7 +196,7 @@ static pj_status_t stereo_get_frame(pjmedia_port *this_port,
 	pjmedia_convert_channel_nto1((pj_int16_t*)frame->buf, 
 				     (const pj_int16_t*)tmp_frame.buf,
 				     dn_afd->channel_count,
-				     PJMEDIA_AFD_SPF(s_afd),
+				     PJMEDIA_AFD_SPF(dn_afd),
 				     (sport->options & PJMEDIA_STEREO_MIX), 0);
     } else {
 	pjmedia_convert_channel_1ton((pj_int16_t*)frame->buf, 


### PR DESCRIPTION
In this series of commits i try to address 4 issues.
- Impossibility to create StereoPort with options (like `PJMEDIA_STEREO_DONT_DESTROY_DN`); #2460 
- Bad sounding in Stereo to Mono conversion (half signaled, half zeroed frames in mono side)
- Unwanted signal amplification in mix algorithm (R+L instead of L+R/2)
- An app memory corruption

All of the problem are detected in setup: StereoConfBridge ==> StereoPort --> MonoSndPort --> AlsaDev
