### PR TITLE
Fix a bug destorying an unreleased lock

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -2163,6 +2163,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
     /* Free mutex */
 
     if (stream->jb_mutex) {
+	pj_mutex_unlock(stream->jb_mutex);
 	pj_mutex_destroy(stream->jb_mutex);
 	stream->jb_mutex = NULL;
     }


### PR DESCRIPTION
It seems the lock `stream->jb_mutex` is not released before destroying, which is undefined behavior.
#2852 