### PR TITLE
Invoke on_call_sdp_created callback for new SDP offer generated by pjsua_call_set_vid_strm()

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1851,7 +1851,7 @@ static void call_get_vid_strm_info(pjsua_call *call,
 
 /* Send SDP reoffer. */
 static pj_status_t call_reoffer_sdp(pjsua_call_id call_id,
-				    const pjmedia_sdp_session *sdp)
+				    pjmedia_sdp_session *sdp)
 {
     pjsua_call *call;
     pjsip_tx_data *tdata;
@@ -1861,6 +1861,13 @@ static pj_status_t call_reoffer_sdp(pjsua_call_id call_id,
     status = acquire_call("call_reoffer_sdp()", call_id, &call, &dlg);
     if (status != PJ_SUCCESS)
 	return status;
+
+    /* Notify application */
+    if (pjsua_var.ua_cfg.cb.on_call_sdp_created) {
+	(*pjsua_var.ua_cfg.cb.on_call_sdp_created)(call_id, sdp,
+						   call->inv->pool_prov,
+						   NULL);
+    }
 
     if (call->inv->state != PJSIP_INV_STATE_CONFIRMED) {
 	PJ_LOG(3,(THIS_FILE, "Can not re-INVITE call that is not confirmed"));

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1862,17 +1862,17 @@ static pj_status_t call_reoffer_sdp(pjsua_call_id call_id,
     if (status != PJ_SUCCESS)
 	return status;
 
+    if (call->inv->state != PJSIP_INV_STATE_CONFIRMED) {
+	PJ_LOG(3,(THIS_FILE, "Can not re-INVITE call that is not confirmed"));
+	pjsip_dlg_dec_lock(dlg);
+	return PJSIP_ESESSIONSTATE;
+    }
+
     /* Notify application */
     if (pjsua_var.ua_cfg.cb.on_call_sdp_created) {
 	(*pjsua_var.ua_cfg.cb.on_call_sdp_created)(call_id, sdp,
 						   call->inv->pool_prov,
 						   NULL);
-    }
-
-    if (call->inv->state != PJSIP_INV_STATE_CONFIRMED) {
-	PJ_LOG(3,(THIS_FILE, "Can not re-INVITE call that is not confirmed"));
-	pjsip_dlg_dec_lock(dlg);
-	return PJSIP_ESESSIONSTATE;
     }
 
     /* Create re-INVITE with new offer */


### PR DESCRIPTION
The `on_call_sdp_created` docs says:
```
     * Notify application when a call has just created a local SDP (for 
     * initial or subsequent SDP offer/answer). ...
```
So, the callback should be called in `pjsua_call_set_vid_strm()` scenario too.

Thanks Albert Umyarov for the report.