### PR TITLE
Supporting mingw-w64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ install:
 		sed -e "s/@PJ_VERSION@/$(PJ_VERSION)/" | \
 		sed -e "s!@PJ_INSTALL_LDFLAGS@!$(PJ_INSTALL_LDFLAGS)!" | \
 		sed -e "s!@PJ_INSTALL_LDFLAGS_PRIVATE@!$(PJ_INSTALL_LDFLAGS_PRIVATE)!" | \
-		sed -e "s!@PJ_INSTALL_CFLAGS@!$(PJ_INSTALL_CFLAGS)!" > $(DESTDIR)/$(libdir)/pkgconfig/libpjproject.pc
+		sed -e "s!@PJ_INSTALL_CFLAGS@!$(PJ_INSTALL_CFLAGS)!" > $(DESTDIR)$(libdir)/pkgconfig/libpjproject.pc
 
 uninstall:
 	$(RM) $(DESTDIR)$(libdir)/pkgconfig/libpjproject.pc

--- a/aconfigure
+++ b/aconfigure
@@ -5160,6 +5160,12 @@ case $target in
 
 	$as_echo "#define WIN32_LEAN_AND_MEAN 1" >>confdefs.h
 
+	case $target in
+	    *w64-mingw* )
+		$as_echo "#define PJ_WIN64 1" >>confdefs.h
+
+	    ;;
+	esac
 	;;
     *darwin*)
 	$as_echo "#define PJ_DARWINOS 1" >>confdefs.h

--- a/aconfigure
+++ b/aconfigure
@@ -5161,7 +5161,7 @@ case $target in
 	$as_echo "#define WIN32_LEAN_AND_MEAN 1" >>confdefs.h
 
 	case $target in
-	    *w64-mingw* )
+	    *_64-w64-mingw* )
 		$as_echo "#define PJ_WIN64 1" >>confdefs.h
 
 	    ;;

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -165,7 +165,7 @@ case $target in
 	AC_DEFINE(PJ_WIN32_WINNT,0x0400)
 	AC_DEFINE(WIN32_LEAN_AND_MEAN)
 	case $target in
-	    *w64-mingw* )
+	    *_64-w64-mingw* )
 		AC_DEFINE(PJ_WIN64,1)
 	    ;;
 	esac

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -164,6 +164,11 @@ case $target in
 	AC_DEFINE(PJ_WIN32,1)
 	AC_DEFINE(PJ_WIN32_WINNT,0x0400)
 	AC_DEFINE(WIN32_LEAN_AND_MEAN)
+	case $target in
+	    *w64-mingw* )
+		AC_DEFINE(PJ_WIN64,1)
+	    ;;
+	esac
 	;;
     *darwin*)
 	AC_DEFINE(PJ_DARWINOS,1)

--- a/pjlib/include/pj/compat/os_auto.h.in
+++ b/pjlib/include/pj/compat/os_auto.h.in
@@ -30,6 +30,7 @@
 #undef PJ_OS_NAME
 
 /* Legacy macros */
+#undef PJ_WIN64
 #undef PJ_WIN32
 #undef PJ_WIN32_WINNT
 #undef WIN32_LEAN_AND_MEAN

--- a/pjnath/src/pjnath-test/stun_sock_test.c
+++ b/pjnath/src/pjnath-test/stun_sock_test.c
@@ -25,8 +25,7 @@ enum {
     RESPOND_STUN    = 1,
     WITH_MAPPED	    = 2,
     WITH_XOR_MAPPED = 4,
-
-    ECHO	    = 8
+    SEND_ECHO	    = 8
 };
 
 /*
@@ -125,7 +124,7 @@ static pj_bool_t srv_on_data_recvfrom(pj_activesock_t *asock,
 
 	pj_pool_release(pool);
 
-    } else if (srv->flag & ECHO) {
+    } else if (srv->flag & SEND_ECHO) {
 	/* Send back */
 	sent = size;
 	pj_activesock_sendto(asock, &srv->send_key, data, &sent, 0, 
@@ -574,7 +573,7 @@ static int keep_alive_test(pj_stun_config *cfg, pj_bool_t use_ipv6)
     PJ_LOG(3,(THIS_FILE, "    sending/receiving data"));
 
     /* Change server operation mode to echo back data */
-    srv->flag = ECHO;
+    srv->flag = SEND_ECHO;
 
     /* Reset server */
     srv->rx_cnt = 0;

--- a/pjnath/src/pjnath-test/stun_sock_test.c
+++ b/pjnath/src/pjnath-test/stun_sock_test.c
@@ -25,7 +25,7 @@ enum {
     RESPOND_STUN    = 1,
     WITH_MAPPED	    = 2,
     WITH_XOR_MAPPED = 4,
-    SEND_ECHO	    = 8
+    ECHO	    = 8
 };
 
 /*
@@ -124,7 +124,7 @@ static pj_bool_t srv_on_data_recvfrom(pj_activesock_t *asock,
 
 	pj_pool_release(pool);
 
-    } else if (srv->flag & SEND_ECHO) {
+    } else if (srv->flag & ECHO) {
 	/* Send back */
 	sent = size;
 	pj_activesock_sendto(asock, &srv->send_key, data, &sent, 0, 
@@ -573,7 +573,7 @@ static int keep_alive_test(pj_stun_config *cfg, pj_bool_t use_ipv6)
     PJ_LOG(3,(THIS_FILE, "    sending/receiving data"));
 
     /* Change server operation mode to echo back data */
-    srv->flag = SEND_ECHO;
+    srv->flag = ECHO;
 
     /* Reset server */
     srv->rx_cnt = 0;


### PR DESCRIPTION
This is the initial works for supporting [Mingw-w64](http://mingw-w64.org/).

### Steps
1. Install [msys2](https://www.msys2.org/).
2. Open just installed app `MSYS2 MinGW 64-bit`, terminal should be shown. Alternatively, you can use `MSYS2 MinGW 32-bit` for 32 bit target, don't forget to also use the appropriate msys2 package version (e.g: with `i686` suffix instead of `x86_64`).
3. Install at least `gcc` & `make` (and optionally other dev tools as needed), e.g:
    ```
    pacman -S mingw-w64-x86_64-gcc
    pacman -S make
    pacman -S autoconf # this is optional
    ```
    Alternatively, install base development and mingw-w64 toolchains packages:
    ```
    pacman -S base-devel mingw-w64-x86_64-toolchain
    ```
4. Verify the environment:
   - `uname` command should print something like `MINGW64_NT-x-y` (instead of `MSYS_NT-x-y`).
   - `gcc -dumpmachine` command should print `x86_64-w64-mingw32` (instead of `x86_64-pc-msys`).
5. Get [PJSIP source code](https://trac.pjsip.org/repos/wiki/Getting-Started/Download-Source) and follow the [Getting Started](https://trac.pjsip.org/repos/wiki/Getting-Started/Autoconf) wiki page.
6. Apply patch from this pull request (if you are using 2.10 or older).

### Video support
1. Check the [Video Support](https://trac.pjsip.org/repos/wiki/Getting-Started/Autoconf#VideoSupportfor2.0andabove) section in the Getting Started wiki page.
2. Install dependency packages, e.g:
    ```
    pacman -S mingw-w64-x86_64-SDL2
    pacman -S mingw-w64-x86_64-openh264
    ``` 
3. Check pull request #2589 and apply its patch (if you are using 2.10 or older).
4. Run `configure --enable-video=yes`, make sure the dependency packages are correctly detected, then `make` as usual.

### Credits
Thanks to Nikolai ZHUBR (@zhubr) for the heads-up and the initial patch for supporting Mingw-w64 platform.