### PR TITLE
Few updates in pjsip-simple RPID

### DIFF
--- a/pjsip/include/pjsip-simple/rpid.h
+++ b/pjsip/include/pjsip-simple/rpid.h
@@ -42,7 +42,7 @@ PJ_BEGIN_DECL
 
 /**
  * This enumeration describes subset of standard activities as 
- * described by RFC 4880, RPID: Rich Presence Extensions to the 
+ * described by RFC 4480, RPID: Rich Presence Extensions to the
  * Presence Information Data Format (PIDF). 
  */
 typedef enum pjrpid_activity
@@ -107,7 +107,8 @@ PJ_DECL(void) pjrpid_element_dup(pj_pool_t *pool, pjrpid_element *dst,
  * Add RPID element information into existing PIDF document. This will also
  * add the appropriate XML namespace attributes into the presence's XML
  * node, if the attributes are not already present, and also a <note> element
- * to the first <tuple> element of the PIDF document.
+ * to the first <tuple> element of the PIDF document, if a <note> element
+ * is not present.
  *
  * @param pres	    The PIDF presence document.
  * @param pool	    Pool.

--- a/pjsip/src/pjsip-simple/rpid.c
+++ b/pjsip/src/pjsip-simple/rpid.c
@@ -115,27 +115,26 @@ PJ_DEF(pj_status_t) pjrpid_add_element(pjpidf_pres *pres,
 
     PJ_UNUSED_ARG(options);
 
-    /* Check if we need to add RPID information into the PIDF document. */
-    if (elem->id.slen==0 && 
-	elem->activity==PJRPID_ACTIVITY_UNKNOWN &&
-	elem->note.slen==0)
-    {
-	/* No RPID information to be added. */
-	return PJ_SUCCESS;
-    }
-
-    /* Add <note> to <tuple> */
+    /* Add <note> to <tuple>, if none */
     if (elem->note.slen != 0) {
 	pj_xml_node *nd_tuple;
 
 	nd_tuple = find_node(pres, "tuple");
-
-	if (nd_tuple) {
+	nd_note = nd_tuple? find_node(nd_tuple, "note"):NULL;
+	if (!nd_note) {
 	    nd_note = pj_xml_node_new(pool, &NOTE);
 	    pj_strdup(pool, &nd_note->content, &elem->note);
 	    pj_xml_add_node(nd_tuple, nd_note);
 	    nd_note = NULL;
 	}
+    }
+
+    /* Check if we need to add RPID information into the PIDF document. */
+    if (elem->id.slen==0 &&
+	elem->activity==PJRPID_ACTIVITY_UNKNOWN)
+    {
+	/* No RPID information to be added. */
+	return PJ_SUCCESS;
     }
 
     /* Update namespace */
@@ -204,7 +203,7 @@ static pj_status_t get_tuple_note(const pjpidf_pres *pres,
     if (!nd_tuple)
 	return PJSIP_SIMPLE_EBADRPID;
 
-    nd_note = find_node(pres, "note");
+    nd_note = find_node(nd_tuple, "note");
     if (nd_note) {
 	pj_strdup(pool, &elem->note, &nd_note->content);
 	return PJ_SUCCESS;


### PR DESCRIPTION
- Allow `<note>` element in `<tuple>` set in `pjsip_pres_status.info[0].rpid.note` without having RPID element in presence message body (thanks to Christian Becker for the feedback).
- Fix wrong parent node for finding note element in `get_tuple_note()`.
- Update docs: fix typo, etc.