### PR TITLE
Fix in the SDP negotiator - if the offer's media is disabled, do not compare transport

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -701,6 +701,17 @@ static pj_status_t process_m_answer( pj_pool_t *pool,
 	return PJMEDIA_SDPNEG_EINVANSMEDIA;
     }
 
+    /* Check if remote has rejected our offer */
+    if (answer->desc.port == 0) {
+	
+	/* Remote has rejected our offer. 
+	 * Deactivate our media too.
+	 */
+	pjmedia_sdp_media_deactivate(pool, offer);
+
+	/* Don't need to proceed */
+	return PJ_SUCCESS;
+    }
 
     /* Check that transport in the answer match our offer. */
 
@@ -714,18 +725,6 @@ static pj_status_t process_m_answer( pj_pool_t *pool,
 	return PJMEDIA_SDPNEG_EINVANSTP;
     }
 
-
-    /* Check if remote has rejected our offer */
-    if (answer->desc.port == 0) {
-	
-	/* Remote has rejected our offer. 
-	 * Deactivate our media too.
-	 */
-	pjmedia_sdp_media_deactivate(pool, offer);
-
-	/* Don't need to proceed */
-	return PJ_SUCCESS;
-    }
 
     /* Ticket #1148: check if remote answer does not set port to zero when
      * offered with port zero. Let's just tolerate it.


### PR DESCRIPTION
This bug has been noticed while trying to negotiate `BFCP` application via SDP with various SIP clients.

We have a SIP client build on top of `pjsip`, we know that pjsip doesn't support BFCP, however we managed to extend the offer by intercepting SDP and extending it with a BFCP application (extra `m=` line).

This works perfectly with SIP clients that support BFCP, however when we try to negotiate with a SIP client that doesn't support BFCP (an outgoing call), we noticed the call won't be established and error is reported with status `PJMEDIA_SDPNEG_EINVANSTP`.

Since that SIP client doesn't support BFCP, it will set port to 0 for that unsupported media (`m=application BFCP`) in the answer to the SDP offer, but as well transport for that media is changed to "unknown" (in the offer it was `"BFCP/UDP"`). Now, since transports are compared before checking if media is disabled, of course we are getting error, because `"unknown" != "BFCP/UDP"`

We noticed that after transport check, there is a check that checks if media is disabled in the answer and if it is, then deactivate the media in the offer as well. 

But we don't understand why media's transport is checked before checking if media is disabled in the answer. If media is disabled, then there is no point in comparing any property of media, since it should be deactivated in the offer as well.

After moving the check that checks if the media is disabled in the answer, in the front of the transport check, the issue is resolved. 

