### PR TITLE
Avoid double BYE when pjsua_call_hangup() is called multiple times

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2827,6 +2827,9 @@ on_return:
     	/* Schedule a retry */
     	if (call->hangup_retry >= CALL_HANGUP_MAX_RETRY) {
     	    /* Forcefully terminate the invite session. */
+	    PJ_LOG(1,(THIS_FILE,"Call %d: failed to hangup after %d retries, "
+				"terminating the session forcefully now!",
+				call->index, call->hangup_retry));
     	    pjsip_inv_terminate(call->inv, call->hangup_code, PJ_TRUE);
     	    return PJ_SUCCESS;
     	}
@@ -2966,7 +2969,6 @@ PJ_DEF(pj_status_t) pjsua_call_hangup(pjsua_call_id call_id,
     	} else {
     	    /* Destroy media session. */
     	    pjsua_media_channel_deinit(call_id);
-
 	    call->hanging_up = PJ_TRUE;
 	    pjsua_check_snd_dev_idle();
 	}
@@ -2981,10 +2983,13 @@ PJ_DEF(pj_status_t) pjsua_call_hangup(pjsua_call_id call_id,
 	    					 &user_event);
 	}
 
+	if (call->inv)
+	    call_inv_end_session(call, code, reason, msg_data);
+    } else {
+	/* Already requested and on progress */
+        PJ_LOG(4,(THIS_FILE, "Call %d hangup request ignored as "
+			     "it is on progress", call_id));
     }
-
-    if (call->inv)
-    	call_inv_end_session(call, code, reason, msg_data);
 
 on_return:
     if (dlg) pjsip_dlg_dec_lock(dlg);


### PR DESCRIPTION
When an app hangs up all calls before calling `pjsua_destroy()`, which will also hangup all calls, there will be two outgoing BYEs.