### PR TITLE
Prevent assertion if Contact URI is not found when checking NAT address

### DIFF
--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -162,8 +162,8 @@ void MyCall::onCallMediaState(OnCallMediaStateParam &prm)
     }
 
     // This will connect the wav file to the call audio media
-    if (wav_player)
-    	wav_player->startTransmit(aud_med);
+//    if (wav_player)
+//    	wav_player->startTransmit(aud_med);
 
     // And this will connect the call audio media to the sound device/speaker
     aud_med.startTransmit(play_dev_med);
@@ -201,10 +201,10 @@ static void mainProg1(Endpoint &ep)
 
     // Add account
     AccountConfig acc_cfg;
-    acc_cfg.idUri = "sip:test1@pjsip.org";
+    acc_cfg.idUri = "sip:402@sip.pjsip.org";
     acc_cfg.regConfig.registrarUri = "sip:sip.pjsip.org";
     acc_cfg.sipConfig.authCreds.push_back( AuthCredInfo("digest", "*",
-                                                        "test1", 0, "test1") );
+                                                        "402", 0, "pw402") );
     MyAccount *acc(new MyAccount);
     try {
 	acc->create(acc_cfg);
@@ -220,10 +220,10 @@ static void mainProg1(Endpoint &ep)
     CallOpParam prm(true);
     prm.opt.audioCount = 1;
     prm.opt.videoCount = 0;
-    call->makeCall("sip:test1@pjsip.org", prm);
+    call->makeCall("sip:401@sip.pjsip.org", prm);
     
     // Hangup all calls
-    pj_thread_sleep(4000);
+    pj_thread_sleep(8000);
     ep.hangupAllCalls();
     pj_thread_sleep(4000);
     

--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -429,6 +429,7 @@ static void mainProg4(Endpoint &ep)
 #endif
 
 
+extern "C"
 int main()
 {
     int ret = 0;

--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -162,8 +162,8 @@ void MyCall::onCallMediaState(OnCallMediaStateParam &prm)
     }
 
     // This will connect the wav file to the call audio media
-//    if (wav_player)
-//    	wav_player->startTransmit(aud_med);
+    if (wav_player)
+    	wav_player->startTransmit(aud_med);
 
     // And this will connect the call audio media to the sound device/speaker
     aud_med.startTransmit(play_dev_med);
@@ -201,10 +201,10 @@ static void mainProg1(Endpoint &ep)
 
     // Add account
     AccountConfig acc_cfg;
-    acc_cfg.idUri = "sip:402@sip.pjsip.org";
+    acc_cfg.idUri = "sip:test1@pjsip.org";
     acc_cfg.regConfig.registrarUri = "sip:sip.pjsip.org";
     acc_cfg.sipConfig.authCreds.push_back( AuthCredInfo("digest", "*",
-                                                        "402", 0, "pw402") );
+                                                        "test1", 0, "test1") );
     MyAccount *acc(new MyAccount);
     try {
 	acc->create(acc_cfg);
@@ -220,10 +220,10 @@ static void mainProg1(Endpoint &ep)
     CallOpParam prm(true);
     prm.opt.audioCount = 1;
     prm.opt.videoCount = 0;
-    call->makeCall("sip:401@sip.pjsip.org", prm);
+    call->makeCall("sip:test1@pjsip.org", prm);
     
     // Hangup all calls
-    pj_thread_sleep(8000);
+    pj_thread_sleep(4000);
     ep.hangupAllCalls();
     pj_thread_sleep(4000);
     
@@ -429,7 +429,6 @@ static void mainProg4(Endpoint &ep)
 #endif
 
 
-extern "C"
 int main()
 {
     int ret = 0;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1733,7 +1733,10 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
 				  acc->contact.slen, NULL);
     pj_assert(contact_hdr != NULL);
     uri = (pjsip_sip_uri*) contact_hdr->uri;
-    pj_assert(uri != NULL);
+    if (!uri) {
+	PJ_LOG(4, (THIS_FILE, "acc_check_nat_addr() No contact URI."));
+	return PJ_FALSE;
+    }
     uri = (pjsip_sip_uri*) pjsip_uri_get_uri(uri);
 
     if (uri->port == 0) {


### PR DESCRIPTION
For some use cases, application may put `*` as its Contact during registration and server may respond with no `Expires` header. This may trigger an assertion (or crash if assertion is disabled), so it may be desirable to handle this case, although this seems to be quite an uncommon scenario.
