### PR TITLE
fix getaddrinfo call on windows

### DIFF
--- a/pjlib/src/pj/addr_resolv_sock.c
+++ b/pjlib/src/pj/addr_resolv_sock.c
@@ -198,7 +198,8 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
 	    continue;
 
 	if (res->ai_socktype != pj_SOCK_DGRAM()
-                    && res->ai_socktype != pj_SOCK_STREAM()) {
+                    && res->ai_socktype != pj_SOCK_STREAM()
+                    && res->ai_socktype != hint.ai_socktype) {
 	        continue;
 	}
 


### PR DESCRIPTION
When trying to connect to a FQDN on Windows with pjsip 2.11 the connection cannot be established with a PJ_ERESOLVE error. Debugging the issue showed, that the getaddrinfo result is not checked properly.
This patch solved the issue for me and might be integrated into master.