### PR TITLE
Added function pjmedia_tonegen_stop_loop()

### DIFF
--- a/pjmedia/include/pjmedia/tonegen.h
+++ b/pjmedia/include/pjmedia/tonegen.h
@@ -200,6 +200,16 @@ PJ_DECL(pj_status_t) pjmedia_tonegen_stop(pjmedia_port *tonegen);
 
 
 /**
+ * Instruct the tone generator to stop looping of the current tone set.
+ *
+ * @param tonegen	    The tone generator instance.
+ *
+ * @return		    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_tonegen_stop_loop(pjmedia_port *tonegen);
+
+
+/**
  * Rewind the playback. This will start the playback to the first
  * tone in the playback list.
  *

--- a/pjmedia/src/pjmedia/tonegen.c
+++ b/pjmedia/src/pjmedia/tonegen.c
@@ -522,7 +522,7 @@ PJ_DEF(pj_status_t) pjmedia_tonegen_stop_loop(pjmedia_port *port)
     TRACE_((THIS_FILE, "tonegen_stop_loop()"));
 
     pj_lock_acquire(tonegen->lock);
-    tonegen->playback_options &= !PJMEDIA_TONEGEN_LOOP;
+    tonegen->playback_options &= ~PJMEDIA_TONEGEN_LOOP;
     pj_lock_release(tonegen->lock);
 
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia/tonegen.c
+++ b/pjmedia/src/pjmedia/tonegen.c
@@ -511,6 +511,22 @@ PJ_DEF(pj_status_t) pjmedia_tonegen_stop(pjmedia_port *port)
     return PJ_SUCCESS;
 }
 
+/*
+ * Instruct the tone generator to stop looping of the current tone set.
+ */
+PJ_DEF(pj_status_t) pjmedia_tonegen_stop_loop(pjmedia_port *port)
+{
+    struct tonegen *tonegen = (struct tonegen*) port;
+    PJ_ASSERT_RETURN(port->info.signature == SIGNATURE, PJ_EINVAL);
+
+    TRACE_((THIS_FILE, "tonegen_stop_loop()"));
+
+    pj_lock_acquire(tonegen->lock);
+    tonegen->playback_options &= !PJMEDIA_TONEGEN_LOOP;
+    pj_lock_release(tonegen->lock);
+
+    return PJ_SUCCESS;
+}
 
 /*
  * Instruct the tone generator to stop current processing.


### PR DESCRIPTION
This pull request adds the function pjmedia_tonegen_stop_loop() to tonegen, which can be used to stop looping of the current tone set.