### PR TITLE
Update default setting for CFHost for getaddrinfo to disabled

### DIFF
--- a/pjlib/include/pj/compat/os_auto.h.in
+++ b/pjlib/include/pj/compat/os_auto.h.in
@@ -191,7 +191,9 @@
 #    if TARGET_OS_IPHONE
 #	include "Availability.h"
 	/* Use CFHost API for pj_getaddrinfo() (see ticket #1246) */
-#	define PJ_GETADDRINFO_USE_CFHOST 1
+#	ifndef PJ_GETADDRINFO_USE_CFHOST
+#	    define PJ_GETADDRINFO_USE_CFHOST 0
+#	endif
 #    	ifdef __IPHONE_4_0
  	    /* Is multitasking support available?  (see ticket #1107) */
 #	    define PJ_IPHONE_OS_HAS_MULTITASKING_SUPPORT 	1


### PR DESCRIPTION
Reported that resolving IP address using `pj_getaddrinfo()` failed on some mobile networks (tested on some LTE networks), while it didn't fail when using POSIX `getaddrinfo()`. Also reported that it only depends on the network and does not depend on iOS version nor device. Known problem caused by this issue was TURN candidate creation failure (due to server resolution error) when TURN server was set using IP address instead of hostname.

CFHost was introduced in #1246, was on iOS 4 era.

Considering that resolution failure should be a bigger issue than library init delay (#1246), we decide to disable CFHost by default (can be enabled by setting `PJ_GETADDRINFO_USE_CFHOST` to 1 in `config_site.h`)

Thanks to Sébastien Blin for the report.