### PR TITLE
Add option to disable auto re-registration.

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3357,15 +3357,17 @@ PJ_DECL(pj_status_t) pjsua_transport_lis_start( pjsua_transport_id id,
 #endif
 
 /**
- * Set this to 0 to disable auto re-registration. This is useful for app
- * that uses Push Notification and doesn't require auto re-registration.
- * App can periodically send refresh registration or send it before making
- * a call. See https://github.com/pjsip/pjproject/pull/2652 for more info.
+ * When the registration is successfull, the auto registration refresh will
+ * be sent before it expires. Setting this to 0 will disable it.
+ * This is useful for app that uses Push Notification and doesn't require auto
+ * registration refresh. App can periodically send refresh registration or
+ * send it before making a call.=
+ * See https://github.com/pjsip/pjproject/pull/2652 for more info.
  *
  * Default: 1 (enabled)
  */
-#ifndef PJSUA_REG_AUTO_REREG
-#   define PJSUA_REG_AUTO_REREG     1
+#ifndef PJSUA_REG_AUTO_REG_REFRESH
+#   define PJSUA_REG_AUTO_REG_REFRESH     1
 #endif
 
 /**

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3356,6 +3356,17 @@ PJ_DECL(pj_status_t) pjsua_transport_lis_start( pjsua_transport_id id,
 #   define PJSUA_REG_RETRY_INTERVAL	300
 #endif
 
+/**
+ * Set this to 0 to disable auto re-registration. This is useful for app
+ * that uses Push Notification and doesn't require auto re-registration.
+ * App can periodically send refresh registration or send it before making
+ * a call. See https://github.com/pjsip/pjproject/pull/2652 for more info.
+ *
+ * Default: 1 (enabled)
+ */
+#ifndef PJSUA_REG_AUTO_REG
+#   define PJSUA_REG_AUTO_REG	1
+#endif
 
 /**
  * This macro specifies the default value for \a contact_rewrite_method

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3364,8 +3364,8 @@ PJ_DECL(pj_status_t) pjsua_transport_lis_start( pjsua_transport_id id,
  *
  * Default: 1 (enabled)
  */
-#ifndef PJSUA_REG_AUTO_REG
-#   define PJSUA_REG_AUTO_REG	1
+#ifndef PJSUA_REG_AUTO_REREG
+#   define PJSUA_REG_AUTO_REREG     1
 #endif
 
 /**

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2364,13 +2364,22 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 	    /* Check and update Service-Route header */
 	    update_service_route(acc, param->rdata);
 
-	    PJ_LOG(3, (THIS_FILE, 
-		       "%s: registration success, status=%d (%.*s), "
-		       "will re-register in %d seconds", 
-		       pjsua_var.acc[acc->index].cfg.id.ptr,
-		       param->code,
-		       (int)param->reason.slen, param->reason.ptr,
-		       param->expiration));
+            if (PJSUA_REG_AUTO_REG) {
+                PJ_LOG(3, (THIS_FILE,
+                           "%s: registration success, status=%d (%.*s), "
+                           "will re-register in %d seconds",
+                           pjsua_var.acc[acc->index].cfg.id.ptr,
+                           param->code,
+                           (int)param->reason.slen, param->reason.ptr,
+                           param->expiration));
+            } else {
+                PJ_LOG(3, (THIS_FILE,
+                           "%s: registration success, status=%d (%.*s), "
+                           "auto re-register disabled",
+                           pjsua_var.acc[acc->index].cfg.id.ptr,
+                           param->code,
+                           (int)param->reason.slen, param->reason.ptr));
+            }
 
 	    /* Start keep-alive timer if necessary. */
 	    update_keep_alive(acc, PJ_TRUE, param);
@@ -2732,7 +2741,8 @@ PJ_DEF(pj_status_t) pjsua_acc_set_registration( pjsua_acc_id acc_id,
 	    goto on_return;
 	}
 
-	status = pjsip_regc_register(pjsua_var.acc[acc_id].regc, 1, 
+	status = pjsip_regc_register(pjsua_var.acc[acc_id].regc,
+                                     PJSUA_REG_AUTO_REG,
 				     &tdata);
 
 	if (0 && status == PJ_SUCCESS && pjsua_var.acc[acc_id].cred_cnt) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2364,7 +2364,7 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 	    /* Check and update Service-Route header */
 	    update_service_route(acc, param->rdata);
 
-#if         PJSUA_REG_AUTO_REREG
+#if         PJSUA_REG_AUTO_REG_REFRESH
 
             PJ_LOG(3, (THIS_FILE,
                         "%s: registration success, status=%d (%.*s), "
@@ -2745,7 +2745,7 @@ PJ_DEF(pj_status_t) pjsua_acc_set_registration( pjsua_acc_id acc_id,
 	}
 
 	status = pjsip_regc_register(pjsua_var.acc[acc_id].regc,
-                                     PJSUA_REG_AUTO_REREG,
+                                     PJSUA_REG_AUTO_REG_REFRESH,
 				     &tdata);
 
 	if (0 && status == PJ_SUCCESS && pjsua_var.acc[acc_id].cred_cnt) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2364,23 +2364,26 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 	    /* Check and update Service-Route header */
 	    update_service_route(acc, param->rdata);
 
-            if (PJSUA_REG_AUTO_REG) {
-                PJ_LOG(3, (THIS_FILE,
-                           "%s: registration success, status=%d (%.*s), "
-                           "will re-register in %d seconds",
-                           pjsua_var.acc[acc->index].cfg.id.ptr,
-                           param->code,
-                           (int)param->reason.slen, param->reason.ptr,
-                           param->expiration));
-            } else {
-                PJ_LOG(3, (THIS_FILE,
-                           "%s: registration success, status=%d (%.*s), "
-                           "auto re-register disabled",
-                           pjsua_var.acc[acc->index].cfg.id.ptr,
-                           param->code,
-                           (int)param->reason.slen, param->reason.ptr));
-            }
+#if         PJSUA_REG_AUTO_REREG
 
+            PJ_LOG(3, (THIS_FILE,
+                        "%s: registration success, status=%d (%.*s), "
+                        "will re-register in %d seconds",
+                        pjsua_var.acc[acc->index].cfg.id.ptr,
+                        param->code,
+                        (int)param->reason.slen, param->reason.ptr,
+                        param->expiration));
+
+#else
+
+            PJ_LOG(3, (THIS_FILE,
+                        "%s: registration success, status=%d (%.*s), "
+                        "auto re-register disabled",
+                        pjsua_var.acc[acc->index].cfg.id.ptr,
+                        param->code,
+                        (int)param->reason.slen, param->reason.ptr));
+
+#endif
 	    /* Start keep-alive timer if necessary. */
 	    update_keep_alive(acc, PJ_TRUE, param);
 
@@ -2742,7 +2745,7 @@ PJ_DEF(pj_status_t) pjsua_acc_set_registration( pjsua_acc_id acc_id,
 	}
 
 	status = pjsip_regc_register(pjsua_var.acc[acc_id].regc,
-                                     PJSUA_REG_AUTO_REG,
+                                     PJSUA_REG_AUTO_REREG,
 				     &tdata);
 
 	if (0 && status == PJ_SUCCESS && pjsua_var.acc[acc_id].cred_cnt) {


### PR DESCRIPTION
Currently (on `pjsua` API) when registration is successful, the library will send auto registration refresh after a successful registration.
On some cases (e.g: Push Notification use), app might require to disable it to save resources.
This patch will add the option (`PJSUA_REG_AUTO_REG_REFRESH`) to disable auto registration refresh.
If this is disabled, app will still be able to send registration refresh periodically or before making a call manually.
