### PR TITLE
Specify media direction when making, answering, or updating call

### DIFF
--- a/pjmedia/include/pjmedia/endpoint.h
+++ b/pjmedia/include/pjmedia/endpoint.h
@@ -60,6 +60,17 @@ typedef enum pjmedia_endpt_flag
 
 } pjmedia_endpt_flag;
 
+/**
+ * This structure specifies various settings that can be passed when creating
+ * audio/video sdp.
+ */
+typedef struct pjmedia_endpt_create_sdp_param
+{
+    /**
+     * Direction of the media.
+     */
+    pjmedia_dir dir;
+} pjmedia_endpt_create_sdp_param;
 
 /**
  * Type of callback to register to pjmedia_endpt_atexit().
@@ -296,16 +307,17 @@ PJ_DECL(pj_status_t) pjmedia_endpt_create_base_sdp(pjmedia_endpt *endpt,
  * @param endpt		The media endpoint.
  * @param pool		Pool to allocate memory from.
  * @param si		Socket information.
- * @param options	Option flags, to indicate the audio direction.
+ * @param options	Options parameter, can be NULL.
  * @param p_m		Pointer to receive the created SDP media.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
  */
-PJ_DECL(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
-                                                    pj_pool_t *pool,
-                                                    const pjmedia_sock_info*si,
-                                                    unsigned options,
-                                                    pjmedia_sdp_media **p_m);
+PJ_DECL(pj_status_t)
+pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
+                               pj_pool_t *pool,
+                               const pjmedia_sock_info *si,
+                               const pjmedia_endpt_create_sdp_param *options,
+                               pjmedia_sdp_media **p_m);
 
 /**
  * Create SDP media line for video media.
@@ -313,16 +325,17 @@ PJ_DECL(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
  * @param endpt		The media endpoint.
  * @param pool		Pool to allocate memory from.
  * @param si		Socket information.
- * @param options	Option flags, to indicate the video direction.
+ * @param options	Options parameter, can be NULL.
  * @param p_m		Pointer to receive the created SDP media.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
  */
-PJ_DECL(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
-                                                    pj_pool_t *pool,
-                                                    const pjmedia_sock_info*si,
-                                                    unsigned options,
-                                                    pjmedia_sdp_media **p_m);
+PJ_DECL(pj_status_t)
+pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
+                               pj_pool_t *pool,
+                               const pjmedia_sock_info *si,
+                               const pjmedia_endpt_create_sdp_param *options,
+                               pjmedia_sdp_media **p_m);
 
 /**
  * Dump media endpoint capabilities.

--- a/pjmedia/include/pjmedia/endpoint.h
+++ b/pjmedia/include/pjmedia/endpoint.h
@@ -296,7 +296,7 @@ PJ_DECL(pj_status_t) pjmedia_endpt_create_base_sdp(pjmedia_endpt *endpt,
  * @param endpt		The media endpoint.
  * @param pool		Pool to allocate memory from.
  * @param si		Socket information.
- * @param options	Option flags, must be zero for now.
+ * @param options	Option flags, to indicate the audio direction.
  * @param p_m		Pointer to receive the created SDP media.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
@@ -313,7 +313,7 @@ PJ_DECL(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
  * @param endpt		The media endpoint.
  * @param pool		Pool to allocate memory from.
  * @param si		Socket information.
- * @param options	Option flags, must be zero for now.
+ * @param options	Option flags, to indicate the video direction.
  * @param p_m		Pointer to receive the created SDP media.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.

--- a/pjmedia/include/pjmedia/endpoint.h
+++ b/pjmedia/include/pjmedia/endpoint.h
@@ -68,8 +68,11 @@ typedef struct pjmedia_endpt_create_sdp_param
 {
     /**
      * Direction of the media.
+     *
+     * Default: PJMEDIA_DIR_ENCODING_DECODING
      */
     pjmedia_dir dir;
+
 } pjmedia_endpt_create_sdp_param;
 
 /**
@@ -77,6 +80,15 @@ typedef struct pjmedia_endpt_create_sdp_param
  */
 typedef void (*pjmedia_endpt_exit_callback)(pjmedia_endpt *endpt);
 
+
+/**
+ * Call this function to initialize \a pjmedia_endpt_create_sdp_param with default 
+ * values.
+ *
+ * @param param	    The param to be initialized.
+ */
+PJ_DECL(void)
+pjmedia_endpt_create_sdp_param_default(pjmedia_endpt_create_sdp_param *param);
 
 /**
  * Create an instance of media endpoint.
@@ -307,7 +319,8 @@ PJ_DECL(pj_status_t) pjmedia_endpt_create_base_sdp(pjmedia_endpt *endpt,
  * @param endpt		The media endpoint.
  * @param pool		Pool to allocate memory from.
  * @param si		Socket information.
- * @param options	Options parameter, can be NULL.
+ * @param options	Options parameter, can be NULL. If set to NULL,
+ *			default values will be used.
  * @param p_m		Pointer to receive the created SDP media.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
@@ -325,7 +338,8 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
  * @param endpt		The media endpoint.
  * @param pool		Pool to allocate memory from.
  * @param si		Socket information.
- * @param options	Options parameter, can be NULL.
+ * @param options	Options parameter, can be NULL. If set to NULL,
+ *			default values will be used.
  * @param p_m		Pointer to receive the created SDP media.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -40,6 +40,8 @@ static const pj_str_t STR_IP6 = { "IP6", 3};
 static const pj_str_t STR_RTP_AVP = { "RTP/AVP", 7 };
 static const pj_str_t STR_SDP_NAME = { "pjmedia", 7 };
 static const pj_str_t STR_SENDRECV = { "sendrecv", 8 };
+static const pj_str_t STR_SENDONLY = { "sendonly", 8 };
+static const pj_str_t STR_RECVONLY = { "recvonly", 8 };
 
 
 
@@ -360,7 +362,8 @@ PJ_DEF(pj_pool_t*) pjmedia_endpt_create_pool( pjmedia_endpt *endpt,
 static pj_status_t init_sdp_media(pjmedia_sdp_media *m,
                                   pj_pool_t *pool,
                                   const pj_str_t *media_type,
-				  const pjmedia_sock_info *sock_info)
+				  const pjmedia_sock_info *sock_info,
+				  pjmedia_dir dir)
 {
     char tmp_addr[PJ_INET6_ADDRSTRLEN];
     pjmedia_sdp_attr *attr;
@@ -398,7 +401,14 @@ static pj_status_t init_sdp_media(pjmedia_sdp_media *m,
 
     /* Add sendrecv attribute. */
     attr = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_attr);
-    attr->name = STR_SENDRECV;
+    if (dir == PJMEDIA_DIR_ENCODING) {
+    	attr->name = STR_SENDONLY;
+    } else if (dir == PJMEDIA_DIR_DECODING) {
+    	attr->name = STR_RECVONLY;
+    } else {
+    	attr->name = STR_SENDRECV;
+    }
+
     m->attr[m->attr_count++] = attr;
 
     return PJ_SUCCESS;
@@ -425,8 +435,6 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
     unsigned used_pt_num = 0;
     unsigned used_pt[PJMEDIA_MAX_SDP_FMT];
 
-    PJ_UNUSED_ARG(options);
-
     /* Check that there are not too many codecs */
     PJ_ASSERT_RETURN(endpt->codec_mgr.codec_cnt <= PJMEDIA_MAX_SDP_FMT,
 		     PJ_ETOOMANY);
@@ -447,7 +455,7 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 
     /* Create and init basic SDP media */
     m = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_media);
-    status = init_sdp_media(m, pool, &STR_AUDIO, si);
+    status = init_sdp_media(m, pool, &STR_AUDIO, si, options);
     if (status != PJ_SUCCESS)
 	return status;
 
@@ -732,15 +740,13 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
     unsigned max_bitrate = 0;
     pj_status_t status;
 
-    PJ_UNUSED_ARG(options);
-
     /* Make sure video codec manager is instantiated */
     if (!pjmedia_vid_codec_mgr_instance())
 	pjmedia_vid_codec_mgr_create(endpt->pool, NULL);
 
     /* Create and init basic SDP media */
     m = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_media);
-    status = init_sdp_media(m, pool, &STR_VIDEO, si);
+    status = init_sdp_media(m, pool, &STR_VIDEO, si, options);
     if (status != PJ_SUCCESS)
 	return status;
 

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -42,7 +42,7 @@ static const pj_str_t STR_SDP_NAME = { "pjmedia", 7 };
 static const pj_str_t STR_SENDRECV = { "sendrecv", 8 };
 static const pj_str_t STR_SENDONLY = { "sendonly", 8 };
 static const pj_str_t STR_RECVONLY = { "recvonly", 8 };
-
+static const pj_str_t STR_INACTIVE = { "inactive", 8 };
 
 
 /* Config to control rtpmap inclusion for static payload types */
@@ -415,11 +415,12 @@ static pj_status_t init_sdp_media(pjmedia_sdp_media *m,
 }
 
 /* Create m=audio SDP media line */
-PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
-                                                   pj_pool_t *pool,
-                                                   const pjmedia_sock_info *si,
-                                                   unsigned options,
-                                                   pjmedia_sdp_media **p_m)
+PJ_DEF(pj_status_t)
+pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
+                               pj_pool_t *pool,
+                               const pjmedia_sock_info *si,
+                               const pjmedia_endpt_create_sdp_param *options,
+                               pjmedia_sdp_media **p_m)
 {
     const pj_str_t STR_AUDIO = { "audio", 5 };
     pjmedia_sdp_media *m;
@@ -455,7 +456,8 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 
     /* Create and init basic SDP media */
     m = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_media);
-    status = init_sdp_media(m, pool, &STR_AUDIO, si, options);
+    status = init_sdp_media(m, pool, &STR_AUDIO, si, options? options->dir:
+    			    PJMEDIA_DIR_ENCODING_DECODING);
     if (status != PJ_SUCCESS)
 	return status;
 
@@ -723,11 +725,12 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
 
 /* Create m=video SDP media line */
-PJ_DEF(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
-                                                   pj_pool_t *pool,
-                                                   const pjmedia_sock_info *si,
-                                                   unsigned options,
-                                                   pjmedia_sdp_media **p_m)
+PJ_DEF(pj_status_t)
+pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
+                               pj_pool_t *pool,
+                               const pjmedia_sock_info *si,
+                               const pjmedia_endpt_create_sdp_param *options,
+                               pjmedia_sdp_media **p_m)
 {
 
 
@@ -746,7 +749,8 @@ PJ_DEF(pj_status_t) pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
 
     /* Create and init basic SDP media */
     m = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_media);
-    status = init_sdp_media(m, pool, &STR_VIDEO, si, options);
+    status = init_sdp_media(m, pool, &STR_VIDEO, si, options? options->dir:
+    			    PJMEDIA_DIR_ENCODING_DECODING);
     if (status != PJ_SUCCESS)
 	return status;
 

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -42,7 +42,6 @@ static const pj_str_t STR_SDP_NAME = { "pjmedia", 7 };
 static const pj_str_t STR_SENDRECV = { "sendrecv", 8 };
 static const pj_str_t STR_SENDONLY = { "sendonly", 8 };
 static const pj_str_t STR_RECVONLY = { "recvonly", 8 };
-static const pj_str_t STR_INACTIVE = { "inactive", 8 };
 
 
 /* Config to control rtpmap inclusion for static payload types */

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -103,6 +103,13 @@ struct pjmedia_endpt
     exit_cb		  exit_cb_list;
 };
 
+
+PJ_DEF(void)
+pjmedia_endpt_create_sdp_param_default(pjmedia_endpt_create_sdp_param *param)
+{
+    param->dir = PJMEDIA_DIR_ENCODING_DECODING;
+}
+
 /**
  * Initialize and get the instance of media endpoint.
  */
@@ -434,6 +441,7 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 #endif
     unsigned used_pt_num = 0;
     unsigned used_pt[PJMEDIA_MAX_SDP_FMT];
+    pjmedia_endpt_create_sdp_param param;
 
     /* Check that there are not too many codecs */
     PJ_ASSERT_RETURN(endpt->codec_mgr.codec_cnt <= PJMEDIA_MAX_SDP_FMT,
@@ -455,8 +463,9 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 
     /* Create and init basic SDP media */
     m = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_media);
+    pjmedia_endpt_create_sdp_param_default(&param);
     status = init_sdp_media(m, pool, &STR_AUDIO, si, options? options->dir:
-    			    PJMEDIA_DIR_ENCODING_DECODING);
+    			    param.dir);
     if (status != PJ_SUCCESS)
 	return status;
 
@@ -740,6 +749,7 @@ pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
     pjmedia_sdp_attr *attr;
     unsigned cnt, i;
     unsigned max_bitrate = 0;
+    pjmedia_endpt_create_sdp_param param;
     pj_status_t status;
 
     /* Make sure video codec manager is instantiated */
@@ -747,9 +757,10 @@ pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
 	pjmedia_vid_codec_mgr_create(endpt->pool, NULL);
 
     /* Create and init basic SDP media */
+    pjmedia_endpt_create_sdp_param_default(&param);
     m = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_media);
     status = init_sdp_media(m, pool, &STR_VIDEO, si, options? options->dir:
-    			    PJMEDIA_DIR_ENCODING_DECODING);
+    			    param.dir);
     if (status != PJ_SUCCESS)
 	return status;
 

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -858,7 +858,8 @@ typedef enum pjsua_call_flag
   PJSUA_CALL_NO_SDP_OFFER = 8,
   PJSUA_CALL_REINIT_MEDIA = 16,
   PJSUA_CALL_UPDATE_VIA = 32,
-  PJSUA_CALL_UPDATE_TARGET = 64
+  PJSUA_CALL_UPDATE_TARGET = 64,
+  PJSUA_CALL_SET_MEDIA_DIR = 128
 } pjsua_call_flag;
 
 typedef enum pjsua_create_media_transport_flag

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1058,10 +1058,14 @@ typedef struct pjsua_call_setting
     /**
      * Media direction. This setting will only be used if the flag
      * PJSUA_CALL_SET_MEDIA_DIR is set, and it will persist for subsequent
-     * offers or answers.
+     * offers or answers. 
      * For example, a media that is set as PJMEDIA_DIR_ENCODING can only
      * mark the stream in the SDP as sendonly or inactive, but will not
      * become sendrecv in subsequent offers and answers.
+     * Application can update the media direction in any API or callback
+     * that accepts pjsua_call_setting as a parameter, such as via
+     * pjsua_call_reinvite/update() or in on_call_rx_offer/reinvite()
+     * callback.
      *
      * The index of the media dir will correspond to the provisional media
      * in pjsua_call_info.prov_media.

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1057,18 +1057,18 @@ typedef struct pjsua_call_setting
 
     /**
      * Media direction. This setting will only be used if the flag
-     * PJSUA_CALL_SET_MEDIA_DIR is set. Note that once the media direction
-     * is set, the setting will persist for subsequent offers or answers.
+     * PJSUA_CALL_SET_MEDIA_DIR is set, and it will persist for subsequent
+     * offers or answers.
      * For example, a media that is set as PJMEDIA_DIR_ENCODING can only
-     * mark the stream in the SDP as sendonly or inactive, but cannot
-     * become sendrecv.
+     * mark the stream in the SDP as sendonly or inactive, but will not
+     * become sendrecv in subsequent offers and answers.
      *
      * The index of the media dir will correspond to the provisional media
      * in pjsua_call_info.prov_media.
      * For offers that involve adding new medias (such as initial offer),
      * the index will correspond to all new audio media first, then video.
      * For example, for a new call with 2 audios and 1 video, media_dir[0]
-     * and media_dir[1] will be for the audio, and media_dir[2] video.
+     * and media_dir[1] will be for the audios, and media_dir[2] video.
      *
      * Default: PJMEDIA_DIR_ENCODING_DECODING
      */

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1059,7 +1059,7 @@ typedef struct pjsua_call_setting
      *
      * Default: PJMEDIA_DIR_ENCODING_DECODING
      */
-    unsigned	     aud_dir[PJSUA_MAX_CALL_MEDIA];
+    pjmedia_dir	     aud_dir[PJSUA_MAX_CALL_MEDIA];
 
     /**
      * Number of simultaneous active video streams for this call. Setting
@@ -1074,7 +1074,7 @@ typedef struct pjsua_call_setting
      *
      * Default: PJMEDIA_DIR_ENCODING_DECODING
      */
-    unsigned	     vid_dir[PJSUA_MAX_CALL_MEDIA];
+    pjmedia_dir	     vid_dir[PJSUA_MAX_CALL_MEDIA];
 
 } pjsua_call_setting;
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -322,6 +322,13 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #endif
 
 /**
+ * Maximum number of call medias to be supported.
+ */
+#ifndef PJSUA_MAX_CALL_MEDIA
+#   define PJSUA_MAX_CALL_MEDIA		PJMEDIA_MAX_SDP_MEDIA
+#endif
+
+/**
  * Default value of SRTP mode usage. Valid values are PJMEDIA_SRTP_DISABLED, 
  * PJMEDIA_SRTP_OPTIONAL, and PJMEDIA_SRTP_MANDATORY.
  */
@@ -1048,12 +1055,26 @@ typedef struct pjsua_call_setting
     unsigned         aud_cnt;
 
     /**
+     * Audio streams' direction for this call.
+     *
+     * Default: PJMEDIA_DIR_ENCODING_DECODING
+     */
+    unsigned	     aud_dir[PJSUA_MAX_CALL_MEDIA];
+
+    /**
      * Number of simultaneous active video streams for this call. Setting
      * this to zero will disable video in this call.
      *
      * Default: 1 (if video feature is enabled, otherwise it is zero)
      */
     unsigned         vid_cnt;
+
+    /**
+     * Video streams' direction for this call.
+     *
+     * Default: PJMEDIA_DIR_ENCODING_DECODING
+     */
+    unsigned	     vid_dir[PJSUA_MAX_CALL_MEDIA];
 
 } pjsua_call_setting;
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -322,13 +322,6 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #endif
 
 /**
- * Maximum number of call medias to be supported.
- */
-#ifndef PJSUA_MAX_CALL_MEDIA
-#   define PJSUA_MAX_CALL_MEDIA		PJMEDIA_MAX_SDP_MEDIA
-#endif
-
-/**
  * Default value of SRTP mode usage. Valid values are PJMEDIA_SRTP_DISABLED, 
  * PJMEDIA_SRTP_OPTIONAL, and PJMEDIA_SRTP_MANDATORY.
  */
@@ -1055,13 +1048,6 @@ typedef struct pjsua_call_setting
     unsigned         aud_cnt;
 
     /**
-     * Audio streams' direction for this call.
-     *
-     * Default: PJMEDIA_DIR_ENCODING_DECODING
-     */
-    pjmedia_dir	     aud_dir[PJSUA_MAX_CALL_MEDIA];
-
-    /**
      * Number of simultaneous active video streams for this call. Setting
      * this to zero will disable video in this call.
      *
@@ -1070,11 +1056,23 @@ typedef struct pjsua_call_setting
     unsigned         vid_cnt;
 
     /**
-     * Video streams' direction for this call.
+     * Media direction. This setting will only be used if the flag
+     * PJSUA_CALL_SET_MEDIA_DIR is set. Note that once the media direction
+     * is set, the setting will persist for subsequent offers or answers.
+     * For example, a media that is set as PJMEDIA_DIR_ENCODING can only
+     * mark the stream in the SDP as sendonly or inactive, but cannot
+     * become sendrecv.
+     *
+     * The index of the media dir will correspond to the provisional media
+     * in pjsua_call_info.prov_media.
+     * For offers that involve adding new medias (such as initial offer),
+     * the index will correspond to all new audio media first, then video.
+     * For example, for a new call with 2 audios and 1 video, media_dir[0]
+     * and media_dir[1] will be for the audio, and media_dir[2] video.
      *
      * Default: PJMEDIA_DIR_ENCODING_DECODING
      */
-    pjmedia_dir	     vid_dir[PJSUA_MAX_CALL_MEDIA];
+    pjmedia_dir	     media_dir[PJMEDIA_MAX_SDP_MEDIA];
 
 } pjsua_call_setting;
 
@@ -5150,7 +5148,12 @@ typedef enum pjsua_call_flag
      * useful in IP address change scenario where IP version has been changed
      * and application needs to update target IP address.
      */
-    PJSUA_CALL_UPDATE_TARGET = 64
+    PJSUA_CALL_UPDATE_TARGET = 64,
+
+    /**
+     * Set media direction as specified in pjsua_call_setting.media_dir.
+     */
+    PJSUA_CALL_SET_MEDIA_DIR = 128
 
 } pjsua_call_flag;
 

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -45,7 +45,8 @@ struct pjsua_call_media
     pj_str_t		 rem_mid;   /**< Remote SDP "a=mid" attribute.	    */
     pjsua_call_media_status state;  /**< Media state.			    */
     pjsua_call_media_status prev_state;/**< Previous media state.           */
-    pjmedia_dir		 dir;       /**< Media direction.		    */
+    pjmedia_dir		 def_dir;   /**< Default media direction.	    */
+    pjmedia_dir		 dir;       /**< Current media direction.	    */
 
     /** The stream */
     struct {
@@ -102,6 +103,10 @@ struct pjsua_call_media
                                  int *sip_err_code);
 };
 
+/**
+ * Maximum number of SDP "m=" lines to be supported.
+ */
+#define PJSUA_MAX_CALL_MEDIA		PJMEDIA_MAX_SDP_MEDIA
 
 /* Call answer's list. */
 typedef struct call_answer
@@ -735,7 +740,7 @@ pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
 				  int *sip_err_code,
                                   pj_bool_t async,
                                   pjsua_med_tp_state_cb cb);
-void pjsua_call_cleanup_setting(pjsua_call_setting *opt);
+void pjsua_call_cleanup_flag(pjsua_call_setting *opt);
 void pjsua_set_media_tp_state(pjsua_call_media *call_med, pjsua_med_tp_st tp_st);
 
 void pjsua_media_prov_clean_up(pjsua_call_id call_id);

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -102,10 +102,6 @@ struct pjsua_call_media
                                  int *sip_err_code);
 };
 
-/**
- * Maximum number of SDP "m=" lines to be supported.
- */
-#define PJSUA_MAX_CALL_MEDIA		PJMEDIA_MAX_SDP_MEDIA
 
 /* Call answer's list. */
 typedef struct call_answer
@@ -739,7 +735,7 @@ pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
 				  int *sip_err_code,
                                   pj_bool_t async,
                                   pjsua_med_tp_state_cb cb);
-void pjsua_call_cleanup_flag(pjsua_call_setting *opt);
+void pjsua_call_cleanup_setting(pjsua_call_setting *opt);
 void pjsua_set_media_tp_state(pjsua_call_media *call_med, pjsua_med_tp_st tp_st);
 
 void pjsua_media_prov_clean_up(pjsua_call_id call_id);

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -298,13 +298,6 @@ struct CallSetting
      * Default: 1
      */
     unsigned        audioCount;
-
-    /**
-     * Audio streams' direction for this call.
-     *
-     * Default: PJMEDIA_DIR_ENCODING_DECODING
-     */
-    std::vector<pjmedia_dir>	audioDir;
     
     /**
      * Number of simultaneous active video streams for this call. Setting
@@ -313,13 +306,6 @@ struct CallSetting
      * Default: 1 (if video feature is enabled, otherwise it is zero)
      */
     unsigned        videoCount;
-
-    /**
-     * Video streams' direction for this call.
-     *
-     * Default: PJMEDIA_DIR_ENCODING_DECODING
-     */
-    std::vector<pjmedia_dir>	videoDir;
     
 public:
     /**

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -314,6 +314,10 @@ struct CallSetting
      * For example, a media that is set as PJMEDIA_DIR_ENCODING can only
      * mark the stream in the SDP as sendonly or inactive, but will not
      * become sendrecv in subsequent offers and answers.
+     * Application can update the media direction in any API or callback
+     * that accepts CallSetting as a parameter, such as via
+     * Call::reinvite/update() or in onCallRxOffer/Reinvite()
+     * callback.
      *
      * The index of the media dir will correspond to the provisional media
      * in CallInfo.provMedia.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -306,6 +306,26 @@ struct CallSetting
      * Default: 1 (if video feature is enabled, otherwise it is zero)
      */
     unsigned        videoCount;
+
+    /**
+     * Media direction. This setting will only be used if the flag
+     * PJSUA_CALL_SET_MEDIA_DIR is set, and it will persist for subsequent
+     * offers or answers.
+     * For example, a media that is set as PJMEDIA_DIR_ENCODING can only
+     * mark the stream in the SDP as sendonly or inactive, but will not
+     * become sendrecv in subsequent offers and answers.
+     *
+     * The index of the media dir will correspond to the provisional media
+     * in CallInfo.provMedia.
+     * For offers that involve adding new medias (such as initial offer),
+     * the index will correspond to all new audio media first, then video.
+     * For example, for a new call with 2 audios and 1 video, mediaDir[0]
+     * and mediaDir[1] will be for the audios, and mediaDir[2] video.
+     *
+     * Default: empty vector
+     */
+    std::vector<pjmedia_dir> mediaDir;
+
     
 public:
     /**

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -298,6 +298,13 @@ struct CallSetting
      * Default: 1
      */
     unsigned        audioCount;
+
+    /**
+     * Audio streams' direction for this call.
+     *
+     * Default: PJMEDIA_DIR_ENCODING_DECODING
+     */
+    std::vector<pjmedia_dir>	audioDir;
     
     /**
      * Number of simultaneous active video streams for this call. Setting
@@ -306,6 +313,13 @@ struct CallSetting
      * Default: 1 (if video feature is enabled, otherwise it is zero)
      */
     unsigned        videoCount;
+
+    /**
+     * Video streams' direction for this call.
+     *
+     * Default: PJMEDIA_DIR_ENCODING_DECODING
+     */
+    std::vector<pjmedia_dir>	videoDir;
     
 public:
     /**

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4119,7 +4119,7 @@ pj_status_t pjsua_acc_handle_call_on_ip_change(pjsua_acc *acc)
 	    {
 		acc->ip_change_op = PJSUA_IP_CHANGE_OP_ACC_REINVITE_CALLS;
 
-		pjsua_call_cleanup_flag(&call_info.setting);
+		pjsua_call_cleanup_setting(&call_info.setting);
 		call_info.setting.flag |=
 					 acc->cfg.ip_change_cfg.reinvite_flags;
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4119,7 +4119,7 @@ pj_status_t pjsua_acc_handle_call_on_ip_change(pjsua_acc *acc)
 	    {
 		acc->ip_change_op = PJSUA_IP_CHANGE_OP_ACC_REINVITE_CALLS;
 
-		pjsua_call_cleanup_setting(&call_info.setting);
+		pjsua_call_cleanup_flag(&call_info.setting);
 		call_info.setting.flag |=
 					 acc->cfg.ip_change_cfg.reinvite_flags;
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -620,15 +620,23 @@ on_error:
 
 
 /*
- * Cleanup call setting flag to avoid one time flags, such as
+ * Cleanup call setting to avoid one time flags, such as
  * PJSUA_CALL_UNHOLD, PJSUA_CALL_UPDATE_CONTACT, or
  * PJSUA_CALL_NO_SDP_OFFER, to be sticky (ticket #1793).
+ *
+ * This function will also reset the media direction to default.
  */
-void pjsua_call_cleanup_flag(pjsua_call_setting *opt)
+void pjsua_call_cleanup_setting(pjsua_call_setting *opt)
 {
+    unsigned i;
+
     opt->flag &= ~(PJSUA_CALL_UNHOLD | PJSUA_CALL_UPDATE_CONTACT |
 		   PJSUA_CALL_NO_SDP_OFFER | PJSUA_CALL_REINIT_MEDIA |
 		   PJSUA_CALL_UPDATE_VIA);
+
+    for (i = 0; i < PJSUA_MAX_CALL_MEDIA; i++) {
+    	opt->aud_dir[i] = opt->vid_dir[i] = PJMEDIA_DIR_ENCODING_DECODING;
+    }
 }
 
 
@@ -637,6 +645,8 @@ void pjsua_call_cleanup_flag(pjsua_call_setting *opt)
  */
 PJ_DEF(void) pjsua_call_setting_default(pjsua_call_setting *opt)
 {
+    unsigned i;
+
     pj_assert(opt);
 
     pj_bzero(opt, sizeof(*opt));
@@ -648,6 +658,10 @@ PJ_DEF(void) pjsua_call_setting_default(pjsua_call_setting *opt)
     opt->req_keyframe_method = PJSUA_VID_REQ_KEYFRAME_SIP_INFO |
 			       PJSUA_VID_REQ_KEYFRAME_RTCP_PLI;
 #endif
+
+    for (i = 0; i < PJSUA_MAX_CALL_MEDIA; i++) {
+    	opt->aud_dir[i] = opt->vid_dir[i] = PJMEDIA_DIR_ENCODING_DECODING;
+    }
 }
 
 /* 
@@ -667,7 +681,7 @@ static pj_status_t apply_call_setting(pjsua_call *call,
     pj_assert(call);
 
     if (!opt) {
-	pjsua_call_cleanup_flag(&call->opt);
+	pjsua_call_cleanup_setting(&call->opt);
     } else {
     	call->opt = *opt;
     }
@@ -1522,7 +1536,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 
 	/* Copy call setting from the replaced call */
 	call->opt = replaced_call->opt;
-	pjsua_call_cleanup_flag(&call->opt);
+	pjsua_call_cleanup_setting(&call->opt);
 
 	/* Notify application */
 	if (!replaced_call->hanging_up &&
@@ -5331,7 +5345,7 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
 	goto on_return;
     }
 
-    pjsua_call_cleanup_flag(&call->opt);
+    pjsua_call_cleanup_setting(&call->opt);
     opt = call->opt;
 
     if (pjsua_var.ua_cfg.cb.on_call_rx_reinvite &&
@@ -5536,7 +5550,7 @@ static void pjsua_call_on_create_offer(pjsip_inv_session *inv,
     }
 #endif
 
-    pjsua_call_cleanup_flag(&call->opt);
+    pjsua_call_cleanup_setting(&call->opt);
 
     if (pjsua_var.ua_cfg.cb.on_call_tx_offer) {
 	(*pjsua_var.ua_cfg.cb.on_call_tx_offer)(call->index, NULL,
@@ -5863,7 +5877,7 @@ static void on_call_transferred( pjsip_inv_session *inv,
 							&code);
     }
 
-    pjsua_call_cleanup_flag(&existing_call->opt);
+    pjsua_call_cleanup_setting(&existing_call->opt);
     call_opt = existing_call->opt;
     if (pjsua_var.ua_cfg.cb.on_call_transfer_request2) {
 	(*pjsua_var.ua_cfg.cb.on_call_transfer_request2)(existing_call->index,

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -628,7 +628,7 @@ void pjsua_call_cleanup_flag(pjsua_call_setting *opt)
 {
     opt->flag &= ~(PJSUA_CALL_UNHOLD | PJSUA_CALL_UPDATE_CONTACT |
 		   PJSUA_CALL_NO_SDP_OFFER | PJSUA_CALL_REINIT_MEDIA |
-		   PJSUA_CALL_UPDATE_VIA);
+		   PJSUA_CALL_UPDATE_VIA | PJSUA_CALL_SET_MEDIA_DIR);
 }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -620,23 +620,15 @@ on_error:
 
 
 /*
- * Cleanup call setting to avoid one time flags, such as
+ * Cleanup call setting flag to avoid one time flags, such as
  * PJSUA_CALL_UNHOLD, PJSUA_CALL_UPDATE_CONTACT, or
  * PJSUA_CALL_NO_SDP_OFFER, to be sticky (ticket #1793).
- *
- * This function will also reset the media direction to default.
  */
-void pjsua_call_cleanup_setting(pjsua_call_setting *opt)
+void pjsua_call_cleanup_flag(pjsua_call_setting *opt)
 {
-    unsigned i;
-
     opt->flag &= ~(PJSUA_CALL_UNHOLD | PJSUA_CALL_UPDATE_CONTACT |
 		   PJSUA_CALL_NO_SDP_OFFER | PJSUA_CALL_REINIT_MEDIA |
 		   PJSUA_CALL_UPDATE_VIA);
-
-    for (i = 0; i < PJSUA_MAX_CALL_MEDIA; i++) {
-    	opt->aud_dir[i] = opt->vid_dir[i] = PJMEDIA_DIR_ENCODING_DECODING;
-    }
 }
 
 
@@ -659,8 +651,8 @@ PJ_DEF(void) pjsua_call_setting_default(pjsua_call_setting *opt)
 			       PJSUA_VID_REQ_KEYFRAME_RTCP_PLI;
 #endif
 
-    for (i = 0; i < PJSUA_MAX_CALL_MEDIA; i++) {
-    	opt->aud_dir[i] = opt->vid_dir[i] = PJMEDIA_DIR_ENCODING_DECODING;
+    for (i = 0; i < PJMEDIA_MAX_SDP_MEDIA; i++) {
+    	opt->media_dir[i] = PJMEDIA_DIR_ENCODING_DECODING;
     }
 }
 
@@ -681,7 +673,7 @@ static pj_status_t apply_call_setting(pjsua_call *call,
     pj_assert(call);
 
     if (!opt) {
-	pjsua_call_cleanup_setting(&call->opt);
+	pjsua_call_cleanup_flag(&call->opt);
     } else {
     	call->opt = *opt;
     }
@@ -1536,7 +1528,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 
 	/* Copy call setting from the replaced call */
 	call->opt = replaced_call->opt;
-	pjsua_call_cleanup_setting(&call->opt);
+	pjsua_call_cleanup_flag(&call->opt);
 
 	/* Notify application */
 	if (!replaced_call->hanging_up &&
@@ -5345,7 +5337,7 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
 	goto on_return;
     }
 
-    pjsua_call_cleanup_setting(&call->opt);
+    pjsua_call_cleanup_flag(&call->opt);
     opt = call->opt;
 
     if (pjsua_var.ua_cfg.cb.on_call_rx_reinvite &&
@@ -5550,7 +5542,7 @@ static void pjsua_call_on_create_offer(pjsip_inv_session *inv,
     }
 #endif
 
-    pjsua_call_cleanup_setting(&call->opt);
+    pjsua_call_cleanup_flag(&call->opt);
 
     if (pjsua_var.ua_cfg.cb.on_call_tx_offer) {
 	(*pjsua_var.ua_cfg.cb.on_call_tx_offer)(call->index, NULL,
@@ -5877,7 +5869,7 @@ static void on_call_transferred( pjsip_inv_session *inv,
 							&code);
     }
 
-    pjsua_call_cleanup_setting(&existing_call->opt);
+    pjsua_call_cleanup_flag(&existing_call->opt);
     call_opt = existing_call->opt;
     if (pjsua_var.ua_cfg.cb.on_call_transfer_request2) {
 	(*pjsua_var.ua_cfg.cb.on_call_transfer_request2)(existing_call->index,

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2469,6 +2469,9 @@ pj_status_t pjsua_media_channel_init(pjsua_call_id call_id,
 
 	if (call->opt.flag & PJSUA_CALL_SET_MEDIA_DIR) {
 	    call_med->def_dir = call->opt.media_dir[mi];
+    	    PJ_LOG(4,(THIS_FILE, "Call %d: setting media direction "
+    	    			 "#%d to %d.", call_id, mi,
+    	    			 call_med->def_dir));
 	} else if (!reinit) {
 	    /* Initialize default initial media direction as bidirectional */
 	    call_med->def_dir = PJMEDIA_DIR_ENCODING_DECODING;
@@ -3559,6 +3562,9 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
     		
     		if (call->opt.flag & PJSUA_CALL_SET_MEDIA_DIR) {
     		    call_med->def_dir = call->opt.media_dir[mi];
+    		    PJ_LOG(4,(THIS_FILE, "Call %d: setting audio media "
+    		    			 "direction #%d to %d.",
+			  		 call_id, mi, call_med->def_dir));
     		}
 
  		/* If the default direction specifies we do not wish
@@ -3790,6 +3796,9 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
     		
     		if (call->opt.flag & PJSUA_CALL_SET_MEDIA_DIR) {
     		    call_med->def_dir = call->opt.media_dir[mi];
+    		    PJ_LOG(4,(THIS_FILE, "Call %d: setting video media "
+    		    			 "direction #%d to %d.",
+			  		 call_id, mi, call_med->def_dir));
     		}
 
  		/* If the default direction specifies we do not wish
@@ -3895,7 +3904,7 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		    call_med->rem_srtp_use = srtp_info->peer_use;
 		}
 
-		/* Update audio channel */
+		/* Update video channel */
 		if (media_changed) {
 		    status = pjsua_vid_channel_update(call_med,
 						      call->inv->pool, si,

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2788,6 +2788,7 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
 	pjmedia_transport_get_info(call_med->tp, &tpinfo);
 
 	/* Ask pjmedia endpoint to create SDP media line */
+	pjmedia_endpt_create_sdp_param_default(&param);
 	param.dir = call_med->dir;
 	switch (call_med->type) {
 	case PJMEDIA_TYPE_AUDIO:

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -228,20 +228,39 @@ bool CallSetting::isEmpty() const
 
 void CallSetting::fromPj(const pjsua_call_setting &prm)
 {
+    int i, mi;
+
     this->flag              = prm.flag;
     this->reqKeyframeMethod = prm.req_keyframe_method;
     this->audioCount        = prm.aud_cnt;
     this->videoCount        = prm.vid_cnt;
+    this->mediaDir.clear();
+    /* Since we don't know the size of media_dir array, we populate
+     * mediaDir vector up to the element with non-default value.
+     */
+    for (mi = PJMEDIA_MAX_SDP_MEDIA - 1; mi >= 0; mi--) {
+    	if (prm.media_dir[mi] != PJMEDIA_DIR_ENCODING_DECODING) break;
+    }
+    for (i = 0; i <= mi; i++) {
+    	this->mediaDir.push_back(prm.media_dir[i]);
+    }
 }
 
 pjsua_call_setting CallSetting::toPj() const
 {
     pjsua_call_setting setting;
+    unsigned mi;
+
+    /* This is important to initialize media_dir array. */
+    pjsua_call_setting_default(&setting);
 
     setting.flag                = this->flag;
     setting.req_keyframe_method = this->reqKeyframeMethod;
     setting.aud_cnt             = this->audioCount;
     setting.vid_cnt             = this->videoCount;
+    for (mi = 0; mi < this->mediaDir.size(); mi++) {
+    	setting.media_dir[mi] = this->mediaDir[mi];
+    }
     
     return setting;
 }

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -228,20 +228,42 @@ bool CallSetting::isEmpty() const
 
 void CallSetting::fromPj(const pjsua_call_setting &prm)
 {
+    unsigned mi;
+
     this->flag              = prm.flag;
     this->reqKeyframeMethod = prm.req_keyframe_method;
     this->audioCount        = prm.aud_cnt;
+    this->audioDir.clear();
+    for (mi = 0; mi < prm.aud_cnt; mi++) {
+    	this->audioDir.push_back(prm.aud_dir[mi]);
+    }
     this->videoCount        = prm.vid_cnt;
+    this->videoDir.clear();
+    for (mi = 0; mi < prm.vid_cnt; mi++) {
+    	this->videoDir.push_back(prm.vid_dir[mi]);
+    }
 }
 
 pjsua_call_setting CallSetting::toPj() const
 {
     pjsua_call_setting setting;
+    unsigned mi;
+
+    /* This is important to initialize all the media directions. */
+    pjsua_call_setting_default(&setting);
 
     setting.flag                = this->flag;
     setting.req_keyframe_method = this->reqKeyframeMethod;
     setting.aud_cnt             = this->audioCount;
+    for (mi = 0; mi < this->audioCount; mi++) {
+    	if (mi >= this->audioDir.size()) break;
+    	setting.aud_dir[mi] = this->audioDir[mi];
+    }    
     setting.vid_cnt             = this->videoCount;
+    for (mi = 0; mi < this->videoCount; mi++) {
+    	if (mi >= this->videoDir.size()) break;
+    	setting.vid_dir[mi] = this->videoDir[mi];
+    }    
     
     return setting;
 }

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -228,42 +228,20 @@ bool CallSetting::isEmpty() const
 
 void CallSetting::fromPj(const pjsua_call_setting &prm)
 {
-    unsigned mi;
-
     this->flag              = prm.flag;
     this->reqKeyframeMethod = prm.req_keyframe_method;
     this->audioCount        = prm.aud_cnt;
-    this->audioDir.clear();
-    for (mi = 0; mi < prm.aud_cnt; mi++) {
-    	this->audioDir.push_back(prm.aud_dir[mi]);
-    }
     this->videoCount        = prm.vid_cnt;
-    this->videoDir.clear();
-    for (mi = 0; mi < prm.vid_cnt; mi++) {
-    	this->videoDir.push_back(prm.vid_dir[mi]);
-    }
 }
 
 pjsua_call_setting CallSetting::toPj() const
 {
     pjsua_call_setting setting;
-    unsigned mi;
-
-    /* This is important to initialize all the media directions. */
-    pjsua_call_setting_default(&setting);
 
     setting.flag                = this->flag;
     setting.req_keyframe_method = this->reqKeyframeMethod;
     setting.aud_cnt             = this->audioCount;
-    for (mi = 0; mi < this->audioCount; mi++) {
-    	if (mi >= this->audioDir.size()) break;
-    	setting.aud_dir[mi] = this->audioDir[mi];
-    }    
     setting.vid_cnt             = this->videoCount;
-    for (mi = 0; mi < this->videoCount; mi++) {
-    	if (mi >= this->videoDir.size()) break;
-    	setting.vid_dir[mi] = this->videoDir[mi];
-    }    
     
     return setting;
 }


### PR DESCRIPTION
To fix #2246

In this PR, we add the flag `PJSUA_CALL_SET_MEDIA_DIR` and `media_dir[]` as part of `pjsua_call_setting` to specify the media direction. The setting will be used when initializing or updating media channel, so it's also applicable for sending/receiving re-INVITE/UPDATE.

Spec:
```
    /**
     * Media direction. This setting will only be used if the flag
     * PJSUA_CALL_SET_MEDIA_DIR is set, and it will persist for subsequent
     * offers or answers. 
     * For example, a media that is set as PJMEDIA_DIR_ENCODING can only
     * mark the stream in the SDP as sendonly or inactive, but will not
     * become sendrecv in subsequent offers and answers.
     * Application can update the media direction in any API or callback
     * that accepts pjsua_call_setting as a parameter, such as via
     * pjsua_call_reinvite/update() or in on_call_rx_offer/reinvite()
     * callback.
     *
     * The index of the media dir will correspond to the provisional media
     * in pjsua_call_info.prov_media.
     * For offers that involve adding new medias (such as initial offer),
     * the index will correspond to all new audio media first, then video.
     * For example, for a new call with 2 audios and 1 video, media_dir[0]
     * and media_dir[1] will be for the audios, and media_dir[2] video.
     *
     * Default: PJMEDIA_DIR_ENCODING_DECODING
     */
    pjmedia_dir	     media_dir[PJMEDIA_MAX_SDP_MEDIA];
```

Example 1:
```
    /* Initiate a call as sendonly audio */
    pjsua_call_setting_default(&call_opt);
    call_opt.flag |= PJSUA_CALL_SET_MEDIA_DIR;
    call_opt.media_dir[0] = PJMEDIA_DIR_ENCODING;
    pjsua_call_make_call(current_acc, &dest, &call_opt, NULL, NULL, &current_call);
    ...
    /* After some time, update the audio to bidirectional */
    call_opt.flag |= PJSUA_CALL_SET_MEDIA_DIR;
    call_opt.media_dir[0] = PJMEDIA_DIR_ENCODING_DECODING;
    pjsua_call_reinvite2(current_call, &call_opt, NULL);
```
Example 2:
```
/* Answer video call as recvonly because we only have a display and no camera */
static void on_incoming_call(...)
{
    pjsua_call_get_info(call_id, &call_info);
    pjsua_call_setting_default(&call_opt);
    call_opt.flag |= PJSUA_CALL_SET_MEDIA_DIR;
    for (mi = 0; mi < call_info.prov_media_cnt; mi++) {
        if (call_info.prov_media[mi].type == PJMEDIA_TYPE_VIDEO)
            call_opt.media_dir[mi] = PJMEDIA_DIR_DECODING;
    }
    pjsua_call_answer2(call_id, &call_opt, 200, NULL, NULL);
```
