### PR TITLE
Add Embox RTOS to supported targets in README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -404,6 +404,7 @@ Creating config_site.h file
      * mingw (i386),
      * FreeBSD and maybe other BSD's (i386, Opteron, etc.),
      * RTEMS with cross compilation (ARM, powerpc),
+     * Embox RTOS (i386, ARM including STM32),
      * etc.
 
 


### PR DESCRIPTION
Hello,

We finally finished porting PJSIP (v2.10) to [Embox RTOS ](https://github.com/embox/embox)and verified it with `simple_pjsua` for STM32.

Here is a short [video](https://youtu.be/fJ-HNopjQkM) where we show a simple SIP Phone on STM32. Here is an [article](https://alexkalmuk.medium.com/sip-phone-with-gui-on-stm32-1c3b4abf7ed4) describing this in more detail. Also, we added a description of how to use PJSIP with Embox to our [wiki](https://github.com/embox/embox/wiki/PJSIP).

We would like to mention this in your README.txt if you like this use case.