### PR TITLE
Check hostname during transport selection

### DIFF
--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -165,6 +165,7 @@ struct pjsip_dialog
     pjsip_route_hdr	route_set;  /**< Route set.			    */
     pj_bool_t		route_set_frozen; /**< Route set has been set.	    */
     pjsip_auth_clt_sess	auth_sess;  /**< Client authentication session.	    */
+    pj_str_t		initial_remote;/**< Initial remote host.  	    */
 
     /** Session counter. */
     int			sess_count; /**< Number of sessions.		    */

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -467,6 +467,10 @@ pj_status_t create_uas_dialog( pjsip_user_agent *ua,
 
     /* Save the remote info. */
     pj_strdup(dlg->pool, &dlg->remote.info_str, &tmp);
+    
+    /* Save initial remote host from transport's info */
+    pj_strdup(dlg->pool, &dlg->initial_remote,
+    	      &rdata->tp_info.transport->remote_name.host);
 
 
     /* Init remote's contact from Contact header.
@@ -1191,6 +1195,19 @@ static pj_status_t dlg_create_request_throw( pjsip_dialog *dlg,
 	if (status != PJ_SUCCESS)
 	    return status;
     }
+
+    /* Save the initial destination used to send the request message. */
+    if (!dlg->initial_remote.slen) {
+    	pjsip_host_info dest_info;
+
+    	pjsip_get_request_dest(tdata, &dest_info);
+	pj_strdup(dlg->pool, &dlg->initial_remote, &dest_info.addr.host);
+    }
+
+    /* Copy the initial destination host to tdata. This information can be
+     * used later by transport for transport selection.
+     */
+    pj_strdup(tdata->pool, &tdata->dest_info.name, &dlg->initial_remote);
 
     /* Done. */
     *p_tdata = tdata;

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2321,6 +2321,17 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
 				tp_ref = tp_iter->tp;
 				break;
 			    }
+			} else if ((type & PJSIP_TRANSPORT_SECURE) && tdata) {
+			    /* For secure transport, make sure tdata's
+			     * destination host matches the transport's
+			     * remote host.
+			     */
+			    if (!pj_stricmp(&tdata->dest_info.name,
+				  	    &tp_iter->tp->remote_name.host))
+			    {
+			    	tp_ref = tp_iter->tp;
+			    	break;
+			    }
 			} else {
 			    tp_ref = tp_iter->tp;
 			    break;

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1417,7 +1417,10 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request_stateless(pjsip_endpoint *endpt,
      */
     if (tdata->dest_info.addr.count == 0) {
 	/* Copy the destination host name to TX data */
-	pj_strdup(tdata->pool, &tdata->dest_info.name, &dest_info.addr.host);
+	if (!tdata->dest_info.name.slen) {
+	    pj_strdup(tdata->pool, &tdata->dest_info.name,
+	    	      &dest_info.addr.host);
+	}
 
 	pjsip_endpt_resolve( endpt, tdata->pool, &dest_info, stateless_data,
 			     &stateless_send_resolver_callback);
@@ -1810,8 +1813,10 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_response( pjsip_endpoint *endpt,
 	}
     } else {
 	/* Copy the destination host name to TX data */
-	pj_strdup(tdata->pool, &tdata->dest_info.name, 
-		  &res_addr->dst_host.addr.host);
+	if (!tdata->dest_info.name.slen) {
+	    pj_strdup(tdata->pool, &tdata->dest_info.name, 
+		      &res_addr->dst_host.addr.host);
+	}
 
 	pjsip_endpt_resolve(endpt, tdata->pool, &res_addr->dst_host, 
 			    send_state, &send_response_resolver_cb);


### PR DESCRIPTION
Currently, the selection criteria to reuse transport is only based on IP address + port + protocol. In this PR, we add checking hostname as well.

Thanks to Lauri Vänskä for the report and suggestion.
