### PR TITLE
Fixed failed reinvite if call setting is NULL

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -639,14 +639,13 @@ static pj_status_t apply_call_setting(pjsua_call *call,
 
     if (!opt) {
 	pjsua_call_cleanup_flag(&call->opt);
-	return PJ_SUCCESS;
+    } else {
+    	call->opt = *opt;
     }
 
 #if !PJMEDIA_HAS_VIDEO
-    pj_assert(opt->vid_cnt == 0);
+    pj_assert(call->opt.vid_cnt == 0);
 #endif
-
-    call->opt = *opt;
 
     if (call->opt.flag & PJSUA_CALL_REINIT_MEDIA) {
     	pjsua_media_channel_deinit(call->index);


### PR DESCRIPTION
Fixed #2477 .

The issue occurs when calling `pjsua_call_reinvite2()` with NULL `pjsua_call_setting` parameter. In this case, `apply_call_setting()` will cleanup call setting's flag and immediately return PJ_SUCCESS without reinitialising media channel.