### PR TITLE
Don't copy sock address if it points to the same memory

### DIFF
--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -916,8 +916,10 @@ PJ_DEF(pj_status_t) pj_gethostip(int af, pj_sockaddr *addr)
 		}
 
 		if (j == cand_cnt) {
-		    pj_sockaddr_copy_addr(&cand_addr[cand_cnt], 
-					  &cand_addr[start_if+i]);
+		    if (cand_cnt != (start_if + i)) {
+			pj_sockaddr_copy_addr(&cand_addr[cand_cnt],
+					      &cand_addr[start_if + i]);
+		    }
 		    cand_weight[cand_cnt] += WEIGHT_INTERFACE;
 		    ++cand_cnt;
 		}


### PR DESCRIPTION
This is to fix #2789.

Currently `pj_gethostip()` will gather candidates and place it on an array. It will use `pj_sockaddr_copy_addr()` which uses `memcpy()` to copy the sock address. This will raise undefined behavior if the the source and destination address refer to the same address.