### PR TITLE
ip_helper_generic: ignore non running interfaces

### DIFF
--- a/pjlib/src/pj/ip_helper_generic.c
+++ b/pjlib/src/pj/ip_helper_generic.c
@@ -97,6 +97,11 @@ static pj_status_t if_enum_by_af(int af,
 	    continue; /* Skip when interface is down */
 	}
 
+	if ((it->ifa_flags & IFF_RUNNING)==0) {
+	    TRACE_((THIS_FILE, "  interface is not running"));
+	    continue; /* Skip when interface is not running */
+	}
+
 #if PJ_IP_HELPER_IGNORE_LOOPBACK_IF
 	if (it->ifa_flags & IFF_LOOPBACK) {
 	    TRACE_((THIS_FILE, "  loopback interface"));
@@ -208,6 +213,11 @@ static pj_status_t if_enum_by_af(int af,
 	    continue; /* Skip when interface is down */
 	}
 
+	if ((iff.ifr_flags & IFF_RUNNING)==0) {
+	    TRACE_((THIS_FILE, "  interface is not running"));
+	    continue; /* Skip when interface is not running */
+	}
+
 #if PJ_IP_HELPER_IGNORE_LOOPBACK_IF
 	if (iff.ifr_flags & IFF_LOOPBACK) {
 	    TRACE_((THIS_FILE, "  loopback interface"));
@@ -284,6 +294,11 @@ static pj_status_t if_enum_by_af(int af, unsigned *p_cnt, pj_sockaddr ifs[])
 	if ((ifreq.ifr_flags & IFF_UP)==0) {
 	    TRACE_((THIS_FILE, "  interface is down"));
 	    continue; /* Skip when interface is down */
+	}
+
+        if ((ifreq.ifr_flags & IFF_RUNNING)==0) {
+	    TRACE_((THIS_FILE, "  interface is not running"));
+	    continue; /* Skip when interface is not running */
 	}
 
 #if PJ_IP_HELPER_IGNORE_LOOPBACK_IF


### PR DESCRIPTION
Some interfaces (typically from docker or virtual machines) were added
in the candidates even if down. For example:

9: br-b8251442502e: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue
state DOWN group default

Even if state=DOWN if_enum_by_af consider the ip as valid and adds it in the
candidates because IFF_UP is true. However, if_enum_by_af should use IFF_RUNNING
to detect if the interface is up and running before adding it. Like
 iproute2/bridge/link.c does for print_link_flags.

Resource: https://man7.org/linux/man-pages/man7/netdevice.7.html

Issue: #2686



Note: this is a behavior change, so I send this PR as asked by Riza to be able to discuss.

Note2: you already have my CLA (from Savoir-Faire Linux)

Regards,
Sébastien