### PR TITLE
Disable auto restart socket in PJMEDIA and PJSIP transports

### DIFF
--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -1343,6 +1343,21 @@ static pj_status_t transport_simulate_lost(pjmedia_transport *tp,
 static pj_status_t transport_restart(pj_bool_t is_rtp, 
 				     struct transport_udp *udp)
 {
+    return PJ_ENOTSUP;
+
+/* This code is disabled for the following reason:
+ * The following code will set ioqueue key to NULL or replace with a new one,
+ * and that may introduces issues, e.g:
+ * - this code is invoked from on_rx_rtp/rtcp(), which is invoked by
+ *   ioqueue_dispatch_read_event(), which may need to unlock ioqueue key
+ *   after returning from the callback (when allow_concurrent is false),
+ *   if the ioqueue key has been unregistered by this code, a crash may occur
+ *   when unlocking the invalid ioqueue key.
+ * - this code may set ioqueue key to NULL, while other code may assume
+ *   it may never be changed to NULL, and cause crash, e.g: transport_detach().
+ */
+#if 0
+
     pj_ioqueue_key_t *key = (is_rtp ? udp->rtp_key : udp->rtcp_key);
     pj_sock_t *sock = (is_rtp ? &udp->rtp_sock : &udp->rtcp_sock);
     pj_status_t status;
@@ -1447,4 +1462,6 @@ on_error:
     PJ_PERROR(1, (udp->base.name, status, 
 		 "Error restarting %s transport", (is_rtp)?"RTP":"RTCP"));
     return status;
+
+#endif
 }

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -1345,7 +1345,7 @@ static pj_status_t transport_restart(pj_bool_t is_rtp,
 {
     return PJ_ENOTSUP;
 
-/* This code is disabled for the following reason:
+/* This code is disabled for the following reason (see also #2881):
  * The following code will set ioqueue key to NULL or replace with a new one,
  * and that may introduces issues, e.g:
  * - this code is invoked from on_rx_rtp/rtcp(), which is invoked by

--- a/pjsip/src/pjsip/sip_transport_udp.c
+++ b/pjsip/src/pjsip/sip_transport_udp.c
@@ -144,7 +144,7 @@ static void udp_on_read_complete( pj_ioqueue_key_t *key,
 
     if (-bytes_read == PJ_ESOCKETSTOP) {
 #if 0
-	/* Auto restart is disabled, see #xyz */
+	/* Auto restart is disabled, see #2881 */
 	--tp->read_loop_spin;
 	/* Try to recover by restarting the transport. */
 	PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));
@@ -327,7 +327,7 @@ static void udp_on_write_complete( pj_ioqueue_key_t *key,
     tdata_op_key->tdata = NULL;
 
 #if 0
-    /* Auto restart is disabled, see #xyz */
+    /* Auto restart is disabled, see #2881 */
     if (-bytes_sent == PJ_ESOCKETSTOP) {
 	pj_status_t status;
 	/* Try to recover by restarting the transport. */
@@ -389,7 +389,7 @@ static pj_status_t udp_send_msg( pjsip_transport *transport,
 
     if (status != PJ_EPENDING) {
 #if 0
-	/* Auto restart is disabled, see #xyz */
+	/* Auto restart is disabled, see #2881 */
 	if (status == PJ_ESOCKETSTOP) {
 	    /* Try to recover by restarting the transport. */
 	    PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));

--- a/pjsip/src/pjsip/sip_transport_udp.c
+++ b/pjsip/src/pjsip/sip_transport_udp.c
@@ -143,6 +143,8 @@ static void udp_on_read_complete( pj_ioqueue_key_t *key,
 	goto on_return;
 
     if (-bytes_read == PJ_ESOCKETSTOP) {
+#if 0
+	/* Auto restart is disabled, see #xyz */
 	--tp->read_loop_spin;
 	/* Try to recover by restarting the transport. */
 	PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));
@@ -158,6 +160,9 @@ static void udp_on_read_complete( pj_ioqueue_key_t *key,
 			 "Error restarting SIP UDP transport"));
 	}
         return;
+#else
+	goto on_return;
+#endif
     }
 
     /*
@@ -321,6 +326,8 @@ static void udp_on_write_complete( pj_ioqueue_key_t *key,
 
     tdata_op_key->tdata = NULL;
 
+#if 0
+    /* Auto restart is disabled, see #xyz */
     if (-bytes_sent == PJ_ESOCKETSTOP) {
 	pj_status_t status;
 	/* Try to recover by restarting the transport. */
@@ -338,6 +345,7 @@ static void udp_on_write_complete( pj_ioqueue_key_t *key,
 	}
         return;
     }
+#endif
 
     if (tdata_op_key->callback) {
 	tdata_op_key->callback(&tp->base, tdata_op_key->token, bytes_sent);
@@ -380,6 +388,8 @@ static pj_status_t udp_send_msg( pjsip_transport *transport,
 			       rem_addr, addr_len);
 
     if (status != PJ_EPENDING) {
+#if 0
+	/* Auto restart is disabled, see #xyz */
 	if (status == PJ_ESOCKETSTOP) {
 	    /* Try to recover by restarting the transport. */
 	    PJ_LOG(4,(tp->base.obj_name, "Restarting SIP UDP transport"));
@@ -395,6 +405,7 @@ static pj_status_t udp_send_msg( pjsip_transport *transport,
 			     "Error restarting SIP UDP transport"));
 	    }
 	}
+#endif
 	tdata->op_key.tdata = NULL;
     }
 


### PR DESCRIPTION
In #2091, socket may be auto-recreated in PJLIB and higher levels. Unfortunately auto recreate in higher levels (currently implemented in PJMEDIA & PJSIP transports only) may introduce problems because it replaces the ioqueue key (by unregistering the old one and registering a new one) or even set it to NULL if replacement fails and it is done from the ioqueue callback. The callback may be called from PJLIB `ioqueue_dispatch_*_event()` which may need to unlock the ioqueue key after the callback returns (i.e: when `allow_concurrent` is false). If the ioqueue key has been unregistered by app, a crash may occur due to unlocking an invalid ioqueue key.
