### PR TITLE
Change interval calculation for sending keep-alive message

### DIFF
--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -58,8 +58,7 @@ typedef struct pjmedia_stream_rtp_sess_info
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
 
 /**
- * Structure of configuration settings for stream keepalive after it
- * is created.
+ * Structure of configuration settings for stream keepalive.
  */
 typedef struct pjmedia_stream_ka_config
 {
@@ -78,6 +77,14 @@ typedef struct pjmedia_stream_ka_config
      * Default: PJMEDIA_STREAM_START_KA_INTERVAL_MSEC
      */
     unsigned			    start_interval;
+
+    /**
+     * The keepalive sending interval, after #start_count number keepalive 
+     * was sent.
+     * 
+     * Defautt: PJMEDIA_STREAM_KA_INTERVAL (seconds)
+     */
+    unsigned			    ka_interval;
 
 } pjmedia_stream_ka_config;
 

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -82,7 +82,7 @@ typedef struct pjmedia_stream_ka_config
      * The keepalive sending interval, after #start_count number keepalive 
      * was sent.
      * 
-     * Defautt: PJMEDIA_STREAM_KA_INTERVAL (seconds)
+     * Default: PJMEDIA_STREAM_KA_INTERVAL (seconds)
      */
     unsigned			    ka_interval;
 

--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -29,6 +29,7 @@ pjmedia_stream_ka_config_default(pjmedia_stream_ka_config *cfg)
     pj_bzero(cfg, sizeof(*cfg));
     cfg->start_count = PJMEDIA_STREAM_START_KA_CNT;
     cfg->start_interval = PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
+    cfg->ka_interval = PJMEDIA_STREAM_KA_INTERVAL;
 }
 
 #endif


### PR DESCRIPTION
Currently keep-alive interval is calculated using frame timestamp. 
If somehow there's a timestamp jump or rollover, the calculation would be incorrect. This patch will use time of day (`pj_gettimeofday()`) instead to calculate the interval.
This ticket will also add `ka_interval` setting to `pjmedia_stream_ka_config` to enable users specify the keep-alive interval instead of specifying it using `PJMEDIA_STREAM_KA_INTERVAL`.