### PR TITLE
Fix possible INVITE response retransmission with wrong code

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2448,9 +2448,6 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
     status = pjsip_tx_data_clone(inv->last_answer, 0, &last_res);
     if (status != PJ_SUCCESS)
 	goto on_return;
-    old_res = inv->last_answer;
-    inv->last_answer = last_res;
-    pjsip_tx_data_dec_ref(old_res);
 
     /* Modify last response. */
     status = pjsip_dlg_modify_response(inv->dlg, last_res, st_code, st_text);
@@ -2474,6 +2471,13 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(	pjsip_inv_session *inv,
 
     /* Cleanup Allow & Supported headers from disabled extensions */
     cleanup_allow_sup_hdr(inv->options, last_res, NULL, NULL);
+
+    /* Update inv->last_answer */
+    old_res = inv->last_answer;
+    inv->last_answer = last_res;
+
+    /* Release old answer */
+    pjsip_tx_data_dec_ref(old_res);
 
     *p_tdata = last_res;
 


### PR DESCRIPTION
Scenario:
1. `pjsip_inv_answer()` is called with response code `180` and the returned message is sent.
2. `pjsip_inv_answer()` is called again with response code `200`, unfortunately it fails after the response code is updated to `200`, e.g: due to `process_answer()` returning non-success.
3. retransmission timer is called to retransmit last response, instead of retransmitting `180` response, it transmits `200` response (likely without SDP).

Proposed fix is to delay `inv->last_answer` update until after `process_answer()` is done successfully.