### PR TITLE
Conf functions to disconnect all sinks/sources

### DIFF
--- a/pjmedia/include/pjmedia/conference.h
+++ b/pjmedia/include/pjmedia/conference.h
@@ -361,6 +361,32 @@ PJ_DECL(pj_status_t) pjmedia_conf_disconnect_port( pjmedia_conf *conf,
 
 
 /**
+ * Disconnect unidirectional audio from all sources to the specified sink slot.
+ *
+ * @param conf		The conference bridge.
+ * @param sink_slot	Sink slot.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_conf_disconnect_port_from_sources( pjmedia_conf *conf,
+					   unsigned sink_slot);
+
+
+/**
+ * Disconnect unidirectional audio from the specified source to all sink slots.
+ *
+ * @param conf		The conference bridge.
+ * @param src_slot	Source slot.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_conf_disconnect_port_from_sinks( pjmedia_conf *conf,
+					 unsigned src_slot);
+
+
+/**
  * Get number of ports currently registered to the conference bridge.
  *
  * @param conf		The conference bridge.

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1107,6 +1107,106 @@ PJ_DEF(pj_status_t) pjmedia_conf_disconnect_port( pjmedia_conf *conf,
     return PJ_SUCCESS;
 }
 
+
+/*
+ * Disconnect port from all sources
+ */
+PJ_DEF(pj_status_t)
+pjmedia_conf_disconnect_port_from_sources( pjmedia_conf *conf,
+					   unsigned sink_slot)
+{
+    unsigned i;
+
+    /* Check arguments */
+    PJ_ASSERT_RETURN(conf && sink_slot<conf->max_ports, PJ_EINVAL);
+
+    /* Remove this port from transmit array of other ports. */
+    for (i=0; i<conf->max_ports; ++i) {
+	unsigned j;
+	struct conf_port *src_port;
+
+	pj_mutex_lock(conf->mutex);
+
+	src_port = conf->ports[i];
+
+	if (!src_port) {
+	    pj_mutex_unlock(conf->mutex);
+	    continue;
+	}
+
+	if (src_port->listener_cnt == 0) {
+	    pj_mutex_unlock(conf->mutex);
+	    continue;
+	}
+
+	for (j=0; j<src_port->listener_cnt; ++j) {
+	    if (src_port->listener_slots[j] == sink_slot) {
+		pj_array_erase(src_port->listener_slots, sizeof(SLOT_TYPE),
+			       src_port->listener_cnt, j);
+		pj_array_erase(src_port->listener_adj_level, sizeof(unsigned),
+			       src_port->listener_cnt, j);
+		pj_assert(conf->connect_cnt > 0);
+		--conf->connect_cnt;
+		--src_port->listener_cnt;
+		break;
+	    }
+	}
+
+	pj_mutex_unlock(conf->mutex);
+    }
+
+    if (conf->connect_cnt == 0) {
+	pause_sound(conf);
+    }
+
+    return PJ_SUCCESS;
+}
+
+
+/*
+ * Disconnect port from all sinks
+ */
+PJ_DEF(pj_status_t)
+pjmedia_conf_disconnect_port_from_sinks( pjmedia_conf *conf,
+					 unsigned src_slot)
+{
+    struct conf_port *src_port;
+
+    /* Check arguments */
+    PJ_ASSERT_RETURN(conf && src_slot<conf->max_ports, PJ_EINVAL);
+
+    pj_mutex_lock(conf->mutex);
+
+    /* Port must be valid. */
+    src_port = conf->ports[src_slot];
+    if (!src_port) {
+	pj_mutex_unlock(conf->mutex);
+	return PJ_EINVAL;
+    }
+
+    /* Update transmitter_cnt of ports we're transmitting to */
+    while (src_port->listener_cnt) {
+	unsigned dst_slot;
+	struct conf_port *dst_port;
+
+	dst_slot = src_port->listener_slots[src_port->listener_cnt-1];
+	dst_port = conf->ports[dst_slot];
+	--dst_port->transmitter_cnt;
+	--src_port->listener_cnt;
+	pj_assert(conf->connect_cnt > 0);
+	--conf->connect_cnt;
+    }
+
+    pj_mutex_unlock(conf->mutex);
+
+    if (conf->connect_cnt == 0) {
+	pause_sound(conf);
+    }
+
+    return PJ_SUCCESS;
+}
+
+
 /*
  * Get number of ports currently registered to the conference bridge.
  */
@@ -1131,7 +1231,6 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
 					      unsigned port )
 {
     struct conf_port *conf_port;
-    unsigned i;
 
     /* Check arguments */
     PJ_ASSERT_RETURN(conf && port < conf->max_ports, PJ_EINVAL);
@@ -1153,43 +1252,15 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
     conf_port->tx_setting = PJMEDIA_PORT_DISABLE;
     conf_port->rx_setting = PJMEDIA_PORT_DISABLE;
 
-    /* Remove this port from transmit array of other ports. */
-    for (i=0; i<conf->max_ports; ++i) {
-	unsigned j;
-	struct conf_port *src_port;
+    pj_mutex_unlock(conf->mutex);
 
-	src_port = conf->ports[i];
+    /* disconnect port from all sources which are transmitting to it */
+    pjmedia_conf_disconnect_port_from_sources(conf, port);
 
-	if (!src_port)
-	    continue;
+    /* disconnect port from all sinks to which it is transmitting to */
+    pjmedia_conf_disconnect_port_from_sinks(conf, port);
 
-	if (src_port->listener_cnt == 0)
-	    continue;
-
-	for (j=0; j<src_port->listener_cnt; ++j) {
-	    if (src_port->listener_slots[j] == port) {
-		pj_array_erase(src_port->listener_slots, sizeof(SLOT_TYPE),
-			       src_port->listener_cnt, j);
-		pj_assert(conf->connect_cnt > 0);
-		--conf->connect_cnt;
-		--src_port->listener_cnt;
-		break;
-	    }
-	}
-    }
-
-    /* Update transmitter_cnt of ports we're transmitting to */
-    while (conf_port->listener_cnt) {
-	unsigned dst_slot;
-	struct conf_port *dst_port;
-
-	dst_slot = conf_port->listener_slots[conf_port->listener_cnt-1];
-	dst_port = conf->ports[dst_slot];
-	--dst_port->transmitter_cnt;
-	--conf_port->listener_cnt;
-	pj_assert(conf->connect_cnt > 0);
-	--conf->connect_cnt;
-    }
+    pj_mutex_lock(conf->mutex);
 
     /* Destroy resample if this conf port has it. */
     if (conf_port->rx_resample) {
@@ -1217,12 +1288,6 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
     --conf->port_cnt;
 
     pj_mutex_unlock(conf->mutex);
-
-
-    /* Stop sound if there's no connection. */
-    if (conf->connect_cnt == 0) {
-	pause_sound(conf);
-    }
 
     return PJ_SUCCESS;
 }

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1661,11 +1661,17 @@ static pj_status_t write_port(pjmedia_conf *conf, struct conf_port *cport,
 
     *frm_type = PJMEDIA_FRAME_TYPE_AUDIO;
 
+    /* Skip port if it is disabled */
+    if (cport->tx_setting != PJMEDIA_PORT_ENABLE) {
+	cport->tx_level = 0;
+	*frm_type = PJMEDIA_FRAME_TYPE_NONE;
+	return PJ_SUCCESS;
+    }
     /* If port is muted or nobody is transmitting to this port, 
      * transmit NULL frame. 
      */
-    if (cport->tx_setting == PJMEDIA_PORT_MUTE || cport->transmitter_cnt==0) {
-
+    else if ((cport->tx_setting == PJMEDIA_PORT_MUTE) ||
+	     (cport->transmitter_cnt == 0)) {
 	pjmedia_frame frame;
 
 	/* Clear left-over samples in tx_buffer, if any, so that it won't
@@ -1698,11 +1704,6 @@ static pj_status_t write_port(pjmedia_conf *conf, struct conf_port *cport,
 	    }
 	}
 
-	cport->tx_level = 0;
-	*frm_type = PJMEDIA_FRAME_TYPE_NONE;
-	return PJ_SUCCESS;
-
-    } else if (cport->tx_setting != PJMEDIA_PORT_ENABLE) {
 	cport->tx_level = 0;
 	*frm_type = PJMEDIA_FRAME_TYPE_NONE;
 	return PJ_SUCCESS;

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1851,7 +1851,7 @@ static void call_get_vid_strm_info(pjsua_call *call,
 
 /* Send SDP reoffer. */
 static pj_status_t call_reoffer_sdp(pjsua_call_id call_id,
-				    const pjmedia_sdp_session *sdp)
+				    pjmedia_sdp_session *sdp)
 {
     pjsua_call *call;
     pjsip_tx_data *tdata;
@@ -1866,6 +1866,13 @@ static pj_status_t call_reoffer_sdp(pjsua_call_id call_id,
 	PJ_LOG(3,(THIS_FILE, "Can not re-INVITE call that is not confirmed"));
 	pjsip_dlg_dec_lock(dlg);
 	return PJSIP_ESESSIONSTATE;
+    }
+
+    /* Notify application */
+    if (pjsua_var.ua_cfg.cb.on_call_sdp_created) {
+	(*pjsua_var.ua_cfg.cb.on_call_sdp_created)(call_id, sdp,
+						   call->inv->pool_prov,
+						   NULL);
     }
 
     /* Create re-INVITE with new offer */


### PR DESCRIPTION
This PR splits the logic of pjmedia_conf_remove_port() into 2 separately usable functions pjmedia_conf_disconnect_port_from_sources() and pjmedia_conf_disconnect_port_from_sinks().