### PR TITLE
Added pj_turn_sock_connect for TURN TCP Allocations

### DIFF
--- a/pjnath/include/pjnath/stun_msg.h
+++ b/pjnath/include/pjnath/stun_msg.h
@@ -311,7 +311,7 @@ typedef enum pj_stun_msg_type
     /**
      * STUN/TURN Connect Request
      */
-    PJ_STUN_CONNECT_REQUEST             = 0x000a,
+    PJ_STUN_CONNECT_REQUEST                 = 0x000a,
 
     /**
      * STUN/TURN ConnectBind Request

--- a/pjnath/include/pjnath/stun_msg.h
+++ b/pjnath/include/pjnath/stun_msg.h
@@ -308,6 +308,10 @@ typedef enum pj_stun_msg_type
      */
     PJ_STUN_CHANNEL_BIND_ERROR_RESPONSE	    = 0x0119,
 
+    /**
+     * STUN/TURN Connect Request
+     */
+    PJ_STUN_CONNECT_REQUEST             = 0x000a,
 
     /**
      * STUN/TURN ConnectBind Request

--- a/pjnath/include/pjnath/turn_session.h
+++ b/pjnath/include/pjnath/turn_session.h
@@ -1,4 +1,4 @@
-
+/* $Id$ */
 /* 
  * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
  * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>

--- a/pjnath/include/pjnath/turn_session.h
+++ b/pjnath/include/pjnath/turn_session.h
@@ -1,4 +1,4 @@
-/* $Id$ */
+
 /* 
  * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
  * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>
@@ -362,7 +362,7 @@ typedef struct pj_turn_session_cb
 				      unsigned addr_len);
 
     /**
-     * Notification for Connection request sent using
+     * Notification for Connect request sent using
      * pj_turn_session_connect().
      *
      * @param sess	The TURN session.
@@ -371,11 +371,11 @@ typedef struct pj_turn_session_cb
      * @param peer_addr	Peer address.
      * @param addr_len	Length of the peer address.
      */
-    void (*on_connect)(pj_turn_session *sess,
-                pj_status_t status,
-                pj_uint32_t conn_id,
-                const pj_sockaddr_t *peer_addr,
-                unsigned addr_len);
+    void (*on_connect_complete)(pj_turn_session *sess,
+		       pj_status_t status,
+		       pj_uint32_t conn_id,
+		       const pj_sockaddr_t *peer_addr,
+		       unsigned addr_len);
 
 } pj_turn_session_cb;
 
@@ -914,7 +914,16 @@ PJ_DECL(pj_status_t) pj_turn_session_connection_bind(
 					    const pj_sockaddr_t *peer_addr,
 					    unsigned addr_len);
 /**
- * Send Connect request.
+ * Initiate connection to the specified peer using Connect request.
+ * Application must call this function when it uses RFC 6062 (TURN TCP
+ * allocations) to initiate a data connection to a peer. When Connect response
+ * received, on_connect_complete will be called, application must implement
+ * this callback and initiate a new data connection to the specified peer.
+ *
+ * According to RFC 6062, a control connection must be a TCP connection,
+ * and application must send TCP Allocate request
+ * (with pj_turn_session_alloc()，set TURN allocation parameter peer_conn_type
+ * to PJ_TURN_TP_TCP) before calling this function.
  *
  * @param sess		The TURN client session.
  * @param peer_addr	Peer address.

--- a/pjnath/include/pjnath/turn_session.h
+++ b/pjnath/include/pjnath/turn_session.h
@@ -361,6 +361,22 @@ typedef struct pj_turn_session_cb
 				      const pj_sockaddr_t *peer_addr,
 				      unsigned addr_len);
 
+    /**
+     * Notification for Connection request sent using
+     * pj_turn_session_connect().
+     *
+     * @param sess	The TURN session.
+     * @param status	The status code.
+     * @param conn_id	The connection ID.
+     * @param peer_addr	Peer address.
+     * @param addr_len	Length of the peer address.
+     */
+    void (*on_connect)(pj_turn_session *sess,
+                pj_status_t status,
+                pj_uint32_t conn_id,
+                const pj_sockaddr_t *peer_addr,
+                unsigned addr_len);
+
 } pj_turn_session_cb;
 
 
@@ -897,6 +913,20 @@ PJ_DECL(pj_status_t) pj_turn_session_connection_bind(
 					    pj_uint32_t conn_id,
 					    const pj_sockaddr_t *peer_addr,
 					    unsigned addr_len);
+/**
+ * Send Connect request.
+ *
+ * @param sess		The TURN client session.
+ * @param peer_addr	Peer address.
+ * @param addr_len	Length of the peer address.
+ *
+ * @return		PJ_SUCCESS if the operation has been successfully
+ *			issued, or the appropriate error code. Note that
+ *			the operation itself will complete asynchronously.
+ */
+PJ_DECL(pj_status_t) pj_turn_session_connect(pj_turn_session *sess,
+                        const pj_sockaddr_t *peer_addr,
+                        unsigned addr_len);
 
 /**
  * @}

--- a/pjnath/include/pjnath/turn_sock.h
+++ b/pjnath/include/pjnath/turn_sock.h
@@ -623,7 +623,16 @@ PJ_DECL(pj_status_t) pj_turn_sock_bind_channel(pj_turn_sock *turn_sock,
 					       const pj_sockaddr_t *peer,
 					       unsigned addr_len);
 /**
- * Send Connect request for the specified a peer address.
+ * Initiate connection to the specified peer using Connect request.
+ * Application must call this function when it uses RFC 6062 (TURN TCP
+ * allocations) to initiate a data connection to a peer. The connection status
+ * will be notified via on_connection_status callback.
+ *
+ * According to RFC 6062, the TURN transport instance must be created with
+ * connection type are set to PJ_TURN_TP_TCP, application must send TCP
+ * Allocate request (with pj_turn_session_alloc()，set TURN allocation
+ * parameter peer_conn_type to PJ_TURN_TP_TCP) before calling this function.
+ *
  *
  * @param turn_sock	The TURN transport instance.
  * @param peer		The remote peer address.
@@ -632,9 +641,24 @@ PJ_DECL(pj_status_t) pj_turn_sock_bind_channel(pj_turn_sock *turn_sock,
  * @return		PJ_SUCCESS if the operation has been successful,
  *			or the appropriate error code on failure.
  */
-PJ_DECL(pj_status_t) pj_turn_sock_connect( pj_turn_sock *turn_sock,
-                        const pj_sockaddr_t *peer,
-                        unsigned addr_len);
+PJ_DECL(pj_status_t) pj_turn_sock_connect(pj_turn_sock *turn_sock,
+					  const pj_sockaddr_t *peer,
+					  unsigned addr_len);
+/**
+ * Close previous TCP data connection for the specified peer.
+ * According to RFC 6062, when the client wishes to terminate its relayed
+ * connection to the peer, it closes the data connection to the server.
+ *
+ * @param turn_sock	The TURN transport instance.
+ * @param peer		The remote peer address.
+ * @param addr_len	Length of the address.
+ *
+ * @return		PJ_SUCCESS if the operation has been successful,
+ *			or the appropriate error code on failure.
+ */
+PJ_DECL(pj_bool_t) pj_turn_sock_disconnect(pj_turn_sock *turn_sock,
+					   const pj_sockaddr_t *peer,
+					   unsigned addr_len);
 
 
 /**

--- a/pjnath/include/pjnath/turn_sock.h
+++ b/pjnath/include/pjnath/turn_sock.h
@@ -622,6 +622,19 @@ PJ_DECL(pj_status_t) pj_turn_sock_sendto(pj_turn_sock *turn_sock,
 PJ_DECL(pj_status_t) pj_turn_sock_bind_channel(pj_turn_sock *turn_sock,
 					       const pj_sockaddr_t *peer,
 					       unsigned addr_len);
+/**
+ * Send Connect request for the specified a peer address.
+ *
+ * @param turn_sock	The TURN transport instance.
+ * @param peer		The remote peer address.
+ * @param addr_len	Length of the address.
+ *
+ * @return		PJ_SUCCESS if the operation has been successful,
+ *			or the appropriate error code on failure.
+ */
+PJ_DECL(pj_status_t) pj_turn_sock_connect( pj_turn_sock *turn_sock,
+                        const pj_sockaddr_t *peer,
+                        unsigned addr_len);
 
 
 /**

--- a/pjnath/include/pjnath/turn_sock.h
+++ b/pjnath/include/pjnath/turn_sock.h
@@ -656,7 +656,7 @@ PJ_DECL(pj_status_t) pj_turn_sock_connect(pj_turn_sock *turn_sock,
  * @return		PJ_SUCCESS if the operation has been successful,
  *			or the appropriate error code on failure.
  */
-PJ_DECL(pj_bool_t) pj_turn_sock_disconnect(pj_turn_sock *turn_sock,
+PJ_DECL(pj_status_t) pj_turn_sock_disconnect(pj_turn_sock *turn_sock,
 					   const pj_sockaddr_t *peer,
 					   unsigned addr_len);
 

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -1800,7 +1800,7 @@ static void stun_on_request_complete(pj_stun_session *stun,
     } else if (method == PJ_STUN_CONNECT_METHOD) {
 	/* Handle Connct response */
 	struct pj_sockaddr_t *peer_addr = (struct pj_sockaddr_t*)token;
-	pj_uint32_t conn_id;
+	pj_uint32_t conn_id = 0;
 
 	if (status != PJ_SUCCESS ||
 	    !PJ_STUN_IS_SUCCESS_RESPONSE(response->hdr.type))
@@ -1826,7 +1826,6 @@ static void stun_on_request_complete(pj_stun_session *stun,
 	    pj_stun_msg_find_attr(response, PJ_STUN_ATTR_CONNECTION_ID, 0);
 	    if (conn_id_attr == NULL) {
 		status = PJNATH_EINSTUNMSG;
-		conn_id = 0;
 		pj_perror(1, sess->obj_name, status,
 			  "Error: Missing CONNECTION-ID attribute");
 	    }

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -1210,8 +1210,8 @@ on_return:
  * Send Connect request.
  */
 PJ_DEF(pj_status_t) pj_turn_session_connect(pj_turn_session *sess,
-                        const pj_sockaddr_t *peer_addr,
-                        unsigned addr_len)
+					    const pj_sockaddr_t *peer_addr,
+					    unsigned addr_len)
 {
     pj_stun_tx_data *tdata;
     pj_status_t status;
@@ -1223,23 +1223,18 @@ PJ_DEF(pj_status_t) pj_turn_session_connect(pj_turn_session *sess,
 
     /* Create blank Connect request */
     status = pj_stun_session_create_req(sess->stun, PJ_STUN_CONNECT_REQUEST,
-                PJ_STUN_MAGIC, NULL, &tdata);
+    					PJ_STUN_MAGIC, NULL, &tdata);
     if (status != PJ_SUCCESS)
 	goto on_return;
 
-
-    pj_sockaddr_t *peer_addr2 = PJ_POOL_ZALLOC_T(tdata->pool, pj_sockaddr);
-    pj_sockaddr_cp(peer_addr2, peer_addr);
-
     status = pj_stun_msg_add_sockaddr_attr(tdata->pool, tdata->msg,
-                       PJ_STUN_ATTR_XOR_PEER_ADDR,
-                       PJ_TRUE, peer_addr, addr_len);
+					   PJ_STUN_ATTR_XOR_PEER_ADDR,
+					   PJ_TRUE, peer_addr, addr_len);
     if (status != PJ_SUCCESS) goto on_return;
-
-    status = pj_stun_session_send_msg(sess->stun, peer_addr2, PJ_FALSE, PJ_FALSE,
-                      sess->srv_addr,
-                      pj_sockaddr_get_len(sess->srv_addr),
-                      tdata);
+    status = pj_stun_session_send_msg(sess->stun, (void *)peer_addr, PJ_FALSE,
+				      PJ_FALSE, sess->srv_addr,
+				      pj_sockaddr_get_len(sess->srv_addr),
+				      tdata);
 
 on_return:
     pj_grp_lock_release(sess->grp_lock);
@@ -1801,39 +1796,51 @@ static void stun_on_request_complete(pj_stun_session *stun,
 	    (*sess->cb.on_connection_bind_status)
 			(sess, status, conn_bind->id,
 			&conn_bind->peer_addr, conn_bind->peer_addr_len);
-    }
-	} else if (method == PJ_STUN_CONNECT_METHOD) {
-    /* Handle Connct response */
-        struct pj_sockaddr_t *peer_addr = (struct pj_sockaddr_t*)token;
-        pj_uint32_t conn_id = 0;
-        if (status != PJ_SUCCESS ||
-            !PJ_STUN_IS_SUCCESS_RESPONSE(response->hdr.type)) 
-        {
-            pj_str_t reason = {0};
-            if (status == PJ_SUCCESS) {
-            const pj_stun_errcode_attr *err_attr;
-            err_attr = (const pj_stun_errcode_attr*)
-                   pj_stun_msg_find_attr(response,
-                             PJ_STUN_ATTR_ERROR_CODE, 0);
-            if (err_attr) {
-                status = PJ_STATUS_FROM_STUN_CODE(err_attr->err_code);
-                reason = err_attr->reason;
-            } else {
-                status = PJNATH_EINSTUNMSG;
-            }
-            }
-            pj_perror(1, sess->obj_name, status, "Connect failed: %.*s",
-                  (int)reason.slen, reason.ptr);
-        }
+	}
+    } else if (method == PJ_STUN_CONNECT_METHOD) {
+	/* Handle Connct response */
+	struct pj_sockaddr_t *peer_addr = (struct pj_sockaddr_t*)token;
+	pj_uint32_t conn_id;
 
-        pj_stun_uint_attr *connection_id_attr = (pj_stun_uint_attr*) pj_stun_msg_find_attr(response, PJ_STUN_ATTR_CONNECTION_ID, 0);
-        if (connection_id_attr) conn_id = connection_id_attr->value;
+	if (status != PJ_SUCCESS ||
+	    !PJ_STUN_IS_SUCCESS_RESPONSE(response->hdr.type))
+	{
+	    pj_str_t reason = {0};
+	    if (status == PJ_SUCCESS) {
+		const pj_stun_errcode_attr *err_attr;
+		err_attr = (const pj_stun_errcode_attr*)
+			   pj_stun_msg_find_attr(response,
+						 PJ_STUN_ATTR_ERROR_CODE, 0);
+		if (err_attr) {
+		    status = PJ_STATUS_FROM_STUN_CODE(err_attr->err_code);
+		    reason = err_attr->reason;
+		} else {
+		    status = PJNATH_EINSTUNMSG;
+		}
+	    }
+	    pj_perror(1, sess->obj_name, status, "Connect failed: %.*s",
+		      (int)reason.slen, reason.ptr);
+	} else {
+	    const pj_stun_uint_attr *conn_id_attr;
+	    conn_id_attr = (const pj_stun_uint_attr*)
+	    pj_stun_msg_find_attr(response, PJ_STUN_ATTR_CONNECTION_ID, 0);
+	    if (conn_id_attr == NULL) {
+		status = PJNATH_EINSTUNMSG;
+		conn_id = 0;
+		pj_perror(1, sess->obj_name, status,
+			  "Error: Missing CONNECTION-ID attribute");
+	    }
+	    else {
+		conn_id = conn_id_attr->value;
+	    }
+	}
 
-        if (sess->cb.on_connect) {
-            (*sess->cb.on_connect)
-                (sess, status, conn_id,
-                peer_addr, pj_sockaddr_get_len(peer_addr));
-        }
+	/* Notify app */
+	if (sess->cb.on_connect_complete) {
+	    (*sess->cb.on_connect_complete)
+			(sess, status, conn_id,
+			peer_addr, pj_sockaddr_get_len(peer_addr));
+	}
     } else {
 	PJ_LOG(4,(sess->obj_name, "Unexpected STUN %s response",
 		  pj_stun_get_method_name(response->hdr.type)));

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -1206,6 +1206,46 @@ on_return:
     return status;
 }
 
+/**
+ * Send Connect request.
+ */
+PJ_DEF(pj_status_t) pj_turn_session_connect(pj_turn_session *sess,
+                        const pj_sockaddr_t *peer_addr,
+                        unsigned addr_len)
+{
+    pj_stun_tx_data *tdata;
+    pj_status_t status;
+
+    PJ_ASSERT_RETURN(sess && peer_addr && addr_len, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sess->state == PJ_TURN_STATE_READY, PJ_EINVALIDOP);
+
+    pj_grp_lock_acquire(sess->grp_lock);
+
+    /* Create blank Connect request */
+    status = pj_stun_session_create_req(sess->stun, PJ_STUN_CONNECT_REQUEST,
+                PJ_STUN_MAGIC, NULL, &tdata);
+    if (status != PJ_SUCCESS)
+	goto on_return;
+
+
+    pj_sockaddr_t *peer_addr2 = PJ_POOL_ZALLOC_T(tdata->pool, pj_sockaddr);
+    pj_sockaddr_cp(peer_addr2, peer_addr);
+
+    status = pj_stun_msg_add_sockaddr_attr(tdata->pool, tdata->msg,
+                       PJ_STUN_ATTR_XOR_PEER_ADDR,
+                       PJ_TRUE, peer_addr, addr_len);
+    if (status != PJ_SUCCESS) goto on_return;
+
+    status = pj_stun_session_send_msg(sess->stun, peer_addr2, PJ_FALSE, PJ_FALSE,
+                      sess->srv_addr,
+                      pj_sockaddr_get_len(sess->srv_addr),
+                      tdata);
+
+on_return:
+    pj_grp_lock_release(sess->grp_lock);
+    return status;
+}
+
 PJ_DEF(pj_status_t) pj_turn_session_on_rx_pkt(pj_turn_session *sess,
 					      void *pkt,
 					      pj_size_t pkt_len,
@@ -1761,7 +1801,39 @@ static void stun_on_request_complete(pj_stun_session *stun,
 	    (*sess->cb.on_connection_bind_status)
 			(sess, status, conn_bind->id,
 			&conn_bind->peer_addr, conn_bind->peer_addr_len);
-	}
+    }
+	} else if (method == PJ_STUN_CONNECT_METHOD) {
+    /* Handle Connct response */
+        struct pj_sockaddr_t *peer_addr = (struct pj_sockaddr_t*)token;
+        pj_uint32_t conn_id = 0;
+        if (status != PJ_SUCCESS ||
+            !PJ_STUN_IS_SUCCESS_RESPONSE(response->hdr.type)) 
+        {
+            pj_str_t reason = {0};
+            if (status == PJ_SUCCESS) {
+            const pj_stun_errcode_attr *err_attr;
+            err_attr = (const pj_stun_errcode_attr*)
+                   pj_stun_msg_find_attr(response,
+                             PJ_STUN_ATTR_ERROR_CODE, 0);
+            if (err_attr) {
+                status = PJ_STATUS_FROM_STUN_CODE(err_attr->err_code);
+                reason = err_attr->reason;
+            } else {
+                status = PJNATH_EINSTUNMSG;
+            }
+            }
+            pj_perror(1, sess->obj_name, status, "Connect failed: %.*s",
+                  (int)reason.slen, reason.ptr);
+        }
+
+        pj_stun_uint_attr *connection_id_attr = (pj_stun_uint_attr*) pj_stun_msg_find_attr(response, PJ_STUN_ATTR_CONNECTION_ID, 0);
+        if (connection_id_attr) conn_id = connection_id_attr->value;
+
+        if (sess->cb.on_connect) {
+            (*sess->cb.on_connect)
+                (sess, status, conn_id,
+                peer_addr, pj_sockaddr_get_len(peer_addr));
+        }
     } else {
 	PJ_LOG(4,(sess->obj_name, "Unexpected STUN %s response",
 		  pj_stun_get_method_name(response->hdr.type)));

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -137,6 +137,11 @@ static void turn_on_connection_bind_status(pj_turn_session *sess,
 					   pj_uint32_t conn_id,
 					   const pj_sockaddr_t *peer_addr,
 					   unsigned addr_len);
+static void turn_on_connect(pj_turn_session *sess,
+                    pj_status_t status,
+                    pj_uint32_t conn_id,
+                    const pj_sockaddr_t *peer_addr,
+                    unsigned addr_len);
 
 static pj_bool_t on_data_read(pj_turn_sock *turn_sock,
 			      void *data,
@@ -348,6 +353,7 @@ PJ_DEF(pj_status_t) pj_turn_sock_create(pj_stun_config *cfg,
     sess_cb.on_channel_bound = &turn_on_channel_bound;
     sess_cb.on_rx_data = &turn_on_rx_data;
     sess_cb.on_state = &turn_on_state;
+    sess_cb.on_connect = &turn_on_connect;
     sess_cb.on_connection_attempt = &turn_on_connection_attempt;
     sess_cb.on_connection_bind_status = &turn_on_connection_bind_status;
     status = pj_turn_session_create(cfg, pool->obj_name, af, conn_type,
@@ -664,6 +670,19 @@ PJ_DEF(pj_status_t) pj_turn_sock_bind_channel( pj_turn_sock *turn_sock,
     PJ_ASSERT_RETURN(turn_sock->sess != NULL, PJ_EINVALIDOP);
 
     return pj_turn_session_bind_channel(turn_sock->sess, peer, addr_len);
+}
+
+/**
+ * Send Connect request for the specified a peer address.
+ */
+PJ_DEF(pj_status_t) pj_turn_sock_connect( pj_turn_sock *turn_sock,
+                        const pj_sockaddr_t *peer,
+                        unsigned addr_len)
+{
+    PJ_ASSERT_RETURN(turn_sock && peer && addr_len, PJ_EINVAL);
+    PJ_ASSERT_RETURN(turn_sock->sess != NULL, PJ_EINVALIDOP);
+
+    return pj_turn_session_connect(turn_sock->sess, peer, addr_len);
 }
 
 
@@ -1553,7 +1572,7 @@ static void turn_on_connection_attempt(pj_turn_session *sess,
 		      return);
 
     PJ_LOG(5,(turn_sock->pool->obj_name, "Connection attempt from peer %s",
-	      pj_sockaddr_print(&peer_addr, addrtxt, sizeof(addrtxt), 3)));
+	      pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3)));
 
     if (turn_sock == NULL) {
 	/* We've been destroyed */
@@ -1765,4 +1784,197 @@ static void turn_on_connection_bind_status(pj_turn_session *sess,
 	(*turn_sock->cb.on_connection_status)(turn_sock, status, conn_id,
 					      peer_addr, addr_len);
     }
+}
+
+static void turn_on_connect(pj_turn_session *sess,
+                    pj_status_t status,
+                    pj_uint32_t conn_id,
+                    const pj_sockaddr_t *peer_addr,
+                    unsigned addr_len)
+{
+    pj_turn_sock *turn_sock = (pj_turn_sock*) 
+			      pj_turn_session_get_user_data(sess);
+    pj_pool_t *pool;
+    tcp_data_conn_t *new_conn;
+    pj_turn_session_info info;
+    pj_sock_t sock = PJ_INVALID_SOCKET;
+    pj_activesock_cfg asock_cfg;
+    pj_activesock_cb asock_cb;
+    pj_sockaddr bound_addr, *cfg_bind_addr;
+    pj_uint16_t max_bind_retry;
+    char addrtxt[PJ_INET6_ADDRSTRLEN+8];
+    unsigned i;
+
+    PJ_ASSERT_ON_FAIL(turn_sock->conn_type == PJ_TURN_TP_TCP &&
+		      turn_sock->alloc_param.peer_conn_type == PJ_TURN_TP_TCP,
+		      return);
+    PJ_LOG(5,(turn_sock->pool->obj_name, "Trying to connect to peer %s",
+	      pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3)));
+
+    if (turn_sock == NULL) {
+	/* We've been destroyed */
+	return;
+    }
+
+    pj_grp_lock_acquire(turn_sock->grp_lock);
+
+    if (turn_sock->data_conn_cnt == PJ_TURN_MAX_TCP_CONN_CNT) {
+	/* Data connection has reached limit */
+	pj_grp_lock_release(turn_sock->grp_lock);
+	return;
+    }
+
+    /* Check if app wants to accept this connection */
+    status = PJ_SUCCESS;
+    if (turn_sock->cb.on_connection_attempt) {
+	status = (*turn_sock->cb.on_connection_attempt)(turn_sock, conn_id,
+							peer_addr, addr_len);
+    }
+    /* App rejects it */
+    if (status != PJ_SUCCESS) {
+	pj_perror(4, turn_sock->pool->obj_name, status,
+		  "Rejected connection attempt from peer %s",
+		  pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3));
+	pj_grp_lock_release(turn_sock->grp_lock);
+	return;
+    }
+
+    /* Find free data connection slot */
+    for (i=0; i < PJ_TURN_MAX_TCP_CONN_CNT; ++i) {
+	if (turn_sock->data_conn[i].state == DATACONN_STATE_NULL)
+	    break;
+    }
+
+    /* Verify that a free slot is found */
+    pj_assert(i < PJ_TURN_MAX_TCP_CONN_CNT);
+    ++turn_sock->data_conn_cnt;
+
+    /* Init new data connection */
+    new_conn = &turn_sock->data_conn[i];
+    pj_bzero(new_conn, sizeof(*new_conn));
+    pool = pj_pool_create(turn_sock->cfg.pf, "dataconn", 128, 128, NULL);
+    new_conn->pool = pool;
+    new_conn->id = conn_id;
+    new_conn->turn_sock = turn_sock;
+    pj_sockaddr_cp(&new_conn->peer_addr, peer_addr);
+    new_conn->peer_addr_len = addr_len;
+    pj_ioqueue_op_key_init(&new_conn->send_key, sizeof(new_conn->send_key));
+    new_conn->state = DATACONN_STATE_INITSOCK;
+
+    /* Init socket */
+    status = pj_sock_socket(turn_sock->af, pj_SOCK_STREAM(), 0, &sock);
+    if (status != PJ_SUCCESS)
+	goto on_return;
+
+    /* Bind socket */
+    cfg_bind_addr = &turn_sock->setting.bound_addr;
+    max_bind_retry = MAX_BIND_RETRY;
+    if (turn_sock->setting.port_range &&
+	turn_sock->setting.port_range < max_bind_retry)
+    {
+	max_bind_retry = turn_sock->setting.port_range;
+    }
+    pj_sockaddr_init(turn_sock->af, &bound_addr, NULL, 0);
+    if (cfg_bind_addr->addr.sa_family == pj_AF_INET() ||
+	cfg_bind_addr->addr.sa_family == pj_AF_INET6())
+    {
+	pj_sockaddr_cp(&bound_addr, cfg_bind_addr);
+    }
+    status = pj_sock_bind_random(sock, &bound_addr,
+				 turn_sock->setting.port_range,
+				 max_bind_retry);
+    if (status != PJ_SUCCESS)
+	goto on_return;
+
+    /* Apply socket buffer size */
+    if (turn_sock->setting.so_rcvbuf_size > 0) {
+	unsigned sobuf_size = turn_sock->setting.so_rcvbuf_size;
+	status = pj_sock_setsockopt_sobuf(sock, pj_SO_RCVBUF(), PJ_TRUE,
+					  &sobuf_size);
+	if (status != PJ_SUCCESS) {
+	    pj_perror(3, turn_sock->obj_name, status,
+		      "Failed setting SO_RCVBUF");
+	} else {
+	    if (sobuf_size < turn_sock->setting.so_rcvbuf_size) {
+		PJ_LOG(4, (turn_sock->obj_name,
+			   "Warning! Cannot set SO_RCVBUF as configured,"
+			   " now=%d, configured=%d", sobuf_size,
+			   turn_sock->setting.so_rcvbuf_size));
+	    } else {
+		PJ_LOG(5, (turn_sock->obj_name, "SO_RCVBUF set to %d",
+			   sobuf_size));
+	    }
+	}
+    }
+    if (turn_sock->setting.so_sndbuf_size > 0) {
+	unsigned sobuf_size = turn_sock->setting.so_sndbuf_size;
+	status = pj_sock_setsockopt_sobuf(sock, pj_SO_SNDBUF(), PJ_TRUE,
+					  &sobuf_size);
+	if (status != PJ_SUCCESS) {
+	    pj_perror(3, turn_sock->obj_name, status,
+		      "Failed setting SO_SNDBUF");
+	} else {
+	    if (sobuf_size < turn_sock->setting.so_sndbuf_size) {
+		PJ_LOG(4, (turn_sock->obj_name,
+			   "Warning! Cannot set SO_SNDBUF as configured,"
+			   " now=%d, configured=%d", sobuf_size,
+			   turn_sock->setting.so_sndbuf_size));
+	    } else {
+		PJ_LOG(5, (turn_sock->obj_name, "SO_SNDBUF set to %d",
+			   sobuf_size));
+	    }
+	}
+    }
+
+    /* Create active socket */
+    pj_activesock_cfg_default(&asock_cfg);
+    asock_cfg.grp_lock = turn_sock->grp_lock;
+
+    pj_bzero(&asock_cb, sizeof(asock_cb));
+    asock_cb.on_data_read = &dataconn_on_data_read;
+    asock_cb.on_data_sent = &dataconn_on_data_sent;
+    asock_cb.on_connect_complete = &dataconn_on_connect_complete;
+    status = pj_activesock_create(pool, sock,
+				  pj_SOCK_STREAM(), &asock_cfg,
+				  turn_sock->cfg.ioqueue, &asock_cb,
+				  new_conn, &new_conn->asock);
+    if (status != PJ_SUCCESS)
+	goto on_return;
+
+    /* Connect to TURN server for data connection */
+    pj_turn_session_get_info(turn_sock->sess, &info);
+    status = pj_activesock_start_connect(new_conn->asock,
+					 pool,
+					 &info.server,
+					 pj_sockaddr_get_len(&info.server));
+    if (status == PJ_SUCCESS) {
+	dataconn_on_connect_complete(new_conn->asock, PJ_SUCCESS);
+	pj_grp_lock_release(turn_sock->grp_lock);
+	return;
+    }
+
+on_return:
+    if (status == PJ_EPENDING) {
+	PJ_LOG(5,(pool->obj_name,
+		  "Connecting to peer %s",
+		  pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3)));
+    } else {
+	/* not PJ_SUCCESS */
+	pj_perror(4, pool->obj_name, status,
+		  "Failed in connect to peer %s",
+		  pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3));
+
+	if (!new_conn->asock && sock != PJ_INVALID_SOCKET)
+	    pj_sock_close(sock);    
+
+	dataconn_cleanup(new_conn);
+	--turn_sock->data_conn_cnt;
+
+	/* Notify app for failure */
+	if (turn_sock->cb.on_connection_status) {
+	    (*turn_sock->cb.on_connection_status)(turn_sock, status, conn_id,
+						  peer_addr, addr_len);
+	}
+    }
+    pj_grp_lock_release(turn_sock->grp_lock);
 }

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1613,6 +1613,14 @@ static void turn_on_connection_attempt(pj_turn_session *sess,
 	return;
     }
 
+    pj_grp_lock_acquire(turn_sock->grp_lock);
+
+    if (turn_sock->data_conn_cnt == PJ_TURN_MAX_TCP_CONN_CNT) {
+	/* Data connection has reached limit */
+	pj_grp_lock_release(turn_sock->grp_lock);
+	return;
+    }
+
     /* Check if app wants to accept this connection */
     status = PJ_SUCCESS;
     if (turn_sock->cb.on_connection_attempt) {
@@ -1624,14 +1632,6 @@ static void turn_on_connection_attempt(pj_turn_session *sess,
 	pj_perror(4, turn_sock->pool->obj_name, status,
 		  "Rejected connection attempt from peer %s",
 		  pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3));
-	pj_grp_lock_release(turn_sock->grp_lock);
-	return;
-    }
-
-    pj_grp_lock_acquire(turn_sock->grp_lock);
-
-    if (turn_sock->data_conn_cnt == PJ_TURN_MAX_TCP_CONN_CNT) {
-	/* Data connection has reached limit */
 	pj_grp_lock_release(turn_sock->grp_lock);
 	return;
     }

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1613,6 +1613,21 @@ static void turn_on_connection_attempt(pj_turn_session *sess,
 	return;
     }
 
+    /* Check if app wants to accept this connection */
+    status = PJ_SUCCESS;
+    if (turn_sock->cb.on_connection_attempt) {
+	status = (*turn_sock->cb.on_connection_attempt)(turn_sock, conn_id,
+							peer_addr, addr_len);
+    }
+    /* App rejects it */
+    if (status != PJ_SUCCESS) {
+	pj_perror(4, turn_sock->pool->obj_name, status,
+		  "Rejected connection attempt from peer %s",
+		  pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3));
+	pj_grp_lock_release(turn_sock->grp_lock);
+	return;
+    }
+
     pj_grp_lock_acquire(turn_sock->grp_lock);
 
     if (turn_sock->data_conn_cnt == PJ_TURN_MAX_TCP_CONN_CNT) {
@@ -1839,21 +1854,6 @@ static void turn_on_connect_complete(pj_turn_session *sess,
 
     if (turn_sock->data_conn_cnt == PJ_TURN_MAX_TCP_CONN_CNT) {
 	/* Data connection has reached limit */
-	pj_grp_lock_release(turn_sock->grp_lock);
-	return;
-    }
-
-    /* Check if app wants to accept this connection */
-    status = PJ_SUCCESS;
-    if (turn_sock->cb.on_connection_attempt) {
-	status = (*turn_sock->cb.on_connection_attempt)(turn_sock, conn_id,
-							peer_addr, addr_len);
-    }
-    /* App rejects it */
-    if (status != PJ_SUCCESS) {
-	pj_perror(4, turn_sock->pool->obj_name, status,
-		  "Rejected connection attempt from peer %s",
-		  pj_sockaddr_print(peer_addr, addrtxt, sizeof(addrtxt), 3));
 	pj_grp_lock_release(turn_sock->grp_lock);
 	return;
     }


### PR DESCRIPTION
Hey. I found that pj_turn_sock couldn't initiate a connect request, so I added this feature to implement RFC 6062:

`pj_turn_sock_connect(turn_sock, &turn_sess_info.relay_addr, pj_sockaddr_get_len(&turn_sess_info.relay_addr));`

disconnect alsa has added

DEMO:
```
#include <pjnath.h>
#include <pjlib-util.h>
#include <pjlib.h>

#define SERVER_IP	"194.5.78.83"
#define SERVER_PORT	3478

pj_caching_pool		cp;
pj_pool_t		*pool;

pj_ice_strans_cfg	ice_cfg;
pj_stun_auth_cred 	cred;

pj_thread_t     	*thread;
pj_bool_t 		running = PJ_TRUE;


static int ice_worker_thread(void *unused)
{
    PJ_UNUSED_ARG(unused);
    while (running) {
        pj_time_val delay = {0, 500};
        pj_timer_heap_poll(ice_cfg.stun_cfg.timer_heap, NULL);
        pj_ioqueue_poll(ice_cfg.stun_cfg.ioqueue, &delay);
    }
}

void turn_on_rx_data(pj_turn_sock *turn_sock,
		     void *pkt,
		     unsigned pkt_len,
		     const pj_sockaddr_t *peer_addr,
		     unsigned addr_len)
{
    printf("turn_on_rx_data %s\n", (char *)pkt);
}

pj_bool_t turn_on_data_sent(pj_turn_sock *sock, pj_ssize_t sent)
{
    printf("on_data_sent\n");
}

void turn_on_state(pj_turn_sock *turn_sock,
		   pj_turn_state_t old_state,
		   pj_turn_state_t new_state)
{
    printf("statue: %s => %s\n",
	   pj_turn_state_name(old_state),
	   pj_turn_state_name(new_state));
}

pj_status_t turn_on_connection_attempt(pj_turn_sock *turn_sock,
				       pj_uint32_t conn_id,
				       const pj_sockaddr_t *peer_addr,
				       unsigned addr_len)
{
    printf("on_connection_attempt\n");
    return PJ_SUCCESS;
}

void turn_on_connection_status(pj_turn_sock *turn_sock,
			       pj_status_t status,
			       pj_uint32_t conn_id,
			       const pj_sockaddr_t *peer_addr,
			       unsigned addr_len)
{
    printf("on_connection_status: %d\n", status);
}

int start_turn(int argc, char *argv[]) {
    pj_str_t server_ip = pj_str(SERVER_IP);
    pj_uint16_t server_port = SERVER_PORT;

    pj_caching_pool_init(&cp, &pj_pool_factory_default_policy, 0);
    pool = pj_pool_create(&cp.factory, "main", 10000, 10000, NULL);
    if (pool == NULL) {
        PJ_PERROR(1, (__FILE__, PJ_ENOMEM, "Error createing poll"));
        return PJ_ENOMEM;
    }

    pj_ice_strans_cfg_default(&ice_cfg);
    ice_cfg.stun_cfg.pf = &cp.factory;
    pj_timer_heap_create(pool, 1000, &ice_cfg.stun_cfg.timer_heap);
    pj_ioqueue_create(pool, 16, &ice_cfg.stun_cfg.ioqueue);

    pj_thread_create(pool, "ice", &ice_worker_thread, NULL, 0, 0, &thread);

    pj_status_t status;
    pj_turn_sock *turn_sock, *turn_sock2;
    pj_turn_sock_cb turn_sock_cb;

    turn_sock_cb.on_rx_data = turn_on_rx_data;
    turn_sock_cb.on_data_sent = turn_on_data_sent;
    turn_sock_cb.on_state = turn_on_state;
    turn_sock_cb.on_connection_attempt = turn_on_connection_attempt;
    turn_sock_cb.on_connection_status = turn_on_connection_status;

    cred.type = PJ_STUN_AUTH_CRED_STATIC;
    cred.data.static_cred.username = pj_str("juice_test");
    cred.data.static_cred.data_type = PJ_STUN_PASSWD_PLAIN;
    cred.data.static_cred.data = pj_str("28245150316902");

    pj_turn_alloc_param alloc_param;
    pj_turn_alloc_param_default(&alloc_param);
    alloc_param.peer_conn_type = PJ_TURN_TP_TCP;

    status = pj_turn_sock_create(&ice_cfg.stun_cfg,
    				 pj_AF_INET(),
				 PJ_TURN_TP_TCP,
				 &turn_sock_cb,
				 NULL,
				 NULL,
				 &turn_sock);

    status = pj_turn_sock_create(&ice_cfg.stun_cfg,
    			         pj_AF_INET(),
				 PJ_TURN_TP_TCP,
				 &turn_sock_cb,
				 NULL,
				 NULL,
				 &turn_sock2);

    status = pj_turn_sock_alloc(turn_sock,
    				&server_ip,
				server_port,
				NULL,
				&cred,
				&alloc_param);

    status = pj_turn_sock_alloc(turn_sock2,
    				&server_ip,
				server_port,
				NULL,
				&cred,
				&alloc_param);

    pj_thread_sleep(5000);

    pj_sockaddr addr[8], addr2[8];
    pj_turn_session_info turn_sess_info;
    pj_turn_session_info turn_sess_info2;

    int addr_cnt = 0;
    status = pj_turn_sock_get_info(turn_sock, &turn_sess_info);
    addr[addr_cnt++] = turn_sess_info.relay_addr;

    int addr_cnt2 = 0;
    status = pj_turn_sock_get_info(turn_sock2, &turn_sess_info2);
    addr2[addr_cnt2++] = turn_sess_info.server;

    /*
     * Need to setup permission otherwise
     * ConnnectBind request to turn_sock2 will be failed
     */
    pj_turn_sock_set_perm(turn_sock2, addr_cnt, addr, 0);
    pj_thread_sleep(2000);
    pj_turn_sock_connect(turn_sock,
			 &turn_sess_info2.relay_addr,
			 pj_sockaddr_get_len(&turn_sess_info2.relay_addr));

    pj_thread_sleep(5000);

    int i;
    for (i = 0; i < 5; i++) {
	pj_turn_sock_sendto(turn_sock, "hello", 6,
			    &turn_sess_info2.relay_addr,
			    sizeof(turn_sess_info2.relay_addr));
	pj_thread_sleep(1000);
    }

    pj_turn_sock_disconnect(turn_sock,
			    &turn_sess_info2.relay_addr,
			    pj_sockaddr_get_len(&turn_sess_info2.relay_addr));

    pj_turn_sock_destroy(turn_sock);

    pj_ioqueue_destroy(ice_cfg.stun_cfg.ioqueue);
    pj_timer_heap_destroy(ice_cfg.stun_cfg.timer_heap);
    pj_pool_release(pool);
    pj_caching_pool_destroy(&cp);

    running = PJ_FALSE;
        
    return 0;
}

int main(int argc, char *argv[]) {
    /*pj_log_set_level(0);*/

    pj_init();
    pjlib_util_init();
    pjnath_init();

    pj_run_app(start_turn, argc, argv, 0);
    pj_shutdown();

    return 0;
}
```