### PR TITLE
Add option to disable ice mismatch check.

### DIFF
--- a/pjmedia/include/pjmedia/transport_ice.h
+++ b/pjmedia/include/pjmedia/transport_ice.h
@@ -157,10 +157,11 @@ enum pjmedia_transport_ice_options
     /**
      * The standard (rfc5245) specify that ice-mismatch attribute is used
      * due to a mismatch of candidates with the default destination for media
-     * signaled in the SDP. However rfc8445 specify that ALGs, can alter
-     * signaling information in ways that break ICE and triggered ice mismatch.
-     * (e.g., by rewriting IP addresses in SDP). So disabling ice mismatch
-     * is required on some scenario.
+     * signaled in the SDP. The purpose is to identify some poorly ALGs that
+     * alter signaling information in ways that break ICE
+     * (e.g., by rewriting IP addresses in SDP). Specifying this option is
+     * to disable the ice mismatch check and allow ICE to continue
+     * if such scenario occur.
      */
     PJMEDIA_ICE_DISABLE_ICE_MISMATCH = 2
 };

--- a/pjmedia/include/pjmedia/transport_ice.h
+++ b/pjmedia/include/pjmedia/transport_ice.h
@@ -152,7 +152,17 @@ enum pjmedia_transport_ice_options
      * are different after several packets are received.
      * Specifying this option will disable this feature.
      */
-    PJMEDIA_ICE_NO_SRC_ADDR_CHECKING = 1
+    PJMEDIA_ICE_NO_SRC_ADDR_CHECKING = 1,
+
+    /**
+     * The standard (rfc5245) specify that ice-mismatch attribute is used
+     * due to a mismatch of candidates with the default destination for media
+     * signaled in the SDP. However rfc8445 specify that ALGs, can alter
+     * signaling information in ways that break ICE and triggered ice mismatch.
+     * (e.g., by rewriting IP addresses in SDP). So disabling ice mismatch
+     * is required on some scenario.
+     */
+    PJMEDIA_ICE_DISABLE_ICE_MISMATCH = 2
 };
 
 

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -1073,16 +1073,14 @@ static pj_status_t verify_ice_sdp(struct transport_ice *tp_ice,
 	if (!comp1_found && cand.comp_id==COMP_RTP)
 	{
             if ((disable_ice_mismatch) ||
-                (!disable_ice_mismatch &&
-                 pj_sockaddr_cmp(&rem_conn_addr, &cand.addr) == 0))
+                (pj_sockaddr_cmp(&rem_conn_addr, &cand.addr) == 0))
             {
                 comp1_found = PJ_TRUE;
             }
 	} else if (!comp2_found && cand.comp_id==COMP_RTCP)
 	{
             if ((disable_ice_mismatch) ||
-                (!disable_ice_mismatch &&
-                 pj_sockaddr_cmp(&rtcp_addr, &cand.addr) == 0))
+                (pj_sockaddr_cmp(&rtcp_addr, &cand.addr) == 0))
             {
                 comp2_found = PJ_TRUE;
             }

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -1068,14 +1068,22 @@ static pj_status_t verify_ice_sdp(struct transport_ice *tp_ice,
 	    continue;
 	}
 
-	if (!comp1_found && cand.comp_id==COMP_RTP &&
-	    pj_sockaddr_cmp(&rem_conn_addr, &cand.addr)==0) 
+	if (!comp1_found && cand.comp_id==COMP_RTP)
 	{
-	    comp1_found = PJ_TRUE;
-	} else if (!comp2_found && cand.comp_id==COMP_RTCP &&
-		    pj_sockaddr_cmp(&rtcp_addr, &cand.addr)==0) 
+            if ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH) ||
+                ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH == 0)
+                 && pj_sockaddr_cmp(&rem_conn_addr, &cand.addr) == 0))
+            {
+                comp1_found = PJ_TRUE;
+            }
+	} else if (!comp2_found && cand.comp_id==COMP_RTCP)
 	{
-	    comp2_found = PJ_TRUE;
+            if ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH) ||
+                ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH == 0)
+                 && pj_sockaddr_cmp(&rtcp_addr, &cand.addr) == 0))
+            {
+                comp2_found = PJ_TRUE;
+            }
 	}
 
 	if (cand.comp_id == COMP_RTCP)

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -1053,6 +1053,8 @@ static pj_status_t verify_ice_sdp(struct transport_ice *tp_ice,
      */
     for (i=0; i<rem_m->attr_count; ++i) {
 	pj_ice_sess_cand cand;
+        unsigned disable_ice_mismatch = tp_ice->options &
+                                        PJMEDIA_ICE_DISABLE_ICE_MISMATCH;
 
 	if (pj_strcmp(&rem_m->attr[i]->name, &STR_CANDIDATE)!=0)
 	    continue;
@@ -1070,17 +1072,17 @@ static pj_status_t verify_ice_sdp(struct transport_ice *tp_ice,
 
 	if (!comp1_found && cand.comp_id==COMP_RTP)
 	{
-            if ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH) ||
-                ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH == 0)
-                 && pj_sockaddr_cmp(&rem_conn_addr, &cand.addr) == 0))
+            if ((disable_ice_mismatch) ||
+                (!disable_ice_mismatch &&
+                 pj_sockaddr_cmp(&rem_conn_addr, &cand.addr) == 0))
             {
                 comp1_found = PJ_TRUE;
             }
 	} else if (!comp2_found && cand.comp_id==COMP_RTCP)
 	{
-            if ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH) ||
-                ((tp_ice->options & PJMEDIA_ICE_DISABLE_ICE_MISMATCH == 0)
-                 && pj_sockaddr_cmp(&rtcp_addr, &cand.addr) == 0))
+            if ((disable_ice_mismatch) ||
+                (!disable_ice_mismatch &&
+                 pj_sockaddr_cmp(&rtcp_addr, &cand.addr) == 0))
             {
                 comp2_found = PJ_TRUE;
             }

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -393,6 +393,14 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #   define PJSUA_SEPARATE_WORKER_FOR_TIMER	0
 #endif
 
+/**
+ * Default options that will be passed when creating ice transport.
+ * See #pjmedia_transport_ice_options.
+ */
+#ifndef PJSUA_ICE_TRANSPORT_OPTION
+#   define PJSUA_ICE_TRANSPORT_OPTION	0
+#endif
+
 
 /**
  * This enumeration represents pjsua state.

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1119,8 +1119,8 @@ static pj_status_t create_ice_media_transport(
 	++comp_cnt;
 
     status = pjmedia_ice_create3(pjsua_var.med_endpt, name, comp_cnt,
-				 &ice_cfg, &ice_cb, 0, call_med,
-				 &call_med->tp);
+				 &ice_cfg, &ice_cb, PJSUA_ICE_TRANSPORT_OPTION,
+                                 call_med, &call_med->tp);
     if (status != PJ_SUCCESS) {
 	pjsua_perror(THIS_FILE, "Unable to create ICE media transport",
 		     status);


### PR DESCRIPTION
RFC [5245 ](https://tools.ietf.org/html/rfc5245#section-5.1) states that:
> The agent will proceed with the ICE procedures defined in this
   specification if, for each media stream in the SDP it received, the
   default destination for each component of that media stream appears
   in a candidate attribute.  For example, in the case of RTP, the IP
   address and port in the c and m lines, respectively, appear in a
   candidate attribute and the value in the rtcp attribute appears in a
   candidate attribute.

If the IP address and port in c and m lines doesn't appears in the candidate attribute, 
then ice-mismatch attribute will be returned.

The updated RFC [8455](https://tools.ietf.org/html/rfc8445#section-5.4) states that:
> Certain middleboxes, such as ALGs, can alter signaling information in
   ways that break ICE (e.g., by rewriting IP addresses in SDP).  This
   is referred to as "ICE mismatch".  If the using protocol is
   vulnerable to ICE mismatch, the responding agent needs to be able to
   detect it and inform the peer ICE agent about the ICE mismatch.

In some scenario, the IP address and port check is not required and might break ICE.

This ticket will allow to disable the check so that the ICE can continue.

