### PR TITLE
Race condition between Apple SSL destroy and event callback

### DIFF
--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -1361,6 +1361,11 @@ static void ssl_destroy(pj_ssl_sock_t *ssock)
     }
 
     event_manager_remove_events(ssock);
+    /* We have removed all events that belong to this ssl socket, but
+     * since calling event callbacks are done without holding event manager's
+     * lock, there may be a race here with those callbacks.
+     */
+    pj_thread_sleep(1000);
 
     /* Important: if we are called from a blocking dispatch block,
      * we need to signal it before destroying ourselves.


### PR DESCRIPTION
A race condition can occur between destroying of Apple SSL socket and its event callback. Specifically, the race happens between `ssl_destroy()` and `ssl_network_event_poll()` in `ssl_sock_apple.m`. `ssl_destroy()` will try to remove all events that belong to the socket by calling `event_manager_remove_events(ssock)`, but at the same time, the event polling may be in the process of calling those event's callback.

Unfortunately, there doesn't seem to be a simple solution for this. Holding the event manager's lock when calling the callbacks will cause deadlock, while adding reference to the socket's group lock prior to calling the callback may have been too late since the destroying process has already started (in fact, `ssl_destroy()` is called by the group lock's destructor handler).

Note: Since event callback is unique to Apple SSL, this shouldn't affect other SSL backends.
