### PR TITLE
Add support to specify Contact URI params specific to REGISTER requests

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3693,6 +3693,17 @@ typedef struct pjsua_acc_config
      */
     pj_str_t	    reg_contact_params;
 
+    /**
+     * Additional URI parameters that will be appended in the Contact URI
+     * for this account. This will only affect REGISTER requests and
+     * will be appended after \a contact_uri_params;
+     *
+     * The parameters should be preceeded by semicolon, and all strings must
+     * be properly escaped. Example:
+     *	 ";my-param=X;another-param=Hi%20there"
+     */
+    pj_str_t	    reg_contact_uri_params;
+
     /** 
      * The optional custom SIP headers to be put in the presence
      * subscription request.

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -81,6 +81,17 @@ struct AccountRegConfig : public PersistentObject
     string	    	contactParams;
 
     /**
+     * Additional parameters that will be appended in the Contact URI
+     * of the registration requests. This will be appended after
+     * \a AccountSipConfig.contactUriParams;
+     *
+     * The parameters should be preceeded by semicolon, and all strings must
+     * be properly escaped. Example:
+     *	 ";my-param=X;another-param=Hi%20there"
+     */
+    string	    	contactUriParams;
+
+    /**
      * Optional interval for registration, in seconds. If the value is zero,
      * default interval will be used (PJSUA_REG_INTERVAL, 300 seconds).
      */

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1613,8 +1613,8 @@ done:
 		reg_contact.slen = pj_ansi_snprintf(
 					    reg_contact.ptr, len,
 					    "<%.*s%.*s>%.*s",
-					    tmp_len, tmp_uri,
-					    uri_param.slen, uri_param.ptr,
+					    (int)tmp_len, tmp_uri,
+					    (int)uri_param.slen, uri_param.ptr,
 					    (int)acc->cfg.contact_params.slen,
 					    acc->cfg.contact_params.ptr);
 		pj_assert(reg_contact.slen > 0);

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -575,6 +575,7 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     ret.unreg_timeout		= regConfig.unregWaitMsec;
     ret.reg_use_proxy		= regConfig.proxyUse;
     ret.reg_contact_params	= str2Pj(regConfig.contactParams);
+    ret.reg_contact_uri_params	= str2Pj(regConfig.contactUriParams);
     for (i=0; i<regConfig.headers.size(); ++i) {
 	pj_list_push_back(&ret.reg_hdr_list, &regConfig.headers[i].toPj());
     }
@@ -725,6 +726,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     regConfig.unregWaitMsec	= prm.unreg_timeout;
     regConfig.proxyUse		= prm.reg_use_proxy;
     regConfig.contactParams	= pj2Str(prm.reg_contact_params);
+    regConfig.contactUriParams	= pj2Str(prm.reg_contact_uri_params);
     regConfig.headers.clear();
     hdr = prm.reg_hdr_list.next;
     while (hdr != &prm.reg_hdr_list) {


### PR DESCRIPTION
In #1965, app can add Contact header params specific to REGISTER requests to specify Push Notification info. However, instead of in the Contact header params, actually the RFC recommends the PN info to be specified in the Contact URI params. So this PR introduces `pjsua_acc_config.reg_contact_uri_params` for PJSUA-LIB and `AccountRegConfig.contactUriParams` for PJSUA2 to allow app to specify Contact URI params specific to REGISTER requests.