### PR TITLE
Update doc for ignoring stream keep alive

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1865,7 +1865,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     }
 
     /* Ignore keep-alive packets */
-    if (bytes_read < (pj_ssize_t) sizeof(pjmedia_rtp_hdr))
+    if (bytes_read <= (pj_ssize_t) sizeof(pjmedia_rtp_hdr))
 	return;
 
     /* Update RTP and RTCP session. */

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1864,8 +1864,8 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 	return;
     }
 
-    /* Ignore keep-alive packets */
-    if (bytes_read <= (pj_ssize_t) sizeof(pjmedia_rtp_hdr))
+    /* Ignore non-RTP keep-alive packets */
+    if (bytes_read < (pj_ssize_t) sizeof(pjmedia_rtp_hdr))
 	return;
 
     /* Update RTP and RTCP session. */


### PR DESCRIPTION
When sending stream keep alive using empty RTP (i.e. by setting `PJMEDIA_STREAM_ENABLE_KA` to `PJMEDIA_STREAM_KA_EMPTY_RTP`), the size of keep-alive packet sent will be equal to the `sizeof(pjmedia_rtp_hdr)`, but the check of ignoring it seem to expect packets strictly smaller than this, so keep-alive packets will never be ignored.

**Update:** Since the behavior seems to be okay, we update the doc instead, so it's clear that we only ignore non-RTP keep alive packets.
