### PR TITLE
Add compile time option to disable auto sending of 100 response

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -395,6 +395,18 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 
 
 /**
+ * Specify whether pjsua should disable automatically sending initial
+ * answer 100/Trying for incoming calls. If disabled, application can
+ * later send 100/Trying if it wishes using pjsua_call_answer().
+ *
+ * Default: 0 (automatic sending enabled)
+ */
+#ifndef PJSUA_DISABLE_AUTO_SEND_100
+#   define PJSUA_DISABLE_AUTO_SEND_100	0
+#endif
+
+
+/**
  * Default options that will be passed when creating ice transport.
  * See #pjmedia_transport_ice_options.
  */

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1988,6 +1988,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 	goto on_return;
 
     } else {
+#if !PJSUA_DISABLE_AUTO_SEND_100
 	status = pjsip_inv_send_msg(inv, response);
 	if (status != PJ_SUCCESS) {
 	    pjsua_perror(THIS_FILE, "Unable to send 100 response", status);
@@ -1996,6 +1997,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 	    call->async_call.dlg = NULL;
 	    goto on_return;
 	}
+#endif
     }
 
     /* Only do this after sending 100/Trying (really! see the long comment


### PR DESCRIPTION
Add compile time option `PJSUA_DISABLE_AUTO_SEND_100` to disable automatic sending of initial answer 100/Trying for incoming calls.
