### PR TITLE
Fix socktype and duplicate checking in pj_getaddrinfo()

### DIFF
--- a/pjlib/src/pj/addr_resolv_sock.c
+++ b/pjlib/src/pj/addr_resolv_sock.c
@@ -197,15 +197,20 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
 	if (af!=PJ_AF_UNSPEC && res->ai_family != af)
 	    continue;
 
-	if (res->ai_socktype != pj_SOCK_DGRAM()
-                    && res->ai_socktype != pj_SOCK_STREAM()) {
+	if (res->ai_socktype != pj_SOCK_DGRAM() &&
+            res->ai_socktype != pj_SOCK_STREAM() &&
+            /* It is possible that the result's sock type
+             * is unspecified.
+             */
+            res->ai_socktype != 0)
+        {
 	        continue;
 	}
 
 	/* Add current address in the resulting list if there
 	 * is no duplicates only. */
 	for (j = 0; j < i; j++) {
-	    if (!pj_memcmp(&ai[j].ai_addr, res->ai_addr, res->ai_addrlen)) {
+	    if (!pj_sockaddr_cmp(&ai[j].ai_addr, res->ai_addr)) {
 		duplicate_found = PJ_TRUE;
 		break;
 	    }


### PR DESCRIPTION
Related to #2619 and the report in #2787.

There are a couple of problems found:
1. Issue with duplicate checking in `pj_getaddrinfo()`. When storing the result, PJSIP will reset the length by calling `PJ_SOCKADDR_RESET_LEN()`. This may cause `pj_memcmp()` when finding duplicates to fail if `res->ai_addr.sa_len` is not zero, even though the address matches. So we should replace this with `pj_sockaddr_cmp()` instead.

2. According to the report and discussion in #2787, it is possible that the result has a socktype of 0.
From: https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo
```
    // Retrieve each address and print out the hex bytes
    for(ptr=result; ptr != NULL ;ptr=ptr->ai_next) {
....
    printf("\tSocket type: ");
        switch (ptr->ai_socktype) {
            case 0:
                printf("Unspecified\n");
                break;
```
So we should allow this. Another alternative, as suggested by @AmarOk1412 , is to completely remove the socktype checking.

