### PR TITLE
Fix deadlock after immediate hangup on video call

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -656,6 +656,21 @@ PJ_INLINE(pj_bool_t) PJSUA_LOCK_IS_LOCKED()
     return pjsua_var.mutex_owner == pj_thread_this();
 }
 
+/* Release all locks currently held by this thread. */
+#define PJSUA_RELEASE_LOCK() \
+    unsigned num_locks = 0; \
+    while (PJSUA_LOCK_IS_LOCKED()) { \
+        num_locks++; \
+        PJSUA_UNLOCK(); \
+    }
+
+/* Re-acquire all the locks released by PJSUA_RELEASE_LOCK(). */
+#define PJSUA_RELOCK() \
+{ \
+    for (; num_locks > 0; num_locks--) \
+        PJSUA_LOCK(); \
+}
+
 #else
 #define PJSUA_LOCK()
 #define PJSUA_TRY_LOCK()	PJ_SUCCESS

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -657,18 +657,21 @@ PJ_INLINE(pj_bool_t) PJSUA_LOCK_IS_LOCKED()
 }
 
 /* Release all locks currently held by this thread. */
-#define PJSUA_RELEASE_LOCK() \
-    unsigned num_locks = 0; \
-    while (PJSUA_LOCK_IS_LOCKED()) { \
-        num_locks++; \
-        PJSUA_UNLOCK(); \
+PJ_INLINE(unsigned) PJSUA_RELEASE_LOCK()
+{
+    unsigned num_locks = 0;
+    while (PJSUA_LOCK_IS_LOCKED()) {
+        num_locks++;
+        PJSUA_UNLOCK();
     }
+    return num_locks;
+}
 
 /* Re-acquire all the locks released by PJSUA_RELEASE_LOCK(). */
-#define PJSUA_RELOCK() \
-{ \
-    for (; num_locks > 0; num_locks--) \
-        PJSUA_LOCK(); \
+PJ_INLINE(void) PJSUA_RELOCK(unsigned num_locks)
+{
+    for (; num_locks > 0; num_locks--)
+        PJSUA_LOCK();
 }
 
 #else

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1378,8 +1378,21 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
     	    	    eve->med_idx == call_med->idx)
     	    	{
     	    	    PJSUA_UNLOCK();
-    	    	    pj_thread_sleep(20);
-    	    	    PJSUA_LOCK();
+
+		    /* If there is no worker thread or
+		     * the function is called from the only worker thread,
+		     * we have to handle the events here.
+		     */
+		    if (pjsua_var.thread[0] == NULL ||
+			(pj_thread_this() == pjsua_var.thread[0] &&
+			 pjsua_var.ua_cfg.thread_cnt == 1))
+		    {
+			pjsua_handle_events(10);
+		    } else {
+			pj_thread_sleep(10);
+		    }
+
+		    PJSUA_LOCK();
     	    	    break;
     	    	}
     	    }


### PR DESCRIPTION
Fix #2778.

In this scenario, `pjsua_vid_stop_stream()` is called from the only worker thread of PJSUA-LIB, so it should not do simple sleep waiting (for timer entry to be executed), instead it should handle events while waiting.