### PR TITLE
SIP authentication may send multiple Authorization headers

### DIFF
--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -1348,7 +1348,7 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_reinit_req(	pjsip_auth_clt_sess *sess,
     chal_cnt = 0;
     auth_cnt = 0;
     last_auth_err = PJSIP_EAUTHNOAUTH;
-    while (hdr != &rdata->msg_info.msg->hdr) {
+    while (hdr != &rdata->msg_info.msg->hdr && auth_cnt == 0) {
 	pjsip_cached_auth *cached_auth;
 	const pjsip_www_authenticate_hdr *hchal;
 	pjsip_authorization_hdr *hauth;


### PR DESCRIPTION
From OpenSIPit02 in RFC8760 tests.

When receiving a 401/407 response with multiple WWW-Authenticate/Proxy-Authenticate headers, the auth client may generate multiple Authorization headers when it finds more than one supported digest methods, while it should only add the top most supported auth header.