### PR TITLE
SDL full-screen mode fixes and enhancement

### DIFF
--- a/pjmedia/include/pjmedia/videodev.h
+++ b/pjmedia/include/pjmedia/videodev.h
@@ -163,6 +163,30 @@ enum pjmedia_vid_dev_std_index
 
 
 /**
+ * Enumeration of window fullscreen flags.
+ */
+typedef enum pjmedia_vid_dev_fullscreen
+{
+    /**
+     * Windowed or disable fullscreen.
+     */
+    PJMEDIA_VID_DEV_WINDOWED = 0,
+
+    /**
+     * Fullscreen enabled, video mode may be changed.
+     */
+    PJMEDIA_VID_DEV_FULLSCREEN = 1,
+
+    /**
+     * Fullscreen enabled by resizing video frame to match to the desktop,
+     * video mode will not be changed.
+     */
+    PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP = 2
+
+} pjmedia_vid_dev_fullscreen;
+
+
+/**
  * This enumeration identifies various video device capabilities. These video
  * capabilities indicates what features are supported by the underlying
  * video device implementation.
@@ -469,10 +493,11 @@ typedef struct pjmedia_vid_dev_param
     unsigned window_flags;
 
     /**
-     * Video window's full screen status. This setting is optional, and will only be
-     * used if PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN is set in the flags.
+     * Video window's fullscreen status. This setting is optional, and will
+     * only be used if PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN is set in the
+     * flags.
      */
-    pj_bool_t window_fullscreen;
+    pjmedia_vid_dev_fullscreen window_fullscreen;
 
 } pjmedia_vid_dev_param;
 

--- a/pjmedia/include/pjmedia/videodev.h
+++ b/pjmedia/include/pjmedia/videodev.h
@@ -165,7 +165,7 @@ enum pjmedia_vid_dev_std_index
 /**
  * Enumeration of window fullscreen flags.
  */
-typedef enum pjmedia_vid_dev_fullscreen
+typedef enum pjmedia_vid_dev_fullscreen_flag
 {
     /**
      * Windowed or disable fullscreen.
@@ -183,7 +183,7 @@ typedef enum pjmedia_vid_dev_fullscreen
      */
     PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP = 2
 
-} pjmedia_vid_dev_fullscreen;
+} pjmedia_vid_dev_fullscreen_flag;
 
 
 /**
@@ -497,7 +497,7 @@ typedef struct pjmedia_vid_dev_param
      * only be used if PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN is set in the
      * flags.
      */
-    pjmedia_vid_dev_fullscreen window_fullscreen;
+    pjmedia_vid_dev_fullscreen_flag window_fullscreen;
 
 } pjmedia_vid_dev_param;
 

--- a/pjmedia/src/pjmedia-videodev/sdl_dev.c
+++ b/pjmedia/src/pjmedia-videodev/sdl_dev.c
@@ -1114,7 +1114,7 @@ static pj_status_t get_cap(void *data)
 	return PJ_SUCCESS;
     } else if (cap == PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN) {
 	Uint32 flag = SDL_GetWindowFlags(strm->window);
-	pjmedia_vid_dev_fullscreen val = PJMEDIA_VID_DEV_WINDOWED;
+	pjmedia_vid_dev_fullscreen_flag val = PJMEDIA_VID_DEV_WINDOWED;
 	if ((flag & SDL_WINDOW_FULLSCREEN_DESKTOP) ==
 		    SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{
@@ -1122,7 +1122,7 @@ static pj_status_t get_cap(void *data)
 	} else if ((flag & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN) {
 	     val = PJMEDIA_VID_DEV_FULLSCREEN;
 	}
-	*((pjmedia_vid_dev_fullscreen*)pval) = val;
+	*((pjmedia_vid_dev_fullscreen_flag*)pval) = val;
 	return PJ_SUCCESS;
     }
 
@@ -1236,7 +1236,8 @@ static pj_status_t set_cap(void *data)
 	return status;	
     } else if (cap == PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN) {
         Uint32 flag;
-	pjmedia_vid_dev_fullscreen val = *(pjmedia_vid_dev_fullscreen*)pval;
+	pjmedia_vid_dev_fullscreen_flag val =
+				    *(pjmedia_vid_dev_fullscreen_flag*)pval;
 
 	flag = SDL_GetWindowFlags(strm->window);
 	if (val == PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP)

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -296,7 +296,7 @@ static void vid_show_help()
     puts("| vid win show|hide ID      Show/hide the specified video window ID           |");
     puts("| vid win move ID X Y       Move window ID to position X,Y                    |");
     puts("| vid win resize ID w h     Resize window ID to the specified width, height   |");
-    puts("| vid win full on|off ID    Set fullscreen on/off for window ID               |");
+    puts("| vid win full off|on|dt ID Set fullscreen off/on/desktop for window ID	|");
     puts("| vid conf list             List all video ports in video conference bridge   |");
     puts("| vid conf cc P Q           Connect port P to Q in the video conf bridge      |");
     puts("| vid conf cd P Q           Disconnect port P to Q in the video conf bridge   |");
@@ -503,8 +503,12 @@ static void vid_handle_menu(char *menuin)
 	} else if (argc==5 && (strcmp(argv[2], "full")==0))
 	{
 	    pjsua_vid_win_id wid = atoi(argv[4]);
-	    pj_bool_t fullscreen = (strcmp(argv[3], "on")==0);
-	    status = pjsua_vid_win_set_fullscreen(wid, fullscreen);
+	    pjmedia_vid_dev_fullscreen mode = PJMEDIA_VID_DEV_WINDOWED;
+	    if (strcmp(argv[3], "on")==0)
+		mode = PJMEDIA_VID_DEV_FULLSCREEN;
+	    else if (strcmp(argv[3], "dt")==0)
+		mode = PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP;
+	    status = pjsua_vid_win_set_fullscreen(wid, mode);
 	} else
 	    goto on_error;
 

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -503,7 +503,7 @@ static void vid_handle_menu(char *menuin)
 	} else if (argc==5 && (strcmp(argv[2], "full")==0))
 	{
 	    pjsua_vid_win_id wid = atoi(argv[4]);
-	    pjmedia_vid_dev_fullscreen mode = PJMEDIA_VID_DEV_WINDOWED;
+	    pjmedia_vid_dev_fullscreen_flag mode = PJMEDIA_VID_DEV_WINDOWED;
 	    if (strcmp(argv[3], "on")==0)
 		mode = PJMEDIA_VID_DEV_FULLSCREEN;
 	    else if (strcmp(argv[3], "dt")==0)

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -299,12 +299,12 @@ typedef enum pjmedia_vid_dev_cap
   PJMEDIA_VID_DEV_CAP_MAX = 16384
 } pjmedia_vid_dev_cap;
 
-typedef enum pjmedia_vid_dev_fullscreen
+typedef enum pjmedia_vid_dev_fullscreen_flag
 {
   PJMEDIA_VID_DEV_WINDOWED = 0,
   PJMEDIA_VID_DEV_FULLSCREEN = 1,
   PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP = 2
-} pjmedia_vid_dev_fullscreen;
+} pjmedia_vid_dev_fullscreen_flag;
 
 typedef enum pjmedia_aud_dev_route
 {

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -299,6 +299,13 @@ typedef enum pjmedia_vid_dev_cap
   PJMEDIA_VID_DEV_CAP_MAX = 16384
 } pjmedia_vid_dev_cap;
 
+typedef enum pjmedia_vid_dev_fullscreen
+{
+  PJMEDIA_VID_DEV_WINDOWED = 0,
+  PJMEDIA_VID_DEV_FULLSCREEN = 1,
+  PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP = 2
+} pjmedia_vid_dev_fullscreen;
+
 typedef enum pjmedia_aud_dev_route
 {
   PJMEDIA_AUD_DEV_ROUTE_DEFAULT = 0,

--- a/pjsip-apps/src/swig/symbols.lst
+++ b/pjsip-apps/src/swig/symbols.lst
@@ -12,7 +12,7 @@ pjmedia/echo.h                  pjmedia_echo_flag
 pjmedia/event.h                 pjmedia_event_type
 pjmedia/transport_srtp.h	pjmedia_srtp_use pjmedia_srtp_crypto_option pjmedia_srtp_keying_method
 pjmedia/vid_stream.h		pjmedia_vid_stream_rc_method
-pjmedia-videodev/videodev.h	pjmedia_vid_dev_index pjmedia_vid_dev_std_index pjmedia_vid_dev_cap
+pjmedia-videodev/videodev.h	pjmedia_vid_dev_index pjmedia_vid_dev_std_index pjmedia_vid_dev_cap pjmedia_vid_dev_fullscreen
 pjmedia-audiodev/audiodev.h 	pjmedia_aud_dev_route pjmedia_aud_dev_cap
 pjmedia/wav_port.h              pjmedia_file_writer_option pjmedia_file_player_option
 pjmedia/tonegen.h		pjmedia_tone_digit pjmedia_tone_digit_map pjmedia_tone_desc

--- a/pjsip-apps/src/swig/symbols.lst
+++ b/pjsip-apps/src/swig/symbols.lst
@@ -12,7 +12,7 @@ pjmedia/echo.h                  pjmedia_echo_flag
 pjmedia/event.h                 pjmedia_event_type
 pjmedia/transport_srtp.h	pjmedia_srtp_use pjmedia_srtp_crypto_option pjmedia_srtp_keying_method
 pjmedia/vid_stream.h		pjmedia_vid_stream_rc_method
-pjmedia-videodev/videodev.h	pjmedia_vid_dev_index pjmedia_vid_dev_std_index pjmedia_vid_dev_cap pjmedia_vid_dev_fullscreen
+pjmedia-videodev/videodev.h	pjmedia_vid_dev_index pjmedia_vid_dev_std_index pjmedia_vid_dev_cap pjmedia_vid_dev_fullscreen_flag
 pjmedia-audiodev/audiodev.h 	pjmedia_aud_dev_route pjmedia_aud_dev_cap
 pjmedia/wav_port.h              pjmedia_file_writer_option pjmedia_file_player_option
 pjmedia/tonegen.h		pjmedia_tone_digit pjmedia_tone_digit_map pjmedia_tone_desc

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -8309,13 +8309,14 @@ PJ_DECL(pj_status_t) pjsua_vid_win_rotate(pjsua_vid_win_id wid,
  * capability. Currently it is only supported on SDL backend.
  *
  * @param wid		The video window ID.
- * @param enabled   	Set to PJ_TRUE if full screen is desired, PJ_FALSE 
- *			otherwise.
+ * @param mode   	Fullscreen mode, see pjmedia_vid_dev_fullscreen.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
  */
-PJ_DECL(pj_status_t) pjsua_vid_win_set_fullscreen(pjsua_vid_win_id wid,
-                                                  pj_bool_t enabled);
+PJ_DECL(pj_status_t) pjsua_vid_win_set_fullscreen(
+					pjsua_vid_win_id wid,
+					pjmedia_vid_dev_fullscreen mode);
+
 
 /*
  * Video codecs API

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -8309,13 +8309,13 @@ PJ_DECL(pj_status_t) pjsua_vid_win_rotate(pjsua_vid_win_id wid,
  * capability. Currently it is only supported on SDL backend.
  *
  * @param wid		The video window ID.
- * @param mode   	Fullscreen mode, see pjmedia_vid_dev_fullscreen.
+ * @param mode   	Fullscreen mode, see pjmedia_vid_dev_fullscreen_flag.
  *
  * @return		PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_DECL(pj_status_t) pjsua_vid_win_set_fullscreen(
 					pjsua_vid_win_id wid,
-					pjmedia_vid_dev_fullscreen mode);
+					pjmedia_vid_dev_fullscreen_flag mode);
 
 
 /*

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1880,6 +1880,16 @@ public:
      */
     void setFullScreen(bool enabled) PJSUA2_THROW(Error);
 
+    /**
+     * Set video window full-screen. This operation is valid only when the
+     * underlying video device supports PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN
+     * capability. Currently it is only supported on SDL backend.
+     *
+     * @param mode		Fullscreen mode, see
+     *				pjmedia_vid_dev_fullscreen.
+     */
+    void setFullScreen2(pjmedia_vid_dev_fullscreen mode) PJSUA2_THROW(Error);
+
 private:
     pjsua_vid_win_id		winId;
 };

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1886,9 +1886,10 @@ public:
      * capability. Currently it is only supported on SDL backend.
      *
      * @param mode		Fullscreen mode, see
-     *				pjmedia_vid_dev_fullscreen.
+     *				pjmedia_vid_dev_fullscreen_flag.
      */
-    void setFullScreen2(pjmedia_vid_dev_fullscreen mode) PJSUA2_THROW(Error);
+    void setFullScreen2(pjmedia_vid_dev_fullscreen_flag mode)
+							PJSUA2_THROW(Error);
 
 private:
     pjsua_vid_win_id		winId;

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1845,7 +1845,7 @@ PJ_DEF(pj_status_t) pjsua_vid_win_rotate( pjsua_vid_win_id wid,
  */
 PJ_DEF(pj_status_t) pjsua_vid_win_set_fullscreen(
 					pjsua_vid_win_id wid,
-					pjmedia_vid_dev_fullscreen mode)
+					pjmedia_vid_dev_fullscreen_flag mode)
 {
     pjsua_vid_win *w;
     pjmedia_vid_dev_stream *s;

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1843,8 +1843,9 @@ PJ_DEF(pj_status_t) pjsua_vid_win_rotate( pjsua_vid_win_id wid,
 /*
  * Set video window fullscreen.
  */
-PJ_DEF(pj_status_t) pjsua_vid_win_set_fullscreen( pjsua_vid_win_id wid,
-                                                  pj_bool_t enabled)
+PJ_DEF(pj_status_t) pjsua_vid_win_set_fullscreen(
+					pjsua_vid_win_id wid,
+					pjmedia_vid_dev_fullscreen mode)
 {
     pjsua_vid_win *w;
     pjmedia_vid_dev_stream *s;
@@ -1862,7 +1863,7 @@ PJ_DEF(pj_status_t) pjsua_vid_win_set_fullscreen( pjsua_vid_win_id wid,
     }
 
     status = pjmedia_vid_dev_stream_set_cap(s,
-			    PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN, &enabled);
+			    PJMEDIA_VID_DEV_CAP_OUTPUT_FULLSCREEN, &mode);
 
     PJSUA_UNLOCK();
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1286,7 +1286,19 @@ void VideoWindow::setWindow(const VideoWindowHandle &win) PJSUA2_THROW(Error)
 void VideoWindow::setFullScreen(bool enabled) PJSUA2_THROW(Error)
 {
 #if PJSUA_HAS_VIDEO
-    PJSUA2_CHECK_EXPR( pjsua_vid_win_set_fullscreen(winId, enabled) );
+    pjmedia_vid_dev_fullscreen mode;
+    mode = enabled? PJMEDIA_VID_DEV_FULLSCREEN : PJMEDIA_VID_DEV_WINDOWED;
+    PJSUA2_CHECK_EXPR( pjsua_vid_win_set_fullscreen(winId, mode) );
+#else
+    PJ_UNUSED_ARG(enabled);
+#endif
+}
+
+void VideoWindow::setFullScreen2(pjmedia_vid_dev_fullscreen mode)
+							PJSUA2_THROW(Error)
+{
+#if PJSUA_HAS_VIDEO
+    PJSUA2_CHECK_EXPR( pjsua_vid_win_set_fullscreen(winId, mode) );
 #else
     PJ_UNUSED_ARG(enabled);
 #endif

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1300,7 +1300,7 @@ void VideoWindow::setFullScreen2(pjmedia_vid_dev_fullscreen mode)
 #if PJSUA_HAS_VIDEO
     PJSUA2_CHECK_EXPR( pjsua_vid_win_set_fullscreen(winId, mode) );
 #else
-    PJ_UNUSED_ARG(enabled);
+    PJ_UNUSED_ARG(mode);
 #endif
 }
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1286,7 +1286,7 @@ void VideoWindow::setWindow(const VideoWindowHandle &win) PJSUA2_THROW(Error)
 void VideoWindow::setFullScreen(bool enabled) PJSUA2_THROW(Error)
 {
 #if PJSUA_HAS_VIDEO
-    pjmedia_vid_dev_fullscreen mode;
+    pjmedia_vid_dev_fullscreen_flag mode;
     mode = enabled? PJMEDIA_VID_DEV_FULLSCREEN : PJMEDIA_VID_DEV_WINDOWED;
     PJSUA2_CHECK_EXPR( pjsua_vid_win_set_fullscreen(winId, mode) );
 #else
@@ -1294,7 +1294,7 @@ void VideoWindow::setFullScreen(bool enabled) PJSUA2_THROW(Error)
 #endif
 }
 
-void VideoWindow::setFullScreen2(pjmedia_vid_dev_fullscreen mode)
+void VideoWindow::setFullScreen2(pjmedia_vid_dev_fullscreen_flag mode)
 							PJSUA2_THROW(Error)
 {
 #if PJSUA_HAS_VIDEO


### PR DESCRIPTION
Continuation of PR #2324. This PR includes the original PR and implements few additional stuffs, e.g: instead of replacing fullscreen with fullscree desktop, this PR provides both modes, as discussed in the original PR.

So this PR covers:
- add fullscreen mode `PJMEDIA_VID_DEV_FULLSCREEN_DESKTOP` (no video mode change), which is mapped to SDL flag `SDL_WINDOW_FULLSCREEN_DESKTOP`,
- fix resizing while in full-screen,
- also update PJSUA, PJSUA2 & pjsua app to accomodate the new fullscreen mode setting, e.g: fullscreen setting was boolean (fullscreen enabled or disabled), now it is enum (disabled, fullscreen, or fullscreen desktop).