### PR TITLE
High video latency when decoder frame rate is initialized lower than actually received

### DIFF
--- a/pjmedia/include/pjmedia/vid_conf.h
+++ b/pjmedia/include/pjmedia/vid_conf.h
@@ -285,6 +285,23 @@ PJ_DECL(pj_status_t) pjmedia_vid_conf_disconnect_port(
 					    unsigned sink_slot);
 
 
+/**
+ * Update or refresh port states from video port info. Some port may
+ * change its port info in the middle of a session, for example when
+ * a video stream decoder learns that incoming video size or frame rate
+ * has changed, video conference needs to be informed to update its
+ * internal states.
+ *
+ * @param vid_conf	The video conference bridge.
+ * @param slot		The media port's slot index to be updated.
+ *
+ * @return		PJ_SUCCESS on success, or the appropriate error
+ *			code.
+ */
+PJ_DECL(pj_status_t) pjmedia_vid_conf_update_port(pjmedia_vid_conf *vid_conf,
+						  unsigned slot);
+
+
 PJ_END_DECL
 
 /**

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -1176,6 +1176,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_update_port( pjmedia_vid_conf *vid_conf,
 	    PJ_LOG(1,(THIS_FILE, "pjmedia_vid_conf_update_port(): "
 				 "unrecognized format %04X",
 				 new_fmt.id));
+	    pj_mutex_unlock(vid_conf->mutex);
 	    return PJMEDIA_EBADFMT;
 	}
 
@@ -1186,6 +1187,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_update_port( pjmedia_vid_conf *vid_conf,
 	    PJ_LOG(1,(THIS_FILE, "pjmedia_vid_conf_update_port(): "
 				 "Failed to apply format %04X",
 				 new_fmt.id));
+	    pj_mutex_unlock(vid_conf->mutex);
 	    return status;
 	}
 	if (cport->port->put_frame) {

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -8519,6 +8519,20 @@ PJ_DECL(pj_status_t) pjsua_vid_conf_disconnect(pjsua_conf_port_id source,
 					       pjsua_conf_port_id sink);
 
 
+/**
+ * Update or refresh port states from video port info. Some port may
+ * change its port info in the middle of a session, for example when
+ * a video stream decoder learns that incoming video size or frame rate
+ * has changed, video conference needs to be informed to update its
+ * internal states.
+ *
+ * @param port_id	The slot id of the port to be updated.
+ *
+ * @return		PJ_SUCCESS on success, or the appropriate error
+ *			code.
+ */
+PJ_DECL(pj_status_t) pjsua_vid_conf_update_port(pjsua_conf_port_id port_id);
+
 
 /* end of VIDEO API */
 /**

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1683,6 +1683,16 @@ public:
     void stopTransmit(const VideoMedia &sink) const PJSUA2_THROW(Error);
 
     /**
+     * Update or refresh port states from video port info. Some port may
+     * change its port info in the middle of a session, for example when
+     * a video stream decoder learns that incoming video size or frame rate
+     * has changed, video conference needs to be informed to update its
+     * internal states.
+     *
+     */
+    void update() const PJSUA2_THROW(Error);
+
+    /**
      * Default Constructor.
      *
      * Normally application will not create VideoMedia object directly,

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1635,28 +1635,10 @@ pj_status_t call_media_on_event(pjmedia_event *event,
 	    if (call_med->strm.v.rdr_win_id != PJSUA_INVALID_ID) {
 		pjsua_vid_win *w = &pjsua_var.win[call_med->strm.v.rdr_win_id];
 		if (event->epub == w->vp_rend) {
-		    /* Renderer just changed format, reregister it to conf,
-		     * and reconnect stream.
+		    /* Renderer just changed format, update its
+		     * conference bridge port.
 		     */
-		    status = pjsua_vid_conf_remove_port(w->rend_slot);
-		    if (status == PJ_SUCCESS) {
-			status =
-			    pjsua_vid_conf_add_port(
-				w->pool,
-				pjmedia_vid_port_get_passive_port(w->vp_rend),
-				NULL, &w->rend_slot);
-		    }
-		    if (status == PJ_SUCCESS) {
-			status = pjsua_vid_conf_connect(
-					call_med->strm.v.strm_dec_slot,
-					w->rend_slot, NULL);
-		    }
-		    if (status != PJ_SUCCESS) {
-			PJ_PERROR(3,(THIS_FILE, status,
-				     "Call %d: Media %d: failed reregistering "
-				     "incoming video renderer after format "
-				     "changed", call->index, call_med->idx));
-		    }
+		    pjsua_vid_conf_update_port(w->rend_slot);
 		}
 	    }
 
@@ -1679,36 +1661,10 @@ pj_status_t call_media_on_event(pjmedia_event *event,
 		if (event->epub != strm_dec)
 		    break;
 
-		/* Stream decoder just changed format, reregister it
-		 * to video conf.
+		/* Stream decoder just changed format, update its
+		 * conference bridge port.
 		 */
-		status = pjsua_vid_conf_remove_port(dec_pid);
-		if (status == PJ_SUCCESS) {
-		    /* Note: conf will create another pool instead of using
-		     * invite pool directly, it only needs the pool factory
-		     * (invite pool itself will not grow).
-		     */
-		    status = pjsua_vid_conf_add_port(call->inv->pool, strm_dec,
-					NULL, &call_med->strm.v.strm_dec_slot);
-		}
-
-		if (status != PJ_SUCCESS) {
-		    PJ_PERROR(3,(THIS_FILE, status,
-				 "Call %d: Media %d: failed reregistering "
-				 "video stream decoder after format changed",
-				 call->index, call_med->idx));
-		    break;
-		}
-
-		dec_pid = call_med->strm.v.strm_dec_slot;
-		status = pjsua_vid_conf_get_port_info(dec_pid, &pi);
-		if (status != PJ_SUCCESS)
-		    break;
-
-		for (i = 0; i < pi.listener_cnt; i++) {
-		    pjsua_vid_conf_disconnect(dec_pid, pi.listeners[i]);
-		    pjsua_vid_conf_connect(dec_pid, pi.listeners[i], NULL);
-		}
+		pjsua_vid_conf_update_port(call_med->strm.v.strm_dec_slot);
 	    }
 	    break;
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -2826,6 +2826,16 @@ PJ_DEF(pj_status_t) pjsua_vid_conf_disconnect(pjsua_conf_port_id source,
     return pjmedia_vid_conf_disconnect_port(pjsua_var.vid_conf, source, sink);
 }
 
+
+/*
+ * Update or refresh port states from video port info.
+ */
+PJ_DEF(pj_status_t) pjsua_vid_conf_update_port(pjsua_conf_port_id id)
+{
+    return pjmedia_vid_conf_update_port(pjsua_var.vid_conf, id);
+}
+
+
 /*
  * Get the video window associated with the call.
  */

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -2048,7 +2048,6 @@ void VideoMedia::update() const PJSUA2_THROW(Error)
 #if PJSUA_HAS_VIDEO
     PJSUA2_CHECK_EXPR( pjsua_vid_conf_update_port(id) );
 #else
-    PJ_UNUSED_ARG(sink);
     PJSUA2_RAISE_ERROR(PJ_EINVALIDOP);
 #endif
 }

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -2042,3 +2042,13 @@ void VideoMedia::stopTransmit(const VideoMedia &sink) const
     PJSUA2_RAISE_ERROR(PJ_EINVALIDOP);
 #endif
 }
+
+void VideoMedia::update() const PJSUA2_THROW(Error)
+{
+#if PJSUA_HAS_VIDEO
+    PJSUA2_CHECK_EXPR( pjsua_vid_conf_update_port(id) );
+#else
+    PJ_UNUSED_ARG(sink);
+    PJSUA2_RAISE_ERROR(PJ_EINVALIDOP);
+#endif
+}


### PR DESCRIPTION
When the video receiver endpoint is initialized with 15 frames per second (default setting in OpenH264) and the sender actually sends 30 frames per second, video latency experienced by the receiver will keep increasing until jitter buffer capacity maxed out. 

After investigation, the video conference only configures the sink port's frame rate once, i.e: when it is registered. While in the event of frame rate changed (or format changed), PJSUA-LIB only reconnect the stream decoder to renderer, which won't update the stream decoder's frame rate in the video conference bridge. This PR's patch introduces new API to update/refresh port states in the video conference bridge, which is invoked by PJSUA-LIB when it receives format change event. Note that with the new API, reconnecting stream decoder to renderer is no longer necessary, also any other connection involving stream decoder or renderer should also be updated (also without reconnecting).

This issue should not be occurred prior to video conference implementation (#2181).
