### PR TITLE
Avoid exception in unregistering socket on iOS after SIP UDP socket-replace fails

### DIFF
--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -508,14 +508,15 @@ PJ_DEF(pj_status_t) pj_ioqueue_unregister( pj_ioqueue_key_t *key)
     /* Ticket #520, key will be erased more than once */
     pj_list_erase(key);
 #endif
-    PJ_FD_CLR(key->fd, &ioqueue->rfdset);
-    PJ_FD_CLR(key->fd, &ioqueue->wfdset);
+
+    /* Remove socket from sets and close socket. */
+    if (key->fd != PJ_INVALID_SOCKET) {
+	PJ_FD_CLR(key->fd, &ioqueue->rfdset);
+	PJ_FD_CLR(key->fd, &ioqueue->wfdset);
 #if PJ_HAS_TCP
-    PJ_FD_CLR(key->fd, &ioqueue->xfdset);
+	PJ_FD_CLR(key->fd, &ioqueue->xfdset);
 #endif
 
-    /* Close socket. */
-    if (key->fd != PJ_INVALID_SOCKET) {
         pj_sock_close(key->fd);
         key->fd = PJ_INVALID_SOCKET;
     }


### PR DESCRIPTION
The `replace_udp_sock()` in `ioqueue_select.c` sets the socket file descriptor to `PJ_INVALID_SOCKET` when the replace fails and the invalid descriptor may raise an exception in `pj_ioqueue_unregister()` on iOS.

Here is the call stack trace of the exception:
```
Exception Type:  EXC_GUARD
Exception Codes: 0x6000000000000012, 0x0000000000000002
Exception Note:  SIMULATED (this is NOT a crash)
Termination Reason: LIBSYSTEM, Application Triggered Fault
Triggered by Thread:  7

Thread 7 Crashed:
0 os_fault_with_payload + 8
1 __darwin_check_fd_set_overflow.cold.1 + 28 (terminate_with_reason.c:37)
2 __darwin_check_fd_set_overflow + 108 (terminate_with_reason.c:38)
3 __darwin_check_fd_set + 28 (_fd_def.h:68)
4 __darwin_fd_isset + 28 (_fd_def.h:82)
5 PJ_FD_ISSET + 48 (sock_select.c:81)
6 PJ_FD_CLR + 24 (sock_select.c:69)
7 pj_ioqueue_unregister + 92 (ioqueue_select.c:505)
8 pjsip_udp_transport_restart2 + 100 (sip_transport_udp.c:1188)
9 udp_on_read_complete + 200 (sip_transport_udp.c:149)
```

Thanks to Sebastian Marek for the report.
