### PR TITLE
Disallow forceful close of pjsua transport

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3175,16 +3175,18 @@ PJ_DECL(pj_status_t) pjsua_transport_set_enable(pjsua_transport_id id,
 
 
 /**
- * Close the transport. If transport is forcefully closed, it will be
- * immediately closed, and any pending transactions that are using the
- * transport may not terminate properly (it may even crash). Otherwise, 
- * the system will wait until all transactions are closed while preventing 
- * new users from using the transport, and will close the transport when 
- * it is safe to do so.
+ * Close the transport. The system will wait until all transactions are
+ * closed while preventing new users from using the transport, and will
+ * close the transport when it is safe to do so.
+ *
+ * NOTE: Forcefully closing transport (force = PJ_TRUE) is deprecated,
+ * since any pending transactions that are using the transport may not
+ * terminate properly and can even crash. Application wishing to immediately
+ * close the transport for the purpose of restarting it should use
+ * #pjsua_handle_ip_change() instead.
  *
  * @param id		Transport ID.
- * @param force		Non-zero to immediately close the transport. This
- *			is not recommended!
+ * @param force		Must be PJ_FALSE. force = PJ_TRUE is deprecated.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
  */

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -2880,20 +2880,26 @@ PJ_DEF(pj_status_t) pjsua_transport_close( pjsua_transport_id id,
 
     tp_type = pjsua_var.tpdata[id].type & ~PJSIP_TRANSPORT_IPV6;
 
-    /* Note: destroy() may not work if there are objects still referencing
-     *	     the transport.
-     */
     if (force) {
-	switch (tp_type) {
+    	/* Forcefully closing transport is deprecated, since any pending
+    	 * transactions that are using the transport may not terminate
+    	 * properly and can even crash.
+    	 */
+	PJ_LOG(1, (THIS_FILE, "pjsua_transport_close(force=PJ_TRUE) is "
+			      "deprecated."));
+    	
+    	/* To minimize the effect to users, we shouldn't hard-deprecate this
+    	 * and let it continue as if force is false.
+    	 */
+    	// return PJ_EINVAL;
+    }
+
+    /* If force is not specified, transports will be closed at their
+     * convenient time.
+     */
+    switch (tp_type) {
 	case PJSIP_TRANSPORT_UDP:
 	    status = pjsip_transport_shutdown(pjsua_var.tpdata[id].data.tp);
-	    if (status  != PJ_SUCCESS)
-		return status;
-	    status = pjsip_transport_destroy(pjsua_var.tpdata[id].data.tp);
-	    if (status != PJ_SUCCESS)
-		return status;
-	    break;
-
 	case PJSIP_TRANSPORT_TLS:
 	case PJSIP_TRANSPORT_TCP:
 	    /* This will close the TCP listener, but existing TCP/TLS
@@ -2901,41 +2907,20 @@ PJ_DEF(pj_status_t) pjsua_transport_close( pjsua_transport_id id,
 	     */
 	    status = (*pjsua_var.tpdata[id].data.factory->destroy)
 			(pjsua_var.tpdata[id].data.factory);
-	    if (status != PJ_SUCCESS)
-		return status;
-
-	    break;
-
 	default:
 	    return PJ_EINVAL;
-	}
-	
-    } else {
-	/* If force is not specified, transports will be closed at their
-	 * convenient time. However this will leak PJSUA-API transport
-	 * descriptors as PJSUA-API wouldn't know when exactly the
-	 * transport is closed thus it can't cleanup PJSUA transport
-	 * descriptor.
-	 */
-	switch (tp_type) {
-	case PJSIP_TRANSPORT_UDP:
-	    return pjsip_transport_shutdown(pjsua_var.tpdata[id].data.tp);
-	case PJSIP_TRANSPORT_TLS:
-	case PJSIP_TRANSPORT_TCP:
-	    return (*pjsua_var.tpdata[id].data.factory->destroy)
-			(pjsua_var.tpdata[id].data.factory);
-	default:
-	    return PJ_EINVAL;
-	}
     }
 
-    /* Cleanup pjsua data when force is applied */
-    if (force) {
-	pjsua_var.tpdata[id].type = PJSIP_TRANSPORT_UNSPECIFIED;
-	pjsua_var.tpdata[id].data.ptr = NULL;
+    /* Cleanup pjsua data. We don't need to keep the transport
+     * descriptor, the transport will be destroyed later by the last user
+     * which decrements the transport's reference.
+     */
+    if (status == PJ_SUCCESS) {
+    	pjsua_var.tpdata[id].type = PJSIP_TRANSPORT_UNSPECIFIED;
+    	pjsua_var.tpdata[id].data.ptr = NULL;
     }
 
-    return PJ_SUCCESS;
+    return status;
 }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -2900,6 +2900,7 @@ PJ_DEF(pj_status_t) pjsua_transport_close( pjsua_transport_id id,
     switch (tp_type) {
 	case PJSIP_TRANSPORT_UDP:
 	    status = pjsip_transport_shutdown(pjsua_var.tpdata[id].data.tp);
+	    break;
 	case PJSIP_TRANSPORT_TLS:
 	case PJSIP_TRANSPORT_TCP:
 	    /* This will close the TCP listener, but existing TCP/TLS
@@ -2907,6 +2908,7 @@ PJ_DEF(pj_status_t) pjsua_transport_close( pjsua_transport_id id,
 	     */
 	    status = (*pjsua_var.tpdata[id].data.factory->destroy)
 			(pjsua_var.tpdata[id].data.factory);
+	    break;
 	default:
 	    return PJ_EINVAL;
     }


### PR DESCRIPTION
To close #1840 .

Since we clearly don't want user to forcefully close the transport (we put so many warnings in the doc), I believe we should deprecate `pjsua_transport_close(force = PJ_TRUE)`. Especially since the use case to immediately close it is typically to restart it, which has now been covered by IP change handling.
Note that in PJSUA2, we already disallow forceful close by not even providing the `force` parameter in `Endpoint::transportClose()`.

For graceful close, the pjsua transport descriptor leak issue can be avoided by immediately cleaning up the transport descriptor and allowing the transport itself to be destroyed at a later timing.
