### PR TITLE
Fix installation of libpjsua2 shared libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,10 @@ cmp_wav:
 
 install:
 	mkdir -p $(DESTDIR)$(libdir)/
-	cp -af $(APP_LIB_FILES) $(DESTDIR)$(libdir)/
 	if [ "$(PJ_EXCLUDE_PJSUA2)x" = "x" ] ; then \
-	    cp -af $(PJ_DIR)/pjsip/lib/libpjsua2-$(LIB_SUFFIX) $(DESTDIR)$(libdir)/; \
+	    cp -af $(APP_LIBXX_FILES) $(DESTDIR)$(libdir)/; \
+	else \
+	    cp -af $(APP_LIB_FILES) $(DESTDIR)$(libdir)/; \
 	fi
 	mkdir -p $(DESTDIR)$(includedir)/
 	for d in pjlib pjlib-util pjnath pjmedia pjsip; do \


### PR DESCRIPTION
Hi, while trying to make and install from release 2.11, I noticed `libpjsua2` shared libraries were not correctly installed.

Here is the patch on the Makefile that I needed to apply to make it back again.