### PR TITLE
Allow macos to share from USB camera

### DIFF
--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -286,7 +286,7 @@ static pj_status_t darwin_factory_destroy(pjmedia_vid_dev_factory *f)
 /* API: refresh the list of devices */
 static pj_status_t darwin_factory_refresh(pjmedia_vid_dev_factory *f)
 {
-struct darwin_factory *qf = (struct darwin_factory*)f;
+    struct darwin_factory *qf = (struct darwin_factory*)f;
     struct darwin_dev_info *qdi;
     unsigned i, l, first_idx, front_idx = -1;
     enum { MAX_DEV_COUNT = 8 };

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -290,15 +290,15 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
     struct darwin_dev_info *qdi;
     unsigned i, l, first_idx, front_idx = -1;
     enum { MAX_DEV_COUNT = 8 };
-
+    
     set_preset_str();
-
+    
     /* Initialize input and output devices here */
     qf->dev_info = (struct darwin_dev_info*)
 		   pj_pool_calloc(qf->pool, MAX_DEV_COUNT,
 				  sizeof(struct darwin_dev_info));
     qf->dev_count = 0;
-
+    
 #if TARGET_OS_IPHONE
     /* Init output device */
     qdi = &qf->dev_info[qf->dev_count++];
@@ -308,7 +308,7 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
     qdi->info.dir = PJMEDIA_DIR_RENDER;
     qdi->info.has_callback = PJ_FALSE;
 #endif
-
+    
     /* Init input device */
     first_idx = qf->dev_count;
     if (NSClassFromString(@"AVCaptureSession")) {
@@ -374,7 +374,7 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
             qdi->dev = device;
         }
     }
-
+    
     /* Set front camera to be the first input device (as default dev) */
     if (front_idx != -1 && front_idx != first_idx) {
         struct darwin_dev_info tmp_dev_info = qf->dev_info[first_idx];
@@ -391,17 +391,17 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
                           PJMEDIA_VID_DEV_CAP_OUTPUT_POSITION |
                           PJMEDIA_VID_DEV_CAP_OUTPUT_HIDE |
                           PJMEDIA_VID_DEV_CAP_ORIENTATION;
-
+	
 	for (l = 0; l < PJ_ARRAY_SIZE(darwin_fmts); l++) {
             pjmedia_format *fmt;
-
+            
             /* Simple renderer UIView only supports BGRA */
             if (qdi->info.dir == PJMEDIA_DIR_RENDER &&
                 darwin_fmts[l].pjmedia_format != PJMEDIA_FORMAT_BGRA)
             {
                 continue;
             }
-
+            
             if (qdi->info.dir == PJMEDIA_DIR_RENDER) {
                 fmt = &qdi->info.fmt[qdi->info.fmt_cnt++];
                 pjmedia_format_init_video(fmt,
@@ -412,7 +412,7 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
             } else {
                 int m;
                 AVCaptureDevice *dev = qdi->dev;
-
+                
                 /* Set supported size for capture device */
                 for(m = 0;
                     m < PJ_ARRAY_SIZE(darwin_sizes) &&
@@ -437,11 +437,11 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
                           	darwin_sizes[m].supported_size_w,
                                 DEFAULT_FPS, 1);
                     }
-                }
+                }                
             }
 	}
     }
-
+    
     PJ_LOG(4, (THIS_FILE, "Darwin video initialized with %d devices:",
 	       qf->dev_count));
     for (i = 0; i < qf->dev_count; i++) {

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -324,7 +324,7 @@ struct darwin_factory *qf = (struct darwin_factory*)f;
 	    NSArray<AVCaptureDeviceType> *dev_types =
 	    	@[AVCaptureDeviceTypeBuiltInWideAngleCamera
 #if TARGET_OS_OSX && defined(__MAC_10_15)
-                  , AVCaptureDeviceTypeExternalUnknown
+	    	  , AVCaptureDeviceTypeExternalUnknown
 #endif
 #if TARGET_OS_IPHONE && defined(__IPHONE_10_0)
 	    	  , AVCaptureDeviceTypeBuiltInDuoCamera


### PR DESCRIPTION
Goal: Allow macOS to share video from attached USB web cams. Three things were done. 

1. Add `AVCaptureDeviceTypeExternalUnknown` when fetching cameras from the system. This will allow pjsip to see USB cameras.
2. Moved contents of `darwin_factory_init` into `darwin_factory_refresh`. As such, `init` now calls `refresh`. This allows pjsip to see added/removed USB camera devices when refreshing devs. 
3. I noticed while sharing a USB camera into a call and unplugging the camera, pjsip would throw an assert. This is because `session_runtime_error` is calling `PJ_LOG` from a non-registered thread in `NSNotificationCenter`. I've commented the LOG statement, but maybe there is a better option to handle this.  