### PR TITLE
Fix double free of stun session

### DIFF
--- a/pjnath/include/pjnath/stun_session.h
+++ b/pjnath/include/pjnath/stun_session.h
@@ -341,6 +341,7 @@ struct pj_stun_tx_data
     pj_pool_t		*pool;		/**< Pool.			    */
     pj_stun_session	*sess;		/**< The STUN session.		    */
     pj_stun_msg		*msg;		/**< The STUN message.		    */
+    pj_bool_t		 is_destroying; /**< Is destroying?		    */
 
     void		*token;		/**< The token.			    */
 

--- a/pjnath/src/pjnath/stun_session.c
+++ b/pjnath/src/pjnath/stun_session.c
@@ -210,6 +210,7 @@ static void destroy_tdata(pj_stun_tx_data *tdata, pj_bool_t force)
 	    /* "Probably" this is to absorb retransmission */
 	    pj_time_val delay = {0, 300};
 	    pj_stun_client_tsx_schedule_destroy(tdata->client_tsx, &delay);
+	    tdata->is_destroying = PJ_FALSE;
 
 	} else {
 	    pj_list_erase(tdata);


### PR DESCRIPTION
To fix #2505

Upon investigation, the double free issue is caused by a race condition between `pj_stun_session_destroy()` and `on_cache_timeout()`. The race is as follows:
- pj_stun_session_destroy() will call `destroy_tdata()` and decrement the session's group lock.
- on_cache_timeout() will also call `destroy_tdata()` and decrement the session's group lock again.

The patch will make sure that the group lock will not be decremented more than once in such case.

Special thanks to Joshua Colp (@jcolp) for his help in testing the patch.
https://gerrit.asterisk.org/c/asterisk/+/15869
