### PR TITLE
Fix some lock issue on pjmedia

### DIFF
--- a/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
@@ -754,6 +754,7 @@ static pj_status_t and_media_alloc_codec(pjmedia_codec_factory *factory,
     }
     if (idx == -1) {
 	*p_codec = NULL;
+	pj_mutex_unlock(and_media_factory.mutex);
 	return PJMEDIA_CODEC_EFAILED;
     }
 

--- a/pjmedia/src/pjmedia-codec/ipp_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ipp_codecs.c
@@ -939,6 +939,7 @@ static pj_status_t ipp_alloc_codec( pjmedia_codec_factory *factory,
     }
     if (idx == -1) {
 	*p_codec = NULL;
+	pj_mutex_unlock(ipp_factory.mutex);
 	return PJMEDIA_CODEC_EFAILED;
     }
 

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -723,6 +723,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
 			    OPUS_APPLICATION_VOIP);
     if (err != OPUS_OK) {
 	PJ_LOG(2, (THIS_FILE, "Unable to create encoder"));
+	pj_mutex_unlock (opus_data->mutex);
 	return PJMEDIA_CODEC_EFAILED;
     }
     
@@ -767,6 +768,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
 			     attr->info.channel_cnt);
     if (err != OPUS_OK) {
 	PJ_LOG(2, (THIS_FILE, "Unable to initialize decoder"));
+	pj_mutex_unlock (opus_data->mutex);
 	return PJMEDIA_CODEC_EFAILED;
     }
 

--- a/pjmedia/src/pjmedia-codec/passthrough.c
+++ b/pjmedia/src/pjmedia-codec/passthrough.c
@@ -625,6 +625,7 @@ static pj_status_t alloc_codec( pjmedia_codec_factory *factory,
     }
     if (idx == -1) {
 	*p_codec = NULL;
+	pj_mutex_unlock(codec_factory.mutex);
 	return PJMEDIA_CODEC_EUNSUP;
     }
 

--- a/pjmedia/src/pjmedia-codec/speex_codec.c
+++ b/pjmedia/src/pjmedia-codec/speex_codec.c
@@ -379,6 +379,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_speex_deinit(void)
     if (!codec_mgr) {
 	pj_pool_release(spx_factory.pool);
 	spx_factory.pool = NULL;
+	pj_mutex_unlock(spx_factory.mutex);
 	return PJ_EINVALIDOP;
     }
 


### PR DESCRIPTION
Some pjmedia methods don't release locks which might trigger deadlock or memory issue.
The issue mostly related to error returned in a method without releasing the lock.
This ticket will fix those issues.