### PR TITLE
Fix build failure on Mac CI machine due to OpenSSL not found

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install opencore-amr swig sipp
+      run: brew install openssl@1.1 opencore-amr swig sipp
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h
     - name: configure
@@ -227,7 +227,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install opencore-amr
+      run: brew install openssl@1.1 opencore-amr
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h
     - name: configure
@@ -245,7 +245,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install opencore-amr
+      run: brew install openssl@1.1 opencore-amr
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h
     - name: configure
@@ -266,7 +266,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install swig
+      run: brew install openssl@1.1 swig
     - name: configure
       run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl@1.1/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib" CXXFLAGS="-fPIC" ./configure
     - name: make
@@ -295,7 +295,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install openh264 libvpx opencore-amr swig sipp 
+      run: brew install openssl@1.1 openh264 libvpx opencore-amr swig sipp 
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
     - name: configure
@@ -319,7 +319,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install openh264 libvpx opencore-amr
+      run: brew install openssl@1.1 openh264 libvpx opencore-amr
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
     - name: configure
@@ -337,7 +337,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install openh264 libvpx opencore-amr
+      run: brew install openssl@1.1 openh264 libvpx opencore-amr
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
     - name: configure
@@ -355,7 +355,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install x264 libvpx nasm swig
+      run: brew install openssl@1.1 x264 libvpx nasm swig
     - name: get ffmpeg
       run: git clone --single-branch --branch release/4.2 https://github.com/FFmpeg/FFmpeg.git
     - name: configure ffmpeg
@@ -377,7 +377,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install libvpx swig
+      run: brew install openssl@1.1 libvpx swig
     - name: config site
       run: echo -e "#define PJMEDIA_HAS_VIDEO 1\n#define PJMEDIA_HAS_VID_TOOLBOX_CODEC 1\n" > pjlib/include/pj/config_site.h
     - name: configure


### PR DESCRIPTION
With the latest version OpenSSL 3.0, now we need to specify the particular OpenSSL version we wish to use.