### PR TITLE
Avoid call disconnection due to request timeout when network is changing

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -181,6 +181,14 @@ typedef struct pjsip_cfg_t
          */
         pj_bool_t accept_multiple_sdp_answers;
 
+	/**
+	 * Don't disconnect the INVITE session after an outgoing request
+	 * gets timed out or responded with 408 (request timeout).
+	 *
+	 * Default is PJ_FALSE.
+	 */
+	pj_bool_t keep_inv_after_tsx_timeout;
+
     } endpt;
 
     /** Transaction layer settings. */

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4082,8 +4082,8 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
     if (inv->state != PJSIP_INV_STATE_DISCONNECTED &&
 	((tsx->status_code == PJSIP_SC_CALL_TSX_DOES_NOT_EXIST &&
 	    tsx->method.id != PJSIP_CANCEL_METHOD) ||
-	 tsx->status_code == PJSIP_SC_REQUEST_TIMEOUT ||
-	 tsx->status_code == PJSIP_SC_TSX_TIMEOUT))
+	 (tsx->status_code == PJSIP_SC_REQUEST_TIMEOUT &&
+	  !pjsip_cfg()->endpt.keep_inv_after_tsx_timeout)))
     {
 	pjsip_tx_data *bye;
 	pj_status_t status;

--- a/pjsip/src/pjsip/sip_config.c
+++ b/pjsip/src/pjsip/sip_config.c
@@ -36,7 +36,8 @@ pjsip_cfg_t pjsip_sip_cfg_var =
        PJSIP_RESOLVE_HOSTNAME_TO_GET_INTERFACE,
        0,
        PJSIP_ENCODE_SHORT_HNAME,
-       PJSIP_ACCEPT_MULTIPLE_SDP_ANSWERS
+       PJSIP_ACCEPT_MULTIPLE_SDP_ANSWERS,
+       0
     },
 
     /* Transaction settings */

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -3817,6 +3817,15 @@ static void restart_listener_cb(void *user_data)
 }
 
 
+static void ip_change_put_back_inv_config(void *user_data)
+{
+    PJ_UNUSED_ARG(user_data);
+
+    PJ_LOG(4,(THIS_FILE,"IP change stops ignoring request timeout"));
+    pjsip_cfg()->endpt.keep_inv_after_tsx_timeout = PJ_FALSE;
+}
+
+
 PJ_DEF(pj_status_t) pjsua_handle_ip_change(const pjsua_ip_change_param *param)
 {
     pj_status_t status = PJ_SUCCESS;
@@ -3835,6 +3844,21 @@ PJ_DEF(pj_status_t) pjsua_handle_ip_change(const pjsua_ip_change_param *param)
     }
 
     PJ_LOG(3, (THIS_FILE, "Start handling IP address change"));
+
+    /* Avoid call disconnection due to request timeout. Some requests may
+     * be in progress when network is changing, they may eventually get
+     * timed out and cause call disconnection.
+     */
+    if (!pjsip_cfg()->endpt.keep_inv_after_tsx_timeout) {
+	pjsip_cfg()->endpt.keep_inv_after_tsx_timeout = PJ_TRUE;
+
+	/* Put it back after some time (transaction timeout setting value) */
+	pjsua_schedule_timer2(&ip_change_put_back_inv_config, NULL,
+			      pjsip_cfg()->tsx.td);
+
+	PJ_LOG(4,(THIS_FILE,"IP change temporarily ignores request timeout"));
+    }
+
     if (param->restart_listener) {
 	PJSUA_LOCK();
 	/* Restart listener/transport, handle_ip_change_on_acc() will


### PR DESCRIPTION
Some requests (within dialog) may be in progress when network is changing, they may eventually get timed out and cause call disconnection.

This PR introduces a new PJSIP endpoint setting: `pjsip_cfg_t.endpt.keep_inv_after_tsx_timeout`, default is `PJ_FALSE` (maintaining the existing behavior). The IP change processing in PJSUA temporarily changes this setting value to `PJ_TRUE` to avoid call disconnection due to request timeout.