### PR TITLE
Add compile-time setting to disable automatic video device subsystem initialization

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7940,6 +7940,31 @@ pjsua_media_transports_attach( pjsua_media_transport tp[],
  * Video devices API
  */
 
+
+/**
+ * Controls whether PJSUA-LIB should not initialize video device subsystem
+ * in the PJSUA initialization. The video device subsystem initialization
+ * may need to open cameras to enumerates available cameras and their
+ * capabilities, which may not be preferable for some applications because
+ * it may trigger privacy-alert/permission notification on application startup
+ * (e.g: on Android app).
+ *
+ * If this is set, later application should manually initialize video device
+ * subsystem when it needs to use any video devices (camera and renderer),
+ * i.e: by invoking pjmedia_vid_dev_subsys_init() for PJSUA or
+ * VidDevManager::initSubsys() for PJSUA2.
+ *
+ * Note that pjmedia_vid_dev_subsys_init() should not be called multiple
+ * times (unless each has corresponding pjmedia_vid_dev_subsys_shutdown()),
+ * while VidDevManager::initSubsys() is safe to be called multiple times.
+ *
+ * Default: 0 (no)
+ */
+#ifndef PJSUA_DONT_INIT_VID_DEV_SUBSYS
+#   define PJSUA_DONT_INIT_VID_DEV_SUBSYS	0
+#endif
+
+
 /**
  * Get the number of video devices installed in the system.
  *

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2087,6 +2087,19 @@ struct VideoSwitchParam
  */
 class VidDevManager {
 public:
+
+    /**
+     * Initialize the video device subsystem. This will register all supported
+     * video device factories to the video device subsystem.
+     *
+     * By default, library will initialize video device subsystem automatically
+     * on library initialization, so application will never need to invoke this
+     * function. However, when PJSUA_DONT_INIT_VID_DEV_SUBSYS is set to
+     * non-zero, application should invoke this function before accessing
+     * video device.
+     */
+    void initSubsys() PJSUA2_THROW(Error);
+
     /**
      * Refresh the list of video devices installed in the system. This function
      * will only refresh the list of video device so all active video streams

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -124,12 +124,15 @@ pj_status_t pjsua_vid_subsys_init(void)
     }
 #endif
 
+#if !defined(PJSUA_DONT_INIT_VID_DEV_SUBSYS) || \
+             PJSUA_DONT_INIT_VID_DEV_SUBSYS==0
     status = pjmedia_vid_dev_subsys_init(&pjsua_var.cp.factory);
     if (status != PJ_SUCCESS) {
 	pjsua_perror(THIS_FILE, "Error creating PJMEDIA video subsystem",
 		     status);
 	goto on_error;
     }
+#endif
 
     for (i=0; i<PJSUA_MAX_VID_WINS; ++i) {
 	if (pjsua_var.win[i].pool == NULL) {

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1501,6 +1501,17 @@ VideoDevInfo::~VideoDevInfo()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+void VidDevManager::initSubsys() PJSUA2_THROW(Error)
+{
+#if PJSUA_HAS_VIDEO && PJSUA_DONT_INIT_VID_DEV_SUBSYS
+    /* Should init once only! */
+    if (pjmedia_get_vid_subsys()->init_count > 0)
+	return;
+
+    PJSUA2_CHECK_EXPR(pjmedia_vid_dev_subsys_init(pjsua_get_pool_factory()));
+#endif
+}
+
 void VidDevManager::refreshDevs() PJSUA2_THROW(Error)
 {
 #if PJSUA_HAS_VIDEO


### PR DESCRIPTION
The video device subsystem initialization may need to open cameras to enumerates available cameras and their capabilities, which may not be preferable for some applications because it may trigger privacy-alert/permission notification on application startup (e.g: on Android app).

The new setting is `PJSUA_DONT_INIT_VID_DEV_SUBSYS`, if it is set to 1, the video device subsystem will not be initialized by PJSUA, so later application should manually initialize video device subsystem when it needs to use any video devices (camera and renderer) i.e: by invoking `pjmedia_vid_dev_subsys_init()` for PJSUA or `VidDevManager::initSubsys()` for PJSUA2.