### PR TITLE
Clone sdp in sip timer to prevent modification

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -906,7 +906,7 @@ static pj_status_t process_m_answer( pj_pool_t *pool,
  * after receiving remote answer.
  */
 static pj_status_t process_answer(pj_pool_t *pool,
-				  pjmedia_sdp_session *offer,
+				  pjmedia_sdp_session *local_offer,
 				  pjmedia_sdp_session *answer,
 				  pj_bool_t allow_asym,
 				  pjmedia_sdp_session **p_active)
@@ -914,10 +914,14 @@ static pj_status_t process_answer(pj_pool_t *pool,
     unsigned omi = 0; /* Offer media index */
     unsigned ami = 0; /* Answer media index */
     pj_bool_t has_active = PJ_FALSE;
+    pjmedia_sdp_session *offer;
     pj_status_t status;
 
     /* Check arguments. */
-    PJ_ASSERT_RETURN(pool && offer && answer && p_active, PJ_EINVAL);
+    PJ_ASSERT_RETURN(pool && local_offer && answer && p_active, PJ_EINVAL);
+
+    /* Duplicate local offer SDP. */
+    offer = pjmedia_sdp_session_clone(pool, local_offer);
 
     /* Check that media count match between offer and answer */
     // Ticket #527, different media count is allowed for more interoperability,

--- a/pjsip/src/pjsip-ua/sip_timer.c
+++ b/pjsip/src/pjsip-ua/sip_timer.c
@@ -411,10 +411,8 @@ static void timer_cb(pj_timer_heap_t *timer_heap, struct pj_timer_entry *entry)
 	    if (status == PJ_SUCCESS)
 		status = pjmedia_sdp_neg_get_neg_local(inv->neg, &offer);
 	    if (status == PJ_SUCCESS) {
-	        pjmedia_sdp_session *sdp_copy;
-		
-		sdp_copy = pjmedia_sdp_session_clone(tdata->pool, offer);
-		status = pjsip_create_sdp_body(tdata->pool, sdp_copy, &body);
+		status = pjsip_create_sdp_body(tdata->pool, 
+					(pjmedia_sdp_session*)offer, &body);
 		tdata->msg->body = body;
 	    }
 	}

--- a/pjsip/src/pjsip-ua/sip_timer.c
+++ b/pjsip/src/pjsip-ua/sip_timer.c
@@ -411,8 +411,10 @@ static void timer_cb(pj_timer_heap_t *timer_heap, struct pj_timer_entry *entry)
 	    if (status == PJ_SUCCESS)
 		status = pjmedia_sdp_neg_get_neg_local(inv->neg, &offer);
 	    if (status == PJ_SUCCESS) {
-		status = pjsip_create_sdp_body(tdata->pool, 
-					(pjmedia_sdp_session*)offer, &body);
+	        pjmedia_sdp_session *sdp_copy;
+		
+		sdp_copy = pjmedia_sdp_session_clone(tdata->pool, offer);
+		status = pjsip_create_sdp_body(tdata->pool, sdp_copy, &body);
 		tdata->msg->body = body;
 	    }
 	}


### PR DESCRIPTION
Fixed #2475.

The patch in this PR is proposed by the creator of the issue above, @mneuhauser.
