### PR TITLE
Invite state not shifting to CONFIRMED state after sending ACK manually

### DIFF
--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -255,7 +255,8 @@ typedef struct pjsip_inv_callback
      * sending of the ACK request (for example, when it needs to 
      * wait for answer from the other call leg, in 3PCC scenarios). 
      *
-     * Application creates the ACK request
+     * Application MUST create the ACK request using pjsip_inv_create_ack()
+     * and send it using pjsip_inv_send_msg().
      *
      * Once it has sent the ACK request, the framework will keep 
      * this ACK request in the cache. Subsequent receipt of 2xx response
@@ -965,7 +966,7 @@ PJ_DECL(pj_status_t) pjsip_inv_update (	pjsip_inv_session *inv,
  *
  * Note that if the invite session has a pending offer to be answered 
  * (for example when the last 2xx response to INVITE contains an offer), 
- * application MUST have set the SDP answer with #pjsip_create_sdp_body()
+ * application MUST have set the SDP answer with #pjsip_inv_set_sdp_answer()
  * prior to creating the ACK request. In this case, the ACK request
  * will be added with SDP message body.
  *

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -3283,6 +3283,32 @@ PJ_DEF(pj_status_t) pjsip_inv_send_msg( pjsip_inv_session *inv,
 	    goto on_error;
 	}
 
+	/* Check if this is delayed manual ACK (see #416) */
+	if (tdata->msg->line.req.method.id == PJSIP_ACK_METHOD &&
+	    mod_inv.cb.on_send_ack && tdata == inv->last_ack)
+	{
+		pjsip_dlg_inc_lock(inv->dlg);
+
+		/* Set state to CONFIRMED (if we're not in CONFIRMED yet).
+		 * But don't set it to CONFIRMED if we're already DISCONNECTED
+		 * (this may have been a late 200/OK response.
+		 */
+		if (inv->state < PJSIP_INV_STATE_CONFIRMED) {
+			pjsip_event ack_e;
+			PJSIP_EVENT_INIT_TX_MSG(ack_e, inv->last_ack);
+			inv_set_state(inv, PJSIP_INV_STATE_CONFIRMED, &ack_e);
+		} else if (inv->state == PJSIP_INV_STATE_DISCONNECTED) {
+			/* Avoid possible leaked tdata when invite session is
+			 * already destroyed.
+			 * https://github.com/pjsip/pjproject/pull/2432
+			 */
+			pjsip_tx_data_dec_ref(inv->last_ack);
+			inv->last_ack = NULL;
+		}
+
+		pjsip_dlg_dec_lock(inv->dlg);
+	}
+
     } else {
 	pjsip_cseq_hdr *cseq;
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -3284,29 +3284,30 @@ PJ_DEF(pj_status_t) pjsip_inv_send_msg( pjsip_inv_session *inv,
 	}
 
 	/* Check if this is delayed manual ACK (see #416) */
-	if (tdata->msg->line.req.method.id == PJSIP_ACK_METHOD &&
-	    mod_inv.cb.on_send_ack && tdata == inv->last_ack)
+	if (mod_inv.cb.on_send_ack &&
+	    tdata->msg->line.req.method.id == PJSIP_ACK_METHOD &&
+	    tdata == inv->last_ack)
 	{
-		pjsip_dlg_inc_lock(inv->dlg);
+	    pjsip_dlg_inc_lock(inv->dlg);
 
-		/* Set state to CONFIRMED (if we're not in CONFIRMED yet).
-		 * But don't set it to CONFIRMED if we're already DISCONNECTED
-		 * (this may have been a late 200/OK response.
+	    /* Set state to CONFIRMED (if we're not in CONFIRMED yet).
+	     * But don't set it to CONFIRMED if we're already DISCONNECTED
+	     * (this may have been a late 200/OK response.
+	     */
+	    if (inv->state < PJSIP_INV_STATE_CONFIRMED) {
+		pjsip_event ack_e;
+		PJSIP_EVENT_INIT_TX_MSG(ack_e, inv->last_ack);
+		inv_set_state(inv, PJSIP_INV_STATE_CONFIRMED, &ack_e);
+	    } else if (inv->state == PJSIP_INV_STATE_DISCONNECTED) {
+		/* Avoid possible leaked tdata when invite session is
+		 * already destroyed.
+		 * https://github.com/pjsip/pjproject/pull/2432
 		 */
-		if (inv->state < PJSIP_INV_STATE_CONFIRMED) {
-			pjsip_event ack_e;
-			PJSIP_EVENT_INIT_TX_MSG(ack_e, inv->last_ack);
-			inv_set_state(inv, PJSIP_INV_STATE_CONFIRMED, &ack_e);
-		} else if (inv->state == PJSIP_INV_STATE_DISCONNECTED) {
-			/* Avoid possible leaked tdata when invite session is
-			 * already destroyed.
-			 * https://github.com/pjsip/pjproject/pull/2432
-			 */
-			pjsip_tx_data_dec_ref(inv->last_ack);
-			inv->last_ack = NULL;
-		}
+		pjsip_tx_data_dec_ref(inv->last_ack);
+		inv->last_ack = NULL;
+	    }
 
-		pjsip_dlg_dec_lock(inv->dlg);
+	    pjsip_dlg_dec_lock(inv->dlg);
 	}
 
     } else {


### PR DESCRIPTION
Feature of allowing app to send ACK manually was added in #416. Unfortunately, there seem to be a bug in the feature, the invite session will not go to the CONFIRMED state and stay in the CONNECTING state after sending the manual ACK. **Only after** an incoming retransmission of the final response (so the library automatically sends the cached ACK), the invite session state will shift to the CONFIRMED state.

Thanks to Thomas Cresson for the report.