### PR TITLE
Add a `getID()` method to PJSUA2 Buddy class

### DIFF
--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -250,6 +250,13 @@ public:
     bool isValid() const;
 
     /**
+     * Get PJSUA-LIB buddy ID or index associated with this buddy.
+     *
+     * @return			Integer greater than or equal to zero.
+     */
+    int getId() const;
+
+    /**
      * Get detailed buddy info.
      *
      * @return			Buddy info.

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -143,6 +143,11 @@ void Buddy::create(Account &account, const BuddyConfig &cfg)
     
     account.addBuddy(this);
 }
+
+int Buddy::getId() const
+{
+    return id;
+}
     
 /*
  * Check if this buddy is valid.


### PR DESCRIPTION
Hi,

here is a proposal. I see both `Account` and `Call` classes in PJSUA2 provide a `getId()` method, that I find very useful for debugging purposes.

With this commit, the `Buddy` class is being added a similar method.
