### PR TITLE
Report disconnection event immediately when hanging up a call

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -911,7 +911,7 @@ static void ui_hangup_call(char menuin[])
 	pjsua_call_hangup_all();
     } else {
 	/* Hangup current calls */
-	pjsua_call_hangup(current_call, 0, NULL, NULL);
+	pjsua_call_hangup2(current_call, PJ_TRUE, 0, NULL, NULL);
     }
 }
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -5574,6 +5574,40 @@ PJ_DECL(pj_status_t) pjsua_call_hangup(pjsua_call_id call_id,
 				       const pjsua_msg_data *msg_data);
 
 /**
+ * Hangup call by using method that is appropriate according to the
+ * call state. This function is different than answering the call with
+ * 3xx-6xx response (with #pjsua_call_answer()), in that this function
+ * will hangup the call regardless of the state and role of the call,
+ * while #pjsua_call_answer() only works with incoming calls on EARLY
+ * state.
+ *
+ * If parameter immediate is set to PJ_TRUE, call DISCONNECTED state
+ * will be immediately reported to app and the call slot can be reused.
+ * The only exception is if media transport creation is in progress
+ * during call setup. In this case, the hangup will be pending upon
+ * the completion of the media transport.
+ * The library will then process the call hangup, such as notifying
+ * the remote and cleaning up used resources, in the background.
+ *
+ * @param call_id	Call identification.
+ * @param immediate	Set to PJ_TRUE to hangup the call immediately.
+ * @param code		Optional status code to be sent when we're rejecting
+ *			incoming call. If the value is zero, "603/Decline"
+ *			will be sent.
+ * @param reason	Optional reason phrase to be sent when we're rejecting
+ *			incoming call.  If NULL, default text will be used.
+ * @param msg_data	Optional list of headers etc to be added to outgoing
+ *			request/response message.
+ *
+ * @return		PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsua_call_hangup2(pjsua_call_id call_id,
+				        pj_bool_t immediate,
+				        unsigned code,
+				        const pj_str_t *reason,
+				        const pjsua_msg_data *msg_data);
+
+/**
  * Accept or reject redirection response. Application MUST call this function
  * after it signaled PJSIP_REDIRECT_PENDING in the \a on_call_redirected() 
  * callback, to notify the call whether to accept or reject the redirection

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -491,6 +491,8 @@ struct pjsua_data
     unsigned		 call_cnt;		/**< Call counter.	*/
     pjsua_call		 calls[PJSUA_MAX_CALLS];/**< Calls array.	*/
     pjsua_call_id	 next_call_id;		/**< Next call id to use*/
+    pjsua_call		 hangup_calls[PJSUA_MAX_CALLS];/**< Calls in
+    						     hangup process.	*/
 
     /* Buddy; */
     unsigned		 buddy_cnt;		    /**< Buddy count.	*/
@@ -694,7 +696,7 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
 pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 				       const pjmedia_sdp_session *local_sdp,
 				       const pjmedia_sdp_session *remote_sdp);
-pj_status_t pjsua_media_channel_deinit(pjsua_call_id call_id);
+pj_status_t pjsua_media_channel_deinit(pjsua_call *call);
 
 /*
  * Error message when media operation is requested while another is in progress
@@ -712,7 +714,7 @@ pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
 void pjsua_call_cleanup_flag(pjsua_call_setting *opt);
 void pjsua_set_media_tp_state(pjsua_call_media *call_med, pjsua_med_tp_st tp_st);
 
-void pjsua_media_prov_clean_up(pjsua_call_id call_id);
+void pjsua_media_prov_clean_up(pjsua_call *call);
 
 /* Callback to receive media events */
 pj_status_t on_media_event(pjmedia_event *event, void *user_data);

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -182,6 +182,7 @@ struct pjsua_call
             struct {		
                 call_answer      answers;/**< A list of call answers.       */
 		pj_bool_t	 hangup;/**< Call is hangup?		    */
+                pj_bool_t	 immediate;/**< Immediate call hangup?	    */
 		pjsip_dialog	*replaced_dlg; /**< Replaced dialog.	    */
             } inc_call;
         } call_var;
@@ -205,6 +206,12 @@ struct pjsua_call
 					    created yet. This temporary 
 					    variable is used to handle such 
 					    case, see ticket #1916.	    */
+
+    pj_timer_entry	 hangup_timer;	/**< Hangup retry timer.	    */
+    unsigned		 hangup_retry;	/**< Number of hangup retries.	    */
+    unsigned		 hangup_code;	/**< Hangup code.	    	    */
+    pj_str_t		 hangup_reason;	/**< Hangup reason.	    	    */
+    pjsua_msg_data	*hangup_msg_data;/**< Hangup message data.	    */
 };
 
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1885,7 +1885,7 @@ PJ_DEF(pj_status_t) pjsua_destroy2(unsigned flags)
 	    /* TODO: check if we're not allowed to send to network in the
 	     *       "flags", and if so do not do TURN allocation...
 	     */
-	    pjsua_media_channel_deinit(i);
+	    pjsua_media_channel_deinit(&pjsua_var.calls[i]);
 	}
 
 	/* Set all accounts to offline */

--- a/pjsip/src/pjsua-lib/pjsua_dump.c
+++ b/pjsip/src/pjsua-lib/pjsua_dump.c
@@ -907,13 +907,14 @@ void print_call(const char *title,
 	        char *buf, pj_size_t size)
 {
     int len;
-    pjsip_inv_session *inv = pjsua_var.calls[call_id].inv;
+    pjsua_call *call = &pjsua_var.calls[call_id];
+    pjsip_inv_session *inv = call->inv;
     pjsip_dialog *dlg;
     char userinfo[PJSIP_MAX_URL_SIZE];
 
     /* Dump invite sesion info. */
 
-    dlg = (inv? inv->dlg: pjsua_var.calls[call_id].async_call.dlg);
+    dlg = (inv? inv->dlg: call->async_call.dlg);
     len = pjsip_hdr_print_on(dlg->remote.info, userinfo, sizeof(userinfo));
     if (len < 0)
 	pj_ansi_strcpy(userinfo, "<--uri too long-->");
@@ -922,8 +923,9 @@ void print_call(const char *title,
 
     len = pj_ansi_snprintf(buf, size, "%s[%s] %s",
 			   title,
-                           pjsip_inv_state_name(inv? inv->state:
-                                                PJSIP_INV_STATE_DISCONNECTED),
+                           pjsip_inv_state_name((call->hanging_up || !inv)?
+                                                PJSIP_INV_STATE_DISCONNECTED:
+                                                inv->state),
 			   userinfo);
     if (len < 1 || len >= (int)size) {
 	pj_ansi_strcpy(buf, "<--uri too long-->");

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1,4 +1,3 @@
-/* $Id$ */
 /* 
  * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
  * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>
@@ -1544,11 +1543,11 @@ pj_status_t call_media_on_event(pjmedia_event *event,
     char ev_name[5];
     pj_status_t status = PJ_SUCCESS;
 
-    pj_assert(call && call_med);
     pjmedia_fourcc_name(event->type, ev_name);
     PJ_LOG(5,(THIS_FILE, "Call %d: Media %d: Received media event, type=%s, "
 			 "src=%p, epub=%p",
-			 call->index, call_med->idx, ev_name,
+			 (call? call->index: -1),
+			 (call_med? call_med->idx: -1), ev_name,
 			 event->src, event->epub));
 
     switch(event->type) {
@@ -1636,7 +1635,7 @@ pj_status_t call_media_on_event(pjmedia_event *event,
 		PJ_PERROR(3,(THIS_FILE, event->data.vid_dev_err.status,
 			     "Video device id=%d error for call %d",
 			     event->data.vid_dev_err.id,
-			     call->index));
+			     (call? call->index: -1)));
 	    }
 	    break;
 #endif

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1921,7 +1921,7 @@ static pj_status_t call_add_video(pjsua_call *call,
     sdp = pjmedia_sdp_session_clone(call->inv->pool_prov, current_sdp);
 
     /* Clean up provisional media before using it */
-    pjsua_media_prov_clean_up(call->index);
+    pjsua_media_prov_clean_up(call);
 
     /* Update provisional media from call media */
     call->med_prov_cnt = call->med_cnt;
@@ -2033,7 +2033,7 @@ static pj_status_t call_modify_video(pjsua_call *call,
     }
 
     /* Clean up provisional media before using it */
-    pjsua_media_prov_clean_up(call->index);
+    pjsua_media_prov_clean_up(call);
 
     /* Update provisional media from call media */
     call->med_prov_cnt = call->med_cnt;
@@ -2151,7 +2151,7 @@ static pj_status_t call_modify_video(pjsua_call *call,
 
 on_error:
 	if (status != PJ_SUCCESS) {
-	    pjsua_media_prov_clean_up(call->index);
+	    pjsua_media_prov_clean_up(call);
 	    return status;
 	}
     


### PR DESCRIPTION
To continue the work in #1049 and close it.

* Add a new API `pjsua_call_hangup2()` which allows user the option to immediately hangup a call. The call slot can then be reused almost immediately while the hangup process itself will be handled in the background. The only exception is if the asynchronous media transport creation is in progress during initial call setup. In this case, the hangup will be pending upon the completion of the media transport. Note that any media transport (re-)creation, such as during reinit media, once the call has been confirmed will not pend the hangup process, since the media tp recreation will be synchronous while acquiring dialog lock.

* Application will not receive any PJSUA call related callback once call is declared to be disconnected.

* Retry creating and sending BYE after a period of `CALL_HANGUP_RETRY_INTERVAL` if it fails. If this keeps happening after `CALL_HANGUP_MAX_RETRY` times, we will hard-terminate the call, i.e. cleanup the call without sending any BYE to the remote.
