### PR TITLE
Server Name Indication on TLS doesn't allow IP literal.

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -1001,7 +1001,8 @@ typedef struct pj_ssl_sock_param
      * (perform outgoing connection) and the server may host multiple
      * 'virtual' servers at a single underlying network address, setting
      * this will allow client to tell the server a name of the server
-     * it is contacting.
+     * it is contacting. This must be set to hostname and literal IP addresses
+     * are not allowed.
      *
      * Default value is zero/not-set.
      */

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -1169,7 +1169,9 @@ static void ssl_set_peer_name(pj_ssl_sock_t *ssock)
     darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
 
     /* Set server name to connect */
-    if (ssock->param.server_name.slen) {
+    if (ssock->param.server_name.slen &&
+        get_ip_addr_ver(&ssock->param.server_name) == 0)
+    {
         OSStatus err;
         
     	err = SSLSetPeerDomainName(dssock->ssl_ctx,

--- a/pjlib/src/pj/ssl_sock_gtls.c
+++ b/pjlib/src/pj/ssl_sock_gtls.c
@@ -1101,7 +1101,9 @@ static void ssl_set_peer_name(pj_ssl_sock_t *ssock)
     gnutls_sock_t *gssock = (gnutls_sock_t *)ssock;
 
     /* Set server name to connect */
-    if (ssock->param.server_name.slen) {
+    if (ssock->param.server_name.slen &&
+        get_ip_addr_ver(&ssock->param.server_name) == 0)
+    {
         int ret;
         /* Server name is null terminated already */
         ret = gnutls_server_name_set(gssock->session, GNUTLS_NAME_DNS,

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -183,6 +183,25 @@ static pj_status_t circ_write(circ_buf_t *cb,
  * Helper functions.
  *******************************************************************
  */
+
+/* Check IP address version. */
+static int get_ip_addr_ver(const pj_str_t *host)
+{
+    pj_in_addr dummy;
+    pj_in6_addr dummy6;
+
+    /* First check if this is an IPv4 address */
+    if (pj_inet_pton(pj_AF_INET(), host, &dummy) == PJ_SUCCESS)
+	return 4;
+
+    /* Then check if this is an IPv6 address */
+    if (pj_inet_pton(pj_AF_INET6(), host, &dummy6) == PJ_SUCCESS)
+	return 6;
+
+    /* Not an IP address */
+    return 0;
+}
+
 #ifndef SSL_SOCK_IMP_USE_OWN_NETWORK
 /* Close sockets */
 static void ssl_close_sockets(pj_ssl_sock_t *ssock)

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1907,7 +1907,9 @@ static void ssl_set_peer_name(pj_ssl_sock_t *ssock)
     ossl_sock_t *ossock = (ossl_sock_t *)ssock;
 
     /* Set server name to connect */
-    if (ssock->param.server_name.slen) {
+    if (ssock->param.server_name.slen &&
+        get_ip_addr_ver(&ssock->param.server_name) == 0)
+    {
 	/* Server name is null terminated already */
 	if (!SSL_set_tlsext_host_name(ossock->ossl_ssl, 
 				      ssock->param.server_name.ptr))

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -171,28 +171,6 @@ static void tls_on_destroy(void *arg);
 
 static void wipe_buf(pj_str_t *buf);
 
-/*
- * Internal:
- *  determine if an address is a valid IP address, and if it is,
- *  return the IP version (4 or 6).
- */
-static int get_ip_addr_ver(const pj_str_t *host)
-{
-    pj_in_addr dummy;
-    pj_in6_addr dummy6;
-
-    /* First check if this is an IPv4 address */
-    if (pj_inet_pton(pj_AF_INET(), host, &dummy) == PJ_SUCCESS)
-	return 4;
-
-    /* Then check if this is an IPv6 address */
-    if (pj_inet_pton(pj_AF_INET6(), host, &dummy6) == PJ_SUCCESS)
-	return 6;
-
-    /* Not an IP address */
-    return 0;
-}
-
 static void tls_perror(const char *sender, const char *title,
 		       pj_status_t status, pj_str_t *remote_name)
 {
@@ -1206,10 +1184,7 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
     ssock_param.async_cnt = 1;
     ssock_param.ioqueue = pjsip_endpt_get_ioqueue(listener->endpt);
     ssock_param.timer_heap = pjsip_endpt_get_timer_heap(listener->endpt);
-    if (get_ip_addr_ver(&remote_name) == 0) {
-        ssock_param.server_name = remote_name; /* Literal IP addresses are not
-                                                * permitted */
-    }
+    ssock_param.server_name = remote_name;
     ssock_param.timeout = listener->tls_setting.timeout;
     ssock_param.user_data = NULL; /* pending, must be set later */
     ssock_param.verify_peer = PJ_FALSE; /* avoid SSL socket closing the socket

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -171,6 +171,7 @@ static void tls_on_destroy(void *arg);
 
 static void wipe_buf(pj_str_t *buf);
 
+
 static void tls_perror(const char *sender, const char *title,
 		       pj_status_t status, pj_str_t *remote_name)
 {

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -171,6 +171,27 @@ static void tls_on_destroy(void *arg);
 
 static void wipe_buf(pj_str_t *buf);
 
+/*
+ * Internal:
+ *  determine if an address is a valid IP address, and if it is,
+ *  return the IP version (4 or 6).
+ */
+static int get_ip_addr_ver(const pj_str_t *host)
+{
+    pj_in_addr dummy;
+    pj_in6_addr dummy6;
+
+    /* First check if this is an IPv4 address */
+    if (pj_inet_pton(pj_AF_INET(), host, &dummy) == PJ_SUCCESS)
+	return 4;
+
+    /* Then check if this is an IPv6 address */
+    if (pj_inet_pton(pj_AF_INET6(), host, &dummy6) == PJ_SUCCESS)
+	return 6;
+
+    /* Not an IP address */
+    return 0;
+}
 
 static void tls_perror(const char *sender, const char *title,
 		       pj_status_t status, pj_str_t *remote_name)
@@ -1185,7 +1206,10 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
     ssock_param.async_cnt = 1;
     ssock_param.ioqueue = pjsip_endpt_get_ioqueue(listener->endpt);
     ssock_param.timer_heap = pjsip_endpt_get_timer_heap(listener->endpt);
-    ssock_param.server_name = remote_name;
+    if (get_ip_addr_ver(&remote_name) == 0) {
+        ssock_param.server_name = remote_name; /* Literal IP addresses are not
+                                                * permitted */
+    }
     ssock_param.timeout = listener->tls_setting.timeout;
     ssock_param.user_data = NULL; /* pending, must be set later */
     ssock_param.verify_peer = PJ_FALSE; /* avoid SSL socket closing the socket


### PR DESCRIPTION
According to [RFC3546](https://tools.ietf.org/html/rfc3546#section-3.1)

> Literal IPv4 and IPv6 addresses are not permitted in "HostName"

This ticket will will set server name only if it is not IP literal.

Thanks to Guru Thodime for the report and suggested fix