### PR TITLE
Fix ai_socktype to be zero when passed to getaddrinfo

### DIFF
--- a/pjlib/src/pj/addr_resolv_sock.c
+++ b/pjlib/src/pj/addr_resolv_sock.c
@@ -178,7 +178,9 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
     /* Call getaddrinfo() */
     pj_bzero(&hint, sizeof(hint));
     hint.ai_family = af;
-    hint.ai_socktype = pj_SOCK_DGRAM() | pj_SOCK_STREAM();
+    /* Zero value of ai_socktype means the implementation shall attempt
+     * to resolve the service name for all supported socket types */
+    hint.ai_socktype = 0;
 
     rc = getaddrinfo(nodecopy, NULL, &hint, &res);
     if (rc != 0)
@@ -191,6 +193,11 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
 	/* Ignore unwanted address families */
 	if (af!=PJ_AF_UNSPEC && res->ai_family != af)
 	    continue;
+
+	if (res->ai_socktype != pj_SOCK_DGRAM()
+                    && res->ai_socktype != pj_SOCK_STREAM()) {
+	        continue;
+	}
 
 	/* Store canonical name (possibly truncating the name) */
 	if (res->ai_canonname) {

--- a/pjlib/src/pj/addr_resolv_sock.c
+++ b/pjlib/src/pj/addr_resolv_sock.c
@@ -190,6 +190,9 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
 
     /* Enumerate each item in the result */
     for (i=0; i<*count && res; res=res->ai_next) {
+	unsigned j;
+	pj_bool_t duplicate_found = PJ_FALSE;
+
 	/* Ignore unwanted address families */
 	if (af!=PJ_AF_UNSPEC && res->ai_family != af)
 	    continue;
@@ -197,6 +200,18 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
 	if (res->ai_socktype != pj_SOCK_DGRAM()
                     && res->ai_socktype != pj_SOCK_STREAM()) {
 	        continue;
+	}
+
+	/* Add current address in the resulting list if there
+	 * is no duplicates only. */
+	for (j = 0; j < i; j++) {
+	    if (!pj_memcmp(&ai[j].ai_addr, res->ai_addr, res->ai_addrlen)) {
+		duplicate_found = PJ_TRUE;
+		break;
+	    }
+	}
+	if (duplicate_found) {
+	    continue;
 	}
 
 	/* Store canonical name (possibly truncating the name) */


### PR DESCRIPTION
`getaddrinfo()` does not accept a bitwise mask as `ai_socktype`, this field represents a single socket type. If we want to resolve the address for multiple socket types we should pass zero instead.  https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html

`(pj_SOCK_DGRAM() | pj_SOCK_STREAM())` is equal to `SOCK_RAW=3` in Linux, so that's why it was working.