### PR TITLE
Prevent regc destroy when it is busy

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2291,6 +2291,13 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
     if (param->status!=PJ_SUCCESS) {
 	pjsua_perror(THIS_FILE, "SIP registration error", 
 		     param->status);
+
+	if (param->status == PJSIP_EBUSY) {
+	    pj_log_pop_indent();
+            PJSUA_UNLOCK();
+	    return;
+	}
+
 	pjsip_regc_destroy(acc->regc);
 	acc->regc = NULL;
 	acc->contact.slen = 0;


### PR DESCRIPTION
When there is a race condition when calling `pjsip_regc_send()`, one of them will return PJSIP_EBUSY. Within the library, this can cause `regc_cb()` in `pjsua_acc.c` to be called, and since the status is non PJ_SUCCESS, the callback will incorrectly destroy the regc.
