### PR TITLE
SIP session timer not retry refreshing after a re-INVITE refresh responded with 503

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4146,14 +4146,7 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
 	return PJ_TRUE;	/* Handled */
 
     } 
-    /* Process 502/503 error */
-    else if ((tsx->state == PJSIP_TSX_STATE_TERMINATED) &&
-	     (tsx->status_code == 503 || tsx->status_code == 502))
-    {
-	pjsip_timer_handle_refresh_error(inv, e);
 
-	return PJ_TRUE;
-    }    
     else {
 	return PJ_FALSE; /* Unhandled */
     }
@@ -5309,6 +5302,11 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
 
 	    if (tsx == inv->invite_tsx)
 		inv->invite_tsx = NULL;
+
+	    /* Process 502/503 error for session timer refresh */
+	    if (tsx->status_code == 503 || tsx->status_code == 502) {
+		pjsip_timer_handle_refresh_error(inv, e);
+	    }
 	}
 
     } else if (tsx->role == PJSIP_ROLE_UAS &&

--- a/pjsip/src/pjsip-ua/sip_timer.c
+++ b/pjsip/src/pjsip-ua/sip_timer.c
@@ -385,6 +385,11 @@ static void timer_cb(pj_timer_heap_t *timer_heap, struct pj_timer_entry *entry)
 	    pjsip_endpt_schedule_timer(inv->dlg->endpt, &inv->timer->timer,
 				       &delay);
 	    pjsip_dlg_dec_lock(inv->dlg);
+
+	    PJ_LOG(3, (obj_name,
+		       "Reschedule refresh request after %d seconds as "
+		       "there is another SDP negotiation in progress",
+		       delay.sec));
 	    return;
 	}
 


### PR DESCRIPTION
In investigation, we found:
- For session timer module, the tsx state check for state `TERMINATED`, so the check of `inv->timer->refresh_tdata == event->body.tsx_state.tsx->last_tx` in `pjsip_timer_handle_refresh_error()` will fail (due to `event->body.tsx_state.tsx->last_tx` pointing to ACK instead of INVITE) and the re-INVITE is not treated as part of the session timer tsx.
- In invite session module, the re-INVITE response check should also reset `invite_tsx` & SDP negotiator state to DONE, otherwise the session timer module will assume that there is another re-INVITE in progress, so it will just reschedule the retry (instead of sending the re-INVITE retry immediately).

Thanks to Marcus Froeschl for the report.
