### PR TITLE
Use EPOLLEXCLUSIVE or EPOLLONESHOT in ioqueue epoll

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -53,6 +53,7 @@
 #define os_epoll_ctl		epoll_ctl
 #define os_epoll_wait		epoll_wait
 
+
 #define THIS_FILE   "ioq_epoll"
 
 //#define TRACE_(expr) PJ_LOG(3,expr)
@@ -107,6 +108,20 @@ struct pj_ioqueue_t
 /* Scan closing keys to be put to free list again */
 static void scan_closing_keys(pj_ioqueue_t *ioqueue);
 #endif
+
+
+/* Use EPOLLEXCLUSIVE or EPOLLONESHOT to signal one thread only at a time */
+#if defined(EPOLLEXCLUSIVE)
+#  define USE_EPOLLEXCLUSIVE	1
+#  define USE_EPOLLONESHOT	0
+#elif defined(EPOLLONESHOT)
+#  define USE_EPOLLEXCLUSIVE	0
+#  define USE_EPOLLONESHOT	1
+#else
+#  define USE_EPOLLEXCLUSIVE	0
+#  define USE_EPOLLONESHOT	0
+#endif
+
 
 /*
  * pj_ioqueue_name()
@@ -328,6 +343,11 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
 */
     /* os_epoll_ctl. */
     ev.events = EPOLLIN | EPOLLERR;
+#if USE_EPOLLEXCLUSIVE
+    ev.events |= EPOLLEXCLUSIVE;
+#elif USE_EPOLLONESHOT
+    ev.events |= EPOLLONESHOT;
+#endif
     ev.epoll_data = (epoll_data_type)key;
     status = os_epoll_ctl(ioqueue->epfd, EPOLL_CTL_ADD, sock, &ev);
     if (status < 0) {
@@ -517,9 +537,18 @@ static void ioqueue_remove_from_set( pj_ioqueue_t *ioqueue,
     if (event_type == WRITEABLE_EVENT) {
 	struct epoll_event ev;
 
-	ev.events = EPOLLIN | EPOLLERR;
 	ev.epoll_data = (epoll_data_type)key;
+	ev.events = EPOLLIN | EPOLLERR;
+#if USE_EPOLLEXCLUSIVE
+	ev.events |= EPOLLEXCLUSIVE;
+	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_DEL, key->fd, &ev);
+	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_ADD, key->fd, &ev);
+#elif USE_EPOLLONESHOT
+	ev.events |= EPOLLONESHOT;
 	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_MOD, key->fd, &ev);
+#else
+	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_MOD, key->fd, &ev);
+#endif
     }	
 }
 
@@ -533,13 +562,31 @@ static void ioqueue_add_to_set( pj_ioqueue_t *ioqueue,
                                 pj_ioqueue_key_t *key,
                                 enum ioqueue_event_type event_type )
 {
-    if (event_type == WRITEABLE_EVENT) {
+#if USE_EPOLLONESHOT==0
+    /* When not using EPOLLONESHOT, only rearm write event,
+     * otherwise, rearm all events.
+     */
+    if (event_type == WRITEABLE_EVENT)
+#endif
+    {
 	struct epoll_event ev;
 
-	ev.events = EPOLLIN | EPOLLOUT | EPOLLERR;
 	ev.epoll_data = (epoll_data_type)key;
+	ev.events = EPOLLIN | EPOLLERR;
+	if (event_type == WRITEABLE_EVENT)
+	    ev.events |= EPOLLOUT;
+
+#if USE_EPOLLEXCLUSIVE
+	ev.events |= EPOLLEXCLUSIVE;
+	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_DEL, key->fd, &ev);
+	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_ADD, key->fd, &ev);
+#elif USE_EPOLLONESHOT
+	ev.events |= EPOLLONESHOT;
 	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_MOD, key->fd, &ev);
-    }	
+#else
+	os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_MOD, key->fd, &ev);
+#endif
+    }
 }
 
 #if PJ_IOQUEUE_HAS_SAFE_UNREG

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1827,7 +1827,7 @@ pj_ssl_sock_start_accept2(pj_ssl_sock_t *ssock,
     pj_activesock_cfg_default(&asock_cfg);
     asock_cfg.async_cnt = ssock->param.async_cnt;
     asock_cfg.concurrency = ssock->param.concurrency;
-    asock_cfg.whole_data = PJ_TRUE;
+    asock_cfg.whole_data = PJ_FALSE;
     asock_cfg.grp_lock = ssock->param.grp_lock;
 
     pj_bzero(&asock_cb, sizeof(asock_cb));

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -323,9 +323,19 @@ static void inv_set_state(pjsip_inv_session *inv, pjsip_inv_state state,
 	(*mod_inv.cb.on_state_changed)(inv, e);
     pjsip_inv_dec_ref(inv);
 
-    /* Only decrement when previous state is not already DISCONNECTED */
+    /* The above callback may change the state, so we need to be careful here
+     * and only decrement inv under the following conditions:
+     * 1. If the state parameter is DISCONNECTED, and previous state is not
+     *    already DISCONNECTED.
+     *    This is to make sure that dec_ref() is not called more than once.
+     * 2. If current state is PJSIP_INV_STATE_DISCONNECTED.
+     *    This is to make sure that dec_ref() is not called if user restarts
+     *    inv within the callback. Note that this check must be last since
+     *    inv may have already been destroyed.
+     */
     if (state == PJSIP_INV_STATE_DISCONNECTED &&
-	prev_state != PJSIP_INV_STATE_DISCONNECTED) 
+	prev_state != PJSIP_INV_STATE_DISCONNECTED &&
+	inv->state == PJSIP_INV_STATE_DISCONNECTED) 
     {
 	pjsip_inv_dec_ref(inv);
     }


### PR DESCRIPTION
Currently all worker threads will be awoken when an event occurs (thundering herd issue). The solution should be using `EPOLLEXCLUSIVE`, or alternatively `EPOLLONESHOT` when `EPOLLEXCLUSIVE` is not available (`EPOLLEXCLUSIVE` is introduced in Linux Kernel 4.5). `EPOLLONESHOT` is perhaps not ideal for socket accept operation as only one thread can process events at a time. `EPOLLEXCLUSIVE` can only work with `EPOLL_CTL_ADD`, so `EPOLL_CTL_MOD` needs to be replaced with `EPOLL_CTL_DEL + EPOLL_CTL_ADD`, so there is an additional `os_epoll_ctl()` call for socket send operation.

Thank you Peter Koletzki for the detailed report and the intensive tests.

### Behavior change
Currently SSL socket listener has concurrency flag disabled (due to `whole_data` set to TRUE), which means that accept callback will be invoked with socket/key mutex protection, this PR will change the concurrency setting to ioqueue default (i.e: enabled, by disabling `whole_data`). Not sure why it is set this way, but from a quick check, it seems to be safe to have the accept callback invoked concurrently.

### Limitation
Somehow `EPOLLEXCLUSIVE` or `EPOLLONESHOT` may cause error (perm handshake) in OpenSSL 1.0.2, so currently it will be disabled when using OpenSSL older than 1.1.0.

