### PR TITLE
Update configure-android to support Android NDK 22

### DIFF
--- a/configure-android
+++ b/configure-android
@@ -42,8 +42,14 @@ fi
 NDK_VER=`sed -n -E 's/^Pkg.Revision *= *([0-9]+).*/\1/p' ${ANDROID_NDK_ROOT}/source.properties`
 
 if test "x$APP_PLATFORM" = "x"; then
-  APP_PLATFORM=`ls ${ANDROID_NDK_ROOT}/platforms/ | sed 's/android-//' | sort -gr | head -1`
-  APP_PLATFORM="android-${APP_PLATFORM}"
+  if test -d ${ANDROID_NDK_ROOT}/platforms; then
+    APP_PLATFORM=`ls ${ANDROID_NDK_ROOT}/platforms/ | sed 's/android-//' | sort -gr | head -1`
+  fi
+  if test "x$APP_PLATFORM" != "x"; then
+    APP_PLATFORM="android-${APP_PLATFORM}"
+  else
+    APP_PLATFORM="latest"
+  fi
   echo "$F: APP_PLATFORM not specified, using ${APP_PLATFORM}"
 fi
 


### PR DESCRIPTION
In this NDK version, folder `platforms` is now removed, the script needs it to detect latest platform version. In such case, the script will just set `APP_PLATFORM` to `latest`.