### PR TITLE
Fixed race condition between media event callback and stopping video

### DIFF
--- a/pjmedia/src/pjmedia/event.c
+++ b/pjmedia/src/pjmedia/event.c
@@ -238,7 +238,7 @@ PJ_DEF(void) pjmedia_event_mgr_destroy(pjmedia_event_mgr *mgr)
         mgr->mutex = NULL;
     }
 
-    if (mgr->mutex) {
+    if (mgr->cb_mutex) {
         pj_mutex_destroy(mgr->cb_mutex);
         mgr->cb_mutex = NULL;
     }

--- a/pjmedia/src/pjmedia/event.c
+++ b/pjmedia/src/pjmedia/event.c
@@ -54,6 +54,7 @@ struct pjmedia_event_mgr
     pj_bool_t       is_quitting;
     pj_sem_t       *sem;
     pj_mutex_t     *mutex;
+    pj_mutex_t     *cb_mutex;
     event_queue     ev_queue;
     event_queue    *pub_ev_queue;       /**< publish() event queue.     */
     esub            esub_list;          /**< list of subscribers.       */
@@ -107,15 +108,22 @@ static pj_status_t event_mgr_distribute_events(pjmedia_event_mgr *mgr,
             void *user_data = sub->user_data;
             pj_status_t status;
             
-            if (rls_lock)
+            if (rls_lock) {
+                /* To make sure that event unsubscription waits
+                 * until the callback completes.
+                 */
+                pj_mutex_lock(mgr->cb_mutex);
                 pj_mutex_unlock(mgr->mutex);
+            }
 
             status = (*cb)(ev, user_data);
             if (status != PJ_SUCCESS && err == PJ_SUCCESS)
 	        err = status;
 
-            if (rls_lock)
+            if (rls_lock) {
+                pj_mutex_unlock(mgr->cb_mutex);
                 pj_mutex_lock(mgr->mutex);
+            }
         }
 	sub = *next_sub;
     }
@@ -183,6 +191,13 @@ PJ_DEF(pj_status_t) pjmedia_event_mgr_create(pj_pool_t *pool,
         return status;
     }
 
+    status = pj_mutex_create_recursive(mgr->pool, "ev_cb_mutex",
+    				       &mgr->cb_mutex);
+    if (status != PJ_SUCCESS) {
+        pjmedia_event_mgr_destroy(mgr);
+        return status;
+    }
+
     if (!event_manager_instance)
 	event_manager_instance = mgr;
 
@@ -221,6 +236,11 @@ PJ_DEF(void) pjmedia_event_mgr_destroy(pjmedia_event_mgr *mgr)
     if (mgr->mutex) {
         pj_mutex_destroy(mgr->mutex);
         mgr->mutex = NULL;
+    }
+
+    if (mgr->mutex) {
+        pj_mutex_destroy(mgr->cb_mutex);
+        mgr->cb_mutex = NULL;
     }
 
     if (mgr->pool)
@@ -298,7 +318,16 @@ pjmedia_event_unsubscribe(pjmedia_event_mgr *mgr,
     if (!mgr) mgr = pjmedia_event_mgr_instance();
     PJ_ASSERT_RETURN(mgr, PJ_EINVAL);
 
-    pj_mutex_lock(mgr->mutex);
+    while(1) {
+    	pj_mutex_lock(mgr->mutex);
+    	if (pj_mutex_trylock(mgr->cb_mutex) == PJ_SUCCESS)
+    	    break;
+    	
+    	/* The callback is currently being called, wait for a while. */
+    	pj_mutex_unlock(mgr->mutex);
+    	pj_thread_sleep(10);
+    }
+
     sub = mgr->esub_list.next;
     while (sub != &mgr->esub_list) {
 	esub *next = sub->next;
@@ -320,6 +349,7 @@ pjmedia_event_unsubscribe(pjmedia_event_mgr *mgr,
         }
 	sub = next;
     }
+    pj_mutex_unlock(mgr->cb_mutex);
     pj_mutex_unlock(mgr->mutex);
 
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia/vid_port.c
+++ b/pjmedia/src/pjmedia/vid_port.c
@@ -856,18 +856,26 @@ PJ_DEF(void) pjmedia_vid_port_destroy(pjmedia_vid_port *vp)
 
     PJ_LOG(4,(THIS_FILE, "Closing %s..", vp->dev_name.ptr));
 
+    /* Unsubscribe events first, otherwise the event callbacks can be called
+     * and try to access already destroyed objects.
+     */
+    if (vp->strm) {
+        pjmedia_event_unsubscribe(NULL, &vidstream_event_cb, vp, vp->strm);
+    }
+    if (vp->client_port) {
+        pjmedia_event_unsubscribe(NULL, &client_port_event_cb, vp,
+                                  vp->client_port);
+    }
+
     if (vp->clock) {
 	pjmedia_clock_destroy(vp->clock);
 	vp->clock = NULL;
     }
     if (vp->strm) {
-        pjmedia_event_unsubscribe(NULL, &vidstream_event_cb, vp, vp->strm);
 	pjmedia_vid_dev_stream_destroy(vp->strm);
 	vp->strm = NULL;
     }
     if (vp->client_port) {
-        pjmedia_event_unsubscribe(NULL, &client_port_event_cb, vp,
-                                  vp->client_port);
 	if (vp->destroy_client_port)
 	    pjmedia_port_destroy(vp->client_port);
 	vp->client_port = NULL;

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -564,6 +564,7 @@ struct pjsua_data
 #endif
 
     /* Timer entry and event list */
+    pjsua_timer_list	 active_timer_list;
     pjsua_timer_list	 timer_list;
     pjsua_event_list	 event_list;
     pj_mutex_t          *timer_mutex;
@@ -736,6 +737,7 @@ void pjsua_media_prov_revert(pjsua_call_id call_id);
 
 /* Callback to receive media events */
 pj_status_t on_media_event(pjmedia_event *event, void *user_data);
+void call_med_event_cb(void *user_data);
 pj_status_t call_media_on_event(pjmedia_event *event,
                                 void *user_data);
 

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1559,7 +1559,7 @@ pj_status_t on_media_event(pjmedia_event *event, void *user_data)
 }
 
 /* Call on_call_media_event() callback using timer */
-static void call_med_event_cb(void *user_data)
+void call_med_event_cb(void *user_data)
 {
     pjsua_event_list *eve = (pjsua_event_list *)user_data;
     


### PR DESCRIPTION
This is a more general case of #2645 .

To avoid deadlock, we usually avoid holding locks when calling a callback. But if the callback happens at the same time with a destroy process, it can potentially cause problems as the callback may access objects being, or already, destroyed.

For the case of media event callback and video stoppage, there are a couple of problems found:
1. In pjsua callback
To call `on_call_media_event()` callback, we use a timer (to avoid deadlock):
```
   if (pjsua_var.ua_cfg.cb.on_call_media_event) {
        ...
    	pjsua_schedule_timer2(&call_med_event_cb, eve, 1);
   }
```
If there’s a race with `pjsua_vid_stop_stream()`, it can cause crash/assertion if inside the callback, user tries to access objects destroyed in `pjsua_vid_stop_stream()`, such as video window or stream.
Example:
In `pjsua_vid_stop_stream()`:
```
    /* Decrement ref count of stream video window */
    dec_vid_win(call_med->strm.v.rdr_win_id);
    call_med->strm.v.rdr_win_id = PJSUA_INVALID_ID;
```
In `on_call_media_event()`:
```
    wid = ci.media[med_idx].stream.vid.win_in;
    pjsua_vid_win_get_info(wid, &win_info);
```
One scenario to reproduce: make a video call (you can make more than one calls at the same time to increase the likelihood of the issue happening), then hangup right at the format change event (usually only about 1-2s after making the calls, just before the video is about to show up).

2. pjmedia event callback
pjmedia event callback is called without holding event manager’s lock, so even though `pjmedia_event_unsubscribe()` has been called, the callback can still be in the process of being invoked.
Example:
In `pjmedia_vid_port_destroy()` (some codes are removed for clarity):
```
   pjmedia_event_unsubscribe(NULL, &vidstream_event_cb, vp, vp->strm);
   pjmedia_vid_dev_stream_destroy(vp->strm);
   vp->strm = NULL;
        
   pjmedia_event_unsubscribe(NULL, &client_port_event_cb, vp,
                                  vp->client_port);
   pjmedia_port_destroy(vp->client_port);
   vp->client_port = NULL;
```
So when `client_port_event_cb()` is called, it’s possible `vp->strm` or `vp->client_port` has been destroyed.
The same scenario above can be used to trigger the issue.

The proposed fixes:
1. Event unsubscription can only happen when event manager is not the middle of calling a callback. This way, we can guarantee that after unsubscription completes, any subscriber's callback that is in progress has been completed and no future callbacks will be called.
2. If a callback is called using a timer, we need to either schedule it with a group lock to prevent objects being destroyed, or wait until it's completed. For this case, since the video media doesn't have its own group lock, we choose the latter approach.

Also fixes #2513.
