### PR TITLE
Avoid deadlock when restarting SIP UDP transport due to holding pjsua lock

### DIFF
--- a/pjsip/include/pjsip/sip_transport_udp.h
+++ b/pjsip/include/pjsip/sip_transport_udp.h
@@ -294,6 +294,14 @@ PJ_DECL(pj_status_t) pjsip_udp_transport_pause(pjsip_transport *transport,
  *    and set the \a local argument to NULL. In both cases, application
  *    may specify the published address of the socket in \a a_name
  *    argument.
+ * 
+ * Note that prior to calling this method, any locks acquired need to 
+ * be released temporarily to avoid any deadlock scenario.  
+ * This method will loop to wait for read operation to finish before actually 
+ * restart the transport. This might lead to deadlock if any other thread with 
+ * the read operation tries to acquire the same lock held by the thread calling
+ * this method. 
+ * Please see https://github.com/pjsip/pjproject/pull/2731 for more details. 
  *
  * @param transport	The UDP transport.
  * @param option	Restart option.
@@ -339,6 +347,14 @@ PJ_DECL(pj_status_t) pjsip_udp_transport_restart(pjsip_transport *transport,
  *    may specify the published address of the socket in \a a_name
  *    argument. This is another version of pjsip_udp_transport_restart() 
  *    able to restart IPv6 transport.
+ * 
+ * Note that prior to calling this method, any locks acquired need to 
+ * be released temporarily to avoid any deadlock scenario.  
+ * This method will loop to wait for read operation to finish before actually 
+ * restart the transport. This might lead to deadlock if any other thread with 
+ * the read operation tries to acquire the same lock held by the thread calling
+ * this method. 
+ * Please see https://github.com/pjsip/pjproject/pull/2731 for more details.
  *
  * @param transport	The UDP transport.
  * @param option	Restart option.

--- a/pjsip/include/pjsip/sip_transport_udp.h
+++ b/pjsip/include/pjsip/sip_transport_udp.h
@@ -123,55 +123,6 @@ typedef struct pjsip_udp_transport_cfg
 
 } pjsip_udp_transport_cfg;
 
-/**
- * Parameter for restarting SIP UDP transport when calling 
- * pjsip_udp_transport_restart3(). Application should initialize this structure
- * with its default values by calling pjsip_udp_transport_res_param_default().
- */
-typedef struct pjsip_udp_transport_res_param
-{
-    /**
-     * Restart option.
-     */
-    unsigned option;
-
-    /**
-     * Optional socket to be used by the transport.
-     */
-    pj_sock_t sock;
-
-    /**
-     * The address where the socket should be bound to. If this argument 
-     * is NULL, socket will be bound to any available port.
-     */
-    const pj_sockaddr* local;
-
-    /**
-     * Optionally specify the published address for the transport. 
-     * If the socket is not replaced (PJSIP_UDP_TRANSPORT_KEEP_SOCKET flag is
-     * specified), then if this argument is NULL, the previous value will be 
-     * used. If the socket is replaced and this argument is NULL, the bound
-     * address will be used as the published address of the transport.
-     */
-    const pjsip_host_port* a_name;
-
-    /**
-     * Optional callback to unlock any lock when the method is busy waiting
-     * for the read spin loop to finish. If a lock is held prior to restarting
-     * the transport, it might cause a deadlock.
-     * (see: https://github.com/pjsip/pjproject/issues/2717).
-     * Use this callback is unlock the lock temporarily while the method waits
-     * for the read spin loop to finish.
-     */
-    void (*unlock)();
-
-    /**
-     * Optional callback to re-lock the lock after the read spin loop finish.
-     */
-    void (*lock)();
-
-} pjsip_udp_transport_res_param;
-
 
 /**
  * Initialize pjsip_udp_transport_cfg structure with default values for
@@ -182,14 +133,6 @@ typedef struct pjsip_udp_transport_res_param
  */
 PJ_DECL(void) pjsip_udp_transport_cfg_default(pjsip_udp_transport_cfg *cfg,
 					      int af);
-
-/**
- * Initialize pjsip_udp_transport_cfg structure with default values.
- *
- * @param param		The param to initialize.
- */
-PJ_DECL(void) pjsip_udp_transport_res_param_default(
-					 pjsip_udp_transport_res_param *param);
 
 
 /**
@@ -420,36 +363,6 @@ PJ_DECL(pj_status_t) pjsip_udp_transport_restart2(pjsip_transport *transport,
 					        pj_sock_t sock,
 					        const pj_sockaddr *local,
 					        const pjsip_host_port *a_name);
-
-/**
- * Restart the transport. Several operations are supported by this function:
- *  - if transport was made temporarily unavailable to SIP stack with
- *    pjsip_udp_transport_pause() and PJSIP_UDP_TRANSPORT_KEEP_SOCKET,
- *    application can make the transport available to the SIP stack
- *    again, by specifying PJSIP_UDP_TRANSPORT_KEEP_SOCKET flag here.
- *  - if application wants to replace the internal socket with a new
- *    socket, it must specify PJSIP_UDP_TRANSPORT_DESTROY_SOCKET when
- *    calling this function, so that the internal socket will be destroyed
- *    if it hasn't been closed. In this case, application has two choices
- *    on how to create the new socket: 1) to let the transport create
- *    the new socket, in this case the \a sock option should be set
- *    to \a PJ_INVALID_SOCKET and optionally the \a local parameter can be
- *    filled with the desired address and port where the new socket 
- *    should be bound to, or 2) to specify its own socket to be used
- *    by this transport, by specifying a valid socket in \a sock argument
- *    and set the \a local argument to NULL. In both cases, application
- *    may specify the published address of the socket in \a a_name
- *    argument. This is another version of pjsip_udp_transport_restart() 
- *    able to restart IPv6 transport.
- *
- * @param transport	The UDP transport.
- * @param param		The restart parameter.
- * 
- * @return 		PJ_SUCCESS if transport can be restarted, or
- *			the appropriate error code.
- */
-PJ_DECL(pj_status_t) pjsip_udp_transport_restart3(pjsip_transport* transport,
-				   const pjsip_udp_transport_res_param* param);
 
 
 PJ_END_DECL

--- a/pjsip/include/pjsip/sip_transport_udp.h
+++ b/pjsip/include/pjsip/sip_transport_udp.h
@@ -123,6 +123,55 @@ typedef struct pjsip_udp_transport_cfg
 
 } pjsip_udp_transport_cfg;
 
+/**
+ * Parameter for restarting SIP UDP transport when calling 
+ * pjsip_udp_transport_restart3(). Application should initialize this structure
+ * with its default values by calling pjsip_udp_transport_res_param_default().
+ */
+typedef struct pjsip_udp_transport_res_param
+{
+    /**
+     * Restart option.
+     */
+    unsigned option;
+
+    /**
+     * Optional socket to be used by the transport.
+     */
+    pj_sock_t sock;
+
+    /**
+     * The address where the socket should be bound to. If this argument 
+     * is NULL, socket will be bound to any available port.
+     */
+    const pj_sockaddr* local;
+
+    /**
+     * Optionally specify the published address for the transport. 
+     * If the socket is not replaced (PJSIP_UDP_TRANSPORT_KEEP_SOCKET flag is
+     * specified), then if this argument is NULL, the previous value will be 
+     * used. If the socket is replaced and this argument is NULL, the bound
+     * address will be used as the published address of the transport.
+     */
+    const pjsip_host_port* a_name;
+
+    /**
+     * Optional callback to unlock any lock when the method is busy waiting
+     * for the read spin loop to finish. If a lock is held prior to restarting
+     * the transport, it might cause a deadlock.
+     * (see: https://github.com/pjsip/pjproject/issues/2717).
+     * Use this callback is unlock the lock temporarily while the method waits
+     * for the read spin loop to finish.
+     */
+    void (*unlock)();
+
+    /**
+     * Optional callback to re-lock the lock after the read spin loop finish.
+     */
+    void (*lock)();
+
+} pjsip_udp_transport_res_param;
+
 
 /**
  * Initialize pjsip_udp_transport_cfg structure with default values for
@@ -133,6 +182,14 @@ typedef struct pjsip_udp_transport_cfg
  */
 PJ_DECL(void) pjsip_udp_transport_cfg_default(pjsip_udp_transport_cfg *cfg,
 					      int af);
+
+/**
+ * Initialize pjsip_udp_transport_cfg structure with default values.
+ *
+ * @param param		The param to initialize.
+ */
+PJ_DECL(void) pjsip_udp_transport_res_param_default(
+					 pjsip_udp_transport_res_param *param);
 
 
 /**
@@ -363,6 +420,36 @@ PJ_DECL(pj_status_t) pjsip_udp_transport_restart2(pjsip_transport *transport,
 					        pj_sock_t sock,
 					        const pj_sockaddr *local,
 					        const pjsip_host_port *a_name);
+
+/**
+ * Restart the transport. Several operations are supported by this function:
+ *  - if transport was made temporarily unavailable to SIP stack with
+ *    pjsip_udp_transport_pause() and PJSIP_UDP_TRANSPORT_KEEP_SOCKET,
+ *    application can make the transport available to the SIP stack
+ *    again, by specifying PJSIP_UDP_TRANSPORT_KEEP_SOCKET flag here.
+ *  - if application wants to replace the internal socket with a new
+ *    socket, it must specify PJSIP_UDP_TRANSPORT_DESTROY_SOCKET when
+ *    calling this function, so that the internal socket will be destroyed
+ *    if it hasn't been closed. In this case, application has two choices
+ *    on how to create the new socket: 1) to let the transport create
+ *    the new socket, in this case the \a sock option should be set
+ *    to \a PJ_INVALID_SOCKET and optionally the \a local parameter can be
+ *    filled with the desired address and port where the new socket 
+ *    should be bound to, or 2) to specify its own socket to be used
+ *    by this transport, by specifying a valid socket in \a sock argument
+ *    and set the \a local argument to NULL. In both cases, application
+ *    may specify the published address of the socket in \a a_name
+ *    argument. This is another version of pjsip_udp_transport_restart() 
+ *    able to restart IPv6 transport.
+ *
+ * @param transport	The UDP transport.
+ * @param param		The restart parameter.
+ * 
+ * @return 		PJ_SUCCESS if transport can be restarted, or
+ *			the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsip_udp_transport_restart3(pjsip_transport* transport,
+				   const pjsip_udp_transport_res_param* param);
 
 
 PJ_END_DECL

--- a/pjsip/src/pjsip/sip_transport_udp.c
+++ b/pjsip/src/pjsip/sip_transport_udp.c
@@ -143,15 +143,18 @@ static void udp_on_read_complete( pj_ioqueue_key_t *key,
 	goto on_return;
 
     if (-bytes_read == PJ_ESOCKETSTOP) {
+	pjsip_udp_transport_res_param res_param;
+	pjsip_udp_transport_res_param_default(&res_param);
+
+	res_param.option = PJSIP_UDP_TRANSPORT_DESTROY_SOCKET;
+	res_param.sock = PJ_INVALID_SOCKET;
+	res_param.local = &tp->base.local_addr;
+	res_param.a_name = &tp->base.local_name;
+
 	--tp->read_loop_spin;
 	/* Try to recover by restarting the transport. */
 	PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));
-	status = pjsip_udp_transport_restart2(
-			    &tp->base,
-			    PJSIP_UDP_TRANSPORT_DESTROY_SOCKET,
-			    PJ_INVALID_SOCKET,
-			    &tp->base.local_addr,
-			    &tp->base.local_name);
+	status = pjsip_udp_transport_restart3(&tp->base, &res_param);
 
 	if (status != PJ_SUCCESS) {
 	    PJ_PERROR(1,(THIS_FILE, status,
@@ -323,14 +326,17 @@ static void udp_on_write_complete( pj_ioqueue_key_t *key,
 
     if (-bytes_sent == PJ_ESOCKETSTOP) {
 	pj_status_t status;
+	pjsip_udp_transport_res_param res_param;
+	pjsip_udp_transport_res_param_default(&res_param);
+
+	res_param.option = PJSIP_UDP_TRANSPORT_DESTROY_SOCKET;
+	res_param.sock = PJ_INVALID_SOCKET;
+	res_param.local = &tp->base.local_addr;
+	res_param.a_name = &tp->base.local_name;
+
 	/* Try to recover by restarting the transport. */
 	PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));
-	status = pjsip_udp_transport_restart2(
-			    &tp->base,
-			    PJSIP_UDP_TRANSPORT_DESTROY_SOCKET,
-			    PJ_INVALID_SOCKET,
-			    &tp->base.local_addr,
-			    &tp->base.local_name);
+	status = pjsip_udp_transport_restart3(&tp->base, &res_param);
 
 	if (status != PJ_SUCCESS) {
 	    PJ_PERROR(1,(THIS_FILE, status,
@@ -381,14 +387,17 @@ static pj_status_t udp_send_msg( pjsip_transport *transport,
 
     if (status != PJ_EPENDING) {
 	if (status == PJ_ESOCKETSTOP) {
+	    pjsip_udp_transport_res_param res_param;
+	    pjsip_udp_transport_res_param_default(&res_param);
+
+	    res_param.option = PJSIP_UDP_TRANSPORT_DESTROY_SOCKET;
+	    res_param.sock = PJ_INVALID_SOCKET;
+	    res_param.local = &tp->base.local_addr;
+	    res_param.a_name = &tp->base.local_name;
+
 	    /* Try to recover by restarting the transport. */
 	    PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));
-	    status = pjsip_udp_transport_restart2(
-				&tp->base,
-				PJSIP_UDP_TRANSPORT_DESTROY_SOCKET,
-				PJ_INVALID_SOCKET,
-				&tp->base.local_addr,
-				&tp->base.local_name);
+	    status = pjsip_udp_transport_restart3(&tp->base, &res_param);
 
 	    if (status != PJ_SUCCESS) {
 		PJ_PERROR(1,(THIS_FILE, status,
@@ -959,6 +968,11 @@ PJ_DEF(void) pjsip_udp_transport_cfg_default(pjsip_udp_transport_cfg *cfg,
     cfg->async_cnt = 1;
 }
 
+PJ_DEF(void) pjsip_udp_transport_res_param_default(
+					  pjsip_udp_transport_res_param* param)
+{
+    pj_bzero(param, sizeof(*param));
+}
 
 /*
  * pjsip_udp_transport_start2()
@@ -1162,10 +1176,26 @@ PJ_DEF(pj_status_t) pjsip_udp_transport_restart2(pjsip_transport *transport,
 					         const pj_sockaddr *local,
 					         const pjsip_host_port *a_name)
 {
+    pjsip_udp_transport_res_param param;
+    pjsip_udp_transport_res_param_default(&param);
+    param.option = option;
+    param.sock = sock;
+    param.local = local;
+    param.a_name = a_name;
+    return pjsip_udp_transport_restart3(transport, &param);
+}
+
+PJ_DEF(pj_status_t) pjsip_udp_transport_restart3(pjsip_transport* transport,
+ 				    const pjsip_udp_transport_res_param* param)
+{
     struct udp_transport *tp;
     pj_status_t status;
     char addr[PJ_INET6_ADDRSTRLEN+10];
     int i;
+    unsigned option = param->option;
+    pj_sock_t sock = param->sock;
+    const pj_sockaddr* local = param->local;
+    const pjsip_host_port* a_name = param->a_name;
 
     PJ_ASSERT_RETURN(transport != NULL, PJ_EINVAL);
     /* Flag must be specified */
@@ -1242,10 +1272,18 @@ PJ_DEF(pj_status_t) pjsip_udp_transport_restart2(pjsip_transport *transport,
 	    udp_set_pub_name(tp, a_name);
     }
 
+    /* If unlock method is specified, then unlock here. */
+    if (param->lock && param->unlock)
+	param->unlock();
+
     /* Make sure all udp_on_read_complete() loop spin are stopped */
-    do {
+    do {	
 	pj_thread_sleep(1);
     } while (tp->read_loop_spin);
+
+    /* If unlock method is specified, then re-lock here. */
+    if (param->lock && param->unlock)
+	param->lock();
 
     /* Re-register new or existing socket to ioqueue. */
     status = register_to_ioqueue(tp);

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -3781,6 +3781,7 @@ static pj_status_t restart_listener(pjsua_transport_id id,
 	int i = 0;
 	pj_bool_t all_done = PJ_TRUE;
 
+	PJSUA_LOCK();
 	pjsua_var.tpdata[id].is_restarting = PJ_FALSE;
 	pjsua_var.tpdata[id].restart_status = status;
 	if (pjsua_var.ua_cfg.cb.on_ip_change_progress) {
@@ -3803,6 +3804,7 @@ static pj_status_t restart_listener(pjsua_transport_id id,
 		break;
 	    }
 	}
+	PJSUA_UNLOCK();
 	if (all_done)
 	    status = handle_ip_change_on_acc();
     }
@@ -3846,12 +3848,12 @@ PJ_DEF(pj_status_t) pjsua_handle_ip_change(const pjsua_ip_change_param *param)
 		pjsua_var.tpdata[i].restart_status = PJ_EUNKNOWN;
 	    }
 	}
+	PJSUA_UNLOCK();
 	for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.tpdata); ++i) {
 	    if (pjsua_var.tpdata[i].data.ptr != NULL) {
 		status = restart_listener(i, param->restart_lis_delay);
 	    }
 	}
-        PJSUA_UNLOCK();
     } else {
 	for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.tpdata); ++i) {
 	    if (pjsua_var.tpdata[i].data.ptr != NULL) {


### PR DESCRIPTION
This ticket is to address #2717 by not holding PJSUA lock when calling `pjsip_udp_transport_restart2()`.