### PR TITLE
Increase SDP version when receiving re-INVITE without SDP

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -449,16 +449,16 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_send_local_offer( pj_pool_t *pool,
 						       neg->active_local_sdp);
 
 #if PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
-    	if (pjmedia_sdp_session_cmp(neg->active_local_sdp, 
+    	if (pjmedia_sdp_session_cmp(neg->neg_local_sdp, 
     				    neg->initial_sdp, 0) != PJ_SUCCESS)
     	{
-	    neg->active_local_sdp->origin.version++;
+	    neg->neg_local_sdp->origin.version++;
     	}    
 #else
-    	neg->active_local_sdp->origin.version++;
+    	neg->neg_local_sdp->origin.version++;
 #endif
 
-	*offer = neg->active_local_sdp;
+	*offer = neg->neg_local_sdp;
 
     } else {
 	/* We assume that we're in STATE_LOCAL_OFFER.

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -447,6 +447,17 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_send_local_offer( pj_pool_t *pool,
 	neg->state = PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER;
 	neg->neg_local_sdp = pjmedia_sdp_session_clone(pool, 
 						       neg->active_local_sdp);
+
+#if PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
+    	if (pjmedia_sdp_session_cmp(neg->active_local_sdp, 
+    				    neg->initial_sdp, 0) != PJ_SUCCESS)
+    	{
+	    neg->active_local_sdp->origin.version++;
+    	}    
+#else
+    	neg->active_local_sdp->origin.version++;
+#endif
+
 	*offer = neg->active_local_sdp;
 
     } else {

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -5154,10 +5154,8 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
 		    status = pjmedia_sdp_neg_send_local_offer(inv->pool_prov,
 							      inv->neg, 
 							      &active_sdp);
-		    if (status == PJ_SUCCESS) {
+		    if (status == PJ_SUCCESS)
 			sdp = (pjmedia_sdp_session*) active_sdp;
-			sdp->origin.version++;
-		    }
 		}
 
 		if (sdp) {

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -5154,8 +5154,10 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
 		    status = pjmedia_sdp_neg_send_local_offer(inv->pool_prov,
 							      inv->neg, 
 							      &active_sdp);
-		    if (status == PJ_SUCCESS)
+		    if (status == PJ_SUCCESS) {
 			sdp = (pjmedia_sdp_session*) active_sdp;
+			sdp->origin.version++;
+		    }
 		}
 
 		if (sdp) {


### PR DESCRIPTION
Related to #2620 

In a scenario described by @jcolp, if app doesn't implement sip_inv's `on_create_offer()` optional callback:
* PJSIP sends an initial INVITE offer
* remote answers (the answer is different than the offer, for example, it will choose only one out of all the offered codecs)
* PJSIP receives re-INVITE without SDP
* Since `on_create_offer()` is not implemented, PJSIP will answer with the active local SDP, which is different than its initial offer, but without the session version number incremented.
