### PR TITLE
Add ios arm64e arch support

### DIFF
--- a/configure-iphone
+++ b/configure-iphone
@@ -118,6 +118,10 @@ if test "${ARCH}" = ""; then
 fi
 export ARCH_VAL=`echo ${ARCH} | sed 's/\-arch //' | sed -e 's/^[ \t]*//;s/[ \t]*$//' `
 
+if test "${ARCH_VAL}" = "arm64e"; then
+ export ARCH_VAL="arm64"
+fi 
+
 if test "${MIN_IOS}" = ""; then
   MIN_IOS_VER="7.0"
   echo "$F: MIN_IOS is not specified, choosing ${MIN_IOS_VER}"


### PR DESCRIPTION
${ARCH} env variable sets with ${CFLAGS} -arch parameter also --host parameter for cross-compile. Apple's new arm64e --host parameter is the same as arm64 --host param but CFLAGS -arch param is arm64e. This pr adds condition if ARCH is arm64e to set correct --host param for aconfigure script