### PR TITLE
Acquire lock before destroying ioqueue epoll

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -231,6 +231,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 
     ioqueue->epfd = os_epoll_create(max_fd);
     if (ioqueue->epfd < 0) {
+    	pj_lock_acquire(ioqueue->lock);
 	ioqueue_destroy(ioqueue);
 	return PJ_RETURN_OS_ERROR(pj_get_native_os_error());
     }


### PR DESCRIPTION
Fix #2803.

In `pj_ioqueue_create()` of `ioqueue_epoll.c`:
```
    rc = pj_ioqueue_set_lock(ioqueue, lock, PJ_TRUE);
    if (rc != PJ_SUCCESS)
        return rc;

    ioqueue->epfd = os_epoll_create(max_fd);
    if (ioqueue->epfd < 0) {
	ioqueue_destroy(ioqueue);
	return PJ_RETURN_OS_ERROR(pj_get_native_os_error());
    }
```

`pj_ioqueue_set_lock(ioqueue, lock, PJ_TRUE);` set `auto_delete_lock` to `PJ_TRUE`.

So when calling `ioqueue_destroy()` it will try to release the lock first before destroying it, hence the assertion reported in #2803.

Thanks to @oldiob for the report and the patch.

