### PR TITLE
Example command line for pjsua testing with sipp.

### DIFF
--- a/tests/pjsua/README.TXT
+++ b/tests/pjsua/README.TXT
@@ -61,5 +61,6 @@ contains specific test flows, and we have few of them:
 Example:
   $ python run.py mod_run.py scripts-run/100_simple.py
   $ python run.py mod_call.py scripts-call/100_simple.py
+  $ python run.py mod_sipp.py scripts-sipp/uac-bad-ack.xml
 
 


### PR DESCRIPTION
Hi, 

Add an example command line for pjsua testing with sipp. 

From original README.md, user maybe think testing with sipp is something like preview example, that should using the `*.py`, 
```
python run.py mod_sipp.py scripts-sipp/uac-bad-ack.py
```
But it's failed to run the cases. I spend minutes to figure out why the error happening.  After read the testing scripts I found it actually use the `*.xml` for testing.
```
python run.py mod_sipp.py scripts-sipp/uac-bad-ack.xml
```

So writing this in the document maybe can save someone like me quite a minutes. : )
