### PR TITLE
Use UTC time in PJSIP presence PIDF timestamp

### DIFF
--- a/pjsip/src/pjsip-simple/presence_body.c
+++ b/pjsip/src/pjsip-simple/presence_body.c
@@ -117,9 +117,18 @@ PJ_DEF(pj_status_t) pjsip_pres_create_pidf( pj_pool_t *pool,
 	  int tslen = 0;
 	  pj_time_val tv;
 	  pj_parsed_time pt;
+	  pj_status_t s;
 
 	  pj_gettimeofday(&tv);
-	  pj_time_local_to_gmt(&tv);
+
+	  /* Convert time to GMT (some platforms may not support it
+	   * such as WinCE).
+	   */
+	  s = pj_time_local_to_gmt(&tv);
+	  if (s != PJ_SUCCESS) {
+	      PJ_PERROR(4,(THIS_FILE,s,
+			   "Warning: failed to convert PIDF time to GMT"));
+	  }
 	  pj_time_decode( &tv, &pt);
 
 	  tslen = pj_ansi_snprintf(buf, sizeof(buf),

--- a/pjsip/src/pjsip-simple/presence_body.c
+++ b/pjsip/src/pjsip-simple/presence_body.c
@@ -119,7 +119,7 @@ PJ_DEF(pj_status_t) pjsip_pres_create_pidf( pj_pool_t *pool,
 	  pj_parsed_time pt;
 
 	  pj_gettimeofday(&tv);
-	  /* TODO: convert time to GMT! (unsupported by pjlib) */
+	  pj_time_local_to_gmt(&tv);
 	  pj_time_decode( &tv, &pt);
 
 	  tslen = pj_ansi_snprintf(buf, sizeof(buf),


### PR DESCRIPTION
The timestamp value in PJSIP presence PIDF is actually in local time instead of UTC although it has "Z" suffix. This PR will fix the timestamp value to be in UTC.

Thanks to Christian Becker for the report.