### PR TITLE
Fixed race condition in sending registration

### DIFF
--- a/pjsip/include/pjsip-ua/sip_regc.h
+++ b/pjsip/include/pjsip-ua/sip_regc.h
@@ -156,6 +156,24 @@ PJ_DECL(pj_status_t) pjsip_regc_create( pjsip_endpoint *endpt, void *token,
  */
 PJ_DECL(pj_status_t) pjsip_regc_destroy(pjsip_regc *regc);
 
+
+/**
+ * Destroy client registration structure. If a registration transaction is
+ * in progress:
+ * - if force is PJ_TRUE, then the structure will be deleted only after
+ *   a final response has been received, and in this case, the callback
+ *   won't be called (this behavior is the same as calling
+ *   pjsip_regc_destroye()).
+ * - if force is PJ_FALSE, the function will return PJ_EBUSY
+ *
+ * @param regc	    The client registration structure.
+ * @param force	    Specify if the function must destroy the structure.
+ *
+ * @return	    PJ_SUCCESS on success, or PJ_EBUSY.
+ */
+PJ_DECL(pj_status_t) pjsip_regc_destroy2(pjsip_regc *regc, pj_bool_t force);
+
+
 /**
  * Get registration info.
  *


### PR DESCRIPTION
In the scenario of #2575, the race condition happens when the first registration is successful and the second one returns PJ_EBUSY, but there's also the opposite scenario when the first registration fails (such as because the network is not ready after IP change) and the second one is actually the successful one. Then there will be two problems when the latter scenario occurs:
- in `pjsua_acc.c` `regc_cb()` the callback will try to delete the registration instance even though there's an ongoing registration in progress.
- in `pjsip_regc` itself, because the registration sent is done without holding a lock, the failed one will mark that the registration currently has no pending transaction (`has_tsx` is false).

This PR will try to fix both:
- In `pjsua_acc`'s reg callback, we will modify the destruction of the registration instance to a non-forceful one, meaning that the destruction will fail if the registration instance is still busy.
- In `pjsip_regc`, we add extra check before resetting `has_tsx`.

Note that if application wants more control over the auto registration mechanism to prevent race condition from happening, it can use the compile-time setting newly introduced in #2652, which can disable auto reregistration in the pjsua level.
