### PR TITLE
Allow app to modify video encoding param via PJSUA callback on_stream_precreate()

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1160,7 +1160,9 @@ typedef struct pjsua_callback
      * Notify application when an audio media session is about to be created
      * (as opposed to #on_stream_created() and #on_stream_created2() which are
      * called *after* the session has been created). The application may change
-     * stream parameters like the jitter buffer size.
+     * some stream info parameter values, i.e: jb_init, jb_min_pre, jb_max_pre,
+     * jb_max, use_ka, rtcp_sdes_bye_disabled, jb_discard_algo (audio),
+     * codec_param->enc_fmt (video).
      *
      * @param call_id       Call identification.
      * @param param         The on stream precreate callback parameter.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -1843,7 +1843,9 @@ public:
      * Notify application when an audio media session is about to be created
      * (as opposed to #on_stream_created() and #on_stream_created2() which are
      * called *after* the session has been created). The application may change
-     * stream parameters like the jitter buffer size.
+     * some stream info parameter values, i.e: jbInit, jbMinPre, jbMaxPre,
+     * jbMax, useKa, rtcpSdesByeDisabled, jbDiscardAlgo (audio),
+     * vidCodecParam.encFmt (video).
      *
      * @param prm       Callback parameter.
      */

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1130,6 +1130,7 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
             si->use_ka = prm.stream_info.info.vid.use_ka;
 #endif
             si->rtcp_sdes_bye_disabled = prm.stream_info.info.vid.rtcp_sdes_bye_disabled;
+	    si->codec_param->enc_fmt = prm.stream_info.info.vid.codec_param->enc_fmt;
         }
 
 	/* Create session based on session info. */

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1113,15 +1113,28 @@ void Endpoint::on_stream_precreate(pjsua_call_id call_id,
     call->onStreamPreCreate(prm);
 
     /* Copy back only the fields which are allowed to be changed. */
-    param->stream_info.info.aud.jb_init = prm.streamInfo.jbInit;
-    param->stream_info.info.aud.jb_min_pre = prm.streamInfo.jbMinPre;
-    param->stream_info.info.aud.jb_max_pre = prm.streamInfo.jbMaxPre;
-    param->stream_info.info.aud.jb_max = prm.streamInfo.jbMax;
-    param->stream_info.info.aud.jb_discard_algo = prm.streamInfo.jbDiscardAlgo;
+    if (param->stream_info.type == PJMEDIA_TYPE_AUDIO) {
+	param->stream_info.info.aud.jb_init = prm.streamInfo.jbInit;
+	param->stream_info.info.aud.jb_min_pre = prm.streamInfo.jbMinPre;
+	param->stream_info.info.aud.jb_max_pre = prm.streamInfo.jbMaxPre;
+	param->stream_info.info.aud.jb_max = prm.streamInfo.jbMax;
+	param->stream_info.info.aud.jb_discard_algo = prm.streamInfo.jbDiscardAlgo;
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
-    param->stream_info.info.aud.use_ka = prm.streamInfo.useKa;
+	param->stream_info.info.aud.use_ka = prm.streamInfo.useKa;
 #endif
-    param->stream_info.info.aud.rtcp_sdes_bye_disabled = prm.streamInfo.rtcpSdesByeDisabled;
+	param->stream_info.info.aud.rtcp_sdes_bye_disabled = prm.streamInfo.rtcpSdesByeDisabled;
+    } else if (param->stream_info.type == PJMEDIA_TYPE_VIDEO) {
+	param->stream_info.info.vid.jb_init = prm.streamInfo.jbInit;
+	param->stream_info.info.vid.jb_min_pre = prm.streamInfo.jbMinPre;
+	param->stream_info.info.vid.jb_max_pre = prm.streamInfo.jbMaxPre;
+	param->stream_info.info.vid.jb_max = prm.streamInfo.jbMax;
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
+	param->stream_info.info.vid.use_ka = prm.streamInfo.useKa;
+#endif
+	param->stream_info.info.vid.rtcp_sdes_bye_disabled = prm.streamInfo.rtcpSdesByeDisabled;
+	param->stream_info.info.vid.codec_param->enc_fmt = prm.streamInfo.vidCodecParam.encFmt.toPj();
+
+    }
 }
 
 void Endpoint::on_stream_created2(pjsua_call_id call_id,


### PR DESCRIPTION
Some application need to be able to set a separate video encoding resolution based on remote peer. As currently codec parameters is a global config and modifying the global codec parameters may suffer from race conditions (e.g: two call initializations happen in the same time), configuring video encoding format via `on_stream_precreate()` callback should be the simplest approach.