### PR TITLE
PJSUA automatically print call dump to log when media is stopped or restarted

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -206,8 +206,7 @@ static void on_call_state(pjsua_call_id call_id, pjsip_event *e)
 	}
 
 	/* Dump media state upon disconnected.
-	 * Moved to on_stream_destroyed() since media has been deactivated
-	 * upon disconnection.
+	 * Now pjsua_media_channel_deinit() automatically log the call dump.
 	 */
 	if (0) {
 	    PJ_LOG(5,(THIS_FILE, 
@@ -282,7 +281,9 @@ static void on_stream_destroyed(pjsua_call_id call_id,
 				unsigned stream_idx)
 {
     PJ_UNUSED_ARG(strm);
-    if (1) {
+
+    /* Now pjsua_media_channel_deinit() automatically log the call dump. */
+    if (0) {
 	PJ_LOG(5,(THIS_FILE, 
 		  "Call %d stream %d destroyed, dumping media stats..", 
 		  call_id, stream_idx));


### PR DESCRIPTION
After #2600, printing end-of-call media stats can be a bit cumbersome for app when the call is video only and the call end is initiated by remote.

Also, some pjsua app may not print the end-of-call media stats while it is usually important in debugging media issues.