### PR TITLE
Add checks and assertion if PJSIP string length is negative

### DIFF
--- a/pjlib/include/pj/string.h
+++ b/pjlib/include/pj/string.h
@@ -46,7 +46,7 @@ PJ_BEGIN_DECL
  *   typedef struct pj_str_t
  *   {
  *       char      *ptr;
- *       pj_size_t  slen;
+ *       pj_ssize_t  slen;
  *   } pj_str_t;
  * </pre>
  *

--- a/pjlib/include/pj/string_i.h
+++ b/pjlib/include/pj/string_i.h
@@ -147,7 +147,7 @@ PJ_IDEF(pj_str_t*) pj_strncpy_with_null( pj_str_t *dst, const pj_str_t *src,
     pj_assert(max > 0);
 
     if (max <= src->slen)
-	max = max-1;
+	max = (max > 0)? max-1: 0;
     else
 	max = (src->slen < 0)? 0: src->slen;
 

--- a/pjlib/include/pj/string_i.h
+++ b/pjlib/include/pj/string_i.h
@@ -33,15 +33,17 @@ PJ_IDEF(pj_str_t*) pj_strdup(pj_pool_t *pool,
 			      pj_str_t *dst,
 			      const pj_str_t *src)
 {
+    pj_assert(src->slen >= 0);
+
     /* Without this, destination will be corrupted */
     if (dst == src)
 	return dst;
 
-    if (src->slen) {
+    if (src->slen > 0) {
 	dst->ptr = (char*)pj_pool_alloc(pool, src->slen);
 	pj_memcpy(dst->ptr, src->ptr, src->slen);
     }
-    dst->slen = src->slen;
+    dst->slen = (src->slen < 0)? 0: src->slen;
     return dst;
 }
 
@@ -49,11 +51,19 @@ PJ_IDEF(pj_str_t*) pj_strdup_with_null( pj_pool_t *pool,
 					pj_str_t *dst,
 					const pj_str_t *src)
 {
-    dst->ptr = (char*)pj_pool_alloc(pool, src->slen+1);
-    if (src->slen) {
-	pj_memcpy(dst->ptr, src->ptr, src->slen);
+    pj_size_t src_slen = src->slen;
+
+    pj_assert(src->slen >= 0);
+
+    /* Check if the source's length is invalid */
+    if (src_slen < 0)
+    	src_slen = 0;
+
+    dst->ptr = (char*)pj_pool_alloc(pool, src_slen+1);
+    if (src_slen) {
+	pj_memcpy(dst->ptr, src->ptr, src_slen);
     }
-    dst->slen = src->slen;
+    dst->slen = src_slen;
     dst->ptr[dst->slen] = '\0';
     return dst;
 }
@@ -101,7 +111,9 @@ PJ_IDEF(pj_str_t*) pj_strassign( pj_str_t *dst, pj_str_t *src )
 
 PJ_IDEF(pj_str_t*) pj_strcpy(pj_str_t *dst, const pj_str_t *src)
 {
-    dst->slen = src->slen;
+    pj_assert(src->slen >= 0);
+
+    dst->slen = (src->slen < 0)? 0: src->slen;
     if (src->slen > 0)
 	pj_memcpy(dst->ptr, src->ptr, src->slen);
     return dst;
@@ -118,25 +130,29 @@ PJ_IDEF(pj_str_t*) pj_strcpy2(pj_str_t *dst, const char *src)
 PJ_IDEF(pj_str_t*) pj_strncpy( pj_str_t *dst, const pj_str_t *src, 
 			       pj_ssize_t max)
 {
+    pj_assert(src->slen >= 0);
     pj_assert(max >= 0);
+
     if (max > src->slen) max = src->slen;
     if (max > 0)
 	pj_memcpy(dst->ptr, src->ptr, max);
-    dst->slen = max;
+    dst->slen = (max < 0)? 0: max;
     return dst;
 }
 
 PJ_IDEF(pj_str_t*) pj_strncpy_with_null( pj_str_t *dst, const pj_str_t *src,
 					 pj_ssize_t max)
 {
+    pj_assert(src->slen >= 0);
     pj_assert(max > 0);
 
     if (max <= src->slen)
 	max = max-1;
     else
-	max = src->slen;
+	max = (src->slen < 0)? 0: src->slen;
 
-    pj_memcpy(dst->ptr, src->ptr, max);
+    if (max > 0)
+    	pj_memcpy(dst->ptr, src->ptr, max);
     dst->ptr[max] = '\0';
     dst->slen = max;
     return dst;
@@ -145,9 +161,12 @@ PJ_IDEF(pj_str_t*) pj_strncpy_with_null( pj_str_t *dst, const pj_str_t *src,
 
 PJ_IDEF(int) pj_strcmp( const pj_str_t *str1, const pj_str_t *str2)
 {
-    if (str1->slen == 0) {
-	return str2->slen==0 ? 0 : -1;
-    } else if (str2->slen == 0) {
+    pj_assert(str1->slen >= 0);
+    pj_assert(str2->slen >= 0);
+
+    if (str1->slen <= 0) {
+	return str2->slen<=0 ? 0 : -1;
+    } else if (str2->slen <= 0) {
 	return 1;
     } else {
 	pj_size_t min = (str1->slen < str2->slen)? str1->slen : str2->slen;
@@ -166,13 +185,16 @@ PJ_IDEF(int) pj_strncmp( const pj_str_t *str1, const pj_str_t *str2,
 {
     pj_str_t copy1, copy2;
 
-    if (len < (unsigned)str1->slen) {
+    pj_assert(str1->slen >= 0);
+    pj_assert(str2->slen >= 0);
+
+    if (len < (unsigned)str1->slen && str1->slen > 0) {
 	copy1.ptr = str1->ptr;
 	copy1.slen = len;
 	str1 = &copy1;
     }
 
-    if (len < (unsigned)str2->slen) {
+    if (len < (unsigned)str2->slen && str2->slen > 0) {
 	copy2.ptr = str2->ptr;
 	copy2.slen = len;
 	str2 = &copy2;
@@ -213,9 +235,12 @@ PJ_IDEF(int) pj_strcmp2( const pj_str_t *str1, const char *str2 )
 
 PJ_IDEF(int) pj_stricmp( const pj_str_t *str1, const pj_str_t *str2)
 {
-    if (str1->slen == 0) {
-	return str2->slen==0 ? 0 : -1;
-    } else if (str2->slen == 0) {
+    pj_assert(str1->slen >= 0);
+    pj_assert(str2->slen >= 0);
+
+    if (str1->slen <= 0) {
+	return str2->slen<=0 ? 0 : -1;
+    } else if (str2->slen <= 0) {
 	return 1;
     } else {
 	pj_size_t min = (str1->slen < str2->slen)? str1->slen : str2->slen;
@@ -320,13 +345,13 @@ PJ_IDEF(int) pj_strnicmp( const pj_str_t *str1, const pj_str_t *str2,
 {
     pj_str_t copy1, copy2;
 
-    if (len < (unsigned)str1->slen) {
+    if (len < (unsigned)str1->slen && str1->slen > 0) {
 	copy1.ptr = str1->ptr;
 	copy1.slen = len;
 	str1 = &copy1;
     }
 
-    if (len < (unsigned)str2->slen) {
+    if (len < (unsigned)str2->slen && str2->slen > 0) {
 	copy2.ptr = str2->ptr;
 	copy2.slen = len;
 	str2 = &copy2;
@@ -352,7 +377,10 @@ PJ_IDEF(int) pj_strnicmp2( const pj_str_t *str1, const char *str2,
 
 PJ_IDEF(void) pj_strcat(pj_str_t *dst, const pj_str_t *src)
 {
-    if (src->slen) {
+    pj_assert(src->slen >= 0);
+    pj_assert(dst->slen >= 0);
+
+    if (src->slen > 0 && dst->slen >= 0) {
 	pj_memcpy(dst->ptr + dst->slen, src->ptr, src->slen);
 	dst->slen += src->slen;
     }
@@ -361,7 +389,10 @@ PJ_IDEF(void) pj_strcat(pj_str_t *dst, const pj_str_t *src)
 PJ_IDEF(void) pj_strcat2(pj_str_t *dst, const char *str)
 {
     pj_size_t len = str? pj_ansi_strlen(str) : 0;
-    if (len) {
+
+    pj_assert(dst->slen >= 0);
+
+    if (len && dst->slen >= 0) {
 	pj_memcpy(dst->ptr + dst->slen, str, len);
 	dst->slen += len;
     }

--- a/pjlib/src/pj/string.c
+++ b/pjlib/src/pj/string.c
@@ -94,8 +94,11 @@ PJ_DEF(pj_ssize_t) pj_strtok(const pj_str_t *str, const pj_str_t *delim,
 {    
     pj_ssize_t str_idx;
 
+    pj_assert(str->slen >= 0);
+    pj_assert(delim->slen >= 0);
+
     tok->slen = 0;
-    if ((str->slen == 0) || ((pj_size_t)str->slen < start_idx)) {
+    if ((str->slen <= 0) || ((pj_size_t)str->slen < start_idx)) {
 	return str->slen;
     }
     
@@ -119,8 +122,10 @@ PJ_DEF(pj_ssize_t) pj_strtok2(const pj_str_t *str, const char *delim,
 {
     pj_ssize_t str_idx;
 
+    pj_assert(str->slen >= 0);
+
     tok->slen = 0;
-    if ((str->slen == 0) || ((pj_size_t)str->slen < start_idx)) {
+    if ((str->slen <= 0) || ((pj_size_t)str->slen < start_idx)) {
 	return str->slen;
     }
 
@@ -143,6 +148,8 @@ PJ_DEF(char*) pj_strstr(const pj_str_t *str, const pj_str_t *substr)
 {
     const char *s, *ends;
 
+    PJ_ASSERT_RETURN(str->slen >= 0 && substr->slen >= 0, NULL);
+
     /* Special case when substr is zero */
     if (substr->slen == 0) {
 	return (char*)str->ptr;
@@ -161,6 +168,8 @@ PJ_DEF(char*) pj_strstr(const pj_str_t *str, const pj_str_t *substr)
 PJ_DEF(char*) pj_stristr(const pj_str_t *str, const pj_str_t *substr)
 {
     const char *s, *ends;
+
+    PJ_ASSERT_RETURN(str->slen >= 0 && substr->slen >= 0, NULL);
 
     /* Special case when substr is zero */
     if (substr->slen == 0) {
@@ -181,6 +190,9 @@ PJ_DEF(pj_str_t*) pj_strltrim( pj_str_t *str )
 {
     char *end = str->ptr + str->slen;
     register char *p = str->ptr;
+ 
+    pj_assert(str->slen >= 0);
+ 
     while (p < end && pj_isspace(*p))
 	++p;
     str->slen -= (p - str->ptr);
@@ -192,6 +204,9 @@ PJ_DEF(pj_str_t*) pj_strrtrim( pj_str_t *str )
 {
     char *end = str->ptr + str->slen;
     register char *p = end - 1;
+
+    pj_assert(str->slen >= 0);
+
     while (p >= str->ptr && pj_isspace(*p))
         --p;
     str->slen -= ((end - p) - 1);
@@ -243,6 +258,8 @@ PJ_DEF(pj_status_t) pj_strtol2(const pj_str_t *str, long *value)
 
     PJ_CHECK_STACK();
 
+    PJ_ASSERT_RETURN(str->slen >= 0, PJ_EINVAL);
+
     if (!str || !value) {
         return PJ_EINVAL;
     }
@@ -289,6 +306,8 @@ PJ_DEF(unsigned long) pj_strtoul(const pj_str_t *str)
 
     PJ_CHECK_STACK();
 
+    pj_assert(str->slen >= 0);
+
     value = 0;
     for (i=0; i<(unsigned)str->slen; ++i) {
 	if (!pj_isdigit(str->ptr[i]))
@@ -305,6 +324,8 @@ PJ_DEF(unsigned long) pj_strtoul2(const pj_str_t *str, pj_str_t *endptr,
     unsigned i;
 
     PJ_CHECK_STACK();
+
+    pj_assert(str->slen >= 0);
 
     value = 0;
     if (base <= 10) {
@@ -328,7 +349,7 @@ PJ_DEF(unsigned long) pj_strtoul2(const pj_str_t *str, pj_str_t *endptr,
 
     if (endptr) {
 	endptr->ptr = str->ptr + i;
-	endptr->slen = str->slen - i;
+	endptr->slen = (str->slen < 0)? 0: (str->slen - i);
     }
 
     return value;
@@ -341,6 +362,8 @@ PJ_DEF(pj_status_t) pj_strtoul3(const pj_str_t *str, unsigned long *value,
     unsigned i;
 
     PJ_CHECK_STACK();
+
+    PJ_ASSERT_RETURN(str->slen >= 0, PJ_EINVAL);
 
     if (!str || !value) {
         return PJ_EINVAL;
@@ -405,7 +428,9 @@ PJ_DEF(float) pj_strtof(const pj_str_t *str)
     char *pdot;
     float val;
 
-    if (str->slen == 0)
+    pj_assert(str->slen >= 0);
+
+    if (str->slen <= 0)
 	return 0;
 
     pdot = (char*)pj_memchr(str->ptr, '.', str->slen);

--- a/pjlib/src/pj/string.c
+++ b/pjlib/src/pj/string.c
@@ -150,8 +150,12 @@ PJ_DEF(char*) pj_strstr(const pj_str_t *str, const pj_str_t *substr)
 
     PJ_ASSERT_RETURN(str->slen >= 0 && substr->slen >= 0, NULL);
 
-    /* Special case when substr is zero */
-    if (substr->slen == 0) {
+    /* Check if the string is empty */
+    if (str->slen <= 0)
+    	return NULL;
+
+    /* Special case when substr is empty */
+    if (substr->slen <= 0) {
 	return (char*)str->ptr;
     }
 
@@ -171,7 +175,11 @@ PJ_DEF(char*) pj_stristr(const pj_str_t *str, const pj_str_t *substr)
 
     PJ_ASSERT_RETURN(str->slen >= 0 && substr->slen >= 0, NULL);
 
-    /* Special case when substr is zero */
+    /* Check if the string is empty */
+    if (str->slen <= 0)
+    	return NULL;
+
+    /* Special case when substr is empty */
     if (substr->slen == 0) {
 	return (char*)str->ptr;
     }


### PR DESCRIPTION
Even though PJSIP string is not supposed to have negative length ever, a runtime bug or improper initialization can cause this to happen. And it may produce issues such as memory overwrite or crash, since the string implementation rarely checks for strings with negative length.

In this PR, we will add handling for string inputs that have negative length, as well as add assertion to allow apps to catch this issue during debugging/development mode.
