### PR TITLE
Resort ICE checklist upon entering nomination stage

### DIFF
--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -2424,6 +2424,11 @@ static void start_nominated_check(pj_ice_sess *ice)
 	pj_timer_heap_cancel_if_active(ice->stun_cfg.timer_heap, &ice->timer,
 	                               TIMER_NONE);
     }
+	
+    /* Sort the list since some checks (with prflx cand in particular) 
+     * may have been added since the last sort.
+     */
+    sort_checklist(ice, &ice->clist);
 
     /* For each component, set the check state of valid check with
      * highest priority to Waiting (it should have Success state now).

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -3464,10 +3464,9 @@ static void handle_incoming_check(pj_ice_sess *ice,
 	     ice->clist.count));
 	pj_log_push_indent();
 
-	ice->clist.count++;
+	perform_check(ice, &ice->clist, ice->clist.count++, nominate);
     	/* Re-sort the list because of the newly added pair. */
     	sort_checklist(ice, &ice->clist);
-	perform_check(ice, &ice->clist, ice->clist.count, nominate);
 
 	pj_log_pop_indent();
 

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -2424,11 +2424,6 @@ static void start_nominated_check(pj_ice_sess *ice)
 	pj_timer_heap_cancel_if_active(ice->stun_cfg.timer_heap, &ice->timer,
 	                               TIMER_NONE);
     }
-	
-    /* Sort the list since some checks (with prflx cand in particular) 
-     * may have been added since the last sort.
-     */
-    sort_checklist(ice, &ice->clist);
 
     /* For each component, set the check state of valid check with
      * highest priority to Waiting (it should have Success state now).
@@ -3468,7 +3463,12 @@ static void handle_incoming_check(pj_ice_sess *ice,
 	LOG4((ice->obj_name, "New triggered check added: %d", 
 	     ice->clist.count));
 	pj_log_push_indent();
-	perform_check(ice, &ice->clist, ice->clist.count++, nominate);
+
+	ice->clist.count++;
+    	/* Re-sort the list because of the newly added pair. */
+    	sort_checklist(ice, &ice->clist);
+	perform_check(ice, &ice->clist, ice->clist.count, nominate);
+
 	pj_log_pop_indent();
 
     } else {


### PR DESCRIPTION
It is reported that in some situations, the successful peer reflexive (prflx) ICE candidates are not nominated, even though having the highest priority. This is because the prefix checks discovered when handling incoming checks (handle_incoming_check()) are added at the end of the check list. A check is performed right away on this new candidate, but the check list is not re-sorted.

The consequence is when the negotiation process enters the nomination stage when the timer `TIMER_START_NOMINATED_CHECK` fires, the checks with prflx candidates will have the wrong order in the list, which can cause the nomination of a check with a lower priority. And since the negotiation may complete as soon as all the components have a nominated check, the prflx may never get the chance to be nominated because they have the wrong order in the check list.

Note that the issue is more obvious with regular nomination, and also, if the Ta timer is larger than the default (20ms) (The reporter tested with a Ta=50ms as recommended in RFC-8445).

The proposed fix is to re-sort the check list each time a new pair is added.

Thanks to Mohamed Chibani for the report and the initial patch.
