### PR TITLE
Remove multiplication by channel count in calculating ALSA buffer size

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -704,7 +704,6 @@ static pj_status_t open_playback (struct alsa_stream* stream,
 	tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_PLAY_LATENCY;
     if (tmp_buf_size < tmp_period_size * 2)
         tmp_buf_size = tmp_period_size * 2;
-    tmp_buf_size *= param->channel_count;
     snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
 					    &tmp_buf_size);
     stream->param.output_latency_ms = tmp_buf_size / (rate / 1000);
@@ -830,7 +829,6 @@ static pj_status_t open_capture (struct alsa_stream* stream,
 	tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_REC_LATENCY;
     if (tmp_buf_size < tmp_period_size * 2)
         tmp_buf_size = tmp_period_size * 2;
-    tmp_buf_size *= param->channel_count;
     snd_pcm_hw_params_set_buffer_size_near (stream->ca_pcm, params,
 					    &tmp_buf_size);
     stream->param.input_latency_ms = tmp_buf_size / (rate / 1000);


### PR DESCRIPTION
In #2549, the calculation of buffer size includes channel count, which is not necessary, as pointed out by @mike2307.

References:
https://www.alsa-project.org/wiki/FramesPeriods
https://www.linuxjournal.com/article/6735
