### PR TITLE
Check for decoding delay in video stream

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -760,7 +760,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     unsigned payloadlen;
     pjmedia_rtp_status seq_st;
     pj_status_t status;
-    unsigned ts_diff;
+    long ts_diff;
     pj_bool_t pkt_discarded = PJ_FALSE;
 
     /* Check for errors */

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -137,6 +137,7 @@ struct pjmedia_vid_stream
     pjmedia_ratio	     dec_max_fps;   /**< Max fps of decoding dir.   */
     pjmedia_frame            dec_frame;	    /**< Current decoded frame.     */
     unsigned		     dec_delay_cnt; /**< Decoding delay (in frames).*/
+    unsigned		     dec_max_delay; /**< Decoding max delay (in ts).*/
     pjmedia_event            fmt_event;	    /**< Buffered fmt_changed event
                                                  to avoid deadlock	    */
     pjmedia_event            miss_keyframe_event;
@@ -759,6 +760,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     unsigned payloadlen;
     pjmedia_rtp_status seq_st;
     pj_status_t status;
+    unsigned ts_diff;
     pj_bool_t pkt_discarded = PJ_FALSE;
 
     /* Check for errors */
@@ -912,7 +914,8 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     /* Quickly see if there may be a full picture in the jitter buffer, and
      * decode them if so. More thorough check will be done in decode_frame().
      */
-    if ((pj_ntohl(hdr->ts) != stream->dec_frame.timestamp.u32.lo) || hdr->m) {
+    ts_diff = pj_ntohl(hdr->ts) - stream->dec_frame.timestamp.u32.lo;
+    if (ts_diff != 0 || hdr->m) {
 	if (PJMEDIA_VID_STREAM_SKIP_PACKETS_TO_REDUCE_LATENCY) {
 	    /* Always decode whenever we have picture in jb and
 	     * overwrite already decoded picture if necessary
@@ -934,6 +937,17 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 	    }
 	    else if (stream->dec_frame.size == 0) {
 		can_decode = PJ_TRUE;
+	    }
+	    /* For video, checking for a full jbuf above is not very useful
+	     * since video jbuf has a rather large capacity (to accommodate
+	     * many chunks per frame) and thus can typically store frames
+	     * that are much longer than max latency/delay specified in jb_max
+	     * setting.
+	     * So we need to compare the last decoded frame's timestamp with
+	     * the current timestamp.
+	     */
+	    else if (ts_diff > stream->dec_max_delay) {
+	    	can_decode = PJ_TRUE;
 	    }
 
 	    if (can_decode) {
@@ -1902,16 +1916,20 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
     stream->dec_frame.buf = pj_pool_alloc(pool, stream->dec_max_size);
 
     /* Init jitter buffer parameters: */
-    frm_ptime	    = 1000 * vfd_enc->fps.denum / vfd_enc->fps.num;
+    frm_ptime	    = 1000 * vfd_dec->fps.denum / vfd_dec->fps.num;
     chunks_per_frm  = stream->frame_size / PJMEDIA_MAX_MRU;
     if (chunks_per_frm < MIN_CHUNKS_PER_FRM)
 	chunks_per_frm = MIN_CHUNKS_PER_FRM;
 
     /* JB max count, default 500ms */
-    if (info->jb_max >= frm_ptime)
+    if (info->jb_max >= frm_ptime) {
 	jb_max	    = info->jb_max * chunks_per_frm / frm_ptime;
-    else
+	stream->dec_max_delay = info->codec_info.clock_rate * info->jb_max /
+				1000;
+    } else {
 	jb_max	    = 500 * chunks_per_frm / frm_ptime;
+	stream->dec_max_delay = info->codec_info.clock_rate * 500 / 1000;
+    }
 
     /* JB min prefetch, default 1 frame */
     if (info->jb_min_pre >= frm_ptime)

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6842,7 +6842,7 @@ struct pjsua_media_config
     /**
      * Set maximum delay that can be accomodated by the jitter buffer msec.
      *
-     * Default: -1 (to use default stream settings, currently 360 msec)
+     * Default: -1 (to use default stream settings, currently 500 msec)
      */
     int			jb_max;
 


### PR DESCRIPTION
For video, the jitter buffer has a much larger capacity (compared to audio) to accommodate a large video frame that can be split into many chunks. However, typically only the keyframes are large in size while the rest are relatively small. Thus the jitter buffer can store video frames that are much longer than max latency/delay specified in jb_max setting (in one local testing, it can easily keep 6-7 seconds of video for a default setting of 500 ms jb_max). Because of this, video rendering latency can potentially be larger than expected/desired.

Currently, the video stream checks if the jitter buffer is full to decide if it's time to decode. While this works for audio, as explained above, this is not enough for video. So in this PR, we propose to check the timestamp difference as well in order to know if it's time to decode.

A simple way to test this issue is by adding a sleep/delay in the local rendering process.
