### PR TITLE
Fix bug in REGISTER Contact length calculation

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1574,7 +1574,9 @@ done:
 	pj_str_t reg_contact;
 
 	acc->rfc5626_status = OUTBOUND_WANTED;
-	len = acc->contact.slen + acc->cfg.reg_contact_params.slen +
+	len = acc->contact.slen +
+	      acc->cfg.contact_params.slen +
+	      acc->cfg.reg_contact_params.slen +
 	      acc->cfg.reg_contact_uri_params.slen +
 	      (need_outbound?
 	       (acc->rfc5626_instprm.slen + acc->rfc5626_regprm.slen): 0);


### PR DESCRIPTION
In #2819, updates in `update_regc_contact()` seems to contain a bug which may cause REGISTER Contact header to be truncated.