### PR TITLE
More works on Trickle ICE

### DIFF
--- a/pjmedia/include/pjmedia/transport_ice.h
+++ b/pjmedia/include/pjmedia/transport_ice.h
@@ -323,15 +323,18 @@ PJ_DECL(pj_bool_t) pjmedia_ice_sdp_has_trickle(const pjmedia_sdp_session *sdp,
 
 
 /**
- * Update check list after new local or remote ICE candidates are added,
- * or signal ICE session that trickling is done. Application typically would
- * call this function after finding (and conveying) new local ICE candidates
- * to remote, after receiving remote ICE candidates, or after receiving
- * end-of-candidates indication.
+ * Update check list after remote ICE candidates list are received or after
+ * or local ICE candidates are conveyed. This function may also be called
+ * after end-of-candidates indication is received or conveyed. ICE
+ * connectivity checks will automatically be started if both sides have
+ * conveyed ICE info (ICE user fragment and/or candidate list).
  *
- * This function is only applicable when trickle ICE is not disabled and
- * after ICE connectivity checks are started, i.e: after
- * pjmedia_transport_media_start() has been invoked.
+ * To update the check list after conveying any new local candidates,
+ * application can set the remote ICE parameters to NULL or zero. Note that
+ * the checklist should only be updated after any newly found local candidates
+ * are conveyed to remote, instead of immediately after the finding.
+ *
+ * This function is only applicable when trickle ICE is not disabled.
  *
  * @param tp		The ICE media transport.
  * @param rem_ufrag	Remote ufrag, as seen in the SDP received from

--- a/pjmedia/include/pjmedia/transport_ice.h
+++ b/pjmedia/include/pjmedia/transport_ice.h
@@ -412,7 +412,8 @@ PJ_DECL(pj_status_t) pjmedia_ice_trickle_encode_sdp(
 
 
 /**
- * Check if trickling ICE has found any new local candidates.
+ * Check if trickling ICE has found any new local candidates since the last
+ * conveyance (via pjmedia_ice_trickle_send_local_cand()).
  *
  * @param tp		The ICE media transport.
  *
@@ -422,9 +423,7 @@ PJ_DECL(pj_bool_t) pjmedia_ice_trickle_has_new_cand(pjmedia_transport *tp);
 
 
 /**
- * Check for new local candidates, and if any new or forced, update the
- * specified SDP with all current local candidates to be conveyed to remote
- * (e.g: via SIP INFO).
+ * Convey all local candidates via the specified SDP.
  *
  * @param tp		The ICE media transport.
  * @param sdp_pool	The memory pool for generating SDP attributes.
@@ -432,10 +431,7 @@ PJ_DECL(pj_bool_t) pjmedia_ice_trickle_has_new_cand(pjmedia_transport *tp);
  * @param p_end_of_cand Optional, pointer to receive the indication that
  *			candidate gathering has been completed.
  *
- * @return		PJ_SUCCESS if any new local candidates is found and
- *			SDP is updated with the candidates,
- *			PJ_ENOTFOUND if no new local candidate is found,
- *			or the appropriate error code.
+ * @return		PJ_SUCCESS, or the appropriate error code.
  */
 PJ_DECL(pj_status_t) pjmedia_ice_trickle_send_local_cand(
 					    pjmedia_transport *tp,

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -1558,6 +1558,14 @@ static pj_status_t verify_ice_sdp(struct transport_ice *tp_ice,
     if (tp_ice->trickle_ice != PJ_ICE_SESS_TRICKLE_DISABLED) {
 	sdp_state->has_trickle = pjmedia_ice_sdp_has_trickle(rem_sdp,
 							     media_index);
+
+	/* Reset ICE mismatch flag if conn addr is default address */
+	if (sdp_state->ice_mismatch && sdp_state->has_trickle) {
+	    pj_sockaddr def_addr;
+	    pj_sockaddr_init(rem_af, &def_addr, NULL, 9);
+	    if (pj_sockaddr_cmp(&rem_conn_addr, &def_addr)==0)
+		sdp_state->ice_mismatch = PJ_FALSE;
+	}
     } else {
 	sdp_state->has_trickle = PJ_FALSE;
     }

--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -470,12 +470,16 @@
 
 /**
  * For trickle ICE, this macro specifies the maximum time of waiting for
- * end-of-candidates indication from remote after remote first signal of its
- * intention of using trickle ICE (e.g: via SDP "a=ice-options:trickle"),
- * in seconds.
+ * end-of-candidates indication from remote once ICE connectivity checks
+ * is started, in seconds. When the timer expires, ICE will assume that
+ * end-of-candidates indication is received so any further remote candidate
+ * update will be ignored.
  *
- * When the timer expires, ICE assumes that end-of-candidates indication
- * has been received, and any further remote candidate update will be ignored.
+ * Note that without remote end-of-candidates indication, ICE will not be
+ * able to conclude the ICE negotiation. Also note that the ICE connectivity
+ * checks should only be started after both agents have started trickling
+ * ICE candidates (e.g: both have sent their SDPs, either via normal SDP
+ * offer/answer or SIP INFO).
  *
  * Default: 60 seconds.
  */

--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -476,15 +476,19 @@
  * update will be ignored.
  *
  * Note that without remote end-of-candidates indication, ICE will not be
- * able to conclude the ICE negotiation. Also note that the ICE connectivity
- * checks should only be started after both agents have started trickling
- * ICE candidates (e.g: both have sent their SDPs, either via normal SDP
- * offer/answer or SIP INFO).
+ * able to conclude that the ICE negotiation has failed when all pair checks
+ * are completed but there is no valid pair (on the other hand, the ICE
+ * negotiation may be completed as successful before the end-of-candidates
+ * indication is received when valid pairs are found very quickly).
  *
- * Default: 60 seconds.
+ * Also note that the ICE connectivity checks should only be started after
+ * both agents have started trickling ICE candidates (e.g: both have sent
+ * their SDPs, either via normal SDP offer/answer or SIP INFO).
+ *
+ * Default: 40 seconds.
  */
 #ifndef PJ_TRICKLE_ICE_END_OF_CAND_TIMEOUT
-#   define PJ_TRICKLE_ICE_END_OF_CAND_TIMEOUT	    60
+#   define PJ_TRICKLE_ICE_END_OF_CAND_TIMEOUT	    40
 #endif
 
 

--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -468,6 +468,22 @@
 #endif
 
 
+/**
+ * For trickle ICE, this macro specifies the maximum time of waiting for
+ * end-of-candidates indication from remote after remote first signal of its
+ * intention of using trickle ICE (e.g: via SDP "a=ice-options:trickle"),
+ * in seconds.
+ *
+ * When the timer expires, ICE assumes that end-of-candidates indication
+ * has been received, and any further remote candidate update will be ignored.
+ *
+ * Default: 60 seconds.
+ */
+#ifndef PJ_TRICKLE_ICE_END_OF_CAND_TIMEOUT
+#   define PJ_TRICKLE_ICE_END_OF_CAND_TIMEOUT	    60
+#endif
+
+
 /** ICE session pool initial size. */
 #ifndef PJNATH_POOL_LEN_ICE_SESS
 #   define PJNATH_POOL_LEN_ICE_SESS		    512

--- a/pjnath/include/pjnath/ice_session.h
+++ b/pjnath/include/pjnath/ice_session.h
@@ -704,6 +704,7 @@ struct pj_ice_sess
 							 sent/received?	    */
     pj_status_t		 ice_status;		    /**< Error status.	    */
     pj_timer_entry	 timer;			    /**< ICE timer.	    */
+    pj_timer_entry	 timer_end_of_cand;	    /**< End-of-cand timer. */
     pj_ice_sess_cb	 cb;			    /**< Callback.	    */
 
     pj_stun_config	 stun_cfg;		    /**< STUN settings.	    */

--- a/pjnath/include/pjnath/ice_session.h
+++ b/pjnath/include/pjnath/ice_session.h
@@ -990,14 +990,11 @@ pj_ice_sess_create_check_list(pj_ice_sess *ice,
 
 
 /**
- * Update check list after new local or remote ICE candidates are added,
- * or signal ICE session that trickling is done. Application typically would
- * call this function after finding (and conveying) new local ICE candidates
- * to remote, after receiving remote ICE candidates, or after receiving
- * end-of-candidates indication.
- *
- * After check list is updated, ICE connectivity check will automatically
- * start if check list has any candidate pair.
+ * Update check list after receiving new remote ICE candidates or after
+ * new local ICE candidates are found and conveyed to remote. This function
+ * can also be called to indicate that trickling has completed, i.e:
+ * local candidates gathering completed and remote has sent end-of-candidate
+ * indication.
  *
  * This function is only applicable when trickle ICE is not disabled.
  *

--- a/pjnath/include/pjnath/ice_strans.h
+++ b/pjnath/include/pjnath/ice_strans.h
@@ -945,48 +945,15 @@ PJ_DECL(pj_status_t) pj_ice_strans_start_ice(pj_ice_strans *ice_st,
 					     unsigned rcand_cnt,
 					     const pj_ice_sess_cand rcand[]);
 
-/**
- * Create ICE check list. This function can only be called after the ICE
- * session has been created in the ICE stream transport with
- * #pj_ice_strans_init_ice().
- *
- * This function pairs local candidates with remote candidates, but will not
- * start the ICE connectivity checks. This is useful for trickle ICE so
- * it can update remote candidate incrementally without starting the checks.
- * This function should be called as soon as remote ICE info such as ufrag
- * and perhaps initial candidates are received (typically from the remote SDP).
- * Application can invoke pj_ice_strans_start_ice() to start the checks.
- *
- * @param ice_st	The ICE stream transport.
- * @param rem_ufrag	Remote ufrag, as seen in the SDP received from 
- *			the remote agent.
- * @param rem_passwd	Remote password, as seen in the SDP received from
- *			the remote agent.
- * @param rcand_cnt	Number of remote candidates in the array.
- * @param rcand		Remote candidates array.
- * @param rcand_end	Set to PJ_TRUE if remote has signalled
- *			end-of-candidate.
- *
- * @return		PJ_SUCCESS, or the appropriate error code.
- */
-PJ_DECL(pj_status_t) pj_ice_strans_create_check_list(
-					    pj_ice_strans *ice_st,
-					    const pj_str_t *rem_ufrag,
-					    const pj_str_t *rem_passwd,
-					    unsigned rcand_cnt,
-					    const pj_ice_sess_cand rcand[],
-					    pj_bool_t rcand_end);
-
 
 /**
- * Update check list after new local or remote ICE candidates are added,
- * or signal ICE session that trickling is done. Application typically would
- * call this function after finding (and conveying) new local ICE candidates
- * to remote, after receiving remote ICE candidates, or after receiving
- * end-of-candidates indication.
+ * Update check list after receiving new remote ICE candidates or after
+ * new local ICE candidates are found and conveyed to remote. This function
+ * can also be called after receiving end of candidate indication from
+ * either remote or local agent.
  *
  * This function is only applicable when trickle ICE is not disabled and
- * after ICE connectivity checks are started using pj_ice_strans_start_ice().
+ * after ICE session has been created using pj_ice_strans_init_ice().
  *
  * @param ice_st	The ICE stream transport.
  * @param rem_ufrag	Remote ufrag, as seen in the SDP received from

--- a/pjnath/include/pjnath/ice_strans.h
+++ b/pjnath/include/pjnath/ice_strans.h
@@ -946,6 +946,39 @@ PJ_DECL(pj_status_t) pj_ice_strans_start_ice(pj_ice_strans *ice_st,
 					     const pj_ice_sess_cand rcand[]);
 
 /**
+ * Create ICE check list. This function can only be called after the ICE
+ * session has been created in the ICE stream transport with
+ * #pj_ice_strans_init_ice().
+ *
+ * This function pairs local candidates with remote candidates, but will not
+ * start the ICE connectivity checks. This is useful for trickle ICE so
+ * it can update remote candidate incrementally without starting the checks.
+ * This function should be called as soon as remote ICE info such as ufrag
+ * and perhaps initial candidates are received (typically from the remote SDP).
+ * Application can invoke pj_ice_strans_start_ice() to start the checks.
+ *
+ * @param ice_st	The ICE stream transport.
+ * @param rem_ufrag	Remote ufrag, as seen in the SDP received from 
+ *			the remote agent.
+ * @param rem_passwd	Remote password, as seen in the SDP received from
+ *			the remote agent.
+ * @param rcand_cnt	Number of remote candidates in the array.
+ * @param rcand		Remote candidates array.
+ * @param rcand_end	Set to PJ_TRUE if remote has signalled
+ *			end-of-candidate.
+ *
+ * @return		PJ_SUCCESS, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pj_ice_strans_create_check_list(
+					    pj_ice_strans *ice_st,
+					    const pj_str_t *rem_ufrag,
+					    const pj_str_t *rem_passwd,
+					    unsigned rcand_cnt,
+					    const pj_ice_sess_cand rcand[],
+					    pj_bool_t rcand_end);
+
+
+/**
  * Update check list after new local or remote ICE candidates are added,
  * or signal ICE session that trickling is done. Application typically would
  * call this function after finding (and conveying) new local ICE candidates

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -2112,14 +2112,18 @@ PJ_DEF(pj_status_t) pj_ice_sess_create_check_list(
 
     ice->clist.count = 0;
     ice->lcand_paired = ice->rcand_paired = 0;
-    status = add_rcand_and_update_checklist(ice, rem_cand_cnt, rem_cand);
-    if (status != PJ_SUCCESS) {
-	pj_grp_lock_release(ice->grp_lock);
-	return status;
-    }
 
-    /* Log checklist */
-    dump_checklist("Checklist created:", ice, clist);
+    /* Build checklist only if both sides have candidates already */
+    if (ice->lcand_cnt > 0 && rem_cand_cnt > 0) {
+	status = add_rcand_and_update_checklist(ice, rem_cand_cnt, rem_cand);
+	if (status != PJ_SUCCESS) {
+	    pj_grp_lock_release(ice->grp_lock);
+	    return status;
+	}
+
+	/* Log checklist */
+	dump_checklist("Checklist created:", ice, clist);
+    }
 
     pj_grp_lock_release(ice->grp_lock);
 

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -941,28 +941,16 @@ static pj_timestamp CALC_CHECK_PRIO(const pj_ice_sess *ice,
 PJ_INLINE(int) CMP_CHECK_STATE(const pj_ice_sess_check *c1,
 			       const pj_ice_sess_check *c2)
 {
-    /* SUCCEEDED has higher state than non-SUCCEEDED */
+    /* SUCCEEDED has higher state than FAILED */
     if (c1->state == PJ_ICE_SESS_CHECK_STATE_SUCCEEDED &&
-	c2->state != PJ_ICE_SESS_CHECK_STATE_SUCCEEDED)
+	c2->state == PJ_ICE_SESS_CHECK_STATE_FAILED)
     {
 	return 1;
     }
     if (c2->state == PJ_ICE_SESS_CHECK_STATE_SUCCEEDED &&
-	c1->state != PJ_ICE_SESS_CHECK_STATE_SUCCEEDED)
+	c1->state == PJ_ICE_SESS_CHECK_STATE_FAILED)
     {
 	return -1;
-    }
-
-    /* FAILED has lower state than non-FAILED */
-    if (c1->state == PJ_ICE_SESS_CHECK_STATE_FAILED &&
-	c2->state != PJ_ICE_SESS_CHECK_STATE_FAILED)
-    {
-	return -1;
-    }
-    if (c2->state == PJ_ICE_SESS_CHECK_STATE_FAILED &&
-	c1->state != PJ_ICE_SESS_CHECK_STATE_FAILED)
-    {
-	return 1;
     }
 
     /* Other state, just compare the state value */
@@ -2699,7 +2687,7 @@ static void on_stun_request_complete(pj_stun_session *stun_sess,
 	    }
 	}
 	if (i == clist->count) {
-	    /* The check may have been pruned */
+	    /* The check may have been pruned (due to low prio) */
 	    check->tdata = NULL;
 	    pj_grp_lock_release(ice->grp_lock);
 	    return;
@@ -2707,6 +2695,7 @@ static void on_stun_request_complete(pj_stun_session *stun_sess,
     }
 
     /* Mark STUN transaction as complete */
+    // Find 'corner case ...'.
     //pj_assert(tdata == check->tdata);
     check->tdata = NULL;
 

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -118,6 +118,14 @@ typedef struct call_answer
 } call_answer;
 
 
+/* Generic states */
+typedef enum pjsua_op_state {
+    PJSUA_OP_STATE_NULL,
+    PJSUA_OP_STATE_READY,
+    PJSUA_OP_STATE_RUNNING,
+    PJSUA_OP_STATE_DONE,
+} pjsua_op_state;
+
 /** 
  * Structure to be attached to invite dialog. 
  * Given a dialog "dlg", application can retrieve this structure
@@ -211,7 +219,7 @@ struct pjsua_call
 	pj_bool_t	 enabled;
 	pj_bool_t	 remote_sup;
 	pj_bool_t	 remote_dlg_est;
-	pj_bool_t	 trickling;
+	pjsua_op_state	 trickling;
 	int		 retrans18x_count;
 	pj_bool_t	 pending_info;
 	pj_timer_entry	 timer;
@@ -713,7 +721,9 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 				       const pjmedia_sdp_session *remote_sdp);
 pj_status_t pjsua_media_channel_deinit(pjsua_call_id call_id);
 
-void pjsua_ice_check_start_trickling(pjsua_call *call, pjsip_event *e);
+void pjsua_ice_check_start_trickling(pjsua_call *call,
+				     pj_bool_t forceful,
+				     pjsip_event *e);
 
 /*
  * Error message when media operation is requested while another is in progress

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -176,6 +176,7 @@ static void reset_call(pjsua_call_id id)
     pjsua_call_setting_default(&call->opt);
     pj_timer_entry_init(&call->reinv_timer, PJ_FALSE,
 			(void*)(pj_size_t)id, &reinv_timer_cb);
+    pj_bzero(&call->trickle_ice, sizeof(call->trickle_ice));
     pj_timer_entry_init(&call->trickle_ice.timer, 0, call,
 			&trickle_ice_send_sip_info);
 }
@@ -4309,7 +4310,7 @@ static void trickle_ice_retrans_18x(pj_timer_heap_t *th,
 				    struct pj_timer_entry *te)
 {
     pjsua_call *call = (pjsua_call*)te->user_data;
-    pjsip_tx_data *tdata;
+    pjsip_tx_data *tdata = NULL;
     pj_time_val delay;
 
     PJ_UNUSED_ARG(th);
@@ -4317,12 +4318,16 @@ static void trickle_ice_retrans_18x(pj_timer_heap_t *th,
     /* If trickling has been started or dialog has been established on
      * both sides, stop 18x retransmission.
      */
-    if (call->trickle_ice.trickling || call->trickle_ice.remote_dlg_est)
+    if (call->trickle_ice.trickling >= PJSUA_OP_STATE_RUNNING ||
+	call->trickle_ice.remote_dlg_est)
+    {
 	return;
+    }
 
     /* Make sure last tdata is 18x response */
-    tdata = call->inv->invite_tsx->last_tx;
-    if (tdata->msg->type != PJSIP_RESPONSE_MSG ||
+    if (call->inv->invite_tsx)
+	tdata = call->inv->invite_tsx->last_tx;
+    if (!tdata || tdata->msg->type != PJSIP_RESPONSE_MSG ||
 	tdata->msg->line.status.code/10 != 18)
     {
 	return;
@@ -4405,8 +4410,13 @@ static void trickle_ice_recv_sip_info(pjsua_call *call, pjsip_rx_data *rdata)
 	    }
 	}
 
-	if (j == med_cnt)
+	if (j == med_cnt) {
+	    pjsua_perror(THIS_FILE, "Cannot add remote candidates from SDP in "
+			 "incoming INFO because media ID (SDP a=mid) is not "
+			 "recognized",
+			 PJ_EIGNORED);
 	    continue;
+	}
 
 	/* Update ICE checklist */
 	status = pjmedia_ice_trickle_update(tp, &ufrag, &pwd, cand_cnt, cand,
@@ -4472,8 +4482,8 @@ static void trickle_ice_send_sip_info(pj_timer_heap_t *th,
 	    goto on_return;
     }
 
-    PJ_LOG(4,(THIS_FILE, "Call %d: ICE trickle sending SIP INFO",
-	      call->index));
+    PJ_LOG(4,(THIS_FILE, "Call %d: ICE trickle sending SIP INFO%s",
+	      call->index, (forced? " (forced)":"")));
 
     /* Create temporary pool */
     tmp_pool = pjsua_pool_create("tmp_ice", 128, 128);
@@ -4533,11 +4543,12 @@ static void trickle_ice_send_sip_info(pj_timer_heap_t *th,
     /* Set flag for pending SIP INFO */
     call->trickle_ice.pending_info = PJ_TRUE;
 
+    /* Stop trickling if local candidate gathering for all media is done */
     if (all_end_of_cand) {
 	PJ_LOG(4,(THIS_FILE, "Call %d: ICE trickle stopped trickling "
 			     "as local candidate gathering completed",
 			     call->index));
-	call->trickle_ice.trickling = PJ_FALSE;
+	call->trickle_ice.trickling = PJSUA_OP_STATE_DONE;
     }
 
 on_return:
@@ -4545,7 +4556,7 @@ on_return:
 	pj_pool_release(tmp_pool);
 
     /* Reschedule if we are trickling */
-    if (call->trickle_ice.trickling) {
+    if (call->trickle_ice.trickling == PJSUA_OP_STATE_RUNNING) {
 	pj_time_val delay = {0, PJSUA_TRICKLE_ICE_NEW_CAND_CHECK_INTERVAL};
 
 	/* Reset forced mode after successfully sending forced SIP INFO */
@@ -4571,13 +4582,14 @@ on_return:
  * - UAC/UAS receiving remote SDP (and check for trickle ICE support),
  *   to start trickling.
  */
-void pjsua_ice_check_start_trickling(pjsua_call *call, pjsip_event *e)
+void pjsua_ice_check_start_trickling(pjsua_call *call,
+				     pj_bool_t forceful,
+				     pjsip_event *e)
 {
     pjsip_inv_session *inv = call->inv;
-    pj_bool_t forced_trickling = PJ_FALSE;
 
     /* Make sure trickling/sending-INFO has not been started */
-    if (call->trickle_ice.trickling)
+    if (!forceful && call->trickle_ice.trickling >= PJSUA_OP_STATE_RUNNING)
 	return;
 
     /* Make sure trickle ICE is enabled */
@@ -4641,10 +4653,10 @@ void pjsua_ice_check_start_trickling(pjsua_call *call, pjsip_event *e)
 		    }
 		} else {
 		    /* Start sending SIP INFO forcefully */
-		    forced_trickling = PJ_TRUE;
+		    forceful = PJ_TRUE;
 		}
 
-		if (forced_trickling || call->trickle_ice.remote_sup) {
+		if (forceful || call->trickle_ice.remote_sup) {
 		    PJ_LOG(4,(THIS_FILE,
 			      "Call %d: ICE trickle started after UAC "
 			      "receiving 18x (with%s SDP)",
@@ -4728,21 +4740,23 @@ void pjsua_ice_check_start_trickling(pjsua_call *call, pjsip_event *e)
     }
 
     /* Check if ICE trickling can be started */
-    if (!forced_trickling &&
+    if (!forceful &&
 	(!call->trickle_ice.remote_dlg_est || !call->trickle_ice.remote_sup))
     {
 	return;
     }
 
     /* Let's start trickling (or sending SIP INFO) */
-    if (!call->trickle_ice.trickling) {
+    if (forceful || call->trickle_ice.trickling < PJSUA_OP_STATE_RUNNING)
+    {
 	pj_timer_entry *te = &call->trickle_ice.timer;
 	pj_time_val delay = {0,0};
 
-	call->trickle_ice.trickling = PJ_TRUE;
+	if (call->trickle_ice.trickling < PJSUA_OP_STATE_RUNNING)
+	    call->trickle_ice.trickling = PJSUA_OP_STATE_RUNNING;
 
 	pjsua_cancel_timer(te);
-	te->id = forced_trickling? 2 : 0;
+	te->id = forceful? 2 : 0;
 	te->cb = &trickle_ice_send_sip_info;
 	pjsua_schedule_timer(te, &delay);
 
@@ -4787,6 +4801,11 @@ static void pjsua_call_on_state_changed(pjsip_inv_session *inv,
 	    break;
 	case PJSIP_INV_STATE_CONFIRMED:
 	    pj_gettimeofday(&call->conn_time);
+
+	    if (call->trickle_ice.enabled) {
+		call->trickle_ice.remote_dlg_est = PJ_TRUE;
+		pjsua_ice_check_start_trickling(call, PJ_FALSE, NULL);
+	    }
 
             /* See if auto reinvite was pended as media update was done in the
              * EARLY state and remote does not support UPDATE.
@@ -5114,6 +5133,20 @@ static void pjsua_call_on_media_update(pjsip_inv_session *inv,
     }
 
     call->med_update_success = (status == PJ_SUCCESS);
+
+    /* Trickle ICE tasks:
+     * - Check remote SDP for trickle ICE support & start sending SIP INFO.
+     */
+    {
+	unsigned i;
+	for (i = 0; i < remote_sdp->media_count; ++i) {
+	    if (pjmedia_ice_sdp_has_trickle(remote_sdp, i))
+		break;
+	}
+	call->trickle_ice.remote_sup = (i < remote_sdp->media_count);
+	if (call->trickle_ice.remote_sup)
+	    pjsua_ice_check_start_trickling(call, PJ_FALSE, NULL);
+    }
 
     /* Update remote's NAT type */
     if (pjsua_var.ua_cfg.nat_type_in_sdp) {
@@ -6362,7 +6395,7 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 	     * - UAS receiving INFO, cease 18x retrans & start trickling
 	     */
 	    if (call->trickle_ice.enabled) {
-		pjsua_ice_check_start_trickling(call, e);
+		pjsua_ice_check_start_trickling(call, PJ_FALSE, e);
 
 		/* Process the SIP INFO content */
 		trickle_ice_recv_sip_info(call, rdata);
@@ -6430,7 +6463,8 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 	 * - UAS sending 18x, start 18x retrans
 	 * - UAC receiving 18x, forcefully send SIP INFO & start trickling
 	 */
-	pjsua_ice_check_start_trickling(call, e);
+	pj_bool_t force = call->trickle_ice.trickling<PJSUA_OP_STATE_RUNNING;
+	pjsua_ice_check_start_trickling(call, force, e);
     } else if (tsx->role == PJSIP_ROLE_UAS &&
 	       pjsip_method_cmp(&tsx->method, pjsip_get_prack_method())==0 &&
 	       tsx->state==PJSIP_TSX_STATE_TRYING)
@@ -6438,9 +6472,8 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 	/* Trickle ICE tasks:
 	 * - UAS receiving PRACK, start trickling
 	 */
-	pjsua_ice_check_start_trickling(call, e);
+	pjsua_ice_check_start_trickling(call, PJ_FALSE, e);
     }
-
 
 on_return:
     pj_log_pop_indent();

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -4551,6 +4551,17 @@ static void trickle_ice_send_sip_info(pj_timer_heap_t *th,
 	call->trickle_ice.trickling = PJSUA_OP_STATE_DONE;
     }
 
+    /* Update ICE checklist after conveying local candidates. */
+    for (i = 0; i < med_cnt; ++i) {
+	pjsua_call_media *cm = use_med_prov? &call->media_prov[i] :
+					     &call->media[i];
+	pjmedia_transport *tp = cm->tp_orig;
+	if (!tp || tp->type != PJMEDIA_TRANSPORT_TYPE_ICE)
+	    continue;
+
+	pjmedia_ice_trickle_update(tp, NULL, NULL, 0, NULL, PJ_FALSE);
+    }
+
 on_return:
     if (tmp_pool)
 	pj_pool_release(tmp_pool);


### PR DESCRIPTION
This PR will address some issues & enhancements in trickle ICE:
- Improve trickling state management (fix no SIP INFO when initial INVITE responded immediately with 200, strayed SIP INFO after trickling is done, etc).
- Fix issues when rtcp-mux is enabled.
- Allow process incoming SIP INFO before receiving remote SDP (as it seems to be allowed by the standard), initially we don't want to process it because remote ICE ufrag is still unknown, now the ufrag from incoming SIP INFO will be used as remote ufrag.
- Use regular ICE on re-INVITE (with reinit media flag).