### PR TITLE
Added pjsip_tsx_set_timers to change timers at runtime

### DIFF
--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -437,7 +437,8 @@ PJ_DECL(pj_status_t) pjsip_tsx_set_timeout(pjsip_transaction *tsx,
 
 /*
  * Change timer values used by transaction layer. Currently scheduled
- * timers will not be changed.
+ * timers will not be changed. Any value set to 0 will be left
+ * unchanged.
  *
  * @param t1 - Transaction T1 timeout, in msec
  * @param t2 - Transaction T2 timeout, in msec
@@ -445,6 +446,11 @@ PJ_DECL(pj_status_t) pjsip_tsx_set_timeout(pjsip_transaction *tsx,
  * @param td - Transaction completed timer for INVITE, in msec
  */
 PJ_DECL(void) pjsip_tsx_set_timers(unsigned t1, unsigned t2, unsigned t4, unsigned td);
+
+/*
+ * (Re)Initializes timer values from `pjsip_cfg()`.
+ */
+PJ_DECL(void) pjsip_tsx_initialize_timer_values(void);
 
 /**
  * Get the transaction instance in the incoming message. If the message

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -435,6 +435,16 @@ PJ_DECL(pj_status_t) pjsip_tsx_stop_retransmit(pjsip_transaction *tsx);
 PJ_DECL(pj_status_t) pjsip_tsx_set_timeout(pjsip_transaction *tsx,
 					   unsigned millisec);
 
+/*
+ * Change timer values used by transaction layer. Currently scheduled
+ * timers will not be changed.
+ *
+ * @param t1 - Transaction T1 timeout, in msec
+ * @param t2 - Transaction T2 timeout, in msec
+ * @param t4 - Transaction completed timer for non-INVITE, in msec
+ * @param td - Transaction completed timer for INVITE, in msec
+ */
+PJ_DECL(void) pjsip_tsx_set_timers(unsigned t1, unsigned t2, unsigned t4, unsigned td);
 
 /**
  * Get the transaction instance in the incoming message. If the message

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -421,6 +421,35 @@ PJ_DEF(pj_status_t) pjsip_tsx_create_key( pj_pool_t *pool, pj_str_t *key,
     }
 }
 
+/*
+ * Change timer values used by transaction layer. Currently scheduled
+ * timers will not be changed.
+ * t1 - Transaction T1 timeout, in msec. Default value is PJSIP_T1_TIMEOUT
+ * t2 - Transaction T2 timeout, in msec. Default value is PJSIP_T2_TIMEOUT
+ * t4 - Transaction completed timer for non-INVITE, in msec.
+ *      Default value is PJSIP_T4_TIMEOUT
+ * td - Transaction completed timer for INVITE, in msec.
+ *      Default value is PJSIP_TD_TIMEOUT
+ */
+PJ_DEF(void) pjsip_tsx_set_timers(unsigned t1, unsigned t2, unsigned t4, unsigned td)
+{
+    /* Lock hash table mutex. */
+    pj_mutex_lock(mod_tsx_layer.mutex);
+
+    /* See Initialize timer in pjsip_tsx_layer_init_module() */
+    t1_timer_val.sec  = t1 / 1000;
+    t1_timer_val.msec = t1 % 1000;
+    t2_timer_val.sec  = t2 / 1000;
+    t2_timer_val.msec = t2 % 1000;
+    t4_timer_val.sec  = t4 / 1000;
+    t4_timer_val.msec = t4 % 1000;
+    td_timer_val.sec  = td / 1000;
+    td_timer_val.msec = td % 1000;
+    timeout_timer_val = td_timer_val;
+
+    pj_mutex_unlock(mod_tsx_layer.mutex);
+}
+
 /*****************************************************************************
  **
  ** Transaction layer module


### PR DESCRIPTION
Added new function pjsip_tsx_set_timers in sip_transaction.c
which allows to change session timers during runtime.
It also allows to change timer values independently,
currently all timers are set at various ratios from
t1 during init. This was required for server which could
change timeout configuration on runtime, but could be
usable in other projects.