### PR TITLE
DNS SRV resolver should not assert on bad DNS type response

### DIFF
--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -573,7 +573,10 @@ static void dns_callback(void *user_data,
 	srv = (struct srv_target*)((pj_int8_t*)common-sizeof(struct common));
 	query_job = srv->parent;
     } else {
-	pj_assert(!"Unexpected user data!");
+	PJ_LOG(5,(THIS_FILE, "Discarded unexpected DNS type %s in answer",
+			     pj_dns_get_type_name(common->type)));
+	// Should not assert for something not under our control
+	//pj_assert(!"Unexpected user data!");
 	return;
     }
 


### PR DESCRIPTION
Reported that there was intermittent occurrence of assertion in DNS SRV query:
```
../src/pjlib-util/srv_resolver.c:576: dns_callback: Assertion `!"Unexpected user data!"' failed.
```
Thanks Varun Ahluwalia for the report.

As the incoming DNS packet is not in our control, I think it should not assert. So this PR tries to replace the assertion with a log line.

There is something else to consider: should we notify the app as resolution error or simply discard this answer (and wait for another valid answer until the query gets timed out), currently the behaviour is the latter.