### PR TITLE
Fix crash in starting CLI telnet when port is in already use

### DIFF
--- a/pjlib-util/src/pjlib-util/cli_telnet.c
+++ b/pjlib-util/src/pjlib-util/cli_telnet.c
@@ -1409,9 +1409,15 @@ static void telnet_fe_destroy(pj_cli_front_end *fe)
 
     pj_mutex_unlock(tfe->mutex);
 
-    pj_activesock_close(tfe->asock);
-    if (tfe->own_ioqueue)
+    if (tfe->asock) {
+	pj_activesock_close(tfe->asock);
+	tfe->asock = NULL;
+    }
+
+    if (tfe->own_ioqueue && tfe->cfg.ioqueue) {
         pj_ioqueue_destroy(tfe->cfg.ioqueue);
+	tfe->cfg.ioqueue = NULL;
+    }
 
     if (tfe->worker_thread) {
 	pj_thread_destroy(tfe->worker_thread);
@@ -1419,6 +1425,7 @@ static void telnet_fe_destroy(pj_cli_front_end *fe)
     }
 
     pj_mutex_destroy(tfe->mutex);
+
     pj_pool_release(tfe->pool);
 }
 
@@ -1603,9 +1610,18 @@ static pj_bool_t telnet_fe_on_accept(pj_activesock_t *asock,
         return PJ_FALSE;
 
     if (status != PJ_SUCCESS && status != PJ_EPENDING) {
-	TRACE_((THIS_FILE, "Error on data accept %d", status));
-	if (status == PJ_ESOCKETSTOP)
-	    telnet_restart(fe);
+	TRACE_((THIS_FILE, "Error on data accept (status=%d)", status));
+	if (status == PJ_ESOCKETSTOP) {
+	    sstatus = telnet_restart(fe);
+	    if (sstatus != PJ_SUCCESS) {
+		if (fe->own_ioqueue && fe->cfg.ioqueue) {
+		    pj_ioqueue_destroy(fe->cfg.ioqueue);
+		    fe->cfg.ioqueue = NULL;
+		}
+		TRACE_((THIS_FILE, "Error restarting telnet (status=%d)",
+			status));
+	    }
+	}
 
         return PJ_FALSE;
     }
@@ -1750,14 +1766,20 @@ PJ_DEF(pj_status_t) pj_cli_telnet_create(pj_cli_t *cli,
     if (p_fe)
         *p_fe = &fe->base;
 
+    TRACE_((THIS_FILE, "Telnet started"));
+
     return PJ_SUCCESS;
 
 on_exit:
-    if (fe->own_ioqueue)
+    if (fe->own_ioqueue && fe->cfg.ioqueue) {
         pj_ioqueue_destroy(fe->cfg.ioqueue);
+	fe->cfg.ioqueue = NULL;
+    }
 
-    if (fe->mutex)
+    if (fe->mutex) {
         pj_mutex_destroy(fe->mutex);
+	fe->mutex = NULL;
+    }
 
     pj_pool_release(pool);
     return status;
@@ -1850,6 +1872,10 @@ static pj_status_t telnet_start(cli_telnet_fe *fe)
             goto on_exit;
     }
 
+    if (fe->cfg.on_started) {
+	(*fe->cfg.on_started)(PJ_SUCCESS);
+    }
+
     return PJ_SUCCESS;
 
 on_exit:
@@ -1857,18 +1883,14 @@ on_exit:
 	(*fe->cfg.on_started)(status);
     }
 
-    if (fe->asock)
+    if (fe->asock) {
         pj_activesock_close(fe->asock);
-    else if (sock != PJ_INVALID_SOCKET)
+	fe->asock = NULL;
+    } else if (sock != PJ_INVALID_SOCKET) {
         pj_sock_close(sock);
+	sock = PJ_INVALID_SOCKET;
+    }
 
-    if (fe->own_ioqueue)
-        pj_ioqueue_destroy(fe->cfg.ioqueue);
-
-    if (fe->mutex)
-        pj_mutex_destroy(fe->mutex);
-
-    pj_pool_release(fe->pool);
     return status;
 }
 
@@ -1880,6 +1902,8 @@ static pj_status_t telnet_restart(cli_telnet_fe *fe)
     fe->is_quitting = PJ_TRUE;
     if (fe->worker_thread) {
 	pj_thread_join(fe->worker_thread);
+	pj_thread_destroy(fe->worker_thread);
+	fe->worker_thread = NULL;
     }
 
     pj_mutex_lock(fe->mutex);
@@ -1898,21 +1922,16 @@ static pj_status_t telnet_restart(cli_telnet_fe *fe)
     if (status != PJ_SUCCESS)
 	goto on_exit;
 
-    if (fe->worker_thread) {
-	pj_thread_destroy(fe->worker_thread);
-	fe->worker_thread = NULL;
-    }
-
+    fe->asock = NULL;
     fe->is_quitting = PJ_FALSE;
 
     /** Start Telnet **/
     status = telnet_start(fe);
-    if (status == PJ_SUCCESS) {
-	if (fe->cfg.on_started) {
-	    (*fe->cfg.on_started)(status);
-	}
-	TRACE_((THIS_FILE, "Telnet Restarted"));
-    }
+    if (status != PJ_SUCCESS)
+	goto on_exit;
+
+    TRACE_((THIS_FILE, "Telnet restarted"));
+
 on_exit:
     return status;
 }

--- a/pjlib-util/src/pjlib-util/cli_telnet.c
+++ b/pjlib-util/src/pjlib-util/cli_telnet.c
@@ -1872,10 +1872,6 @@ static pj_status_t telnet_start(cli_telnet_fe *fe)
             goto on_exit;
     }
 
-    if (fe->cfg.on_started) {
-	(*fe->cfg.on_started)(PJ_SUCCESS);
-    }
-
     return PJ_SUCCESS;
 
 on_exit:
@@ -1929,6 +1925,10 @@ static pj_status_t telnet_restart(cli_telnet_fe *fe)
     status = telnet_start(fe);
     if (status != PJ_SUCCESS)
 	goto on_exit;
+
+    if (fe->cfg.on_started) {
+	(*fe->cfg.on_started)(PJ_SUCCESS);
+    }
 
     TRACE_((THIS_FILE, "Telnet restarted"));
 

--- a/pjsip-apps/src/samples/clidemo.c
+++ b/pjsip-apps/src/samples/clidemo.c
@@ -114,13 +114,13 @@ static struct cmd_xml_t cmd_xmls[] = {
      "    <ARG name='whom' type='text' desc='Whom to say to'/>"
      "</CMD>",
      &say},
-    {"<CMD name='vid' id='1' desc='Video Command'>"
-     "   <CMD name='help' id='2' desc='Show Help' />"
-     "   <CMD name='enable' id='3' desc='Enable Video' />"
-     "   <CMD name='disable' id='4' desc='Disable Video' />"
-     "   <CMD name='call' id='5' desc='Video call' >"
-     "            <CMD name='add' id='6' desc='Add Call' />"
-     "            <CMD name='cap' id='7' desc='Capture Call' >"
+    {"<CMD name='vid' id='7' desc='Video Command'>"
+     "   <CMD name='help' id='72' desc='Show Help' />"
+     "   <CMD name='enable' id='73' desc='Enable Video' />"
+     "   <CMD name='disable' id='74' desc='Disable Video' />"
+     "   <CMD name='call' id='75' desc='Video call' >"
+     "            <CMD name='add' id='756' desc='Add Call' />"
+     "            <CMD name='cap' id='757' desc='Capture Call' >"
      "               <ARG name='streamno' type='int' desc='Stream No' id='1'/>"
      "               <ARG name='devid' type='int' desc='Device Id' id='2'/>"
      "            </CMD>"
@@ -128,7 +128,7 @@ static struct cmd_xml_t cmd_xmls[] = {
      "</CMD>",
      NULL},
     {"<CMD name='disable_codec' id='8' desc='Disable codec'>"
-     "	<ARG name='codec_list' type='choice' id='3' desc='Codec list'>"
+     "	<ARG name='codec_list' type='choice' id='38' desc='Codec list'>"
      "	    <CHOICE value='g711' desc='G711 Codec'/>"
      "	    <CHOICE value='g722' desc='G722 Codec'/>"
      "	</ARG>"
@@ -176,9 +176,13 @@ int main()
     for (i = 0; i < sizeof(cmd_xmls)/sizeof(cmd_xmls[0]); i++) {
         xml = pj_str(cmd_xmls[i].xml);	
         status = pj_cli_add_cmd_from_xml(cli, NULL, &xml, 
-	    cmd_xmls[i].handler, NULL, get_codec_list);
-        if (status != PJ_SUCCESS)
+					 cmd_xmls[i].handler, NULL,
+					 get_codec_list);
+        if (status != PJ_SUCCESS) {
+	    PJ_PERROR(1,(THIS_FILE, status,
+			 "Failed adding command from XML #%d", i));
 	    goto on_return;
+	}
     }
 
     /*


### PR DESCRIPTION
Call stack trace:
```
pjsua-x86_64-unknown-linux-gnu: ../src/pj/os_core_unix.c:1333: pj_mutex_unlock: Assertion `mutex->owner == pj_thread_this()' failed.
Error: signal 6:
/lib/x86_64-linux-gnu/libc.so.6(+0x3f040)[0x7fb4650e5040]
/lib/x86_64-linux-gnu/libc.so.6(gsignal+0xc7)[0x7fb4650e4fb7]
/lib/x86_64-linux-gnu/libc.so.6(abort+0x141)[0x7fb4650e6921]
/lib/x86_64-linux-gnu/libc.so.6(+0x3048a)[0x7fb4650d648a]
/lib/x86_64-linux-gnu/libc.so.6(+0x30502)[0x7fb4650d6502]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(pj_mutex_unlock+0x75)[0x55a77182e5f0]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(pj_lock_release+0x54)[0x55a771836847]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(+0x1ee665)[0x55a771829665]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(pj_ioqueue_destroy+0x123)[0x55a77182b831]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(pj_cli_telnet_create+0x219)[0x55a7717a47ba]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(cli_init+0x126)[0x55a771676db7]
../../pjsip-apps/bin/pjsua-x86_64-unknown-linux-gnu(pjsua_app_init+0x4d)[0x55a77167662c]
```

From investigation, the cause seems to be failing `telnet_start()` destroys ioqueue & mutex, but then when returning back to `pj_cli_telnet_create()`, ioqueue & mutex are to be destroyed again.

The call stack trace shows an assertion, while the problem should be access to an invalid memory address which usually it will raise a crash (hence the PR title).

This PR also fixes `clidemo` sample app, which failed to run due to bad/duplicated command ID.