### PR TITLE
Modify pjsua maximum calls setting

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -2017,10 +2017,9 @@ typedef struct pjsua_config
 
     /** 
      * Maximum calls to support (default: 4). The value specified here
-     * must be smaller than the compile time maximum settings 
-     * PJSUA_MAX_CALLS, which by default is 32. To increase this 
-     * limit, the library must be recompiled with new PJSUA_MAX_CALLS
-     * value.
+     * must be smaller than or equal to the compile time maximum settings
+     * PJSUA_MAX_CALLS. To increase this limit, the library must be
+     * recompiled with new PJSUA_MAX_CALLS value.
      */
     unsigned	    max_calls;
 
@@ -4806,7 +4805,7 @@ PJ_DECL(pj_status_t) pjsua_acc_set_transport(pjsua_acc_id acc_id,
  * Maximum simultaneous calls.
  */
 #ifndef PJSUA_MAX_CALLS
-#   define PJSUA_MAX_CALLS	    32
+#   define PJSUA_MAX_CALLS	    4
 #endif
 
 /**

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -104,7 +104,7 @@ PJ_DEF(void) pjsua_config_default(pjsua_config *cfg)
 {
     pj_bzero(cfg, sizeof(*cfg));
 
-    cfg->max_calls = ((PJSUA_MAX_CALLS) < 4) ? (PJSUA_MAX_CALLS) : 4;
+    cfg->max_calls = PJSUA_MAX_CALLS;
     cfg->thread_cnt = PJSUA_SEPARATE_WORKER_FOR_TIMER? 2 : 1;
     cfg->nat_type_in_sdp = 1;
     cfg->stun_ignore_failure = PJ_TRUE;


### PR DESCRIPTION
This PR is originally submitted by @SalihPalamut in #2647 

The modification is as follows:
- Change pjsua's default config of max calls to the compile-time setting `PJSUA_MAX_CALLS` (previously it was `max(PJSUA_MAX_CALLS, 4)`).
- Change default value of `PJSUA_MAX_CALLS` to 4, since 32 is a bit too high for most apps and 4 is the current run-time default value.
- Adjust the doc accordingly.

