### PR TITLE
Fix click noise in libsamplerate

### DIFF
--- a/pjmedia/src/pjmedia/resample_libsamplerate.c
+++ b/pjmedia/src/pjmedia/resample_libsamplerate.c
@@ -116,10 +116,10 @@ PJ_DEF(pj_status_t) pjmedia_resample_create( pj_pool_t *pool,
     }
 
     /* Kick off. The first process may return samples a lot less than
-     * samples_per_frame (perhaps on some platforms only, such as Mac OSX),
-     * which will cause 'extra' mechanism active and will introduce click
-     * noise, so let's feed the engine with silent audio here to avoid that.
-     * This will introduce delay at most one audio frame length.
+     * samples_per_frame, which will cause 'extra' mechanism active and
+     * will introduce click noise, so let's feed the engine with silent
+     * audio here to avoid that. This will introduce delay at most one
+     * audio frame length.
      */
     {
 	SRC_DATA src_data;


### PR DESCRIPTION
Reported that resampling using libsamplerate backend may cause audio distortion, e.g: rapid click noise, perhaps only on some platforms, e.g: reproducible on MacOS 10.15.7. Thanks to Stefan Hörnqvist for the report.

After investigation, the first resampling process may return only partial audio frame inputted, so the PJMEDIA wrapper will apply some 'extra' mechanism to fill in the output buffer (which may introduce click noise), unfortunately the mechanism cannot be reverted back and affect the whole resampling session.

There are some alternative fixes:
- perform kick-off resampling process in creation, so all next resampling processes will always return full frame, this is simple and less risk (no behaviour change), but will introduce additional delay, at most one audio frame.
- disable the 'extra' mechanism completely, it seems to be needed for odd sample rates only, e.g: 11025, 22050, where samples number for 10ms or 20ms frame length is not an integer.
- rebuffering, e.g: buffer all output samples until full frame can be returned.
- ...?

