### PR TITLE
Suppress CodeQL warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,8 +48,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -57,10 +57,10 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+       ./configure --disable-libyuv --disable-libwebrtc --disable-speex-codec --disable-speex-aec
+       make
+       mv tests/pjsua/inc_cfg.py tests/pjsua/inc_cfg.txt
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/pjlib/src/pj/array.c
+++ b/pjlib/src/pj/array.c
@@ -31,7 +31,7 @@ PJ_DEF(void) pj_array_insert( void *array,
     if (count && pos < count) {
 	pj_memmove( (char*)array + (pos+1)*elem_size,
 		    (char*)array + pos*elem_size,
-		    (count-pos)*elem_size);
+		    (count-pos)*(pj_size_t)elem_size);
     }
     pj_memmove((char*)array + pos*elem_size, value, elem_size);
 }
@@ -45,7 +45,7 @@ PJ_DEF(void) pj_array_erase( void *array,
     if (pos < count-1) {
 	pj_memmove( (char*)array + pos*elem_size,
 		    (char*)array + (pos+1)*elem_size,
-		    (count-pos-1)*elem_size);
+		    (count-pos-1)*(pj_size_t)elem_size);
     }
 }
 

--- a/pjmedia/src/pjmedia-codec/ilbc.c
+++ b/pjmedia/src/pjmedia-codec/ilbc.c
@@ -595,7 +595,7 @@ static pj_status_t  ilbc_codec_parse( pjmedia_codec *codec,
 	frames[count].type = PJMEDIA_FRAME_TYPE_AUDIO;
 	frames[count].buf = pkt;
 	frames[count].size = ilbc_codec->dec_frame_size;
-	frames[count].timestamp.u64 = ts->u64 + count * 
+	frames[count].timestamp.u64 = ts->u64 + (pj_uint64_t)count * 
 				      ilbc_codec->dec_samples_per_frame;
 
 	pkt = ((char*)pkt) + ilbc_codec->dec_frame_size;

--- a/pjmedia/src/pjmedia-codec/speex_codec.c
+++ b/pjmedia/src/pjmedia-codec/speex_codec.c
@@ -851,7 +851,8 @@ static pj_status_t  spx_codec_parse( pjmedia_codec *codec,
 	/* Bit info contains start bit offset of the frame */
 	frames[count].bit_info = bit_ptr;
 	frames[count].type = PJMEDIA_FRAME_TYPE_AUDIO;
-	frames[count].timestamp.u64 = ts->u64 + count * samples_per_frame;
+	frames[count].timestamp.u64 = ts->u64 +
+				      (pj_uint64_t)count * samples_per_frame;
 	frames[count].size = spx->dec_bits.charPtr - char_ptr;
 	if (spx->dec_bits.bitPtr)
 	    ++frames[count].size;

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -179,7 +179,7 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
     clock->max_jump = MAX_JUMP_MSEC * clock->freq.u64 / 1000;
     clock->timestamp_inc = (unsigned)(param->usec_interval *
                                       param->clock_rate /
-				      USEC_IN_SEC);
+				      (unsigned)USEC_IN_SEC);
     clock->options = options;
     clock->cb = cb;
     clock->user_data = user_data;
@@ -266,7 +266,7 @@ PJ_DEF(pj_status_t) pjmedia_clock_modify(pjmedia_clock *clock,
                           USEC_IN_SEC;
     clock->timestamp_inc = (unsigned)(param->usec_interval *
                                       param->clock_rate /
-				      USEC_IN_SEC);
+				      (unsigned)USEC_IN_SEC);
 
     return PJ_SUCCESS;
 }

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -540,14 +540,13 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 	if (codec_param.setting.dec_fmtp.cnt > 0) {
 	    enum { MAX_FMTP_STR_LEN = 160 };
 	    char buf[MAX_FMTP_STR_LEN];
-	    unsigned buf_len = 0, ii;
+	    unsigned buf_len = 0, n, ii;
 	    pjmedia_codec_fmtp *dec_fmtp = &codec_param.setting.dec_fmtp;
 
 	    /* Print codec PT */
-	    buf_len += pj_ansi_snprintf(buf,
-					MAX_FMTP_STR_LEN - buf_len,
-					"%d",
-					pt);
+	    n = pj_ansi_snprintf(buf, MAX_FMTP_STR_LEN - buf_len,
+				 "%d", pt);
+	    buf_len = PJ_MIN(buf_len + n, MAX_FMTP_STR_LEN);
 
 	    for (ii = 0; ii < dec_fmtp->cnt; ++ii) {
 		pj_size_t test_len = 2;
@@ -559,26 +558,28 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 		    return PJ_ETOOBIG;
 
 		/* Print delimiter */
-		buf_len += pj_ansi_snprintf(&buf[buf_len], 
-					    MAX_FMTP_STR_LEN - buf_len,
-					    (ii == 0?" ":";"));
+		n = pj_ansi_snprintf(&buf[buf_len], 
+				     MAX_FMTP_STR_LEN - buf_len,
+				     (ii == 0?" ":";"));
+		buf_len = PJ_MIN(buf_len + n, MAX_FMTP_STR_LEN);
 
 		/* Print an fmtp param */
 		if (dec_fmtp->param[ii].name.slen)
-		    buf_len += pj_ansi_snprintf(
-					    &buf[buf_len],
-					    MAX_FMTP_STR_LEN - buf_len,
-					    "%.*s=%.*s",
-					    (int)dec_fmtp->param[ii].name.slen,
-					    dec_fmtp->param[ii].name.ptr,
-					    (int)dec_fmtp->param[ii].val.slen,
-					    dec_fmtp->param[ii].val.ptr);
+		    n = pj_ansi_snprintf(&buf[buf_len],
+					 MAX_FMTP_STR_LEN - buf_len,
+					 "%.*s=%.*s",
+					 (int)dec_fmtp->param[ii].name.slen,
+					 dec_fmtp->param[ii].name.ptr,
+					 (int)dec_fmtp->param[ii].val.slen,
+					  dec_fmtp->param[ii].val.ptr);
 		else
-		    buf_len += pj_ansi_snprintf(&buf[buf_len], 
-					    MAX_FMTP_STR_LEN - buf_len,
-					    "%.*s", 
-					    (int)dec_fmtp->param[ii].val.slen,
-					    dec_fmtp->param[ii].val.ptr);
+		    n = pj_ansi_snprintf(&buf[buf_len], 
+					 MAX_FMTP_STR_LEN - buf_len,
+					 "%.*s", 
+					 (int)dec_fmtp->param[ii].val.slen,
+					 dec_fmtp->param[ii].val.ptr);
+		
+		buf_len = PJ_MIN(buf_len + n, MAX_FMTP_STR_LEN);
 	    }
 
 	    attr = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_attr);
@@ -802,14 +803,14 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
 	if (codec_param.dec_fmtp.cnt > 0) {
 	    enum { MAX_FMTP_STR_LEN = 160 };
 	    char buf[MAX_FMTP_STR_LEN];
-	    unsigned buf_len = 0, j;
+	    unsigned buf_len = 0, n, j;
 	    pjmedia_codec_fmtp *dec_fmtp = &codec_param.dec_fmtp;
 
 	    /* Print codec PT */
-	    buf_len += pj_ansi_snprintf(buf, 
-					MAX_FMTP_STR_LEN - buf_len, 
-					"%d", 
-					codec_info[i].pt);
+	    n = pj_ansi_snprintf(buf, MAX_FMTP_STR_LEN - buf_len, 
+				 "%d", 
+				 codec_info[i].pt);
+	    buf_len = PJ_MIN(buf_len + n, MAX_FMTP_STR_LEN);
 
 	    for (j = 0; j < dec_fmtp->cnt; ++j) {
 		pj_size_t test_len = 2;
@@ -821,26 +822,28 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
 		    return PJ_ETOOBIG;
 
 		/* Print delimiter */
-		buf_len += pj_ansi_snprintf(&buf[buf_len], 
-					    MAX_FMTP_STR_LEN - buf_len,
-					    (j == 0?" ":";"));
+		n = pj_ansi_snprintf(&buf[buf_len], 
+				     MAX_FMTP_STR_LEN - buf_len,
+				     (j == 0?" ":";"));
+	    	buf_len = PJ_MIN(buf_len + n, MAX_FMTP_STR_LEN);
 
 		/* Print an fmtp param */
 		if (dec_fmtp->param[j].name.slen)
-		    buf_len += pj_ansi_snprintf(
-					    &buf[buf_len],
-					    MAX_FMTP_STR_LEN - buf_len,
-					    "%.*s=%.*s",
-					    (int)dec_fmtp->param[j].name.slen,
-					    dec_fmtp->param[j].name.ptr,
-					    (int)dec_fmtp->param[j].val.slen,
-					    dec_fmtp->param[j].val.ptr);
+		    n = pj_ansi_snprintf(&buf[buf_len],
+					 MAX_FMTP_STR_LEN - buf_len,
+					 "%.*s=%.*s",
+					 (int)dec_fmtp->param[j].name.slen,
+					 dec_fmtp->param[j].name.ptr,
+					 (int)dec_fmtp->param[j].val.slen,
+					 dec_fmtp->param[j].val.ptr);
 		else
-		    buf_len += pj_ansi_snprintf(&buf[buf_len], 
-					    MAX_FMTP_STR_LEN - buf_len,
-					    "%.*s", 
-					    (int)dec_fmtp->param[j].val.slen,
-					    dec_fmtp->param[j].val.ptr);
+		    n = pj_ansi_snprintf(&buf[buf_len], 
+					 MAX_FMTP_STR_LEN - buf_len,
+					 "%.*s", 
+					 (int)dec_fmtp->param[j].val.slen,
+					 dec_fmtp->param[j].val.ptr);
+		
+		buf_len = PJ_MIN(buf_len + n, MAX_FMTP_STR_LEN);
 	    }
 
 	    attr = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_attr);

--- a/pjmedia/src/pjmedia/jbuf.c
+++ b/pjmedia/src/pjmedia/jbuf.c
@@ -198,7 +198,7 @@ static pj_status_t jb_framelist_init( pj_pool_t *pool,
     framelist->max_count    = max_count;
     framelist->content	    = (char*)
 			      pj_pool_alloc(pool,
-					    framelist->frame_size*
+					    (pj_size_t)framelist->frame_size*
 					    framelist->max_count);
     framelist->frame_type   = (int*)
 			      pj_pool_alloc(pool,

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2111,7 +2111,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 
 	    /* Adjust the timestamp of the parsed frames */
 	    for (i=0; i<count; ++i) {
-		frames[i].timestamp.u64 = ts.u64 + ts_span * i;
+		frames[i].timestamp.u64 = ts.u64 + (pj_uint64_t)ts_span * i;
 	    }
 
 	} else {

--- a/pjmedia/src/pjmedia/wsola.c
+++ b/pjmedia/src/pjmedia/wsola.c
@@ -248,7 +248,7 @@ static pj_int16_t *find_pitch(pj_int16_t *frm, pj_int16_t *beg, pj_int16_t *end,
 
 	/* Process remaining samples. */
 	for (; i<template_cnt; ++i) {
-	    corr += ((float)frm[i]) * ((float)sr[i]);
+	    corr += ((double)frm[i]) * ((float)sr[i]);
 	}
 
 	if (first) {

--- a/pjmedia/src/test/codec_vectors.c
+++ b/pjmedia/src/test/codec_vectors.c
@@ -222,7 +222,7 @@ static int read_ITU_format(FILE  *fp_bitstream,
 			   pj_bool_t swap_endian)
 {
     enum { MAX_BITS_PER_FRAME = 160*8 };
-    short i,j;
+    int i,j;
     short nsamp;
     short packed_word;
     short bit_count;

--- a/pjsip-apps/src/samples/jbsim.c
+++ b/pjsip-apps/src/samples/jbsim.c
@@ -765,7 +765,7 @@ static void rx_tick(const pj_time_val *t)
 
     pkt_interval = PJMEDIA_PIA_SPF(&port->info) * 1000 /
 		   PJMEDIA_PIA_SRATE(&port->info) *
-		   g_app.cfg.rx_snd_burst;
+		   (long)g_app.cfg.rx_snd_burst;
 
     if (PJ_TIME_VAL_GTE(*t, strm->state.rx.next_schedule)) {
 	unsigned i;

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -966,7 +966,8 @@ public:
     MediaPort *setNoDev();
 
     /**
-     * Set sound device mode.
+     * Set sound device mode. Note that calling the APIs to set sound device
+     * (setPlaybackDev()/setCaptureDev()) will reset the mode.
      * 
      * @param mode		The sound device mode, as bitmask combination 
      *				of #pjsua_snd_dev_mode

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -625,7 +625,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
     if (dd->uas_state->retransmit_count < 6) {
 	delay.sec = 0;
 	delay.msec = (1 << dd->uas_state->retransmit_count) * 
-		     pjsip_cfg()->tsx.t1;
+		     (long)pjsip_cfg()->tsx.t1;
 	pj_time_val_normalize(&delay);
     } else {
 	delay.sec = 1;

--- a/pjsip/src/test/transport_udp_test.c
+++ b/pjsip/src/test/transport_udp_test.c
@@ -27,7 +27,7 @@
 static pj_status_t multi_transport_test(pjsip_transport *tp[], unsigned num_tp)
 {
     pj_status_t status;
-    pj_uint16_t i = 0;
+    unsigned i = 0;
     pj_str_t s;
     pjsip_transport *udp_tp;
     pj_sockaddr_in rem_addr;    


### PR DESCRIPTION
Also in this PR:
- Exclude the build of third party libraries: libyuv, libwebrtc, libspeex (codec and aec)
- Exclude `tests/pjsua/inc_cfg.py` from analysis
