### PR TITLE
Avoid invoking callback on_pager_status twice when resending with auth fails

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_im.c
+++ b/pjsip/src/pjsua-lib/pjsua_im.c
@@ -394,6 +394,12 @@ static void im_callback(void *token, pjsip_event *e)
 		    return;
 		}
 		pjsip_auth_clt_deinit(&auth);
+
+		/* Don't invoke callback if another callback (with auth,
+		 * different tsx) has been called.
+		 */
+                if (im_data2->acc_id == PJSUA_INVALID_ID)
+                    return;
 	    }
 	}
 
@@ -438,6 +444,9 @@ static void im_callback(void *token, pjsip_event *e)
 						 tsx->last_tx,
 						 rdata, im_data->acc_id);
 	}
+
+	/* Reset acc_id after invoking callback */
+	im_data->acc_id = PJSUA_INVALID_ID;
     }
 }
 


### PR DESCRIPTION
Reported that after outgoing IM using SIP MESSAGE is challenged, the sending of the new request with auth headers fails, PJSUA callback `on_pager_status/on_pager_status2` will be called twice, first with status code 503, then with 401. While it should be only once, with 503.

#### Investigation from reporter
1. App wants to send SIP MESSAGE. We are using pjsua_im_send() API to send the SIP MESSAGE.
1. For the SIP MESSAGE, client received 401. This completes the sip transaction. Lets call this transaction TR1.
1. SIP transaction layer provides the callback to sip_util_stateful layer which in turn provides callback to pjsua_im layer.
1. In pjsua_im layer callback i.e. `im_callback`, as part of 401 processing, another request with auth is sent by calling `pjsip_endpt_send_request()`.
1. This request with auth will be a different transaction. Lets call it TR2.
1. At the same time, the transport was broken by another thread.
1. So the sending SIP MESSAGE with auth request failed due to transport error.
1. Since this failure in sending SIP MESSAGE is different transaction(TR2) from the one for which we received 401(TR1), so sip transaction layer provided CB for this transaction(TR2) to sip_util_stateful layer which in turn provides callback to pjsua_im layer with status code as 503.
1. Here the transaction changed from NULL state to TERMINATED state. In the same thread context, the callback is provided.
1. The pjsua_im callback (`im_callback`) in turn provided a callback to our application for this failure.
1. The 401 processing in `im_callback` is again triggering the callback to our application.
1. So our app receives two failure callbacks from pjsua_im layer for the same request.

Since the callback from the application layer for the pjsua_im layer is for SIP MESSAGE requests as a whole and not for individual transactions, I believe, the app should not receive a callback for 401 again. The first callback with status code as 503 was the right callback for the application.

Thanks to Santosh Kumar for the report and the analysis.