### PR TITLE
Play WAV data even if the data length is truncated

### DIFF
--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -342,8 +342,13 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool,
 
     /* Validate length. */
     if (wave_hdr.data_hdr.len > fport->fsize - fport->start_data) {
-	pj_file_close(fport->fd);
-	return PJMEDIA_EWAVEUNSUPP;
+    	/* Actual data length may be shorter than declared. We should still
+    	 * try to play whatever data is there instead of immediately returning
+    	 * error.
+    	 */
+    	wave_hdr.data_hdr.len = fport->fsize - fport->start_data;
+	// pj_file_close(fport->fd);
+	// return PJMEDIA_EWAVEUNSUPP;
     }
     if (wave_hdr.data_hdr.len < ptime * wave_hdr.fmt_hdr.sample_rate *
 				wave_hdr.fmt_hdr.nchan / 1000)


### PR DESCRIPTION
If the declared WAV data length is longer than the actual data, the current behavior is to immediately close the WAV file and return error. But it should be better if we just try to play whatever data is available instead.
