### PR TITLE
Remove ioqueue key from set when calling pj_ioqueue_post_completion()

### DIFF
--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -1326,6 +1326,13 @@ PJ_DEF(pj_status_t) pj_ioqueue_post_completion( pj_ioqueue_key_t *key,
         op_rec = op_rec->next;
     }
 
+    /* Clear connecting operation. */
+    if (key->connecting) {
+        key->connecting = 0;
+        ioqueue_remove_from_set(key->ioqueue, key, WRITEABLE_EVENT);
+        ioqueue_remove_from_set(key->ioqueue, key, EXCEPTION_EVENT);
+    }
+
     pj_ioqueue_unlock_key(key);
     
     return PJ_EINVALIDOP;

--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -1282,6 +1282,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_post_completion( pj_ioqueue_key_t *key,
         if (op_rec == (void*)op_key) {
             pj_list_erase(op_rec);
             op_rec->op = PJ_IOQUEUE_OP_NONE;
+            ioqueue_remove_from_set(key->ioqueue, key, READABLE_EVENT);
             pj_ioqueue_unlock_key(key);
 
             if (key->cb.on_read_complete)
@@ -1297,6 +1298,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_post_completion( pj_ioqueue_key_t *key,
         if (op_rec == (void*)op_key) {
             pj_list_erase(op_rec);
             op_rec->op = PJ_IOQUEUE_OP_NONE;
+            ioqueue_remove_from_set(key->ioqueue, key, WRITEABLE_EVENT);
             pj_ioqueue_unlock_key(key);
 
             if (key->cb.on_write_complete)


### PR DESCRIPTION
The call to `pj_ioqueue_post_completion()` will find and remove the operation from the ioqueue operation list.
However, it wouldn't clear the key from the ioqueue descriptor set.
This might lead to `pj_ioqueue_poll()` to busy loop, and spike the CPU usage.

This is printed on the trace log, which indicates that there are still event's based on descriptor set, but no pending operation is found.
```
poll: count=2 events=0 processed=0
poll: count=2 events=0 processed=0
```