### PR TITLE
Fix compilation of 3rdparty_media_sample (introduced by #1463)

### DIFF
--- a/pjsip-apps/src/3rdparty_media_sample/Makefile
+++ b/pjsip-apps/src/3rdparty_media_sample/Makefile
@@ -9,7 +9,7 @@ export _CFLAGS 	:= $(PJ_CFLAGS) $(CFLAGS)
 export _CXXFLAGS:= $(PJ_CXXFLAGS)
 export _LDFLAGS := $(PJ_LDFLAGS) $(PJ_LDLIBS) $(LDFLAGS)
 
-OBJS = alt_pjsua_aud.o alt_pjsua_vid.o pjsua_app.o main.o
+OBJS = alt_pjsua_aud.o alt_pjsua_vid.o pjsua_app.o main.o pjsua_app_cli.o pjsua_app_common.o pjsua_app_config.o pjsua_app_legacy.o
 
 all: alt_pjsua
 
@@ -20,6 +20,21 @@ pjsua_app.o: ../pjsua/pjsua_app.c
 	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
 
 main.o: ../pjsua/main.c
+	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
+
+#main_rtems.o: ../pjsua/main_rtems.c
+#	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
+
+pjsua_app_cli.o: ../pjsua/pjsua_app_cli.c
+	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
+
+pjsua_app_common.o: ../pjsua/pjsua_app_common.c
+	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
+
+pjsua_app_config.o: ../pjsua/pjsua_app_config.c
+	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
+
+pjsua_app_legacy.o: ../pjsua/pjsua_app_legacy.c
 	$(PJ_CC) $(_CFLAGS) -c -o $@ $<
 
 %.o: %.c


### PR DESCRIPTION
The 3rd-party media sample does not compile anymore (following steps in  #1463), since pjsua_app has changed.
This PR fixes the Makefile.