### PR TITLE
Differentiate video codec ID by assigning each codec backend a specific PT number

### DIFF
--- a/pjmedia/include/pjmedia-codec/types.h
+++ b/pjmedia/include/pjmedia-codec/types.h
@@ -126,7 +126,11 @@ enum pjmedia_video_pt
      PJMEDIA_RTP_PT_H264_RSV4,
 
      PJMEDIA_RTP_PT_VP8,
+     PJMEDIA_RTP_PT_VP8_RSV1,
+     PJMEDIA_RTP_PT_VP8_RSV2,
      PJMEDIA_RTP_PT_VP9,
+     PJMEDIA_RTP_PT_VP9_RSV1,
+     PJMEDIA_RTP_PT_VP9_RSV2,
 
      /* Caution!
       * Ensure the value of the last pt above is <= 127.

--- a/pjmedia/include/pjmedia-codec/types.h
+++ b/pjmedia/include/pjmedia-codec/types.h
@@ -118,18 +118,18 @@ enum pjmedia_video_pt
 {
      /* Video payload types */
      PJMEDIA_RTP_PT_VID_START = (PJMEDIA_RTP_PT_DYNAMIC-1),
-     PJMEDIA_RTP_PT_H263P,
-     PJMEDIA_RTP_PT_H264,
-     PJMEDIA_RTP_PT_H264_RSV1,
-     PJMEDIA_RTP_PT_H264_RSV2,
-     PJMEDIA_RTP_PT_H264_RSV3,
+     PJMEDIA_RTP_PT_H263P,      /* used by ffmpeg avcodec     */
+     PJMEDIA_RTP_PT_H264,       /* used by OpenH264           */
+     PJMEDIA_RTP_PT_H264_RSV1,  /* used by video toolbox      */
+     PJMEDIA_RTP_PT_H264_RSV2,  /* used by MediaCodec         */
+     PJMEDIA_RTP_PT_H264_RSV3,  /* used by ffmpeg avcodec     */
      PJMEDIA_RTP_PT_H264_RSV4,
 
-     PJMEDIA_RTP_PT_VP8,
-     PJMEDIA_RTP_PT_VP8_RSV1,
+     PJMEDIA_RTP_PT_VP8,        /* used by VPX                */
+     PJMEDIA_RTP_PT_VP8_RSV1,   /* used by MediaCodec         */
      PJMEDIA_RTP_PT_VP8_RSV2,
-     PJMEDIA_RTP_PT_VP9,
-     PJMEDIA_RTP_PT_VP9_RSV1,
+     PJMEDIA_RTP_PT_VP9,        /* used by VPX                */
+     PJMEDIA_RTP_PT_VP9_RSV1,   /* used by MediaCodec         */
      PJMEDIA_RTP_PT_VP9_RSV2,
 
      /* Caution!

--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -81,6 +81,8 @@
 #endif
 #define AVCODEC_HAS_DECODE(c)		(c->decode)
 
+/* AVCodec H264 default PT */
+#define AVC_H264_PT                       PJMEDIA_RTP_PT_H264_RSV3
 
 /* Prototypes for FFMPEG codecs factory */
 static pj_status_t ffmpeg_test_alloc( pjmedia_vid_codec_factory *factory, 
@@ -285,7 +287,7 @@ static ffmpeg_codec_desc codec_desc[] =
 {
 #if PJMEDIA_HAS_FFMPEG_CODEC_H264
     {
-	{PJMEDIA_FORMAT_H264, PJMEDIA_RTP_PT_H264, {"H264",4},
+	{PJMEDIA_FORMAT_H264, AVC_H264_PT, {"H264",4},
 	 {"Constrained Baseline (level=30, pack=1)", 39}},
 	0,
 	{720, 480},	{15, 1},	256000, 256000,

--- a/pjmedia/src/pjmedia-codec/openh264.cpp
+++ b/pjmedia/src/pjmedia-codec/openh264.cpp
@@ -56,6 +56,8 @@
 #define MAX_RX_WIDTH		1200
 #define MAX_RX_HEIGHT		800
 
+/* OpenH264 default PT */
+#define OH264_PT                PJMEDIA_RTP_PT_H264
 
 /*
  * Factory operations.
@@ -248,7 +250,7 @@ static pj_status_t oh264_test_alloc(pjmedia_vid_codec_factory *factory,
     PJ_ASSERT_RETURN(factory == &oh264_factory.base, PJ_EINVAL);
 
     if (info->fmt_id == PJMEDIA_FORMAT_H264 &&
-	info->pt != 0)
+	info->pt == OH264_PT)
     {
 	return PJ_SUCCESS;
     }
@@ -304,7 +306,7 @@ static pj_status_t oh264_enum_info(pjmedia_vid_codec_factory *factory,
 
     *count = 1;
     info->fmt_id = PJMEDIA_FORMAT_H264;
-    info->pt = PJMEDIA_RTP_PT_H264;
+    info->pt = OH264_PT;
     info->encoding_name = pj_str((char*)"H264");
     info->encoding_desc = pj_str((char*)"OpenH264 codec");
     info->clock_rate = 90000;

--- a/pjmedia/src/pjmedia-codec/vid_toolbox.m
+++ b/pjmedia/src/pjmedia-codec/vid_toolbox.m
@@ -61,6 +61,8 @@
 /* Maximum duration from one key frame to the next (in seconds). */
 #define KEYFRAME_INTERVAL	5
 
+/* vidtoolbox H264 default PT */
+#define VT_H264_PT		PJMEDIA_RTP_PT_H264_RSV1
 /*
  * Factory operations.
  */
@@ -265,7 +267,7 @@ static pj_status_t vtool_test_alloc(pjmedia_vid_codec_factory *factory,
     PJ_ASSERT_RETURN(factory == &vtool_factory.base, PJ_EINVAL);
 
     if (info->fmt_id == PJMEDIA_FORMAT_H264 &&
-	info->pt != 0)
+	info->pt == VT_H264_PT)
     {
 	return PJ_SUCCESS;
     }
@@ -321,7 +323,7 @@ static pj_status_t vtool_enum_info(pjmedia_vid_codec_factory *factory,
 
     *count = 1;
     info->fmt_id = PJMEDIA_FORMAT_H264;
-    info->pt = PJMEDIA_RTP_PT_H264;
+    info->pt = VT_H264_PT;
     info->encoding_name = pj_str((char*)"H264");
     info->encoding_desc = pj_str((char*)"Video Toolbox codec");
     info->clock_rate = 90000;

--- a/pjmedia/src/pjmedia-codec/vpx.c
+++ b/pjmedia/src/pjmedia-codec/vpx.c
@@ -56,6 +56,10 @@
 
 #define MAX_RX_RES		1200
 
+/* VPX VP8 default PT */
+#define VPX_VP8_PT		PJMEDIA_RTP_PT_VP8
+/* VPX VP9 default PT */
+#define VPX_VP9_PT		PJMEDIA_RTP_PT_VP9
 
 /*
  * Factory operations.
@@ -229,8 +233,8 @@ static pj_status_t vpx_test_alloc(pjmedia_vid_codec_factory *factory,
 {
     PJ_ASSERT_RETURN(factory == &vpx_factory.base, PJ_EINVAL);
 
-    if ((info->fmt_id == PJMEDIA_FORMAT_VP8 ||
-         info->fmt_id == PJMEDIA_FORMAT_VP9) && info->pt != 0)
+    if (((info->fmt_id == PJMEDIA_FORMAT_VP8) && (info->pt == VPX_VP8_PT)) ||
+        ((info->fmt_id == PJMEDIA_FORMAT_VP9) && (info->pt == VPX_VP9_PT)))
     {
 	return PJ_SUCCESS;
     }
@@ -291,7 +295,7 @@ static pj_status_t vpx_enum_info(pjmedia_vid_codec_factory *factory,
 
 #if PJMEDIA_HAS_VPX_CODEC_VP8
     info[i].fmt_id = PJMEDIA_FORMAT_VP8;
-    info[i].pt = PJMEDIA_RTP_PT_VP8;
+    info[i].pt = VPX_VP8_PT;
     info[i].encoding_name = pj_str((char*)"VP8");
     info[i].encoding_desc = pj_str((char*)"VPX VP8 codec");
     i++;
@@ -300,7 +304,7 @@ static pj_status_t vpx_enum_info(pjmedia_vid_codec_factory *factory,
 #if PJMEDIA_HAS_VPX_CODEC_VP9
     if (i + 1 < *count) {
     	info[i].fmt_id = PJMEDIA_FORMAT_VP9;
-    	info[i].pt = PJMEDIA_RTP_PT_VP9;
+        info[i].pt = VPX_VP9_PT;
     	info[i].encoding_name = pj_str((char*)"VP9");
     	info[i].encoding_desc = pj_str((char*)"VPX VP9 codec");
     	i++;


### PR DESCRIPTION
Currently the library supports multiple codec backend implementation (e.g: H264 using `OpenH264`, `ffmpeg` or `vid_toolbox`).
When enabling those codec backend, user cannot set their priority and only one video codec will be active.
This is useful when user want prioritize or disable one codec backend. (e.g: on iOS user want to prioritize `vid_toolbox` over `OpenH264`).
Video codec implementation uses PT as part of its ID, so assigning each video codec implementation specific PT will allow user will to choose which codec implementation to use.