### PR TITLE
Implement audio stream configuration callback

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -531,6 +531,58 @@ typedef struct pjsua_reg_info
 
 
 /**
+ * Media stream info.
+ */
+typedef struct pjsua_stream_info
+{
+    /** Media type of this stream. */
+    pjmedia_type type;
+
+    /** Stream info (union). */
+    union {
+	/** Audio stream info */
+	pjmedia_stream_info	aud;
+
+	/** Video stream info */
+	pjmedia_vid_stream_info	vid;
+    } info;
+
+} pjsua_stream_info;
+
+
+/**
+ * Media stream statistic.
+ */
+typedef struct pjsua_stream_stat
+{
+    /** RTCP statistic. */
+    pjmedia_rtcp_stat	rtcp;
+
+    /** Jitter buffer statistic. */
+    pjmedia_jb_state	jbuf;
+
+} pjsua_stream_stat;
+
+
+/**
+ * Structure to be passed to on stream precreate callback.
+ * See #on_stream_precreate().
+ */
+typedef struct pjsua_on_stream_precreate_param
+{
+    /**
+     * Stream index in the media session, read-only.
+     */
+    unsigned            stream_idx;
+
+    /**
+     * Parameters that the stream will be created from.
+     */
+    pjsua_stream_info   stream_info;
+} pjsua_on_stream_precreate_param;
+
+
+/**
  * Structure to be passed to on stream created callback.
  * See #on_stream_created2().
  */
@@ -1047,6 +1099,17 @@ typedef struct pjsua_callback
 			        pj_pool_t *pool,
 			        const pjmedia_sdp_session *rem_sdp);
 
+    /**
+     * Notify application when an audio media session is about to be created
+     * (as opposed to #on_stream_created() and #on_stream_created2() which are
+     * called *after* the session has been created). The application may change
+     * stream parameters like the jitter buffer size.
+     *
+     * @param call_id       Call identification.
+     * @param param         The on stream precreate callback parameter.
+     */
+    void (*on_stream_precreate)(pjsua_call_id call_id,
+                                pjsua_on_stream_precreate_param *param);
 
     /**
      * Notify application when audio media session is created and before it is
@@ -5015,40 +5078,6 @@ typedef enum pjsua_call_flag
     PJSUA_CALL_UPDATE_TARGET = 64
 
 } pjsua_call_flag;
-
-
-/**
- * Media stream info.
- */
-typedef struct pjsua_stream_info
-{
-    /** Media type of this stream. */
-    pjmedia_type type;
-
-    /** Stream info (union). */
-    union {
-	/** Audio stream info */
-	pjmedia_stream_info	aud;
-
-	/** Video stream info */
-	pjmedia_vid_stream_info	vid;
-    } info;
-
-} pjsua_stream_info;
-
-
-/**
- * Media stream statistic.
- */
-typedef struct pjsua_stream_stat
-{
-    /** RTCP statistic. */
-    pjmedia_rtcp_stat	rtcp;
-
-    /** Jitter buffer statistic. */
-    pjmedia_jb_state	jbuf;
-
-} pjsua_stream_stat;
 
 /**
  * This enumeration represents video stream operation on a call.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -589,6 +589,44 @@ struct StreamInfo
      */
     VidCodecParam       vidCodecParam;
 
+    /**
+     * Jitter buffer init delay in msec.
+     */
+    int                 jbInit;
+
+    /**
+     * Jitter buffer minimum prefetch delay in msec.
+     */
+    int                 jbMinPre;
+
+    /**
+     * Jitter buffer maximum prefetch delay in msec.
+     */
+    int                 jbMaxPre;
+
+    /**
+     * Jitter buffer max delay in msec.
+     */
+    int                 jbMax;
+
+    /**
+     * Jitter buffer discard algorithm.
+     */
+    pjmedia_jb_discard_algo jbDiscardAlgo;
+
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
+    /**
+     * Stream keep-alive and NAT hole punch (see #PJMEDIA_STREAM_ENABLE_KA) is
+     * enabled?
+     */
+    bool                useKa;
+#endif
+
+    /**
+     * Disable automatic sending of RTCP SDES and BYE.
+     */
+    bool                rtcpSdesByeDisabled;
+
 public:
     /**
      * Default constructor
@@ -669,6 +707,23 @@ struct OnCallSdpCreatedParam
      * The remote SDP, will be empty if local is SDP offerer.
      */
     SdpSession remSdp;
+};
+
+/**
+ * This structure contains parameters for Call::onStreamPreCreate()
+ * callback.
+ */
+struct OnStreamPreCreateParam
+{
+    /**
+     * Stream index in the media session, read-only.
+     */
+    unsigned    streamIdx;
+
+    /**
+     * Parameters that the stream will be created from.
+     */
+    StreamInfo streamInfo;
 };
 
 /**
@@ -1759,7 +1814,18 @@ public:
      */
     virtual void onCallSdpCreated(OnCallSdpCreatedParam &prm)
     { PJ_UNUSED_ARG(prm); }
-    
+
+    /**
+     * Notify application when an audio media session is about to be created
+     * (as opposed to #on_stream_created() and #on_stream_created2() which are
+     * called *after* the session has been created). The application may change
+     * stream parameters like the jitter buffer size.
+     *
+     * @param prm       Callback parameter.
+     */
+    virtual void onStreamPreCreate(OnStreamPreCreateParam &prm)
+    { PJ_UNUSED_ARG(prm); }
+
     /**
      * Notify application when audio media session is created and before it is
      * registered to the conference bridge. Application may return different

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1795,6 +1795,8 @@ private:
                                     pjmedia_sdp_session *sdp,
                                     pj_pool_t *pool,
                                     const pjmedia_sdp_session *rem_sdp);
+    static void on_stream_precreate(pjsua_call_id call_id,
+                                    pjsua_on_stream_precreate_param *param);
     static void on_stream_created2(pjsua_call_id call_id,
 				   pjsua_on_stream_created_param *param);
     static void on_stream_destroyed(pjsua_call_id call_id,

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -666,6 +666,25 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
 	si->use_ka = pjsua_var.acc[call->acc_id].cfg.use_stream_ka;
 #endif
 
+        if (pjsua_var.ua_cfg.cb.on_stream_precreate) {
+            pjsua_on_stream_precreate_param prm;
+            prm.stream_idx = strm_idx;
+            prm.stream_info.type = PJMEDIA_TYPE_AUDIO;
+            prm.stream_info.info.aud = *si;
+            (*pjsua_var.ua_cfg.cb.on_stream_precreate)(call->index, &prm);
+
+            /* Copy back only the fields which are allowed to be changed. */
+            si->jb_init = prm.stream_info.info.aud.jb_init;
+            si->jb_min_pre = prm.stream_info.info.aud.jb_min_pre;
+            si->jb_max_pre = prm.stream_info.info.aud.jb_max_pre;
+            si->jb_max = prm.stream_info.info.aud.jb_max;
+            si->jb_discard_algo = prm.stream_info.info.aud.jb_discard_algo;
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
+            si->use_ka = prm.stream_info.info.aud.use_ka;
+#endif
+            si->rtcp_sdes_bye_disabled = prm.stream_info.info.aud.rtcp_sdes_bye_disabled;
+        }
+
 	/* Create session based on session info. */
 	status = pjmedia_stream_create(pjsua_var.med_endpt, NULL, si,
 				       call_med->tp, NULL,

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1098,6 +1098,24 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
 	    }
 	}
 
+        if (pjsua_var.ua_cfg.cb.on_stream_precreate) {
+            pjsua_on_stream_precreate_param prm;
+            prm.stream_idx = call_med->idx;
+            prm.stream_info.type = PJMEDIA_TYPE_VIDEO;
+            prm.stream_info.info.vid = *si;
+            (*pjsua_var.ua_cfg.cb.on_stream_precreate)(call->index, &prm);
+
+            /* Copy back only the fields which are allowed to be changed. */
+            si->jb_init = prm.stream_info.info.vid.jb_init;
+            si->jb_min_pre = prm.stream_info.info.vid.jb_min_pre;
+            si->jb_max_pre = prm.stream_info.info.vid.jb_max_pre;
+            si->jb_max = prm.stream_info.info.vid.jb_max;
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
+            si->use_ka = prm.stream_info.info.vid.use_ka;
+#endif
+            si->rtcp_sdes_bye_disabled = prm.stream_info.info.vid.rtcp_sdes_bye_disabled;
+        }
+
 	/* Create session based on session info. */
 	status = pjmedia_vid_stream_create(pjsua_var.med_endpt, NULL, si,
 					   call_med->tp, NULL,

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -327,6 +327,15 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
         codecName = pj2Str(info.info.aud.fmt.encoding_name);
         codecClockRate = info.info.aud.fmt.clock_rate;
         audCodecParam.fromPj(*info.info.aud.param);
+        jbInit = info.info.aud.jb_init;
+        jbMinPre = info.info.aud.jb_min_pre;
+        jbMaxPre = info.info.aud.jb_max_pre;
+        jbMax = info.info.aud.jb_max;
+        jbDiscardAlgo = info.info.aud.jb_discard_algo;
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
+        useKa = PJ2BOOL(info.info.aud.use_ka);
+#endif
+        rtcpSdesByeDisabled = PJ2BOOL(info.info.aud.rtcp_sdes_bye_disabled);
     } else if (type == PJMEDIA_TYPE_VIDEO) {
         proto = info.info.vid.proto;
         dir = info.info.vid.dir;
@@ -337,8 +346,17 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
         txPt = info.info.vid.tx_pt;
         rxPt = info.info.vid.rx_pt;
         codecName = pj2Str(info.info.vid.codec_info.encoding_name);
-        codecClockRate = info.info.vid.codec_info.clock_rate;        
-	vidCodecParam.fromPj(*info.info.vid.codec_param);
+        codecClockRate = info.info.vid.codec_info.clock_rate;
+        vidCodecParam.fromPj(*info.info.vid.codec_param);
+        jbInit = info.info.vid.jb_init;
+        jbMinPre = info.info.vid.jb_min_pre;
+        jbMaxPre = info.info.vid.jb_max_pre;
+        jbMax = info.info.vid.jb_max;
+        jbDiscardAlgo = PJMEDIA_JB_DISCARD_NONE;
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
+        useKa = PJ2BOOL(info.info.vid.use_ka);
+#endif
+        rtcpSdesByeDisabled = PJ2BOOL(info.info.vid.rtcp_sdes_bye_disabled);
     }
 }
 

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1098,6 +1098,32 @@ void Endpoint::on_call_sdp_created(pjsua_call_id call_id,
     }
 }
 
+void Endpoint::on_stream_precreate(pjsua_call_id call_id,
+                                   pjsua_on_stream_precreate_param *param)
+{
+    Call *call = Call::lookup(call_id);
+    if (!call) {
+        return;
+    }
+
+    OnStreamPreCreateParam prm;
+    prm.streamIdx = param->stream_idx;
+    prm.streamInfo.fromPj(param->stream_info);
+
+    call->onStreamPreCreate(prm);
+
+    /* Copy back only the fields which are allowed to be changed. */
+    param->stream_info.info.aud.jb_init = prm.streamInfo.jbInit;
+    param->stream_info.info.aud.jb_min_pre = prm.streamInfo.jbMinPre;
+    param->stream_info.info.aud.jb_max_pre = prm.streamInfo.jbMaxPre;
+    param->stream_info.info.aud.jb_max = prm.streamInfo.jbMax;
+    param->stream_info.info.aud.jb_discard_algo = prm.streamInfo.jbDiscardAlgo;
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
+    param->stream_info.info.aud.use_ka = prm.streamInfo.useKa;
+#endif
+    param->stream_info.info.aud.rtcp_sdes_bye_disabled = prm.streamInfo.rtcpSdesByeDisabled;
+}
+
 void Endpoint::on_stream_created2(pjsua_call_id call_id,
 				  pjsua_on_stream_created_param *param)
 {
@@ -1735,6 +1761,7 @@ void Endpoint::libInit(const EpConfig &prmEpConfig) PJSUA2_THROW(Error)
     ua_cfg.cb.on_call_tsx_state         = &Endpoint::on_call_tsx_state;
     ua_cfg.cb.on_call_media_state       = &Endpoint::on_call_media_state;
     ua_cfg.cb.on_call_sdp_created       = &Endpoint::on_call_sdp_created;
+    ua_cfg.cb.on_stream_precreate       = &Endpoint::on_stream_precreate;
     ua_cfg.cb.on_stream_created2        = &Endpoint::on_stream_created2;
     ua_cfg.cb.on_stream_destroyed       = &Endpoint::on_stream_destroyed;
     //ua_cfg.cb.on_dtmf_digit             = &Endpoint::on_dtmf_digit;


### PR DESCRIPTION
Currently it is not possible to modify jitter buffer settings per stream. The global jitter buffer settings [are applied to all streams created by pjsua](https://github.com/pjsip/pjproject/blob/32153443e7452ff790e4ef04ef5c1834b9da3e2a/pjsip/src/pjsua-lib/pjsua_aud.c#L645) (and hence pjsua2).
This PR introduces the callbacks `pjsua_callback::on_stream_configure` (pjsua) and `pj::Call::onStreamConfigure` (pjsua2) which enable on-demand modification of the `pjmedia_stream_info` structure before the stream is actually created.

Changes affect pjsua and pjsua2.