### PR TITLE
Modify on_new_session callback as optional.

### DIFF
--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -131,7 +131,7 @@ typedef struct pjsip_inv_callback
      * This callback is called when the invite usage module has created 
      * a new dialog and invite because of forked outgoing request.
      *
-     * This callback is mandatory.
+     * This callback is optional.
      *
      * @param inv	The new invite session.
      * @param e		The event which has caused the dialog to fork.

--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -131,7 +131,8 @@ typedef struct pjsip_inv_callback
      * This callback is called when the invite usage module has created 
      * a new dialog and invite because of forked outgoing request.
      *
-     * This callback is optional.
+     * Currently the invite session does not create a new dialog in
+     * forking scenario, so this callback will never be invoked.
      *
      * @param inv	The new invite session.
      * @param e		The event which has caused the dialog to fork.

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -827,7 +827,7 @@ PJ_DEF(pj_status_t) pjsip_inv_usage_init( pjsip_endpoint *endpt,
     PJ_ASSERT_RETURN(endpt && cb, PJ_EINVAL);
 
     /* Some callbacks are mandatory */
-    PJ_ASSERT_RETURN(cb->on_state_changed && cb->on_new_session, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cb->on_state_changed, PJ_EINVAL);
 
     /* Check if module already registered. */
     PJ_ASSERT_RETURN(mod_inv.mod.id == -1, PJ_EINVALIDOP);


### PR DESCRIPTION
Currently ```on_new_session()``` of ```pjsip_inv_callback``` is treated as mandatory forcing it to be implemented.
However, it's not yet implemented and would be safe to set it as optional