### PR TITLE
Handle multiple handshake fail on TLS connection

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -257,14 +257,14 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
     if (ssock->is_server) {
 	pj_bool_t ret = PJ_TRUE;
 
+	if (!ssock->parent) {
+	    return PJ_FALSE;
+	}
+
 	if (status != PJ_SUCCESS) {
 	    /* Handshake failed in accepting, destroy our self silently. */
 
 	    char buf[PJ_INET6_ADDRSTRLEN+10];
-
-	    if (!ssock->parent) {
-		return PJ_FALSE;
-	    }
 
 	    PJ_PERROR(3,(ssock->pool->obj_name, status,
 			 "Handshake failed in accepting %s",

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -262,6 +262,10 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
 
 	    char buf[PJ_INET6_ADDRSTRLEN+10];
 
+	    if (!ssock->parent) {
+		return PJ_FALSE;
+	    }
+
 	    PJ_PERROR(3,(ssock->pool->obj_name, status,
 			 "Handshake failed in accepting %s",
 			 pj_sockaddr_print(&ssock->rem_addr, buf,
@@ -275,7 +279,7 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
 	    }
 
 	    /* Decrement ref count of parent */
-	    if (ssock->parent->param.grp_lock) {
+	    if (ssock->parent && ssock->parent->param.grp_lock) {
 		pj_grp_lock_dec_ref(ssock->parent->param.grp_lock);
 		ssock->parent = NULL;
 	    }
@@ -339,7 +343,7 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
 	/* Decrement ref count of parent and reset parent (we don't need it
 	 * anymore, right?).
 	 */
-	if (ssock->parent->param.grp_lock) {
+	if (ssock->parent && ssock->parent->param.grp_lock) {
 	    pj_grp_lock_dec_ref(ssock->parent->param.grp_lock);
 	    ssock->parent = NULL;
 	}

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -243,6 +243,11 @@ static void ssl_close_sockets(pj_ssl_sock_t *ssock)
 static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock, 
 				       pj_status_t status)
 {
+    /* Previously error handshake detected. */
+    if (ssock->is_server && status == PJ_EINVALIDOP) {
+	return PJ_FALSE;
+    }
+
     /* Cancel handshake timer */
     if (ssock->timer.id == TIMER_HANDSHAKE_TIMEOUT) {
 	pj_timer_heap_cancel(ssock->param.timer_heap, &ssock->timer);
@@ -256,10 +261,6 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
     /* Accepting */
     if (ssock->is_server) {
 	pj_bool_t ret = PJ_TRUE;
-
-	if (!ssock->parent) {
-	    return PJ_FALSE;
-	}
 
 	if (status != PJ_SUCCESS) {
 	    /* Handshake failed in accepting, destroy our self silently. */

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -112,6 +112,7 @@ struct pj_ssl_sock_t
     pj_ioqueue_op_key_t	  shutdown_op_key;
     pj_timer_entry	  timer;
     pj_status_t		  verify_status;
+    pj_status_t		  handshake_status;
 
     unsigned long	  last_err;
 


### PR DESCRIPTION
When accepting a new connection as a server, there's a scenario where multiple read event was received.
This will lead to multiple handshake fail, and on multi worker thread settings might lead to crash.
```
02-11 08:50:41,030 ssl0x7f9810051390 !Certificate chain loaded from buffer
02-11 08:50:41,032 ssl0x7f9810051390  CA certificates loaded from buffer (cnt=9)
02-11 08:50:41,032 ssl0x7f9810051390  Private key loaded from buffer
02-11 08:50:41,033 ssl0x7f9810051390  CA certificates loaded from buffer
02-11 08:50:41,033 SSL  SSL_ERROR_SSL (Handshake): Level: 0 err: <336130315> <SSL routines-ssl3_get_record-wrong version number> len: 0 peer: 
02-11 08:50:41,033 ssl0x7f9810051390  Handshake failed in accepting 89.248.165.50:63040: wrong version number
02-11 08:50:41,033 SSL !BIO error, SSL_ERROR_SYSCALL (Handshake): errno: <11> <Resource temporarily unavailable> len: 0
02-11 08:50:41,033 ssl0x7f9810051390  Handshake failed in accepting : DH lib
```

This is due to this code:
```
	    if (ssock->parent->param.grp_lock) {
		pj_grp_lock_dec_ref(ssock->parent->param.grp_lock);
		ssock->parent = NULL;
	    }
```
This patch will add check if `ssock->parent` has been reset to avoid the crash.

Thanks to Peter Koletzki for the report.
