### PR TITLE
Avoid possible heap buffer overflow in pj_scan_skip_line() reported by fuzzing harness test

### DIFF
--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -195,7 +195,7 @@ PJ_DEF(void) pj_scan_skip_whitespace( pj_scanner *scanner )
 
 PJ_DEF(void) pj_scan_skip_line( pj_scanner *scanner )
 {
-    char *s = pj_ansi_strchr(scanner->curptr, '\n');
+    char *s = pj_memchr(scanner->curptr, '\n', scanner->end - scanner->curptr);
     if (!s) {
 	scanner->curptr = scanner->end;
     } else {


### PR DESCRIPTION
Perhaps it is because of the usage of `strchr()` without a guarantee that the input string is NULL terminated (other than docs/specs). The scanner specifies that it requires input string to be NULL terminated, so do the apps using it, e.g: SIP & SDP parsers. Also checked the library code, the NULL terminated requirements seems to be consistently met, for example, before invoking `pjsip_parse_rdata()`, null char termination in the input string is set/added manually.

Anyway, replacing `strchr()` with `memchr()` may improve safety to some degree, also it may avoid security warning triggered by code analyzers.

Thanks to Aaron Lichtman for the report and the patch.