### PR TITLE
Report disconnection event immediately when hanging up a call

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1317,6 +1317,20 @@ int stdout_refresh_proc(void *arg)
     return 0;
 }
 
+static void on_stream_created2(pjsua_call_id call_id,
+			       pjsua_on_stream_created_param *param)
+{
+printf("on stream created\n");
+}
+
+static void on_stream_destroyed(pjsua_call_id call_id,
+                                pjmedia_stream *strm,
+				unsigned stream_idx)
+{
+printf("on stream destroyed\n");
+}
+
+
 static pj_status_t app_init(void)
 {
     pjsua_transport_id transport_id = -1;
@@ -1350,6 +1364,9 @@ static pj_status_t app_init(void)
     }
 
     /* Initialize application callbacks */
+    app_config.cfg.cb.on_stream_created2 = &on_stream_created2;
+    app_config.cfg.cb.on_stream_destroyed = &on_stream_destroyed;
+
     app_config.cfg.cb.on_call_state = &on_call_state;
     app_config.cfg.cb.on_call_media_state = &on_call_media_state;
     app_config.cfg.cb.on_incoming_call = &on_incoming_call;

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -205,8 +205,11 @@ static void on_call_state(pjsua_call_id call_id, pjsip_event *e)
 	    find_next_call();
 	}
 
-	/* Dump media state upon disconnected */
-	if (1) {
+	/* Dump media state upon disconnected.
+	 * Moved to on_stream_destroyed() since media has been deactivated
+	 * upon disconnection.
+	 */
+	if (0) {
 	    PJ_LOG(5,(THIS_FILE, 
 		      "Call %d disconnected, dumping media stats..", 
 		      call_id));
@@ -268,6 +271,21 @@ static void on_call_state(pjsua_call_id call_id, pjsip_event *e)
 	if (current_call==PJSUA_INVALID_ID)
 	    current_call = call_id;
 
+    }
+}
+
+/*
+ * Handler when audio stream is destroyed.
+ */
+static void on_stream_destroyed(pjsua_call_id call_id,
+                                pjmedia_stream *strm,
+				unsigned stream_idx)
+{
+    if (1) {
+	PJ_LOG(5,(THIS_FILE, 
+		  "Call %d stream %d destroyed, dumping media stats..", 
+		  call_id, stream_idx));
+	log_call_dump(call_id);
     }
 }
 
@@ -1317,19 +1335,6 @@ int stdout_refresh_proc(void *arg)
     return 0;
 }
 
-static void on_stream_created2(pjsua_call_id call_id,
-			       pjsua_on_stream_created_param *param)
-{
-printf("on stream created\n");
-}
-
-static void on_stream_destroyed(pjsua_call_id call_id,
-                                pjmedia_stream *strm,
-				unsigned stream_idx)
-{
-printf("on stream destroyed\n");
-}
-
 
 static pj_status_t app_init(void)
 {
@@ -1364,10 +1369,8 @@ static pj_status_t app_init(void)
     }
 
     /* Initialize application callbacks */
-    app_config.cfg.cb.on_stream_created2 = &on_stream_created2;
-    app_config.cfg.cb.on_stream_destroyed = &on_stream_destroyed;
-
     app_config.cfg.cb.on_call_state = &on_call_state;
+    app_config.cfg.cb.on_stream_destroyed = &on_stream_destroyed;
     app_config.cfg.cb.on_call_media_state = &on_call_media_state;
     app_config.cfg.cb.on_incoming_call = &on_incoming_call;
     app_config.cfg.cb.on_dtmf_digit2 = &call_on_dtmf_callback2;

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -5277,9 +5277,11 @@ pjsua_call_send_dtmf_param_default(pjsua_call_send_dtmf_param *param);
 PJ_DECL(unsigned) pjsua_call_get_max_count(void);
 
 /**
- * Get number of currently active calls.
+ * Get the number of current calls. The number includes active calls
+ * (pjsua_call_is_active(call_id) == PJ_TRUE), as well as calls that
+ * are no longer active but still in the process of hanging up.
  *
- * @return		Number of currently active calls.
+ * @return		Number of current calls.
  */
 PJ_DECL(unsigned) pjsua_call_get_count(void);
 
@@ -5557,10 +5559,17 @@ pjsua_call_answer_with_sdp(pjsua_call_id call_id,
  * while #pjsua_call_answer() only works with incoming calls on EARLY
  * state.
  *
- * After calling this function, media will immediately be deinitialized
- * (call media callbacks, if any, will still be received) and then,
- * on_call_state() will be called with state DISCONNECTED. No further
- * call callbacks will be received after this.
+ * After calling this function, media will be deinitialized (call media
+ * callbacks, if any, will still be received) and then, on_call_state()
+ * will be immediately called with state DISCONNECTED. No further
+ * call callbacks will be received after this. The call hangup process
+ * itself (sending BYE, waiting for the response, and resource cleanup)
+ * will continue in the background and the call slot can be reused only
+ * after this process is completed. If application has limited call slots
+ * and would like to check if there are any free slots remaining, it can
+ * query the number of free slots using the APIs:
+ * pjsua_call_get_max_count()-pjsua_call_get_count()
+ *
  * Note that on_call_tsx_state() will not be called when using this API.
  *
  * @param call_id	Call identification.

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -5557,6 +5557,12 @@ pjsua_call_answer_with_sdp(pjsua_call_id call_id,
  * while #pjsua_call_answer() only works with incoming calls on EARLY
  * state.
  *
+ * After calling this function, media will immediately be deinitialized
+ * (call media callbacks, if any, will still be received) and then,
+ * on_call_state() will be called with state DISCONNECTED. No further
+ * call callbacks will be received after this.
+ * Note that on_call_tsx_state() will not be called when using this API.
+ *
  * @param call_id	Call identification.
  * @param code		Optional status code to be sent when we're rejecting
  *			incoming call. If the value is zero, "603/Decline"

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -205,6 +205,12 @@ struct pjsua_call
 					    created yet. This temporary 
 					    variable is used to handle such 
 					    case, see ticket #1916.	    */
+
+    pj_timer_entry	 hangup_timer;	/**< Hangup retry timer.	    */
+    unsigned		 hangup_retry;	/**< Number of hangup retries.	    */
+    unsigned		 hangup_code;	/**< Hangup code.	    	    */
+    pj_str_t		 hangup_reason;	/**< Hangup reason.	    	    */
+    pjsua_msg_data	*hangup_msg_data;/**< Hangup message data.	    */
 };
 
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2753,6 +2753,12 @@ static pj_status_t call_inv_end_session(pjsua_call *call,
 	    code = PJSIP_SC_REQUEST_TERMINATED;
     }
 
+    /* Stop hangup timer, if it is active. */
+    if (call->hangup_timer.id) {
+	pjsua_cancel_timer(&call->hangup_timer);
+	call->hangup_timer.id = PJ_FALSE;
+    }
+
     status = pjsip_inv_end_session(call->inv, code, reason, &tdata);
     if (status != PJ_SUCCESS) {
 	pjsua_perror(THIS_FILE,

--- a/pjsip/src/pjsua-lib/pjsua_dump.c
+++ b/pjsip/src/pjsua-lib/pjsua_dump.c
@@ -907,13 +907,14 @@ void print_call(const char *title,
 	        char *buf, pj_size_t size)
 {
     int len;
-    pjsip_inv_session *inv = pjsua_var.calls[call_id].inv;
+    pjsua_call *call = &pjsua_var.calls[call_id];
+    pjsip_inv_session *inv = call->inv;
     pjsip_dialog *dlg;
     char userinfo[PJSIP_MAX_URL_SIZE];
 
     /* Dump invite sesion info. */
 
-    dlg = (inv? inv->dlg: pjsua_var.calls[call_id].async_call.dlg);
+    dlg = (inv? inv->dlg: call->async_call.dlg);
     len = pjsip_hdr_print_on(dlg->remote.info, userinfo, sizeof(userinfo));
     if (len < 0)
 	pj_ansi_strcpy(userinfo, "<--uri too long-->");
@@ -922,8 +923,9 @@ void print_call(const char *title,
 
     len = pj_ansi_snprintf(buf, size, "%s[%s] %s",
 			   title,
-                           pjsip_inv_state_name(inv? inv->state:
-                                                PJSIP_INV_STATE_DISCONNECTED),
+                           pjsip_inv_state_name((call->hanging_up || !inv)?
+                                                PJSIP_INV_STATE_DISCONNECTED:
+                                                inv->state),
 			   userinfo);
     if (len < 1 || len >= (int)size) {
 	pj_ansi_strcpy(buf, "<--uri too long-->");

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1549,7 +1549,6 @@ pj_status_t call_media_on_event(pjmedia_event *event,
     char ev_name[5];
     pj_status_t status = PJ_SUCCESS;
 
-    pj_assert(call && call_med);
     pjmedia_fourcc_name(event->type, ev_name);
     PJ_LOG(5,(THIS_FILE, "Call %d: Media %d: Received media event, type=%s, "
 			 "src=%p, epub=%p",

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -808,7 +808,8 @@ static void ice_failed_nego_cb(void *user_data)
 	return;
     }
 
-    pjsua_var.ua_cfg.cb.on_call_media_state(call_id);
+    if (!call->hanging_up)
+    	pjsua_var.ua_cfg.cb.on_call_media_state(call_id);
 
     if (dlg)
         pjsip_dlg_dec_lock(dlg);
@@ -843,7 +844,9 @@ static void on_ice_complete(pjmedia_transport *tp,
         } else {
 	    call_med->state = PJSUA_CALL_MEDIA_ERROR;
 	    call_med->dir = PJMEDIA_DIR_NONE;
-	    if (call && pjsua_var.ua_cfg.cb.on_call_media_state) {
+	    if (call && !call->hanging_up &&
+	        pjsua_var.ua_cfg.cb.on_call_media_state)
+	    {
 		/* Defer the callback to a timer */
 		pjsua_schedule_timer2(&ice_failed_nego_cb,
 				      (void*)(pj_ssize_t)call->index, 1);
@@ -860,7 +863,9 @@ static void on_ice_complete(pjmedia_transport *tp,
 		         "ICE keep alive failure for transport %d:%d",
 		         call->index, call_med->idx));
 	}
-        if (pjsua_var.ua_cfg.cb.on_call_media_transport_state) {
+        if (!call->hanging_up &&
+            pjsua_var.ua_cfg.cb.on_call_media_transport_state)
+        {
             pjsua_med_tp_state_info info;
 
             pj_bzero(&info, sizeof(info));
@@ -1660,6 +1665,9 @@ pj_status_t call_media_on_event(pjmedia_event *event,
     	pj_mutex_unlock(pjsua_var.timer_mutex);
     	
     	if (call) {
+    	    if (call->hanging_up)
+    	    	return status;
+
     	    eve->call_id = call->index;
     	    eve->med_idx = call_med->idx;
     	} else {
@@ -1678,7 +1686,8 @@ pj_status_t call_media_on_event(pjmedia_event *event,
 void pjsua_set_media_tp_state(pjsua_call_media *call_med,
                               pjsua_med_tp_st tp_st)
 {
-    if (pjsua_var.ua_cfg.cb.on_call_media_transport_state &&
+    if (!call_med->call->hanging_up &&
+        pjsua_var.ua_cfg.cb.on_call_media_transport_state &&
         call_med->tp_st != tp_st)
     {
         pjsua_med_tp_state_info info;
@@ -1713,7 +1722,9 @@ static void on_srtp_nego_complete(pjmedia_transport *tp,
     if (result != PJ_SUCCESS) {
 	call_med->state = PJSUA_CALL_MEDIA_ERROR;
 	call_med->dir = PJMEDIA_DIR_NONE;
-	if (call && pjsua_var.ua_cfg.cb.on_call_media_state) {
+	if (call && !call->hanging_up &&
+	    pjsua_var.ua_cfg.cb.on_call_media_state)
+	{
 	    /* Defer the callback to a timer */
 	    pjsua_schedule_timer2(&ice_failed_nego_cb,
 				  (void*)(pj_ssize_t)call->index, 1);
@@ -2910,7 +2921,7 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
     call->rem_offerer = (rem_sdp != NULL);
 
     /* Notify application */
-    if (pjsua_var.ua_cfg.cb.on_call_sdp_created) {
+    if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_call_sdp_created) {
 	(*pjsua_var.ua_cfg.cb.on_call_sdp_created)(call_id, sdp,
 						   pool, rem_sdp);
     }

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1100,7 +1100,7 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
 	    }
 	}
 
-        if (pjsua_var.ua_cfg.cb.on_stream_precreate) {
+        if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_stream_precreate) {
             pjsua_on_stream_precreate_param prm;
             prm.stream_idx = call_med->idx;
             prm.stream_info.type = PJMEDIA_TYPE_VIDEO;
@@ -1869,7 +1869,7 @@ static pj_status_t call_reoffer_sdp(pjsua_call_id call_id,
     }
 
     /* Notify application */
-    if (pjsua_var.ua_cfg.cb.on_call_sdp_created) {
+    if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_call_sdp_created) {
 	(*pjsua_var.ua_cfg.cb.on_call_sdp_created)(call_id, sdp,
 						   call->inv->pool_prov,
 						   NULL);


### PR DESCRIPTION
To continue the work in #1049 and close it.
* When calling `pjsua_call_hangup()`, application will immediately receive `on_call_state()` callback with DISCONNECTED state. No further call related callbacks will be received after this. The call hangup process itself (sending BYE, waiting for the response, and resource cleanup) will continue in the background and the call slot can be reused only after this process is completed.
* Retry creating and sending BYE after a period of `CALL_HANGUP_RETRY_INTERVAL` if it fails. If this keeps happening after `CALL_HANGUP_MAX_RETRY` times, we will hard-terminate the call, i.e. cleanup the call without sending any BYE to the remote.

This will introduce some behavioural changes though:
- Media will be deinitialised immediately upon hanging up, before disconnected state is reported. So media callbacks such as `on_stream_destroyed()` will be called before `on_call_state()`. Previously, it was the reverse.
- Application can no longer dump end-of-call media stats upon receiving disconnection report. This is because media has been deactivated by then. One alternative is to dump media stats in `on_stream_destroyed()`, but note that `on_stream_destroyed()` can also be called during media update, can be called multiple times if there are more than one audio streams, and won't be called if there is no audio (such as in video-only calls).
