### PR TITLE
Add parameter assertion check in pjsip_uri_get_uri()

### DIFF
--- a/pjsip/include/pjsip/sip_uri.h
+++ b/pjsip/include/pjsip/sip_uri.h
@@ -27,6 +27,7 @@
 
 #include <pjsip/sip_types.h>
 #include <pjsip/sip_config.h>
+#include <pj/assert.h>
 #include <pj/list.h>
 #include <pjlib-util/scanner.h>
 
@@ -269,6 +270,7 @@ PJ_INLINE(const pj_str_t*) pjsip_uri_get_scheme(const void *uri)
  */
 PJ_INLINE(void*) pjsip_uri_get_uri(const void *uri)
 {
+    PJ_ASSERT_RETURN(uri, NULL);
     return (*((pjsip_uri*)uri)->vptr->p_get_uri)((void*)uri);
 }
 


### PR DESCRIPTION
This patch is proposed by Peter Koletzki.
When remote sends ```Contact: *```, `contact_hdr->uri` will be NULL and it will cause call to `pjsip_uri_get_uri()` in the application to crash.

While it's true that application can check if the URI is NULL before calling the API, he suggests that the check is also added within the API itself.

Somewhat related to #2826.
