### PR TITLE
Crash when pjsua_destroy2() is invoked during ongoing transaction

### DIFF
--- a/pjsip/src/pjsip/sip_ua_layer.c
+++ b/pjsip/src/pjsip/sip_ua_layer.c
@@ -165,6 +165,12 @@ static void mod_ua_on_tsx_state( pjsip_transaction *tsx, pjsip_event *e)
 {
     pjsip_dialog *dlg;
 
+    /* If the module id is -1, it could mean that the module has been
+     * destroyed.
+     */
+    if (mod_ua.mod.id == -1)
+	return;
+
     /* Get the dialog where this transaction belongs. */
     dlg = (pjsip_dialog*) tsx->mod_data[mod_ua.mod.id];
     


### PR DESCRIPTION
### Scenario
1. Receive INVITE from TCP transport
2. Send 200 OK
3. No ACK received (yet)
4. Invoke pjsua_destroy2() before the call times out

### Call stack
```
strlen(unsigned char * buf) Line 81 Unknown
pj_log(const char * sender, int level, const char * format, char * marker) Line 384 C
pj_log_5(const char * obj, const char * format, ...) Line 535 C
pjsip_dlg_on_tsx_state(pjsip_dialog * dlg, pjsip_transaction * tsx, pjsip_event * e) Line 2131 C
mod_ua_on_tsx_state(pjsip_transaction * tsx, pjsip_event * e) Line 178 C
tsx_set_state(pjsip_transaction * tsx, pjsip_tsx_state_e state, pjsip_event_id_e event_src_type, void * event_src, int flag) Line 1301 C
send_msg_callback(pjsip_send_state * send_state, long sent, int * cont) Line 2009 C
stateless_send_transport_cb(void * token, pjsip_tx_data * tdata, long sent) Line 1135 C
transport_send_callback(pjsip_transport * transport, void * token, long size) Line 877 C
on_data_sent(pj_activesock_t * asock, pj_ioqueue_op_key_t * op_key, long bytes_sent) Line 1231 C
tcp_destroy(pjsip_transport * transport, int reason) Line 860 C
tcp_destroy_transport(pjsip_transport * transport) Line 812 C
destroy_transport(pjsip_tpmgr * mgr, pjsip_transport * tp) Line 1377 C
pjsip_tpmgr_destroy(pjsip_tpmgr * mgr) Line 1878 C
pjsip_endpt_destroy(pjsip_endpoint * endpt) Line 607 C
pjsua_destroy2(unsigned int flags) Line 2018 C
```

When crash happens, the `mod_ua.mod.id` has a value of `-1` indicating it has been unregistered. However when the transport manager is being destroyed, it may trigger send completion callback which eventually update the corresponding transaction state, so when it reaches `mod_ua_on_tsx_state()` in the line below, the `dlg` points to invalid memory address:
```
    /* Get the dialog where this transaction belongs. */
    dlg = (pjsip_dialog*) tsx->mod_data[mod_ua.mod.id];
```
Thanks to Marcus Froeschl for the report and the analysis.
