### PR TITLE
turn_sock: wait for destruction before erasing user_data

### DIFF
--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1401,9 +1401,6 @@ static void turn_on_state(pj_turn_session *sess,
     if (new_state >= PJ_TURN_STATE_DESTROYING && turn_sock->sess) {
 	pj_time_val delay = {0, 0};
 
-	turn_sock->sess = NULL;
-	pj_turn_session_set_user_data(sess, NULL);
-
 	pj_timer_heap_cancel_if_active(turn_sock->cfg.timer_heap,
 	                               &turn_sock->timer, 0);
 	pj_timer_heap_schedule_w_grp_lock(turn_sock->cfg.timer_heap,


### PR DESCRIPTION
Turn sock's user_data and session were erased before the end of the
destruction without any protection. ice->grp_lock must be locked when
erasing the user_data to avoid any potential crash. Indeed, for example, in
turn_sock.c, on_data_read can be called at the same time we erase the session.
Moreover, this is unneeded, because destroy() will clean the data.




For example, this is the crash I saw

```
0x0000555555a429c6 in pj_turn_session_on_rx_pkt2 ()
(gdb) bt
#0  0x0000555555a429c6 in pj_turn_session_on_rx_pkt2 ()
#1  0x0000555555a42bf2 in pj_turn_session_on_rx_pkt ()
#2  0x0000555555a4430e in on_data_read_asock ()
#3  0x0000555555a575bd in ioqueue_on_read_complete ()
#4  0x0000555555a5282c in ioqueue_dispatch_read_event ()
#5  0x0000555555a541bb in pj_ioqueue_poll ()
#6  0x0000555555882060 in jami::IceTransport::Impl::handleEvents(unsigned int) ()
#7  0x00005555558822a6 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<jami::IceTransport::Impl::Impl(char const*, int, bool, jami::IceTransportOptions const&)::{lambda()#6}> > >::_M_run() ()
#8  0x00007ffff795ccb4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007ffff7c1d609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#10 0x00007ffff764a103 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```