### PR TITLE
Match tx telephone events clock rate with local's clock rate

### DIFF
--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -83,6 +83,7 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
     const pjmedia_sdp_attr *attr;
     pjmedia_sdp_rtpmap *rtpmap;
     unsigned i, fmti, pt = 0;
+    unsigned rx_ev_clock_rate;
     pj_status_t status;
 
     /* Find the first codec which is not telephone-event */
@@ -315,6 +316,7 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
 	    continue;
 	if (pj_strcmp(&r.enc_name, &ID_TELEPHONE_EVENT) == 0) {
 	    si->rx_event_pt = pj_strtoul(&r.pt);
+	    rx_ev_clock_rate = r.clock_rate;
 	    break;
 	}
     }
@@ -330,8 +332,13 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
 	if (pjmedia_sdp_attr_get_rtpmap(attr, &r) != PJ_SUCCESS)
 	    continue;
 	if (pj_strcmp(&r.enc_name, &ID_TELEPHONE_EVENT) == 0) {
-	    si->tx_event_pt = pj_strtoul(&r.pt);
-	    break;
+	    /* Check if the clock rate matches local event's clock rate. */
+	    if (r.clock_rate == rx_ev_clock_rate) {
+	    	si->tx_event_pt = pj_strtoul(&r.pt);
+	    	break;
+	    } else if (si->tx_event_pt == -1) {
+	    	si->tx_event_pt = pj_strtoul(&r.pt);
+	    }
 	}
     }
 

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -83,7 +83,7 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
     const pjmedia_sdp_attr *attr;
     pjmedia_sdp_rtpmap *rtpmap;
     unsigned i, fmti, pt = 0;
-    unsigned rx_ev_clock_rate;
+    unsigned rx_ev_clock_rate = 0;
     pj_status_t status;
 
     /* Find the first codec which is not telephone-event */


### PR DESCRIPTION
Currently, when remote offers two telephone events with different clock rates, such as:
```
      m=audio 4000 RTP/AVP 102 0 103 101
      a=rtpmap:102 opus/48000/2
      a=rtpmap:0 PCMU/8000
      a=rtpmap:103 telephone-event/48000
      a=rtpmap:101 telephone-event/8000
```
and we answer with:
```
a=rtpmap:0 PCMU/8000
a=rtpmap:101 telephone-event/8000
```
We will still send telephone-event with the first payload type that we find, which is 103, regardless of the clock rate.

In this PR, we will compare the remote telephone event's clock rate to find the one matching the local's clock rate. Only if it's not found we will choose the first one.
