### PR TITLE
Pass JB discard algorithm along other JB settings

### DIFF
--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -138,6 +138,8 @@ typedef struct pjmedia_stream_info
     int			jb_max_pre; /**< Jitter buffer maximum prefetch
 					 delay in msec (-1 for default).    */
     int			jb_max;	    /**< Jitter buffer max delay in msec.   */
+    pjmedia_jb_discard_algo jb_discard_algo;
+                                    /**< Jitter buffer discard algorithm.   */
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
     pj_bool_t		use_ka;	    /**< Stream keep-alive and NAT hole punch

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2682,6 +2682,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
 
     /* Set up jitter buffer */
     pjmedia_jbuf_set_adaptive( stream->jb, jb_init, jb_min_pre, jb_max_pre);
+    pjmedia_jbuf_set_discard(stream->jb, info->jb_discard_algo);
 
     /* Create decoder channel: */
 

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -598,6 +598,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
 
     /* Set default jitter buffer parameter. */
     si->jb_init = si->jb_max = si->jb_min_pre = si->jb_max_pre = -1;
+    si->jb_discard_algo = PJMEDIA_JB_DISCARD_PROGRESSIVE;
 
     /* Get local RTCP-FB info */
     status = pjmedia_rtcp_fb_decode_sdp2(pool, endpt, NULL, local, stream_idx,

--- a/pjmedia/src/test/mips_test.c
+++ b/pjmedia/src/test/mips_test.c
@@ -1773,6 +1773,7 @@ static pjmedia_port* create_stream( pj_pool_t *pool,
     si.rx_event_pt = 101;
     si.ssrc = pj_rand();
     si.jb_init = si.jb_min_pre = si.jb_max_pre = si.jb_max = -1;
+    si.jb_discard_algo = PJMEDIA_JB_DISCARD_PROGRESSIVE;
 
     /* Create loop transport */
     status = pjmedia_transport_loop_create(sp->endpt, &sp->transport);

--- a/pjsip-apps/src/samples/jbsim.c
+++ b/pjsip-apps/src/samples/jbsim.c
@@ -333,6 +333,7 @@ static pj_status_t stream_init(const struct stream_cfg *cfg, struct stream **p_s
 	si.jb_min_pre = g_app.cfg.rx_jb_min_pre;
 	si.jb_max_pre = g_app.cfg.rx_jb_max_pre;
 	si.jb_max = g_app.cfg.rx_jb_max;
+        si.jb_discard_algo = PJMEDIA_JB_DISCARD_PROGRESSIVE;
     }
 
     /* Get the codec info and param */

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6708,6 +6708,14 @@ struct pjsua_media_config
     int			jb_max;
 
     /**
+     * Set the algorithm the jitter buffer uses to discard frames in order to
+     * adjust the latency.
+     *
+     * Default: PJMEDIA_JB_DISCARD_PROGRESSIVE
+     */
+    pjmedia_jb_discard_algo jb_discard_algo;
+
+    /**
      * Enable ICE
      */
     pj_bool_t		enable_ice;

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -867,6 +867,14 @@ public:
     int			jbMax;
 
     /**
+     * Set the algorithm the jitter buffer uses to discard frames in order to
+     * adjust the latency.
+     *
+     * Default: PJMEDIA_JB_DISCARD_PROGRESSIVE
+     */
+    pjmedia_jb_discard_algo jbDiscardAlgo;
+
+    /**
      * Specify idle time of sound device before it is automatically closed,
      * in seconds. Use value -1 to disable the auto-close feature of sound
      * device

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -646,6 +646,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
 	si->jb_min_pre = pjsua_var.media_cfg.jb_min_pre;
 	si->jb_max_pre = pjsua_var.media_cfg.jb_max_pre;
 	si->jb_max = pjsua_var.media_cfg.jb_max;
+        si->jb_discard_algo = pjsua_var.media_cfg.jb_discard_algo;
 
 	/* Set SSRC and CNAME */
 	si->ssrc = call_med->ssrc;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -415,6 +415,7 @@ PJ_DEF(void) pjsua_media_config_default(pjsua_media_config *cfg)
     cfg->snd_rec_latency = PJMEDIA_SND_DEFAULT_REC_LATENCY;
     cfg->snd_play_latency = PJMEDIA_SND_DEFAULT_PLAY_LATENCY;
     cfg->jb_init = cfg->jb_min_pre = cfg->jb_max_pre = cfg->jb_max = -1;
+    cfg->jb_discard_algo = PJMEDIA_JB_DISCARD_PROGRESSIVE;
     cfg->snd_auto_close_time = 1;
 
     cfg->ice_max_host_cands = -1;

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -349,6 +349,7 @@ void MediaConfig::fromPj(const pjsua_media_config &mc)
     this->jbMinPre = mc.jb_min_pre;
     this->jbMaxPre = mc.jb_max_pre;
     this->jbMax = mc.jb_max;
+    this->jbDiscardAlgo = mc.jb_discard_algo;
     this->sndAutoCloseTime = mc.snd_auto_close_time;
     this->vidPreviewEnableNative = PJ2BOOL(mc.vid_preview_enable_native);
 }
@@ -380,6 +381,7 @@ pjsua_media_config MediaConfig::toPj() const
     mcfg.jb_min_pre = this->jbMinPre;
     mcfg.jb_max_pre = this->jbMaxPre;
     mcfg.jb_max = this->jbMax;
+    mcfg.jb_discard_algo = this->jbDiscardAlgo;
     mcfg.snd_auto_close_time = this->sndAutoCloseTime;
     mcfg.vid_preview_enable_native = this->vidPreviewEnableNative;
 
@@ -411,6 +413,7 @@ void MediaConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
     NODE_READ_INT     ( this_node, jbMinPre);
     NODE_READ_INT     ( this_node, jbMaxPre);
     NODE_READ_INT     ( this_node, jbMax);
+    NODE_READ_NUM_T   ( this_node, pjmedia_jb_discard_algo, jbDiscardAlgo);
     NODE_READ_INT     ( this_node, sndAutoCloseTime);
     NODE_READ_BOOL    ( this_node, vidPreviewEnableNative);
 }
@@ -440,6 +443,7 @@ void MediaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
     NODE_WRITE_INT     ( this_node, jbMinPre);
     NODE_WRITE_INT     ( this_node, jbMaxPre);
     NODE_WRITE_INT     ( this_node, jbMax);
+    NODE_WRITE_NUM_T   ( this_node, pjmedia_jb_discard_algo, jbDiscardAlgo);
     NODE_WRITE_INT     ( this_node, sndAutoCloseTime);
     NODE_WRITE_BOOL    ( this_node, vidPreviewEnableNative);
 }


### PR DESCRIPTION
So far it has not been possible to choose the jitter buffer's discard algorithm when using pjmedia's `pjmedia_stream_create` (directly or indirectly through pjsua or pjsua2), because of a hardcoded call to [`pjmedia_jbuf_set_adaptive`](https://github.com/pjsip/pjproject/blob/32153443e7452ff790e4ef04ef5c1834b9da3e2a/pjmedia/src/pjmedia/stream.c#L2684).

The changes made by this PR essentially pass along the `pjmedia_jb_discard_algo` to use everywhere jitter buffer settings are handled and set the actual algorithm to use right after the call to `pjmedia_jbuf_set_adaptive` (using `pjmedia_jbuf_set_discard`).

Changes affect pjmedia, pjsua and pjsua2.