### PR TITLE
Added underlying buffer configurability for splitcomb

### DIFF
--- a/pjmedia/include/pjmedia/splitcomb.h
+++ b/pjmedia/include/pjmedia/splitcomb.h
@@ -113,7 +113,10 @@ PJ_DECL(pj_status_t) pjmedia_splitcomb_set_channel(pjmedia_port *splitcomb,
  * @param options	    Normally is zero, but the lower 8-bit of the 
  *			    options can be used to specify the number of 
  *			    buffers in the circular buffer. If zero, then
- *			    default number will be used (default: 8).
+ *			    default number will be used (default: 8). The second
+ *			    lowest 8 bits can be used to specify the options for
+ *			    the underlying delay buffer (see
+ *			    #pjmedia_delay_buf_flag for the possible options).
  * @param p_chport	    The media port created with reverse phase for
  *			    the specified audio channel.
  *

--- a/pjmedia/src/pjmedia/splitcomb.c
+++ b/pjmedia/src/pjmedia/splitcomb.c
@@ -309,6 +309,7 @@ PJ_DEF(pj_status_t) pjmedia_splitcomb_create_rev_channel( pj_pool_t *pool,
     struct splitcomb *sc = (struct splitcomb*) splitcomb;
     struct reverse_port *rport;
     unsigned buf_cnt;
+    unsigned buf_options;
     const pjmedia_audio_format_detail *sc_afd, *p_afd;
     pjmedia_port *port;
     pj_status_t status;
@@ -352,6 +353,9 @@ PJ_DEF(pj_status_t) pjmedia_splitcomb_create_rev_channel( pj_pool_t *pool,
     if (buf_cnt == 0)
 	buf_cnt = MAX_BUF_CNT;
 
+    /* Buffer options */
+    buf_options = (options >> 8U) & 0xFF;
+
     rport->max_burst = MAX_BURST;
     rport->max_null_frames = MAX_NULL_FRAMES;
 
@@ -361,7 +365,8 @@ PJ_DEF(pj_status_t) pjmedia_splitcomb_create_rev_channel( pj_pool_t *pool,
 				      PJMEDIA_PIA_SPF(&port->info),
 				      p_afd->channel_count,
 				      buf_cnt * p_afd->frame_time_usec / 1000,
-				      0, &rport->buf[DIR_DOWNSTREAM].dbuf);
+				      buf_options,
+				      &rport->buf[DIR_DOWNSTREAM].dbuf);
     if (status != PJ_SUCCESS) {
 	return status;
     }
@@ -372,7 +377,8 @@ PJ_DEF(pj_status_t) pjmedia_splitcomb_create_rev_channel( pj_pool_t *pool,
 				      PJMEDIA_PIA_SPF(&port->info),
 				      p_afd->channel_count,
 				      buf_cnt * p_afd->frame_time_usec / 1000,
-				      0, &rport->buf[DIR_UPSTREAM].dbuf);
+				      buf_options,
+				      &rport->buf[DIR_UPSTREAM].dbuf);
     if (status != PJ_SUCCESS) {
 	pjmedia_delay_buf_destroy(rport->buf[DIR_DOWNSTREAM].dbuf);
 	return status;


### PR DESCRIPTION
This pull request adds the possibility to handover options for the underlying buffer when creating an instance of splitcomb.