### PR TITLE
Replace deprecated Android Camera framework with Camera2

### DIFF
--- a/pjmedia/src/pjmedia-videodev/android/PjCamera2.java
+++ b/pjmedia/src/pjmedia-videodev/android/PjCamera2.java
@@ -1,0 +1,307 @@
+/* $Id$ */
+/*
+ * Copyright (C) 2021 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.pjsip;
+
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CameraDevice;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CameraMetadata;
+import android.hardware.camera2.CaptureRequest;
+import android.media.Image;
+import android.media.ImageReader;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Log;
+import android.util.Range;
+import android.view.Surface;
+import android.view.SurfaceView;
+import android.view.SurfaceHolder;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pjsip.PjCameraInfo2;
+
+public class PjCamera2
+{
+    private final String TAG = "PjCamera2";
+
+    private CameraDevice camera = null;
+    private CameraCaptureSession previewSession = null;
+
+    private boolean isRunning = false;
+    private boolean start_with_fps = true;
+    private int camIdx;
+    private final long userData;
+    private final int fps;
+
+    private final ImageReader imageReader;
+    private HandlerThread handlerThread = null;
+    private Handler handler;
+
+    /* For debugging purpose only */
+    private final SurfaceView surfaceView;
+
+    native void PushFrame2(long userData_,
+			   ByteBuffer plane0, int rowStride0, int pixStride0,
+			   ByteBuffer plane1, int rowStride1, int pixStride1,
+			   ByteBuffer plane2, int rowStride2, int pixStride2);
+
+    ImageReader.OnImageAvailableListener imageAvailListener = new ImageReader.OnImageAvailableListener() {
+	@Override
+	public void onImageAvailable(ImageReader reader) {
+	    if (!isRunning)
+		return;
+
+	    Image image = reader.acquireLatestImage();
+	    if (image == null)
+		return;
+
+	    /* Get planes buffers. According to the docs, the buffers are always direct buffers */
+	    Image.Plane[] planes = image.getPlanes();
+	    ByteBuffer plane0 = planes[0].getBuffer();
+	    ByteBuffer plane1 = planes.length > 1 ? planes[1].getBuffer() : null;
+	    ByteBuffer plane2 = planes.length > 2 ? planes[2].getBuffer() : null;
+	    assert plane0.isDirect();
+
+	    //for (Image.Plane p: planes) {
+	    //	Log.d(TAG, String.format("size=%d bytes, getRowStride()=%d getPixelStride()=%d", p.getBuffer().remaining(), p.getRowStride(), p.getPixelStride()));
+	    //}
+
+	    PushFrame2(	userData,
+		       	plane0, planes[0].getRowStride(), planes[0].getPixelStride(),
+		       	plane1, plane1!=null? planes[1].getRowStride():0, plane1!=null? planes[1].getPixelStride():0,
+		    	plane2, plane2!=null? planes[2].getRowStride():0, plane2!=null? planes[2].getPixelStride():0);
+
+	    image.close();
+	}
+    };
+
+    private final CameraDevice.StateCallback camStateCallback = new CameraDevice.StateCallback() {
+	@Override
+	public void onOpened(CameraDevice c) {
+	    Log.i(TAG, "CameraDevice.StateCallback.onOpened");
+	    camera = c;
+	    StartPreview();
+	}
+	@Override
+	public void onClosed(CameraDevice c) {
+	    Log.i(TAG, "CameraDevice.StateCallback.onClosed");
+	}
+	@Override
+	public void onDisconnected(CameraDevice c) {
+	    Log.i(TAG, "CameraDevice.StateCallback.onDisconnected");
+	    Stop();
+	}
+	@Override
+	public void onError(CameraDevice c, int error) {
+	    Log.e(TAG, "CameraDevice.StateCallback.onError: " + error);
+
+	    boolean was_with_fps = start_with_fps;
+	    Stop();
+
+	    /* First retry */
+	    if ((error == CameraDevice.StateCallback.ERROR_CAMERA_DEVICE ||
+		 error == CameraDevice.StateCallback.ERROR_CAMERA_SERVICE) &&
+		was_with_fps)
+	    {
+		Log.i(TAG, "Retrying without enforcing frame rate..");
+		start_with_fps = false;
+		Start();
+	    }
+	}
+    };
+
+    private final SurfaceHolder.Callback surfaceHolderCallback = new SurfaceHolder.Callback() {
+	@Override
+	public void surfaceCreated(SurfaceHolder holder) {
+	    Log.d(TAG, "SurfaceHolder.Callback.surfaceCreated");
+	    if (camera != null) {
+		StartPreview();
+	    }
+	}
+
+	@Override
+	public void surfaceChanged(SurfaceHolder holder,
+				   int format, int width, int height)
+	{
+	    Log.d(TAG, "SurfaceHolder.Callback.surfaceChanged");
+	}
+
+	@Override
+	public void surfaceDestroyed(SurfaceHolder holder)
+	{
+	    Log.d(TAG, "SurfaceHolder.Callback.surfaceDestroyed");
+	}
+    };
+
+    public PjCamera2(int idx, int w, int h, int fmt, int fps_,
+	    	    long userData_, SurfaceView surface)
+    {
+	camIdx = idx;
+	userData = userData_;
+	fps = fps_;
+	surfaceView = surface;
+
+	/* Some say to put a larger maxImages to improve FPS */
+	imageReader = ImageReader.newInstance(w, h, fmt, 3);
+	imageReader.setOnImageAvailableListener(imageAvailListener, null);
+
+    }
+
+    public int SwitchDevice(int idx)
+    {
+	boolean isCaptureRunning = isRunning;
+	int oldIdx = camIdx;
+
+	if (isCaptureRunning)
+	    Stop();
+
+	camIdx = idx;
+
+	if (isCaptureRunning) {
+	    int ret = Start();
+	    if (ret != 0) {
+		/* Try to revert back */
+		camIdx = oldIdx;
+		Start();
+		return ret;
+	    }
+	}
+
+	return 0;
+    }
+
+    private void StartPreview()
+    {
+	try {
+	    List<Surface> surfaceList = new ArrayList<>();
+	    surfaceList.add(imageReader.getSurface());
+	    if (surfaceView != null)
+		surfaceList.add(surfaceView.getHolder().getSurface());
+
+	    camera.createCaptureSession(surfaceList,
+		new CameraCaptureSession.StateCallback() {
+		    @Override
+		    public void onConfigured(CameraCaptureSession session) {
+			Log.d(TAG, "CameraCaptureSession.StateCallback.onConfigured");
+
+			try {
+			    CaptureRequest.Builder previewBuilder = camera.createCaptureRequest(CameraDevice.TEMPLATE_RECORD);
+			    previewBuilder.addTarget(imageReader.getSurface());
+			    if (surfaceView != null)
+				previewBuilder.addTarget(surfaceView.getHolder().getSurface());
+			    previewBuilder.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
+			    if (start_with_fps) {
+				Range<Integer> fpsRange = new Range<>(fps, fps);
+				previewBuilder.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange);
+			    }
+			    session.setRepeatingRequest(previewBuilder.build(), null, handler);
+			    previewSession = session;
+			} catch (Exception e) {
+			    Log.d(TAG, e.getMessage());
+			    Stop();
+			}
+			if (surfaceView!=null)
+			    surfaceView.getHolder().addCallback(surfaceHolderCallback);
+		    }
+		    @Override
+		    public void onConfigureFailed(CameraCaptureSession session) {
+			Log.e(TAG, "CameraCaptureSession.StateCallback.onConfigureFailed");
+			Stop();
+		    }
+		}, handler);
+	} catch (Exception e) {
+	    Log.d(TAG, e.getMessage());
+	    Stop();
+	}
+    }
+
+    public int Start()
+    {
+	PjCameraInfo2 ci = PjCameraInfo2.GetCameraInfo(camIdx);
+	if (ci == null) {
+	    Log.e(TAG, "Invalid device index: " + camIdx);
+	    return -1;
+	}
+
+	CameraManager cm = PjCameraInfo2.GetCameraManager();
+	if (cm == null)
+	    return -2;
+
+	handlerThread = new HandlerThread("Cam2HandlerThread");
+	handlerThread.start();
+	handler = new Handler(handlerThread.getLooper());
+	isRunning = true;
+
+	try {
+	    cm.openCamera(ci.id, camStateCallback, handler);
+	} catch (Exception e) {
+	    Log.d(TAG, e.getMessage());
+	    Stop();
+	    return -10;
+	}
+
+	return 0;
+    }
+
+    public void Stop()
+    {
+        if (!isRunning)
+            return;
+
+	isRunning = false;
+	Log.d(TAG, "Stopping..");
+
+	if (previewSession != null) {
+	    previewSession.close();
+	    previewSession = null;
+	}
+
+	if (camera != null) {
+	    camera.close();
+	    camera = null;
+	}
+
+	if (surfaceView != null)
+	    surfaceView.getHolder().removeCallback(surfaceHolderCallback);
+
+	if (handlerThread != null) {
+	    handlerThread.quitSafely();
+	    try {
+	        if (handlerThread.getId() != Thread.currentThread().getId()) {
+		    Log.d(TAG, "Wait thread..");
+		    handlerThread.join();
+		    Log.d(TAG, "Wait thread done");
+		}
+		handlerThread = null;
+		handler = null;
+	    } catch (InterruptedException e) {
+		e.printStackTrace();
+	    }
+	}
+
+	/* Reset setting */
+	start_with_fps = true;
+
+	Log.d(TAG, "Stopped.");
+    }
+
+}

--- a/pjmedia/src/pjmedia-videodev/android/PjCamera2.java
+++ b/pjmedia/src/pjmedia-videodev/android/PjCamera2.java
@@ -1,4 +1,3 @@
-/* $Id$ */
 /*
  * Copyright (C) 2021 Teluu Inc. (http://www.teluu.com)
  *

--- a/pjmedia/src/pjmedia-videodev/android/PjCameraInfo2.java
+++ b/pjmedia/src/pjmedia-videodev/android/PjCameraInfo2.java
@@ -1,4 +1,3 @@
-/* $Id$ */
 /*
  * Copyright (C) 2021 Teluu Inc. (http://www.teluu.com)
  *

--- a/pjmedia/src/pjmedia-videodev/android/PjCameraInfo2.java
+++ b/pjmedia/src/pjmedia-videodev/android/PjCameraInfo2.java
@@ -1,0 +1,203 @@
+/* $Id$ */
+/*
+ * Copyright (C) 2021 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.pjsip;
+
+import java.util.Arrays;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.params.StreamConfigurationMap;
+import android.util.Log;
+import android.util.Size;
+import android.graphics.ImageFormat;
+
+public class PjCameraInfo2 {
+    public String id;
+    public int facing;			// 0: back, 1: front, 2: external
+    public int orient;
+    public int[] supportedSize;		// [w1, h1, w2, h2, ...]
+    public int[] supportedFps1000;	// [min1, max1, min2, max2, ...]
+    public int[] supportedFormat;	// [fmt1, fmt2, ...]
+
+    private static final String TAG = "PjCameraInfo2";
+
+    /* The camera2 is a bit tricky with format, for example it reports
+     * for I420 support (and no NV21 support), however the incoming frame
+     * buffers are actually in NV21 format (e.g: pixel stride is 2).
+     *
+     * For now, we only support I420.
+     */
+    private static final int[] PJ_SUPPORTED_FORMAT = {
+    	ImageFormat.YUV_420_888,	// PJMEDIA_FORMAT_I420
+    };
+
+    private static boolean is_inited = false;
+    private static PjCameraInfo2[] camInfo = null;
+    private static int camInfoCnt = 0;
+    private static CameraManager cameraManager = null;
+
+    public static void SetCameraManager(CameraManager cm) {
+        cameraManager = cm;
+    }
+
+    public static CameraManager GetCameraManager() {
+	return cameraManager;
+    }
+
+    private static int Refresh() {
+	CameraManager cm = GetCameraManager();
+	if (cm==null) {
+	    Log.e(TAG, "Need camera manager instance for enumerating camera");
+	    return -1;
+	}
+
+	is_inited = false;
+
+	String[] camIds;
+	try {
+	    camIds = cm.getCameraIdList();
+	} catch (CameraAccessException e) {
+	    Log.d(TAG, e.getMessage());
+	    e.printStackTrace();
+	    return -1;
+	}
+
+	camInfo = new PjCameraInfo2[camIds.length];
+	camInfoCnt = 0;
+
+	Log.i(TAG, "Found " + camIds.length + " cameras:");
+	for (int i = 0; i < camIds.length; ++i) {
+	    Integer facing;
+	    CameraCharacteristics cc;
+	    StreamConfigurationMap scm;
+	    int[] outFmts;
+
+	    /* Query basic info */
+	    try {
+		cc = cm.getCameraCharacteristics(camIds[i]);
+		facing = cc.get(CameraCharacteristics.LENS_FACING);
+		scm = cc.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+		outFmts = scm.getOutputFormats();
+	    } catch (Exception e) {
+		Log.d(TAG, e.getMessage());
+		Log.w(TAG, String.format("%3d: id=%s skipped due to failure in querying info",
+			i, camIds[i]));
+		continue;
+	    }
+
+	    PjCameraInfo2 pjci = new PjCameraInfo2();
+	    pjci.id = camIds[i];
+	    switch(facing) {
+		case CameraCharacteristics.LENS_FACING_BACK:
+		    pjci.facing = 0;
+		    break;
+		case CameraCharacteristics.LENS_FACING_FRONT:
+		    pjci.facing = 1;
+		    break;
+		default:
+		    pjci.facing = 2;
+		    break;
+	    }
+
+	    int[] fmts = new int[outFmts.length];
+	    int fmtCnt = 0;
+	    for (int pjFmt : PJ_SUPPORTED_FORMAT) {
+		for (int outFmt : outFmts) {
+		    if (outFmt == pjFmt) {
+			fmts[fmtCnt++] = pjFmt;
+			break;
+		    }
+		}
+	    }
+	    Log.i(TAG, String.format("%3d: id=%s formats=%s",
+		    i, pjci.id, Arrays.toString(outFmts)));
+	    if (fmtCnt == 0) {
+		Log.w(TAG, String.format("%3d: id=%s skipped due to no PJSIP compatible format",
+			i, pjci.id));
+		continue;
+	    }
+
+	    pjci.supportedFormat = new int[fmtCnt];
+	    System.arraycopy(fmts, 0, pjci.supportedFormat, 0, fmtCnt);
+
+	    /* Query additional info */
+	    try {
+		pjci.orient = cc.get(CameraCharacteristics.SENSOR_ORIENTATION);
+	    } catch (Exception e) {
+		Log.d(TAG, e.getMessage());
+		Log.w(TAG, String.format("%3d: id=%s failed in getting orient",
+			i, camIds[i]));
+	    }
+
+	    try {
+		Size[] suppSize = scm.getOutputSizes(pjci.supportedFormat[0]);
+		pjci.supportedSize = new int[suppSize.length * 2];
+		for (int j = 0; j < suppSize.length; ++j) {
+		    pjci.supportedSize[j*2] 	= suppSize[j].getWidth();
+		    pjci.supportedSize[j*2 + 1] = suppSize[j].getHeight();
+		}
+	    } catch (Exception e) {
+		Log.d(TAG, e.getMessage());
+		Log.w(TAG, String.format("%3d: id=%s failed in getting sizes",
+			i, camIds[i]));
+
+		/* Query failed, let's just hardcode the supported sizes */
+		pjci.supportedSize = new int[] {176, 144, 320, 240, 352, 288, 640, 480, 1280, 720, 1920, 1080};
+	    }
+
+	    /* FPS info is not really used for now, let's just hardcode it */
+	    pjci.supportedFps1000 = new int[] { 1000, 30000 };
+
+	    camInfo[camInfoCnt++] = pjci;
+
+	    Log.i(TAG, String.format("%3d: id=%s facing=%d orient=%d formats=%s sizes=%s",
+		    		     i, pjci.id, pjci.facing, pjci.orient,
+		    		     Arrays.toString(pjci.supportedFormat),
+		    		     Arrays.toString(pjci.supportedSize)));
+	}
+
+	is_inited = true;
+	return 0;
+    }
+
+    public static int GetCameraCount()
+    {
+        /* Always refresh */
+	if (Refresh() != 0) {
+	    return -1;
+	}
+	return camInfoCnt;
+    }
+
+    /* Get camera info: facing, orientation, supported size/fps/format. */
+    public static PjCameraInfo2 GetCameraInfo(int idx)
+    {
+	if (!is_inited) {
+	    Log.e(TAG, "Not initalized");
+	    return null;
+	}
+
+	if (idx < 0 || idx >= camInfoCnt) {
+	    Log.e(TAG, "Invalid camera ID");
+	    return null;
+	}
+
+	return camInfo[idx];
+    }
+}

--- a/pjmedia/src/pjmedia-videodev/android_dev.c
+++ b/pjmedia/src/pjmedia-videodev/android_dev.c
@@ -130,8 +130,7 @@ typedef struct and_stream
     pjmedia_vid_dev_conv    conv;
     
     /** Frame format param for NV21/YV12 -> I420 conversion */
-    pjmedia_video_apply_fmt_param
-			    vafp;
+    pjmedia_video_apply_fmt_param vafp;
 } and_stream;
 
 
@@ -197,8 +196,22 @@ static pjmedia_vid_dev_stream_op stream_op =
  * JNI stuff
  */
 extern JavaVM *pj_jni_jvm;
-#define PJ_CAMERA_CLASS_PATH		"org/pjsip/PjCamera"
-#define PJ_CAMERA_INFO_CLASS_PATH	"org/pjsip/PjCameraInfo"
+
+/* Use camera2 (since Android API level 21) */
+#define USE_CAMERA2	1
+
+#if USE_CAMERA2
+#define PJ_CAMERA			"PjCamera2"
+#define PJ_CAMERA_INFO			"PjCameraInfo2"
+#else
+#define PJ_CAMERA			"PjCamera"
+#define PJ_CAMERA_INFO			"PjCameraInfo"
+#endif
+
+#define PJ_CLASS_PATH			"org/pjsip/"
+#define PJ_CAMERA_CLASS_PATH		PJ_CLASS_PATH PJ_CAMERA
+#define PJ_CAMERA_INFO_CLASS_PATH	PJ_CLASS_PATH PJ_CAMERA_INFO
+
 
 static struct jni_objs_t
 {
@@ -224,9 +237,17 @@ static struct jni_objs_t
 } jobjs;
 
 
+#if USE_CAMERA2
+static void JNICALL OnGetFrame2(JNIEnv *env, jobject obj,
+				jlong user_data,
+				jobject plane0, jint rowStride0, jint pixStride0,
+				jobject plane1, jint rowStride1, jint pixStride1,
+				jobject plane2, jint rowStride2, jint pixStride2);
+#else
 static void JNICALL OnGetFrame(JNIEnv *env, jobject obj,
                                jbyteArray data, jint length,
 			       jlong user_data);
+#endif
 
 
 static pj_bool_t jni_get_env(JNIEnv **jni_env)
@@ -310,33 +331,33 @@ static pj_status_t jni_init_ids()
     }
 
     /* PjCamera class info */
-    GET_CLASS(PJ_CAMERA_CLASS_PATH, "PjCamera", jobjs.cam.cls);
-    GET_METHOD_ID(jobjs.cam.cls, "PjCamera", "<init>",
+    GET_CLASS(PJ_CAMERA_CLASS_PATH, PJ_CAMERA, jobjs.cam.cls);
+    GET_METHOD_ID(jobjs.cam.cls, PJ_CAMERA, "<init>",
 		  "(IIIIIJLandroid/view/SurfaceView;)V",
 		  jobjs.cam.m_init);
-    GET_METHOD_ID(jobjs.cam.cls, "PjCamera", "Start", "()I",
+    GET_METHOD_ID(jobjs.cam.cls, PJ_CAMERA, "Start", "()I",
 		  jobjs.cam.m_start);
-    GET_METHOD_ID(jobjs.cam.cls, "PjCamera", "Stop", "()V",
+    GET_METHOD_ID(jobjs.cam.cls, PJ_CAMERA, "Stop", "()V",
 		  jobjs.cam.m_stop);
-    GET_METHOD_ID(jobjs.cam.cls, "PjCamera", "SwitchDevice", "(I)I",
+    GET_METHOD_ID(jobjs.cam.cls, PJ_CAMERA, "SwitchDevice", "(I)I",
 		  jobjs.cam.m_switch);
 
     /* PjCameraInfo class info */
-    GET_CLASS(PJ_CAMERA_INFO_CLASS_PATH, "PjCameraInfo", jobjs.cam_info.cls);
-    GET_SMETHOD_ID(jobjs.cam_info.cls, "PjCameraInfo", "GetCameraCount", "()I",
+    GET_CLASS(PJ_CAMERA_INFO_CLASS_PATH, PJ_CAMERA_INFO, jobjs.cam_info.cls);
+    GET_SMETHOD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "GetCameraCount", "()I",
 		   jobjs.cam_info.m_get_cnt);
-    GET_SMETHOD_ID(jobjs.cam_info.cls, "PjCameraInfo", "GetCameraInfo",
+    GET_SMETHOD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "GetCameraInfo",
 		   "(I)L" PJ_CAMERA_INFO_CLASS_PATH ";",
 		   jobjs.cam_info.m_get_info);
-    GET_FIELD_ID(jobjs.cam_info.cls, "PjCameraInfo", "facing", "I",
+    GET_FIELD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "facing", "I",
 		 jobjs.cam_info.f_facing);
-    GET_FIELD_ID(jobjs.cam_info.cls, "PjCameraInfo", "orient", "I",
+    GET_FIELD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "orient", "I",
 		 jobjs.cam_info.f_orient);
-    GET_FIELD_ID(jobjs.cam_info.cls, "PjCameraInfo", "supportedSize", "[I",
+    GET_FIELD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "supportedSize", "[I",
 		 jobjs.cam_info.f_sup_size);
-    GET_FIELD_ID(jobjs.cam_info.cls, "PjCameraInfo", "supportedFormat", "[I",
+    GET_FIELD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "supportedFormat", "[I",
 		 jobjs.cam_info.f_sup_fmt);
-    GET_FIELD_ID(jobjs.cam_info.cls, "PjCameraInfo", "supportedFps1000", "[I",
+    GET_FIELD_ID(jobjs.cam_info.cls, PJ_CAMERA_INFO, "supportedFps1000", "[I",
 		 jobjs.cam_info.f_sup_fps);
 
 #undef GET_CLASS_ID
@@ -346,7 +367,11 @@ static pj_status_t jni_init_ids()
 
     /* Register native function */
     {
+#if USE_CAMERA2
+	JNINativeMethod m = { "PushFrame2", "(JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)V", (void*)&OnGetFrame2 };
+#else
 	JNINativeMethod m = { "PushFrame", "([BIJ)V", (void*)&OnGetFrame };
+#endif
 	if ((*jni_env)->RegisterNatives(jni_env, jobjs.cam.cls, &m, 1)) {
 	    PJ_LOG(3, (THIS_FILE, "[JNI] Failed in registering native "
 				  "function 'OnGetFrame()'"));
@@ -808,8 +833,13 @@ static pj_status_t and_factory_create_stream(
     pj_memcpy(&strm->vafp, &vafp, sizeof(vafp));
     strm->ts_inc = PJMEDIA_SPF2(param->clock_rate, &vfd->fps, 1);
 
-    /* Allocate buffer for YV12 -> I420 conversion */
-    if (convert_to_i420) {
+    /* Allocate buffer for YV12 -> I420 conversion.
+     * The camera2 is a bit tricky with format, for example it reports
+     * for I420 support (and no NV21 support), however the incoming frame
+     * buffers are actually in NV21 format (e.g: pixel stride is 2), so
+     * we should always check and conversion buffer may be needed.
+     */
+    if (USE_CAMERA2 || convert_to_i420) {
 	pj_assert(vfi->plane_cnt > 1);
 	strm->convert_to_i420 = convert_to_i420;
 	strm->convert_buf = pj_pool_alloc(pool, vafp.plane_bytes[1]);
@@ -829,7 +859,11 @@ static pj_status_t and_factory_create_stream(
 				 strm->cam_size.w,	/* w */
 				 strm->cam_size.h,	/* h */
 				 and_fmt,		/* fmt */
+#if USE_CAMERA2
+				 vfd->fps.num/
+#else
 				 vfd->fps.num*1000/
+#endif
 				 vfd->fps.denum,	/* fps */
 				 (jlong)(intptr_t)strm,	/* user data */
 				 NULL			/* SurfaceView */
@@ -1109,6 +1143,162 @@ static pj_status_t and_stream_destroy(pjmedia_vid_dev_stream *s)
     return PJ_SUCCESS;
 }
 
+#if USE_CAMERA2
+
+static void JNICALL OnGetFrame2(JNIEnv *env, jobject obj,
+				jlong user_data,
+				jobject plane0, jint rowStride0, jint pixStride0,
+				jobject plane1, jint rowStride1, jint pixStride1,
+				jobject plane2, jint rowStride2, jint pixStride2)
+{
+    and_stream *strm = (and_stream*)(intptr_t)user_data;
+    pjmedia_frame f;
+    pj_uint8_t *p0, *p1, *p2;
+    jlong p0_len, p1_len, p2_len;
+    pj_uint8_t *Y, *U, *V;
+    pj_status_t status;
+    void *frame_buf, *data_buf;
+    
+    strm->frame_ts.u64 += strm->ts_inc;
+    if (!strm->vid_cb.capture_cb)
+	return;
+
+    if (strm->thread_initialized == 0 || !pj_thread_is_registered()) {
+	pj_status_t status;
+	pj_bzero(strm->thread_desc, sizeof(pj_thread_desc));
+	status = pj_thread_register("and_cam", strm->thread_desc,
+				    &strm->thread);
+	if (status != PJ_SUCCESS)
+	    return;
+	strm->thread_initialized = 1;
+	PJ_LOG(5,(THIS_FILE, "Android camera thread registered"));
+    }
+
+    p0 = (pj_uint8_t*)(*env)->GetDirectBufferAddress(env, plane0);
+    p1 = (pj_uint8_t*)(*env)->GetDirectBufferAddress(env, plane1);
+    p2 = (pj_uint8_t*)(*env)->GetDirectBufferAddress(env, plane2);
+    p0_len = (*env)->GetDirectBufferCapacity(env, plane0);
+    p1_len = (*env)->GetDirectBufferCapacity(env, plane1);
+    p2_len = (*env)->GetDirectBufferCapacity(env, plane2);
+    
+    /* Assuming the buffers are originally a large contigue buffer */
+    pj_assert(p1 < p0+strm->vafp.framebytes && p2 < p0+strm->vafp.framebytes);
+
+    f.type = PJMEDIA_FRAME_TYPE_VIDEO;
+    f.size = strm->vafp.framebytes;
+    f.timestamp.u64 = strm->frame_ts.u64;
+    f.buf = data_buf = p0;
+
+    Y = (pj_uint8_t*)f.buf;
+    U = Y + strm->vafp.plane_bytes[0];
+    V = U + strm->vafp.plane_bytes[1];
+
+    /* Check if we need conversion here, this is the tricky part of camera2.
+     * When we request I420, the returned buffer may not be actually I420,
+     * for example it is NV21 in Samsung S10. The camera2 'cheats' us via
+     * it's Plane type which has pixel stride attribute. For example, I420
+     * may be contained in the Plane array with the following attributes:
+     * - U/Plane[1] = Y/Plane[0] + Ysize + 1.
+     * - V/Plane[2] = Y/Plane[0] + Ysize.
+     * - pixel stride = 2 for U & V planes, and 1 for Y plane.
+     */
+
+    /* Already I420, nothing to do */
+    if (p1 == U && p2 == V) {}
+
+    /* The buffer may be originally NV21, i.e: V/U is interleaved */
+    else if (p2==U && p1-p2==1 && pixStride1==2 && pixStride2==2)
+    {
+	pj_uint8_t *src = U;
+	pj_uint8_t *dst_u = U;
+	pj_uint8_t *end_u = U + strm->vafp.plane_bytes[1];
+	pj_uint8_t *dst_v = strm->convert_buf;
+	while (dst_u < end_u) {
+	    *dst_v++ = *src++;
+	    *dst_u++ = *src++;
+	}
+	pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[2]);
+    }
+    
+    /* The buffer may be originally YV12, i.e: U & V planes are swapped.
+     * We also need to strip out padding, if any.
+     */
+    else if ((p2 == p0+rowStride0*strm->vafp.size.h) &&
+	     (p1 == p2+rowStride2*strm->vafp.size.h/2))
+    {
+	/* Strip out Y padding */
+	if (rowStride0 > strm->vafp.size.w) {
+	    int i;
+	    pj_uint8_t *src = Y + rowStride0;
+	    pj_uint8_t *dst = Y + strm->vafp.size.w;
+
+	    for (i = 1; i < strm->vafp.size.h; ++i) {
+		memmove(dst, src, strm->vafp.size.w);
+		src += rowStride0;
+		dst += strm->vafp.size.w;
+	    }
+	}
+
+	/* Swap U & V planes */
+	if (rowStride1 == strm->vafp.size.w/2) {
+
+	    /* No padding, note Y plane should be no padding too! */
+	    pj_assert(rowStride0 == strm->vafp.size.w);
+	    pj_memcpy(strm->convert_buf, U, strm->vafp.plane_bytes[1]);
+	    pj_memmove(U, V, strm->vafp.plane_bytes[1]);
+	    pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[1]);
+
+	} else if (rowStride1 > strm->vafp.size.w/2) {
+
+	    /* Strip & copy V plane into conversion buffer */
+	    pj_uint8_t *src = Y + rowStride0*strm->vafp.size.h;
+	    pj_uint8_t *dst = strm->convert_buf;
+	    unsigned dst_stride = strm->vafp.size.w/2;
+	    int i;
+	    for (i = 0; i < strm->vafp.size.h/2; ++i) {
+		memmove(dst, src, dst_stride);
+		src += rowStride1;
+		dst += dst_stride;
+	    }
+
+	    /* Strip U plane */
+	    dst = U;
+	    for (i = 0; i < strm->vafp.size.h/2; ++i) {
+		memmove(dst, src, dst_stride);
+		src += rowStride1;
+		dst += dst_stride;
+	    }
+
+	    /* Get V plane data from conversion buffer */
+	    pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[2]);
+
+	}
+    }
+    
+    /* Else, let's just print log for now */
+    else {
+	PJ_LOG(1,(THIS_FILE, "Unrecognized image format from Android camera2, "
+			     "please report the following plane format:"));
+	PJ_LOG(1,(THIS_FILE, " Planes (buf/len/row_stride/pix_stride):"
+			     " p0=%p/%d/%d/%d p1=%p/%d/%d/%d p2=%p/%d/%d/%d",
+			     p0, p0_len, rowStride0, pixStride0,
+			     p1, p1_len, rowStride1, pixStride1,
+			     p2, p2_len, rowStride2, pixStride2));
+	return;
+    }
+
+    status = pjmedia_vid_dev_conv_resize_and_rotate(&strm->conv, 
+    						    f.buf,
+    				       		    &frame_buf);
+    if (status == PJ_SUCCESS) {
+        f.buf = frame_buf;
+    }
+
+    (*strm->vid_cb.capture_cb)(&strm->base, strm->user_data, &f);
+}
+
+#else
+
 static void JNICALL OnGetFrame(JNIEnv *env, jobject obj,
                                jbyteArray data, jint length,
 			       jlong user_data)
@@ -1224,5 +1414,7 @@ static void JNICALL OnGetFrame(JNIEnv *env, jobject obj,
     (*strm->vid_cb.capture_cb)(&strm->base, strm->user_data, &f);
     (*env)->ReleaseByteArrayElements(env, data, data_buf, JNI_ABORT);
 }
+
+#endif /* USE_CAMERA2 */
 
 #endif	/* PJMEDIA_VIDEO_DEV_HAS_ANDROID */

--- a/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.pjsip.pjsua2.app_kotlin"
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/pjsip-apps/src/swig/java/android/app/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "org.pjsip.pjsua2.app"
-        minSdkVersion 11
+        minSdkVersion 23
         targetSdkVersion 26
     }
 

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -19,6 +19,7 @@
 package org.pjsip.pjsua2.app;
 
 import android.content.IntentFilter;
+import android.hardware.camera2.CameraManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -46,6 +47,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.pjsip.PjCameraInfo2;
 import org.pjsip.pjsua2.*;
 
 public class MainActivity extends Activity
@@ -127,6 +129,9 @@ public class MainActivity extends Activity
     {
 	super.onCreate(savedInstanceState);
 	setContentView(R.layout.activity_main);
+
+	CameraManager cm = (CameraManager)getSystemService(Context.CAMERA_SERVICE);
+	PjCameraInfo2.SetCameraManager(cm);
 
 	if (app == null) {
 	    app = new MyApp();

--- a/pjsip-apps/src/swig/java/android/build.gradle
+++ b/pjsip-apps/src/swig/java/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
+++ b/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
@@ -3,13 +3,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion 23
+        targetSdkVersion 26
 
 
         ndk {
@@ -37,3 +35,4 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }
+


### PR DESCRIPTION
Camera2 is the latest Android camera framework API that replaces the deprecated camera framework libraries, as described [here](https://developer.android.com/training/camera2). This framework is added in API level 21 (or Android 5.0 released in Oct 2014). In this framework, enumerating cameras and their capabilities (e.g: format, size) does not seem to need camera permission, so application can request for user permission only when about to use it (instead of in the library initialization).

PS: there is also [CameraX](https://developer.android.com/training/camerax) framework as jetpack support library, which seems to be a wrapper of both Camera & camera2 frameworks, but it seems to be still in alpha version. Also it does not seem to work (straightforwardly) with `SurfaceView` for video preview (initially this is the main reason of not using this framework, but lately realized that we use `SurfaceView` for debugging purpose only).

An interesting fact when testing camera2 in Samsung S10, it does not report NV21 format capability as in older framework Camera, it reports I420/YUV_420_888 capability (along with few private formats). However, when capturing using I420 format, the returned frame buffer is actually in NV21 format, but represented as I420 via camera2 Plane structure, which has 'pixel stride' attribute (note: it is different from 'row stride').