### PR TITLE
Speaker only setting still requires audio input device

### DIFF
--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -966,7 +966,8 @@ public:
     MediaPort *setNoDev();
 
     /**
-     * Set sound device mode.
+     * Set sound device mode. Note that calling the APIs to set sound device
+     * (setPlaybackDev()/setCaptureDev()) will reset the mode.
      * 
      * @param mode		The sound device mode, as bitmask combination 
      *				of #pjsua_snd_dev_mode


### PR DESCRIPTION
When setting sound device using `pjsua_set_snd_dev2()` with mode `PJSUA_SND_DEV_SPEAKER_ONLY`, it will still require the availability of audio input device, even though it will not be used. This PR will try to fix this.

Also add doc in PJSUA2 that the mode set via `AudDevManager::setSndDevMode()` will be reset again when setting a sound device.
