### PR TITLE
One way audio due to Opus falsely detecting codec ptime change

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -867,19 +867,31 @@ static pj_status_t  codec_parse( pjmedia_codec *codec,
 					   ((unsigned char*)pkt) + out_pos,
 					   sizeof(tmp_buf));
 	if (size < 0) {
-	    PJ_LOG(5, (THIS_FILE, "Parse failed! (%d)", pkt_size));
+	    PJ_LOG(5, (THIS_FILE, "Parse failed! (pkt_size=%d, err=%d)",
+		       pkt_size, size));
             pj_mutex_unlock (opus_data->mutex);
 	    return PJMEDIA_CODEC_EFAILED;
 	}
 	frames[i].type = PJMEDIA_FRAME_TYPE_AUDIO;
 	frames[i].buf = ((char*)pkt) + out_pos;
 	frames[i].size = size;
-	frames[i].bit_info = opus_packet_get_nb_samples(frames[i].buf,
-			     frames[i].size, opus_data->cfg.sample_rate);
+	frames[i].bit_info = 0;
 
 	if (i == 0) {
-    	    unsigned ptime = frames[i].bit_info * 1000 /
-    	    		     opus_data->cfg.sample_rate;
+	    int nsamples;
+	    unsigned ptime;
+
+	    nsamples = opus_packet_get_nb_samples(frames[i].buf,
+						  frames[i].size,
+						  opus_data->cfg.sample_rate);
+	    if (nsamples <= 0) {
+		PJ_LOG(5, (THIS_FILE, "Parse failed to get samples number! "
+				      "(err=%d)", nsamples));
+		pj_mutex_unlock (opus_data->mutex);
+		return PJMEDIA_CODEC_EFAILED;
+	    }
+
+	    ptime = nsamples * 1000 / opus_data->cfg.sample_rate;
     	    if (ptime != opus_data->dec_ptime) {
              	PJ_LOG(4, (THIS_FILE, "Opus ptime change detected: %d ms "
              			      "--> %d ms",
@@ -890,7 +902,7 @@ static pj_status_t  codec_parse( pjmedia_codec *codec,
         	/* Signal to the stream about ptime change. */
      	    	frames[i].bit_info |= 0x10000;
     	    }
-     	    samples_per_frame = frames[i].bit_info;
+	    samples_per_frame = nsamples;
    	}
 
 	frames[i].timestamp.u64 = ts->u64 + i * samples_per_frame;


### PR DESCRIPTION
Reported that in a more than one hour long audio call using Opus, audio sometimes becomes one way, and the log file shows a lot of discarded packets. The log also has line ```codec decode ptime change detected``` but nothing like ```Opus ptime change detected: 10 ms --> 20 ms```.

After investigation, it looks like the Opus wrapper does not handle possible error returned by `opus_packet_get_nb_samples()`, which may cause false codec ptime change.

Thanks to Marcus Froeschl for the report and the analysis.