### PR TITLE
Fix unexpected ptime change detection when parsed frame count is 0

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -861,6 +861,12 @@ static pj_status_t  codec_parse( pjmedia_codec *codec,
     opus_repacketizer_cat(opus_data->dec_packer, tmp_buf, pkt_size);
 
     num_frames = opus_repacketizer_get_nb_frames(opus_data->dec_packer);
+    if (num_frames == 0) {
+      PJ_LOG(2, (THIS_FILE, "No frames retrieved (num_frames = 0)"));
+      pj_mutex_unlock(opus_data->mutex);
+      return PJMEDIA_CODEC_EFAILED;
+    }
+
     out_pos = 0;
     for (i = 0; i < num_frames; ++i) {
 	size = opus_repacketizer_out_range(opus_data->dec_packer, i, i+1,

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2038,6 +2038,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 	unsigned i, count = MAX;
 	unsigned ts_span;
 	pjmedia_frame frames[MAX];
+	pj_bzero(frames, sizeof(frames[0]) * MAX);
 
 	/* Get the timestamp of the first sample */
 	ts.u64 = pj_ntohl(hdr->ts);
@@ -2049,6 +2050,8 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 	    LOGERR_((stream->port.info.name.ptr, status,
 		     "Codec parse() error"));
 	    count = 0;
+	} else if (count == 0) {
+		PJ_LOG(2, (stream->port.info.name.ptr, "codec parsed 0 frames"));
 	} else if (stream->detect_ptime_change &&
 		   frames[0].bit_info > 0xFFFF)
 	{


### PR DESCRIPTION
- zero-init frames before parsing
- check if parsed frame count is 0
- add logs