### PR TITLE
Support for SHA-256 algorithm in SIP Digest Authentication

### DIFF
--- a/pjsip/include/pjsip/sip_auth.h
+++ b/pjsip/include/pjsip/sip_auth.h
@@ -43,8 +43,11 @@ PJ_BEGIN_DECL
  * @{
  */
 
-/** Length of digest string. */
-#define PJSIP_MD5STRLEN 32
+/** Length of digest MD5 string. */
+#define PJSIP_MD5STRLEN		32
+
+/** Length of digest SHA256 string. */
+#define PJSIP_SHA256STRLEN	64
 
 
 /** Type of data in the credential information in #pjsip_cred_info. */

--- a/pjsip/include/pjsip/sip_auth_parser.h
+++ b/pjsip/include/pjsip/sip_auth_parser.h
@@ -66,7 +66,7 @@ extern const pj_str_t	pjsip_USERNAME_STR, /**< "username" string const.   */
 			pjsip_PGP_STR,	    /**< "pgp" string const.	    */
 			pjsip_BEARER_STR,   /**< "bearer" string const.     */
 			pjsip_MD5_STR,	    /**< "md5" string const.	    */
-                        pjsip_SHA256_STR,   /**< "SHA-256" string const.    */
+			pjsip_SHA256_STR,   /**< "SHA-256" string const.    */
 			pjsip_AUTH_STR;	    /**< "auth" string const.	    */
 
 PJ_END_DECL

--- a/pjsip/include/pjsip/sip_auth_parser.h
+++ b/pjsip/include/pjsip/sip_auth_parser.h
@@ -66,7 +66,7 @@ extern const pj_str_t	pjsip_USERNAME_STR, /**< "username" string const.   */
 			pjsip_PGP_STR,	    /**< "pgp" string const.	    */
 			pjsip_BEARER_STR,   /**< "bearer" string const.     */
 			pjsip_MD5_STR,	    /**< "md5" string const.	    */
-            pjsip_SHA256_STR,	/**< "SHA-256" string const.	*/
+                        pjsip_SHA256_STR,   /**< "SHA-256" string const.    */
 			pjsip_AUTH_STR;	    /**< "auth" string const.	    */
 
 PJ_END_DECL

--- a/pjsip/include/pjsip/sip_auth_parser.h
+++ b/pjsip/include/pjsip/sip_auth_parser.h
@@ -66,6 +66,7 @@ extern const pj_str_t	pjsip_USERNAME_STR, /**< "username" string const.   */
 			pjsip_PGP_STR,	    /**< "pgp" string const.	    */
 			pjsip_BEARER_STR,   /**< "bearer" string const.     */
 			pjsip_MD5_STR,	    /**< "md5" string const.	    */
+            pjsip_SHA256_STR,	/**< "SHA-256" string const.	*/
 			pjsip_AUTH_STR;	    /**< "auth" string const.	    */
 
 PJ_END_DECL

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -288,7 +288,7 @@ PJ_DEF(void) pjsip_auth_create_digestSHA256(pj_str_t *result,
 	pj_assert(!"Invalid data_type");
     }
 
-    AUTH_TRACE_((THIS_FILE, " ha1=%.32s", ha1));
+    AUTH_TRACE_((THIS_FILE, " ha1=%.64s", ha1));
 
     /***
      *** ha2 = SHA256(method ":" req_uri)
@@ -300,7 +300,7 @@ PJ_DEF(void) pjsip_auth_create_digestSHA256(pj_str_t *result,
     SHA256_Final( digest, &pms);
     digestNtoStr(digest, 32, ha2);
 
-    AUTH_TRACE_((THIS_FILE, " ha2=%.32s", ha2));
+    AUTH_TRACE_((THIS_FILE, " ha2=%.64s", ha2));
 
     /***
      *** When qop is not used:
@@ -331,7 +331,7 @@ PJ_DEF(void) pjsip_auth_create_digestSHA256(pj_str_t *result,
     result->slen = PJSIP_SHA256STRLEN;
     digestNtoStr(digest, 32, result->ptr);
 
-    AUTH_TRACE_((THIS_FILE, " digest=%.32s", result->ptr));
+    AUTH_TRACE_((THIS_FILE, " digest=%.64s", result->ptr));
     AUTH_TRACE_((THIS_FILE, "Digest created"));
 
 #else

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -33,7 +33,9 @@
 #include <pj/assert.h>
 #include <pj/ctype.h>
 
-
+#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+#include <openssl/sha.h>
+#endif
 
 /* A macro just to get rid of type mismatch between char and unsigned char */
 #define MD5_APPEND(pms,buf,len)	pj_md5_update(pms, (const pj_uint8_t*)buf, \
@@ -125,12 +127,12 @@ PJ_DEF(void) pjsip_auth_clt_pref_dup( pj_pool_t *pool,
  *
  * NOTE: THE OUTPUT STRING IS NOT NULL TERMINATED!
  */
-static void digest2str(const unsigned char digest[], char *output)
+static void digestNtoStr(const unsigned char digest[], int n, char *output)
 {
     int i;
-    for (i = 0; i<16; ++i) {
-	pj_val_to_hex_digit(digest[i], output);
-	output += 2;
+    for (i = 0; i<n; ++i) {
+        pj_val_to_hex_digit(digest[i], output);
+        output += 2;
     }
 }
 
@@ -170,7 +172,7 @@ PJ_DEF(void) pjsip_auth_create_digest( pj_str_t *result,
 	MD5_APPEND( &pms, cred_info->data.ptr, cred_info->data.slen);
 	pj_md5_final(&pms, digest);
 
-	digest2str(digest, ha1);
+	digestNtoStr(digest, 16, ha1);
 
     } else if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_DIGEST) {
 	pj_assert(cred_info->data.slen == 32);
@@ -189,7 +191,7 @@ PJ_DEF(void) pjsip_auth_create_digest( pj_str_t *result,
     MD5_APPEND( &pms, ":", 1);
     MD5_APPEND( &pms, uri->ptr, uri->slen);
     pj_md5_final(&pms, digest);
-    digest2str(digest, ha2);
+    digestNtoStr(digest, 16, ha2);
 
     AUTH_TRACE_((THIS_FILE, "  ha2=%.32s", ha2));
 
@@ -220,11 +222,108 @@ PJ_DEF(void) pjsip_auth_create_digest( pj_str_t *result,
 
     /* Convert digest to string and store in chal->response. */
     result->slen = PJSIP_MD5STRLEN;
-    digest2str(digest, result->ptr);
+    digestNtoStr(digest, 16, result->ptr);
 
     AUTH_TRACE_((THIS_FILE, "  digest=%.32s", result->ptr));
     AUTH_TRACE_((THIS_FILE, "Digest created"));
 }
+
+#define PJSIP_SHA256STRLEN 64
+
+#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+
+/*
+ * Create response SHA-256 digest based on the parameters and store the
+ * digest ASCII in 'result'.
+ */
+PJ_DEF(void) pjsip_auth_create_digestSHA256( pj_str_t *result,
+    const pj_str_t *nonce,
+    const pj_str_t *nc,
+    const pj_str_t *cnonce,
+    const pj_str_t *qop,
+    const pj_str_t *uri,
+    const pj_str_t *realm,
+    const pjsip_cred_info *cred_info,
+    const pj_str_t *method)
+{
+    char ha1[PJSIP_SHA256STRLEN];
+    char ha2[PJSIP_SHA256STRLEN];
+    unsigned char digest[32];
+    SHA256_CTX  pms;
+
+    pj_assert(result->slen >= PJSIP_SHA256STRLEN);
+
+    AUTH_TRACE_((THIS_FILE, "Begin creating digest"));
+
+    if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_PLAIN_PASSWD) {
+        /***
+        *** ha1 = SHA256(username ":" realm ":" password)
+        ***/
+        SHA256_Init(&pms);
+        SHA256_Update( &pms, cred_info->username.ptr, cred_info->username.slen);
+        SHA256_Update( &pms, ":", 1);
+        SHA256_Update( &pms, realm->ptr, realm->slen);
+        SHA256_Update( &pms, ":", 1);
+        SHA256_Update( &pms, cred_info->data.ptr, cred_info->data.slen);
+        SHA256_Final(digest, &pms);
+
+        digestNtoStr(digest, 32, ha1);
+
+    } else if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_DIGEST) {
+        pj_assert(cred_info->data.slen == 32);
+        pj_memcpy( ha1, cred_info->data.ptr, cred_info->data.slen );
+    } else {
+        pj_assert(!"Invalid data_type");
+    }
+
+    AUTH_TRACE_((THIS_FILE, " ha1=%.32s", ha1));
+
+    /***
+    *** ha2 = SHA256(method ":" req_uri)
+    ***/
+    SHA256_Init(&pms);
+    SHA256_Update( &pms, method->ptr, method->slen);
+    SHA256_Update( &pms, ":", 1);
+    SHA256_Update( &pms, uri->ptr, uri->slen);
+    SHA256_Final( digest, &pms);
+    digestNtoStr(digest, 32, ha2);
+
+    AUTH_TRACE_((THIS_FILE, " ha2=%.32s", ha2));
+
+    /***
+    *** When qop is not used:
+    *** response = SHA256(ha1 ":" nonce ":" ha2)
+
+    *** When qop=auth is used:
+    *** response = SHA256(ha1 ":" nonce ":" nc ":" cnonce ":" qop ":" ha2)
+    ***/
+    SHA256_Init(&pms);
+    SHA256_Update( &pms, ha1, PJSIP_MD5STRLEN);
+    SHA256_Update( &pms, ":", 1);
+    SHA256_Update( &pms, nonce->ptr, nonce->slen);
+    if (qop && qop->slen != 0) {
+        SHA256_Update( &pms, ":", 1);
+        SHA256_Update( &pms, nc->ptr, nc->slen);
+        SHA256_Update( &pms, ":", 1);
+        SHA256_Update( &pms, cnonce->ptr, cnonce->slen);
+        SHA256_Update( &pms, ":", 1);
+        SHA256_Update( &pms, qop->ptr, qop->slen);
+    }
+    SHA256_Update( &pms, ":", 1);
+    SHA256_Update( &pms, ha2, PJSIP_MD5STRLEN);
+
+    /* This is the final response digest. */
+    SHA256_Final(digest, &pms);
+
+    /* Convert digest to string and store in chal->response. */
+    result->slen = PJSIP_SHA256STRLEN;
+    digestNtoStr(digest, 32, result->ptr);
+
+    AUTH_TRACE_((THIS_FILE, " digest=%.32s", result->ptr));
+    AUTH_TRACE_((THIS_FILE, "Digest created"));
+}
+#endif
+
 
 /*
  * Finds out if qop offer contains "auth" token.
@@ -279,15 +378,19 @@ static pj_status_t respond_digest( pj_pool_t *pool,
 
     /* Check algorithm is supported. We support MD5 and AKAv1-MD5. */
     if (chal->algorithm.slen==0 ||
-	(pj_stricmp(&chal->algorithm, &pjsip_MD5_STR)==0 ||
-	 pj_stricmp(&chal->algorithm, &pjsip_AKAv1_MD5_STR)==0))
-    {
-	;
+        (pj_stricmp(&chal->algorithm, &pjsip_MD5_STR)==0
+        || pj_stricmp(&chal->algorithm, &pjsip_AKAv1_MD5_STR)==0
+#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+        || pj_stricmp(&chal->algorithm, &pjsip_SHA256_STR)==0
+#endif
+       )) {
+        PJ_LOG(4,(THIS_FILE, "Digest algorithm is \"%.*s\"",
+          chal->algorithm.slen, chal->algorithm.ptr));
     }
     else {
-	PJ_LOG(4,(THIS_FILE, "Unsupported digest algorithm \"%.*s\"",
+    	PJ_LOG(4,(THIS_FILE, "Unsupported digest algorithm \"%.*s\"",
 		  chal->algorithm.slen, chal->algorithm.ptr));
-	return PJSIP_EINVALIDALGORITHM;
+	    return PJSIP_EINVALIDALGORITHM;
     }
 
     /* Build digest credential from arguments. */
@@ -299,8 +402,18 @@ static pj_status_t respond_digest( pj_pool_t *pool,
     pj_strdup(pool, &cred->opaque, &chal->opaque);
 
     /* Allocate memory. */
-    cred->response.ptr = (char*) pj_pool_alloc(pool, PJSIP_MD5STRLEN);
-    cred->response.slen = PJSIP_MD5STRLEN;
+#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+    if (pj_stricmp(&chal->algorithm, &pjsip_SHA256_STR)==0) {
+        cred->response.ptr = (char*) pj_pool_alloc(pool, PJSIP_SHA256STRLEN);
+        cred->response.slen = PJSIP_SHA256STRLEN;
+    }
+    else {
+#endif
+        cred->response.ptr = (char*) pj_pool_alloc(pool, PJSIP_MD5STRLEN);
+        cred->response.slen = PJSIP_MD5STRLEN;
+#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+    }
+#endif
 
     if (chal->qop.slen == 0) {
 	/* Server doesn't require quality of protection. */

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -33,8 +33,18 @@
 #include <pj/assert.h>
 #include <pj/ctype.h>
 
-#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
-#include <openssl/sha.h>
+
+#if PJ_HAS_SSL_SOCK && PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+#  if !defined(PJSIP_AUTH_HAS_DIGEST_SHA256)
+#    define PJSIP_AUTH_HAS_DIGEST_SHA256    1
+#  endif
+#else
+#  undef  PJSIP_AUTH_HAS_DIGEST_SHA256
+#  define PJSIP_AUTH_HAS_DIGEST_SHA256	    0
+#endif
+
+#if PJSIP_AUTH_HAS_DIGEST_SHA256
+#  include <openssl/sha.h>
 #endif
 
 /* A macro just to get rid of type mismatch between char and unsigned char */
@@ -228,59 +238,61 @@ PJ_DEF(void) pjsip_auth_create_digest( pj_str_t *result,
     AUTH_TRACE_((THIS_FILE, "Digest created"));
 }
 
-#define PJSIP_SHA256STRLEN 64
-
-#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
 
 /*
  * Create response SHA-256 digest based on the parameters and store the
  * digest ASCII in 'result'.
  */
-PJ_DEF(void) pjsip_auth_create_digestSHA256( pj_str_t *result,
-    const pj_str_t *nonce,
-    const pj_str_t *nc,
-    const pj_str_t *cnonce,
-    const pj_str_t *qop,
-    const pj_str_t *uri,
-    const pj_str_t *realm,
-    const pjsip_cred_info *cred_info,
-    const pj_str_t *method)
+PJ_DEF(void) pjsip_auth_create_digestSHA256(pj_str_t *result,
+					    const pj_str_t *nonce,
+					    const pj_str_t *nc,
+					    const pj_str_t *cnonce,
+					    const pj_str_t *qop,
+					    const pj_str_t *uri,
+					    const pj_str_t *realm,
+					    const pjsip_cred_info *cred_info,
+					    const pj_str_t *method)
 {
+#if PJSIP_AUTH_HAS_DIGEST_SHA256
+
     char ha1[PJSIP_SHA256STRLEN];
     char ha2[PJSIP_SHA256STRLEN];
     unsigned char digest[32];
-    SHA256_CTX  pms;
+    SHA256_CTX pms;
 
     pj_assert(result->slen >= PJSIP_SHA256STRLEN);
 
     AUTH_TRACE_((THIS_FILE, "Begin creating digest"));
 
-    if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_PLAIN_PASSWD) {
-        /***
-        *** ha1 = SHA256(username ":" realm ":" password)
-        ***/
-        SHA256_Init(&pms);
-        SHA256_Update( &pms, cred_info->username.ptr, cred_info->username.slen);
-        SHA256_Update( &pms, ":", 1);
-        SHA256_Update( &pms, realm->ptr, realm->slen);
-        SHA256_Update( &pms, ":", 1);
-        SHA256_Update( &pms, cred_info->data.ptr, cred_info->data.slen);
-        SHA256_Final(digest, &pms);
+    if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_PLAIN_PASSWD)
+    {
+	/***
+	 *** ha1 = SHA256(username ":" realm ":" password)
+	 ***/
+	SHA256_Init(&pms);
+	SHA256_Update( &pms, cred_info->username.ptr,
+		       cred_info->username.slen);
+	SHA256_Update( &pms, ":", 1);
+	SHA256_Update( &pms, realm->ptr, realm->slen);
+	SHA256_Update( &pms, ":", 1);
+	SHA256_Update( &pms, cred_info->data.ptr, cred_info->data.slen);
+	SHA256_Final(digest, &pms);
 
-        digestNtoStr(digest, 32, ha1);
+	digestNtoStr(digest, 32, ha1);
 
-    } else if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_DIGEST) {
-        pj_assert(cred_info->data.slen == 32);
-        pj_memcpy( ha1, cred_info->data.ptr, cred_info->data.slen );
+    } else if ((cred_info->data_type & PASSWD_MASK) == PJSIP_CRED_DATA_DIGEST)
+    {
+	pj_assert(cred_info->data.slen == 32);
+	pj_memcpy( ha1, cred_info->data.ptr, cred_info->data.slen );
     } else {
-        pj_assert(!"Invalid data_type");
+	pj_assert(!"Invalid data_type");
     }
 
     AUTH_TRACE_((THIS_FILE, " ha1=%.32s", ha1));
 
     /***
-    *** ha2 = SHA256(method ":" req_uri)
-    ***/
+     *** ha2 = SHA256(method ":" req_uri)
+     ***/
     SHA256_Init(&pms);
     SHA256_Update( &pms, method->ptr, method->slen);
     SHA256_Update( &pms, ":", 1);
@@ -291,26 +303,26 @@ PJ_DEF(void) pjsip_auth_create_digestSHA256( pj_str_t *result,
     AUTH_TRACE_((THIS_FILE, " ha2=%.32s", ha2));
 
     /***
-    *** When qop is not used:
-    *** response = SHA256(ha1 ":" nonce ":" ha2)
-
-    *** When qop=auth is used:
-    *** response = SHA256(ha1 ":" nonce ":" nc ":" cnonce ":" qop ":" ha2)
-    ***/
+     *** When qop is not used:
+     ***   response = SHA256(ha1 ":" nonce ":" ha2)
+     ***
+     *** When qop=auth is used:
+     ***   response = SHA256(ha1 ":" nonce ":" nc ":" cnonce ":" qop ":" ha2)
+     ***/
     SHA256_Init(&pms);
-    SHA256_Update( &pms, ha1, PJSIP_MD5STRLEN);
+    SHA256_Update( &pms, ha1, PJSIP_SHA256STRLEN);
     SHA256_Update( &pms, ":", 1);
     SHA256_Update( &pms, nonce->ptr, nonce->slen);
     if (qop && qop->slen != 0) {
-        SHA256_Update( &pms, ":", 1);
-        SHA256_Update( &pms, nc->ptr, nc->slen);
-        SHA256_Update( &pms, ":", 1);
-        SHA256_Update( &pms, cnonce->ptr, cnonce->slen);
-        SHA256_Update( &pms, ":", 1);
-        SHA256_Update( &pms, qop->ptr, qop->slen);
+	SHA256_Update( &pms, ":", 1);
+	SHA256_Update( &pms, nc->ptr, nc->slen);
+	SHA256_Update( &pms, ":", 1);
+	SHA256_Update( &pms, cnonce->ptr, cnonce->slen);
+	SHA256_Update( &pms, ":", 1);
+	SHA256_Update( &pms, qop->ptr, qop->slen);
     }
     SHA256_Update( &pms, ":", 1);
-    SHA256_Update( &pms, ha2, PJSIP_MD5STRLEN);
+    SHA256_Update( &pms, ha2, PJSIP_SHA256STRLEN);
 
     /* This is the final response digest. */
     SHA256_Final(digest, &pms);
@@ -321,8 +333,19 @@ PJ_DEF(void) pjsip_auth_create_digestSHA256( pj_str_t *result,
 
     AUTH_TRACE_((THIS_FILE, " digest=%.32s", result->ptr));
     AUTH_TRACE_((THIS_FILE, "Digest created"));
-}
+
+#else
+    PJ_UNUSED_ARG(result)
+    PJ_UNUSED_ARG(nonce)
+    PJ_UNUSED_ARG(nc)
+    PJ_UNUSED_ARG(cnonce)
+    PJ_UNUSED_ARG(qop)
+    PJ_UNUSED_ARG(uri)
+    PJ_UNUSED_ARG(realm)
+    PJ_UNUSED_ARG(cred_info)
+    PJ_UNUSED_ARG(method)
 #endif
+}
 
 
 /*
@@ -375,22 +398,26 @@ static pj_status_t respond_digest( pj_pool_t *pool,
 				   const pj_str_t *method)
 {
     const pj_str_t pjsip_AKAv1_MD5_STR = { "AKAv1-MD5", 9 };
+    pj_bool_t algo_sha256 = PJ_FALSE;
 
-    /* Check algorithm is supported. We support MD5 and AKAv1-MD5. */
-    if (chal->algorithm.slen==0 ||
-        (pj_stricmp(&chal->algorithm, &pjsip_MD5_STR)==0
-        || pj_stricmp(&chal->algorithm, &pjsip_AKAv1_MD5_STR)==0
-#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
-        || pj_stricmp(&chal->algorithm, &pjsip_SHA256_STR)==0
+    /* Check if algo is sha256 */
+#if PJSIP_AUTH_HAS_DIGEST_SHA256
+    algo_sha256 = (pj_stricmp(&chal->algorithm, &pjsip_SHA256_STR)==0);
 #endif
-       )) {
-        PJ_LOG(4,(THIS_FILE, "Digest algorithm is \"%.*s\"",
-          chal->algorithm.slen, chal->algorithm.ptr));
+
+    /* Check algorithm is supported. We support MD5, AKAv1-MD5, and SHA256. */
+    if (chal->algorithm.slen==0 ||
+        (algo_sha256 ||
+	 pj_stricmp(&chal->algorithm, &pjsip_MD5_STR)==0 ||
+         pj_stricmp(&chal->algorithm, &pjsip_AKAv1_MD5_STR)==0))
+    {
+	PJ_LOG(4,(THIS_FILE, "Digest algorithm is \"%.*s\"",
+		  chal->algorithm.slen, chal->algorithm.ptr));
     }
     else {
-    	PJ_LOG(4,(THIS_FILE, "Unsupported digest algorithm \"%.*s\"",
+	PJ_LOG(4,(THIS_FILE, "Unsupported digest algorithm \"%.*s\"",
 		  chal->algorithm.slen, chal->algorithm.ptr));
-	    return PJSIP_EINVALIDALGORITHM;
+	return PJSIP_EINVALIDALGORITHM;
     }
 
     /* Build digest credential from arguments. */
@@ -402,18 +429,8 @@ static pj_status_t respond_digest( pj_pool_t *pool,
     pj_strdup(pool, &cred->opaque, &chal->opaque);
 
     /* Allocate memory. */
-#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
-    if (pj_stricmp(&chal->algorithm, &pjsip_SHA256_STR)==0) {
-        cred->response.ptr = (char*) pj_pool_alloc(pool, PJSIP_SHA256STRLEN);
-        cred->response.slen = PJSIP_SHA256STRLEN;
-    }
-    else {
-#endif
-        cred->response.ptr = (char*) pj_pool_alloc(pool, PJSIP_MD5STRLEN);
-        cred->response.slen = PJSIP_MD5STRLEN;
-#if PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
-    }
-#endif
+    cred->response.slen = algo_sha256? PJSIP_SHA256STRLEN : PJSIP_MD5STRLEN;
+    cred->response.ptr = (char*) pj_pool_alloc(pool, cred->response.slen);
 
     if (chal->qop.slen == 0) {
 	/* Server doesn't require quality of protection. */
@@ -425,9 +442,16 @@ static pj_status_t respond_digest( pj_pool_t *pool,
 	}
 	else {
 	    /* Convert digest to string and store in chal->response. */
-	    pjsip_auth_create_digest( &cred->response, &cred->nonce, NULL,
-				      NULL,  NULL, uri, &chal->realm,
-				      cred_info, method);
+	    if (algo_sha256) {
+		pjsip_auth_create_digestSHA256(
+					  &cred->response, &cred->nonce, NULL,
+					  NULL,  NULL, uri, &chal->realm,
+					  cred_info, method);
+	    } else {
+		pjsip_auth_create_digest( &cred->response, &cred->nonce, NULL,
+					  NULL,  NULL, uri, &chal->realm,
+					  cred_info, method);
+	    }
 	}
 
     } else if (has_auth_qop(pool, &chal->qop)) {
@@ -451,9 +475,21 @@ static pj_status_t respond_digest( pj_pool_t *pool,
 					    method, cred);
 	}
 	else {
-	    pjsip_auth_create_digest( &cred->response, &cred->nonce,
-				      &cred->nc, &cred->cnonce, &pjsip_AUTH_STR,
-				      uri, &chal->realm, cred_info, method );
+	    /* Convert digest to string and store in chal->response. */
+	    if (algo_sha256) {
+		pjsip_auth_create_digestSHA256(
+					  &cred->response, &cred->nonce,
+					  &cred->nc, &cred->cnonce,
+					  &pjsip_AUTH_STR, uri,
+					  &chal->realm, cred_info,
+					  method);
+	    } else {
+		pjsip_auth_create_digest( &cred->response, &cred->nonce,
+					  &cred->nc, &cred->cnonce,
+					  &pjsip_AUTH_STR, uri,
+					  &chal->realm, cred_info,
+					  method);
+	    }
 	}
 
     } else {

--- a/pjsip/src/pjsip/sip_auth_parser.c
+++ b/pjsip/src/pjsip/sip_auth_parser.c
@@ -62,6 +62,8 @@ const pj_str_t	pjsip_USERNAME_STR =	    { "username", 8 },
 		pjsip_BEARER_STR =          { "Bearer", 6 },
 		pjsip_MD5_STR =		    { "md5", 3 },
 		pjsip_QUOTED_MD5_STR =	    { "\"md5\"", 5},
+		pjsip_SHA256_STR =		    { "SHA-256", 7 },
+		pjsip_QUOTED_SHA256_STR =	    { "\"SHA-256\"", 9},
 		pjsip_AUTH_STR =	    { "auth", 4},
 		pjsip_QUOTED_AUTH_STR =	    { "\"auth\"", 6 };
 

--- a/pjsip/src/pjsip/sip_auth_parser.c
+++ b/pjsip/src/pjsip/sip_auth_parser.c
@@ -62,8 +62,8 @@ const pj_str_t	pjsip_USERNAME_STR =	    { "username", 8 },
 		pjsip_BEARER_STR =          { "Bearer", 6 },
 		pjsip_MD5_STR =		    { "md5", 3 },
 		pjsip_QUOTED_MD5_STR =	    { "\"md5\"", 5},
-		pjsip_SHA256_STR =		    { "SHA-256", 7 },
-		pjsip_QUOTED_SHA256_STR =	    { "\"SHA-256\"", 9},
+		pjsip_SHA256_STR =	    { "SHA-256", 7 },
+		pjsip_QUOTED_SHA256_STR =   { "\"SHA-256\"", 9},
 		pjsip_AUTH_STR =	    { "auth", 4},
 		pjsip_QUOTED_AUTH_STR =	    { "\"auth\"", 6 };
 


### PR DESCRIPTION
Support for SHA-256 diggest algorythm. 
It requires OpenSSL.
See https://github.com/pjsip/pjproject/issues/2734
