### PR TITLE
Avoid PJ_ERESOLVE when using IPv6

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1643,7 +1643,7 @@ static pj_status_t app_init(void)
     }
 
     /* Add UDP transport unless it's disabled. */
-    if (!app_config.no_udp) {
+    if (!app_config.no_udp && !app_config.ipv6) {
 	pjsua_acc_id aid;
 	pjsip_transport_type_e type = PJSIP_TRANSPORT_UDP;
 


### PR DESCRIPTION
This patch fixed the following:

when running pjsua with the parameters --ipv6  --ip-addr=xxx , the following error is being thrown:

`pjsua_core.c  Unable to resolve transport public address: gethostbyname() has returned error (PJ_ERESOLVE) [status=70018]
`
This is due to the wrong (ipv4) code branch being taken, as the value of app_config.ipv6 is being ignored.