### PR TITLE
Fix bad Video SDP when using 3rdPartyMedia and PJMEDIA_DIR_ENCODING only

### DIFF
--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -773,9 +773,8 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
 	    break;
 	}
 
-	/* Must support RTP packetization and bidirectional */
-	if ((codec_info[i].packings & PJMEDIA_VID_PACKING_PACKETS) == 0 ||
-	    codec_info[i].dir != PJMEDIA_DIR_ENCODING_DECODING)
+        /* Must support RTP packetization */
+        if ((codec_info[i].packings & PJMEDIA_VID_PACKING_PACKETS) == 0)
 	{
 	    continue;
 	}


### PR DESCRIPTION
When using PJMEDIA_DIR_ENCODING with 3rd Party Media in the video structure, the SDP part of the INVITE is not set properly. This commit omits the direction to be PJMEDIA_DIR_ENCODING_DECODING.