### PR TITLE
Option to send keep alive periodically when stream is started for NAT hole punching

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1625,10 +1625,10 @@
  *
  * Setting this to 0 will disable it.
  *
- * Default : 0
+ * Default : 2
  */
 #ifndef PJMEDIA_STREAM_START_KA_CNT
-#   define PJMEDIA_STREAM_START_KA_CNT	0
+#   define PJMEDIA_STREAM_START_KA_CNT	2
 #endif
 
 
@@ -1638,8 +1638,8 @@
  *
  * Default : 1000
  */
-#ifndef PJMEDIA_STREAM_START_KA_NTERVAL_MSEC
-#   define PJMEDIA_STREAM_START_KA_NTERVAL_MSEC  1000
+#ifndef PJMEDIA_STREAM_START_KA_INTERVAL_MSEC
+#   define PJMEDIA_STREAM_START_KA_INTERVAL_MSEC  1000
 #endif
 
 

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1262,6 +1262,30 @@
 
 
 /**
+ * Specify the number of keep-alive needed to be sent after the stream is
+ * created.
+ *
+ * Setting this to 0 will disable it.
+ *
+ * Default : 2
+ */
+#ifndef PJMEDIA_STREAM_START_KA_CNT
+#   define PJMEDIA_STREAM_START_KA_CNT	2
+#endif
+
+
+/**
+ * Specify the interval to send keep-alive after the stream is created,
+ * in msec.
+ *
+ * Default : 1000
+ */
+#ifndef PJMEDIA_STREAM_START_KA_INTERVAL_MSEC
+#   define PJMEDIA_STREAM_START_KA_INTERVAL_MSEC  1000
+#endif
+
+
+/**
  * Specify the number of identical consecutive error that will be ignored when 
  * receiving RTP/RTCP data before the library tries to restart the transport.
  *
@@ -1616,30 +1640,6 @@
  */
 #ifndef PJMEDIA_VID_STREAM_DECODE_MIN_DELAY_MSEC
 #   define PJMEDIA_VID_STREAM_DECODE_MIN_DELAY_MSEC	    100
-#endif
-
-
-/**
- * Specify the number of keep-alive needed to be sent after the stream is
- * created.
- *
- * Setting this to 0 will disable it.
- *
- * Default : 2
- */
-#ifndef PJMEDIA_STREAM_START_KA_CNT
-#   define PJMEDIA_STREAM_START_KA_CNT	2
-#endif
-
-
-/**
- * Specify the interval to send keep-alive after the stream is created,
- * in msec.
- *
- * Default : 1000
- */
-#ifndef PJMEDIA_STREAM_START_KA_INTERVAL_MSEC
-#   define PJMEDIA_STREAM_START_KA_INTERVAL_MSEC  1000
 #endif
 
 

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1619,6 +1619,29 @@
 #endif
 
 
+/**
+ * Specify the number of keep-alive needed to be sent after the stream is
+ * created.
+ *
+ * Setting this to 0 will disable it.
+ *
+ * Default : 0
+ */
+#ifndef PJMEDIA_STREAM_START_KA_CNT
+#   define PJMEDIA_STREAM_START_KA_CNT	0
+#endif
+
+
+/**
+ * Specify the interval to send keep-alive after the stream is created,
+ * in msec.
+ *
+ * Default : 1000
+ */
+#ifndef PJMEDIA_STREAM_START_KA_NTERVAL_MSEC
+#   define PJMEDIA_STREAM_START_KA_NTERVAL_MSEC  1000
+#endif
+
 
 /**
  * @}

--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -85,7 +85,7 @@ PJ_BEGIN_DECL
  */
 typedef struct pjmedia_channel pjmedia_channel;
 
-/** 
+/**
  * This structure describes media stream information. Each media stream
  * corresponds to one "m=" line in SDP session descriptor, and it has
  * its own RTP/RTCP socket pair.
@@ -145,6 +145,8 @@ typedef struct pjmedia_stream_info
     pj_bool_t		use_ka;	    /**< Stream keep-alive and NAT hole punch
 					 (see #PJMEDIA_STREAM_ENABLE_KA)
 					 is enabled?			    */
+    pjmedia_stream_ka_config ka_cfg;
+                                    /**< Stream send kep-alive settings.    */
 #endif
     pj_bool_t           rtcp_sdes_bye_disabled; 
                                     /**< Disable automatic sending of RTCP

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -55,7 +55,39 @@ typedef struct pjmedia_stream_rtp_sess_info
 
 } pjmedia_stream_rtp_sess_info;
 
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
 
+/**
+ * Structure of configuration settings for stream keepalive after it
+ * is created.
+ */
+typedef struct pjmedia_stream_ka_config
+{
+    /**
+     * The number of keepalive to be sent after the stream is created.
+     *
+     * Default: PJMEDIA_STREAM_START_KA_CNT
+     */
+    unsigned			    start_count;
+
+    /**
+     * The keepalive sending interval after the stream is created.
+     *
+     * Default: PJMEDIA_STREAM_START_KA_NTERVAL_MSEC
+     */
+    unsigned			    start_interval;
+
+} pjmedia_stream_ka_config;
+
+/**
+ * Initialize the stream send keep-alive with default settings.
+ *
+ * @param cfg		Stream send keep-alive structure to be initialized.
+ */
+PJ_DECL(void)
+pjmedia_stream_ka_config_default(pjmedia_stream_ka_config *cfg);
+
+#endif
 
 /**
  * This is internal function for parsing SDP format parameter of specific

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -65,8 +65,8 @@ typedef struct pjmedia_stream_ka_config
 {
     /**
      * The number of keepalive to be sent after the stream is created.
-     * Although this is set to 0, keepalive will be sent once for NAT hole
-     * punching.
+     * When this is set to 0, keepalive will be sent once for NAT hole
+     * punching if stream's #use_ka is enabled.
      *
      * Default: PJMEDIA_STREAM_START_KA_CNT
      */

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -65,6 +65,8 @@ typedef struct pjmedia_stream_ka_config
 {
     /**
      * The number of keepalive to be sent after the stream is created.
+     * Although this is set to 0, keepalive will be sent once for NAT hole
+     * punching.
      *
      * Default: PJMEDIA_STREAM_START_KA_CNT
      */

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -73,7 +73,7 @@ typedef struct pjmedia_stream_ka_config
     /**
      * The keepalive sending interval after the stream is created.
      *
-     * Default: PJMEDIA_STREAM_START_KA_NTERVAL_MSEC
+     * Default: PJMEDIA_STREAM_START_KA_INTERVAL_MSEC
      */
     unsigned			    start_interval;
 

--- a/pjmedia/include/pjmedia/vid_stream.h
+++ b/pjmedia/include/pjmedia/vid_stream.h
@@ -185,6 +185,8 @@ typedef struct pjmedia_vid_stream_info
     pj_bool_t		use_ka;	    /**< Stream keep-alive and NAT hole punch
 					 (see #PJMEDIA_STREAM_ENABLE_KA)
 					 is enabled?			    */
+    pjmedia_stream_ka_config ka_cfg;
+                                    /**< Stream send kep-alive settings.    */
 #endif
 
     pjmedia_vid_codec_info   codec_info;  /**< Incoming codec format info.  */

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2887,7 +2887,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
     /* NAT hole punching by sending KA packet via RTP transport. */
-    if (stream->use_ka && (stream->start_ka_count == 0))
+    if (stream->use_ka)
 	send_keep_alive_packet(stream);
 #endif
 

--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -21,6 +21,18 @@
 
 #define THIS_FILE	"stream_common.c"
 
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
+
+PJ_DEF(void)
+pjmedia_stream_ka_config_default(pjmedia_stream_ka_config *cfg)
+{
+    pj_bzero(cfg, sizeof(*cfg));
+    cfg->start_count = PJMEDIA_STREAM_START_KA_CNT;
+    cfg->start_interval = PJMEDIA_STREAM_START_KA_NTERVAL_MSEC;
+}
+
+#endif
+
 /*
  * Parse fmtp for specified format/payload type.
  */

--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -28,7 +28,7 @@ pjmedia_stream_ka_config_default(pjmedia_stream_ka_config *cfg)
 {
     pj_bzero(cfg, sizeof(*cfg));
     cfg->start_count = PJMEDIA_STREAM_START_KA_CNT;
-    cfg->start_interval = PJMEDIA_STREAM_START_KA_NTERVAL_MSEC;
+    cfg->start_interval = PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
 }
 
 #endif

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -1999,7 +1999,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
     /* NAT hole punching by sending KA packet via RTP transport. */
-    if (stream->use_ka && (stream->start_ka_count == 0))
+    if (stream->use_ka)
 	send_keep_alive_packet(stream);
 #endif
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4118,6 +4118,13 @@ typedef struct pjsua_acc_config
      * Default: PJ_FALSE (disabled)
      */
     pj_bool_t	     use_stream_ka;
+
+    /**
+     * Specify the keepalive configuration for stream.
+     *
+     * Default: see #pjmedia_stream_ka_config
+     */
+    pjmedia_stream_ka_config stream_ka_cfg;
 #endif
 
     /**

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -664,6 +664,8 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
 	/* Enable/disable stream keep-alive and NAT hole punch. */
 	si->use_ka = pjsua_var.acc[call->acc_id].cfg.use_stream_ka;
+
+        si->ka_cfg = pjsua_var.acc[call->acc_id].cfg.stream_ka_cfg;
 #endif
 
 	/* Create session based on session info. */

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -365,6 +365,7 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
 			 PJSUA_REG_USE_ACC_PROXY;
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
     cfg->use_stream_ka = (PJMEDIA_STREAM_ENABLE_KA != 0);
+    pjmedia_stream_ka_config_default(&cfg->stream_ka_cfg);
 #endif
     pj_list_init(&cfg->reg_hdr_list);
     pj_list_init(&cfg->sub_hdr_list);

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1064,7 +1064,9 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
 	/* Enable/disable stream keep-alive and NAT hole punch. */
-	si->use_ka = pjsua_var.acc[call->acc_id].cfg.use_stream_ka;
+	si->use_ka = acc->cfg.use_stream_ka;
+
+        si->ka_cfg = acc->cfg.stream_ka_cfg;
 #endif
 
 	/* Try to get shared format ID between the capture device and 


### PR DESCRIPTION
Consider a call involving a media server. 
When the call is connected, it will not send any data before it receive any data from remote.
Current behavior:
- keep-alive packet is sent when the stream is created. Since it was sent before the 200/OK is sent, the media server might ignore this.
- keep-alive packet is sent after ```PJMEDIA_STREAM_KA_INTERVAL``` is passed. This means that when the call is set to "recvonly", the call will receive the data from the server after that interval pass. (default: 5s)

This ticket will introduce new build settings ```PJMEDIA_STREAM_START_KA_CNT``` and ```PJMEDIA_STREAM_START_KA_NTERVAL_MSEC``` with their runtime counterpart ```pjmedia_stream_ka_config```. This will allow user to specify the number of keep-alive packet sent and it's interval when the stream is started.