### PR TITLE
Allow registration refresh to continue when REGISTER response contains expires parameter set to 0

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1244,15 +1244,14 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
- * Specify the default expire refresh value when the registers sent a Contact
+ * Allow client to send refresh registration when the registrar sent a Contact
  * header with expire parameter 0 in the 200/OK REGISTER response.
- * This value will be used when the REGISTER request doesn't include a 
- * Expire header.
+ * Refer to https://github.com/pjsip/pjproject/pull/2809 for more info.
  *
- * Default is 30.
+ * Default is 1.
  */
-#ifndef PJSIP_REGISTER_EXP_REFRESH
-#   define PJSIP_REGISTER_EXP_REFRESH	30
+#ifndef PJSIP_REGISTER_ALLOW_EXP_REFRESH
+#   define PJSIP_REGISTER_ALLOW_EXP_REFRESH	1
 #endif
 
 

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1242,6 +1242,20 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #   define PJSIP_REGISTER_CLIENT_ADD_XUID_PARAM	0
 #endif
 
+
+/**
+ * Specify the default expire refresh value when the registers sent a Contact
+ * header with expire parameter 0 in the 200/OK REGISTER response.
+ * This value will be used when the REGISTER request doesn't include a 
+ * Expire header.
+ *
+ * Default is 30.
+ */
+#ifndef PJSIP_REGISTER_EXP_REFRESH
+#   define PJSIP_REGISTER_EXP_REFRESH	30
+#endif
+
+
 /**
  * Maximum size of pool allowed for auth client session in pjsip_regc.
  * After the size exceeds because of Digest authentication processing,

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1359,6 +1359,14 @@ handle_err:
 						       PJSIP_REGC_MAX_CONTACT,
 						       contact);
 
+	    if (expiration == 0 && regc->current_op != REGC_UNREGISTERING) {
+		if (regc->expires_hdr && regc->expires_hdr->ivalue) {
+		    expiration = regc->expires_hdr->ivalue;
+		} else {
+		    expiration = PJSIP_REGISTER_EXP_REFRESH;
+		}
+	    }
+
 	    /* Schedule next registration */
             schedule_registration(regc, expiration);
 

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1365,7 +1365,14 @@ handle_err:
 		 * continue refresh registration.
 		 * Refer to: https://github.com/pjsip/pjproject/pull/2809
 		 */
-		if (regc->expires_hdr && regc->expires_hdr->ivalue) {
+		const pjsip_msg *msg = rdata->msg_info.msg;
+		const pjsip_expires_hdr *expires;
+		expires = (const pjsip_expires_hdr*) pjsip_msg_find_hdr(msg, 
+							PJSIP_H_EXPIRES, NULL);
+
+		if (expires) {
+		    expiration = expires->ivalue;
+		} else if (regc->expires_hdr && regc->expires_hdr->ivalue) {
 		    expiration = regc->expires_hdr->ivalue;
 		} else {
 		    expiration = 3600;

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1359,14 +1359,21 @@ handle_err:
 						       PJSIP_REGC_MAX_CONTACT,
 						       contact);
 
+#if PJSIP_REGISTER_ALLOW_EXP_REFRESH
 	    if (expiration == 0 && regc->current_op != REGC_UNREGISTERING) {
+		/* Response contain expires contact param 0, allow client to
+		 * continue refresh registration.
+		 * Refer to: https://github.com/pjsip/pjproject/pull/2809
+		 */
 		if (regc->expires_hdr && regc->expires_hdr->ivalue) {
 		    expiration = regc->expires_hdr->ivalue;
 		} else {
-		    expiration = PJSIP_REGISTER_EXP_REFRESH;
+		    expiration = 3600;
 		}
+		PJ_LOG(4, (THIS_FILE, "Modify response's expiration from 0 "
+			   "to %d", expiration));
 	    }
-
+#endif
 	    /* Schedule next registration */
             schedule_registration(regc, expiration);
 


### PR DESCRIPTION
Consider this scenario:
- Client is behind a firewall/NAT and send registration and responded with 200/OK
- The firewall is restarted. And the client send refresh registration
- Server adds a new Contact header to the 200/OK response since it detects a different Via address on the request
- The first binding is never refreshed and eventually expires. This is reflected on the 200/OK REGISTER response
- When the client received the expires parameter to 0, it stops refreshing the registration although the registration should still be active

In this case, the client should be allowed to continue the refresh registration. If the server receive an expired refresh registration, it should send error response instead of a 200/OK response.

Note that this scenario can be avoided by setting `pjsua_acc_config.allow_contact_rewrite` set to PJ_TRUE. This way the library will send an updated contact to the server when it detects any IP/port changes on the REGISTER response.