### PR TITLE
Reset DTLS state when stopping DTLS transport

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -1632,6 +1632,15 @@ static pj_status_t dtls_media_stop(pjmedia_transport *tp)
 
     if (ds->clock)
 	pjmedia_clock_stop(ds->clock);
+    
+    /* Reset DTLS state */
+    ssl_destroy(ds);
+    ds->setup = DTLS_SETUP_UNKNOWN;
+    ds->nego_started = PJ_FALSE;
+    ds->nego_completed = PJ_FALSE;
+    ds->got_keys = PJ_FALSE;
+    ds->rem_fingerprint.slen = 0;
+    ds->rem_fprint_status = PJ_EPENDING;
 
     return PJ_SUCCESS;
 }


### PR DESCRIPTION
To fix #2721.

According to our doc: `pjmedia_transport_media_stop(), to deinitialize the media transport and reset the transport to its idle state.` However, currently `dtls_media_stop()` only stops the clock. So in this PR, we will destroy the SSL and reset its state in the `dtls_media_stop()`.

Successfully tested with the scenario of receiving re-INVITE without SDP to restart ICE:
```
18:56:59.976           pjsua_core.c  .RX 839 bytes Request msg INVITE/cseq=8854 (rdata0x13589cd18) from TLS 139.162.62.29:5061:
INVITE sips:402@219.74.137.243:56450;transport=TLS;ob SIP/2.0
Content-Length:  0

18:56:59.976        dtls0x11588a400  ......dtls_media_stop()
18:56:59.977                icetp00  ......Stopping ICE, reason=media stop requested
18:56:59.977        dtls0x11588a400  ......dtls_media_create()
18:56:59.977           pjsua_call.c  ......Restarting ICE for media 0
18:56:59.977           pjsua_call.c  ......Call 0: asked to send a new offer
18:56:59.977        dtls0x11588a400  ......dtls_encode_sdp()
18:56:59.993        dtls0x11588a400  ....dtls_media_start()
```