### PR TITLE
ALSA dev incorrectly sets the number of samples per frame

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -702,6 +702,9 @@ static pj_status_t open_playback (struct alsa_stream* stream,
 	tmp_buf_size = (rate / 1000) * param->output_latency_ms;
     else
 	tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_PLAY_LATENCY;
+    if (tmp_buf_size < tmp_period_size * 2)
+        tmp_buf_size = tmp_period_size * 2;
+    tmp_buf_size *= param->channel_count;
     snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
 					    &tmp_buf_size);
     stream->param.output_latency_ms = tmp_buf_size / (rate / 1000);
@@ -825,6 +828,9 @@ static pj_status_t open_capture (struct alsa_stream* stream,
 	tmp_buf_size = (rate / 1000) * param->input_latency_ms;
     else
 	tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_REC_LATENCY;
+    if (tmp_buf_size < tmp_period_size * 2)
+        tmp_buf_size = tmp_period_size * 2;
+    tmp_buf_size *= param->channel_count;
     snd_pcm_hw_params_set_buffer_size_near (stream->ca_pcm, params,
 					    &tmp_buf_size);
     stream->param.input_latency_ms = tmp_buf_size / (rate / 1000);

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -689,8 +689,11 @@ static pj_status_t open_playback (struct alsa_stream* stream,
     tmp_period_size = stream->pb_frames;
     snd_pcm_hw_params_set_period_size_near (stream->pb_pcm, params,
 					    &tmp_period_size, NULL);
-    stream->pb_frames = tmp_period_size > stream->pb_frames ? tmp_period_size : 
-                                                              stream->pb_frames;					    					    
+    /* Commenting this as it may cause the number of samples per frame
+     * to be incorrest.
+     */  
+    // stream->pb_frames = tmp_period_size > stream->pb_frames ?
+    //			tmp_period_size : stream->pb_frames;					    					    
     TRACE_((THIS_FILE, "open_playback: period size set to: %d",
 	    tmp_period_size));
 
@@ -809,8 +812,11 @@ static pj_status_t open_capture (struct alsa_stream* stream,
     tmp_period_size = stream->ca_frames;
     snd_pcm_hw_params_set_period_size_near (stream->ca_pcm, params,
 					    &tmp_period_size, NULL);
-    stream->ca_frames = tmp_period_size > stream->ca_frames ? tmp_period_size : 
-                                                              stream->ca_frames;
+    /* Commenting this as it may cause the number of samples per frame
+     * to be incorrest.
+     */
+    // stream->ca_frames = tmp_period_size > stream->ca_frames ?
+    //			tmp_period_size : stream->ca_frames;
     TRACE_((THIS_FILE, "open_capture: period size set to: %d",
 	    tmp_period_size));
 


### PR DESCRIPTION
The fix of issue #2223 seems to be causing an adverse effect, which is that it will set the number of samples per frame incorrectly. This will trigger an assertion in the conference, as reported in:
https://github.com/pjsip/pjproject/issues/2345, https://github.com/pjsip/pjproject/issues/2401, and https://github.com/pjsip/pjproject/issues/2547

It also causes audio issue such as reported in:
https://github.com/pjsip/pjproject/issues/2339

Managed to reproduce the issue on CentOS 8, which will return period size of 341 for samples per frame of 320 (16 KHz 20 ms). Reverting issue #2223 works, and doesn't seem to cause the problem described there (i.e. crash due to incorrect buffer size). `snd_pcm_readi()` and `snd_pcm_writei()` has `nframes` as a parameter, so I'm not clear how or why ALSA can cause buffer overflow.

Original report for issue #2223 can be found here:
http://lists.pjsip.org/pipermail/pjsip_lists.pjsip.org/2019-August/041426.html

So for now, I propose to revert issue #2223 first, until a proper, or better fix is found.
