### PR TITLE
Assertion in media update of session refresh after SDP reoffer is rejected

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -732,6 +732,7 @@ void pjsua_call_cleanup_flag(pjsua_call_setting *opt);
 void pjsua_set_media_tp_state(pjsua_call_media *call_med, pjsua_med_tp_st tp_st);
 
 void pjsua_media_prov_clean_up(pjsua_call_id call_id);
+void pjsua_media_prov_revert(pjsua_call_id call_id);
 
 /* Callback to receive media events */
 pj_status_t on_media_event(pjmedia_event *event, void *user_data);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5068,8 +5068,8 @@ static void pjsua_call_on_media_update(pjsip_inv_session *inv,
 
 	pjsua_perror(THIS_FILE, "SDP negotiation has failed", status);
 
-	/* Clean up provisional media */
-	pjsua_media_prov_clean_up(call->index);
+	/* Revert back provisional media. */
+	pjsua_media_prov_revert(call->index);
 
 	/* Do not deinitialize media since this may be a re-INVITE or
 	 * UPDATE (which in this case the media should not get affected
@@ -6178,9 +6178,9 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
             (tsx->status_code/100 != 2 || !call->med_update_success))
         {
             /* Either we get non-2xx or media update failed,
-             * clean up provisional media.
+             * revert back provisional media.
              */
-	    pjsua_media_prov_clean_up(call->index);
+	    pjsua_media_prov_revert(call->index);
         }
     } else if (tsx->role == PJSIP_ROLE_UAC &&
                pjsip_method_cmp(&tsx->method, &pjsip_update_method)==0 &&
@@ -6194,9 +6194,9 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
             (tsx->status_code/100 != 2 || !call->med_update_success))
         {
             /* Either we get non-2xx or media update failed,
-             * clean up provisional media.
+             * revert back provisional media.
              */
-	    pjsua_media_prov_clean_up(call->index);
+	    pjsua_media_prov_revert(call->index);
         }
     } else if (tsx->role==PJSIP_ROLE_UAS &&
 	       tsx->state==PJSIP_TSX_STATE_TRYING &&

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1927,13 +1927,8 @@ static pj_status_t call_add_video(pjsua_call *call,
 
     sdp = pjmedia_sdp_session_clone(call->inv->pool_prov, current_sdp);
 
-    /* Clean up provisional media before using it */
-    pjsua_media_prov_clean_up(call->index);
-
-    /* Update provisional media from call media */
-    call->med_prov_cnt = call->med_cnt;
-    pj_memcpy(call->media_prov, call->media,
-	      sizeof(call->media[0]) * call->med_cnt);
+    /* Clean up & sync provisional media before using it */
+    pjsua_media_prov_revert(call->index);
 
     /* Initialize call media */
     call_med = &call->media_prov[call->med_prov_cnt++];
@@ -2039,13 +2034,8 @@ static pj_status_t call_modify_video(pjsua_call *call,
 	med_idx = first_active;
     }
 
-    /* Clean up provisional media before using it */
-    pjsua_media_prov_clean_up(call->index);
-
-    /* Update provisional media from call media */
-    call->med_prov_cnt = call->med_cnt;
-    pj_memcpy(call->media_prov, call->media,
-	      sizeof(call->media[0]) * call->med_cnt);
+    /* Clean up & sync provisional media before using it */
+    pjsua_media_prov_revert(call->index);
 
     call_med = &call->media_prov[med_idx];
 
@@ -2158,7 +2148,9 @@ static pj_status_t call_modify_video(pjsua_call *call,
 
 on_error:
 	if (status != PJ_SUCCESS) {
-	    pjsua_media_prov_clean_up(call->index);
+	    /* Revert back provisional media. */
+	    pjsua_media_prov_revert(call->index);
+
 	    return status;
 	}
     

--- a/tests/pjsua/mod_sipp.py
+++ b/tests/pjsua/mod_sipp.py
@@ -205,10 +205,14 @@ def exec_pjsua_expects(t, sipp):
         ua_idx = expect[0]
         expect_st = expect[1]
         send_cmd = resolve_driver_macros(expect[2])
+        timeout = expect[3] if len(expect)>=4 else 0
         # Handle exception in pjsua flow, to avoid zombie SIPp process
         try:
             if expect_st != "":
-                ua[ua_idx].expect(expect_st, raise_on_error = True)
+                if timeout > 0:
+                    ua[ua_idx].expect(expect_st, raise_on_error = True, timeout = timeout)
+                else:
+                    ua[ua_idx].expect(expect_st, raise_on_error = True)
             if send_cmd != "":
                 ua[ua_idx].send(send_cmd)
         except TestError, e:

--- a/tests/pjsua/run.py
+++ b/tests/pjsua/run.py
@@ -196,7 +196,7 @@ class Expect(threading.Thread):
             self.proc.stdin.writelines(cmd + "\n")
             self.proc.stdin.flush()
         
-    def expect(self, pattern, raise_on_error=True, title=""):
+    def expect(self, pattern, raise_on_error=True, title="", timeout=15):
         # no prompt for telnet
         if self.use_telnet and pattern==const.PROMPT:
             return
@@ -234,7 +234,7 @@ class Expect(threading.Thread):
             else:
                 t1 = time.time()
                 dur = int(t1 - t0)
-                if dur > 15:
+                if dur > timeout:
                     self.trace("Timed-out!")
                     if raise_on_error:
                         raise inc.TestError(self.name + " " + title + ": Timeout expecting pattern: \"" + pattern + "\"")

--- a/tests/pjsua/scripts-sipp/uas-reinv-after-failed-nego.py
+++ b/tests/pjsua/scripts-sipp/uas-reinv-after-failed-nego.py
@@ -1,0 +1,10 @@
+# $Id$
+#
+import inc_const as const
+
+PJSUA = ["--null-audio --max-calls=1 --use-timer=3 --timer-se=90 --no-tcp $SIPP_URI"]
+
+PJSUA_EXPECTS = [[0, const.STATE_CONFIRMED, "v"],
+                 [0, "SDP rejected for test", ""],
+                 [0, "Audio updated", "", 50] # wait for session timer refresh about 45 secs
+                ]

--- a/tests/pjsua/scripts-sipp/uas-reinv-after-failed-nego.xml
+++ b/tests/pjsua/scripts-sipp/uas-reinv-after-failed-nego.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+<!--                                                                    -->
+<!-- You should have received a copy of the GNU General Public License  -->
+<!-- along with this program; if not, write to the                      -->
+<!-- Free Software Foundation, Inc.,                                    -->
+<!-- 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA             -->
+
+
+<!--                                                                    -->
+<!--   Session timer where UAS doesn't indicate support for UPDATE.     -->
+<!--   In this case, UAC MUST use re-INVITE with SDP.                   -->
+
+<scenario name="Basic UAS responder">
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]> 
+      Content-Type: application/sdp
+      Content-Length: [len]
+ 
+      v=0
+      o=Some-UserAgent 68 210 IN IP4 [local_ip]
+      s=SIP Call
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 17294 RTP/AVP 0
+      c=IN IP4 [local_ip]
+    ]]>
+  </send>
+
+  <recv request="ACK"
+        optional="true"
+        rtd="true"
+        crlf="true"> 
+  </recv> 
+ 
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 500 SDP rejected for test
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]> 
+    ]]>
+  </send>
+
+  <recv request="ACK"
+        rtd="true"
+        crlf="true"> 
+  </recv> 
+
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]> 
+      Content-Type: application/sdp
+      Content-Length: [len]
+ 
+      v=0
+      o=Some-UserAgent 68 210 IN IP4 [local_ip]
+      s=SIP Call
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 17294 RTP/AVP 0
+      c=IN IP4 [local_ip]
+    ]]>
+  </send>
+
+  <recv request="ACK"
+        rtd="true"
+        crlf="true"> 
+  </recv> 
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+


### PR DESCRIPTION
Reproducing steps:
1. Start pjsua app with session timer (better set to always).
2. Establish a call as normal.
3. Send SDP reoffer (e.g: via call reinvite or hold) and remote should reject it (non-200 response).
4. Wait for SIP session timer refresh kicking in, this time remote should answer normally (200 response with SDP).
5. Assertion is raised at [this line](https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsua-lib/pjsua_media.c#L3326).

When an SDP reoffer is rejected, `pjsua_media_prov_clean_up()` is called, which will clear provisional media (`call->med_prov_cnt` is set to 0). Later, session refresh will send SDP reoffer using current active SDP (note that session refresh is done in the PJSIP level, not PJSUA, so `call->med_prov_cnt` is not touched), so when media update is invoked after a successful SDP nego, the assertion occurs.

This PR introduces a new function `pjsua_media_prov_revert()`, so when SDP reoffer is rejected, provisional media (`call->media_prov`) will be reverted back to active media (`call->media`) instead of being cleared (set to zero).