### PR TITLE
fix unix pthread create, attribute not destroy, cause memory leak

### DIFF
--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -621,6 +621,7 @@ PJ_DEF(pj_status_t) pj_thread_create( pj_pool_t *pool,
     /* Set thread's stack size */
     rc = pthread_attr_setstacksize(&thread_attr, stack_size);
     if (rc != 0)
+	pthread_attr_destroy(&thread_attr);
 	return PJ_RETURN_OS_ERROR(rc);
 #endif	/* PJ_THREAD_SET_STACK_SIZE */
 
@@ -632,6 +633,7 @@ PJ_DEF(pj_status_t) pj_thread_create( pj_pool_t *pool,
 
     rc = pthread_attr_setstackaddr(&thread_attr, stack_addr);
     if (rc != 0)
+	pthread_attr_destroy(&thread_attr);
 	return PJ_RETURN_OS_ERROR(rc);
 #endif	/* PJ_THREAD_ALLOCATE_STACK */
 
@@ -641,9 +643,11 @@ PJ_DEF(pj_status_t) pj_thread_create( pj_pool_t *pool,
     rec->arg = arg;
     rc = pthread_create( &rec->thread, &thread_attr, &thread_main, rec);
     if (rc != 0) {
+	pthread_attr_destroy(&thread_attr);
 	return PJ_RETURN_OS_ERROR(rc);
     }
 
+    pthread_attr_destroy(&thread_attr);
     *ptr_thread = rec;
 
     PJ_LOG(6, (rec->obj_name, "Thread created"));


### PR DESCRIPTION
In freebsd platform， valgrind check it has memory leak.
After thread has created, need destroy the thread attribute that pthread_attr_init initialized.

pthread_attr_init/pthread_attr_destroy man page say:

> When a thread attributes object is no longer required, it should be destroyed using the pthread_attr_destroy() function. Destroying a thread attributes object has no effect on threads that were created using that object.