### PR TITLE
Add configure script option to enable Speex resample

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -816,6 +816,7 @@ enable_speex_codec
 enable_ilbc_codec
 enable_libsamplerate
 enable_resample_dll
+enable_speex_resample
 with_sdl
 enable_sdl
 with_ffmpeg
@@ -1495,6 +1496,7 @@ Optional Features:
   --disable-ilbc-codec    Exclude iLBC codec in the build
   --enable-libsamplerate  Link with libsamplerate when available.
   --enable-resample-dll   Build libresample as shared library
+  --enable-speex-resample Enable Speex resample
   --disable-sdl           Disable SDL (default: not disabled)
   --disable-ffmpeg        Disable ffmpeg (default: not disabled)
   --disable-v4l2          Disable Video4Linux2 (default: not disabled)
@@ -6970,6 +6972,24 @@ else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: Building libresample as shared library... no" >&5
 $as_echo "Building libresample as shared library... no" >&6; }
 
+fi
+
+
+# Check whether --enable-speex-resample was given.
+if test "${enable_speex_resample+set}" = set; then :
+  enableval=$enable_speex_resample;
+           if test "$enable_speex_resample" = "yes"; then
+             { $as_echo "$as_me:${as_lineno-$LINENO}: result: Checking if Speex resample is enabled... yes" >&5
+$as_echo "Checking if Speex resample is enabled... yes" >&6; }
+             ac_pjmedia_resample=speex
+           else
+             { $as_echo "$as_me:${as_lineno-$LINENO}: result: Checking if Speex resample is enabled... no" >&5
+$as_echo "Checking if Speex resample is enabled... no" >&6; }
+           fi
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: Checking if Speex resample is enabled... no" >&5
+$as_echo "Checking if Speex resample is enabled... no" >&6; }
 fi
 
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -1068,6 +1068,19 @@ AC_ARG_ENABLE(resample_dll,
 	      AC_MSG_RESULT([Building libresample as shared library... no])
 	      )
 
+dnl # Include Speex resample
+AC_ARG_ENABLE(speex-resample,
+           AS_HELP_STRING([--enable-speex-resample],
+			  [Enable Speex resample]),
+           [
+           if test "$enable_speex_resample" = "yes"; then
+             AC_MSG_RESULT([Checking if Speex resample is enabled... yes])
+             [ac_pjmedia_resample=speex]
+           else
+             AC_MSG_RESULT([Checking if Speex resample is enabled... no])
+           fi
+           ], AC_MSG_RESULT([Checking if Speex resample is enabled... no]))
+
 dnl # SDL alt prefix
 AC_ARG_WITH(sdl,
     AS_HELP_STRING([--with-sdl=DIR],


### PR DESCRIPTION
Currently the only way to enable Speex resample is via `config_site.h`, i.e: by adding `#define PJMEDIA_RESAMPLE_IMP PJMEDIA_RESAMPLE_SPEEX`. Unfortunately this causes a lot of compile warning of macro redefinition. This PR add configure script option `--enable-speex-resample` to enable Speex resample.