### PR TITLE
Deadly overflow causing hang after running 106 days

### DIFF
--- a/pjlib/src/pj/os_timestamp_common.c
+++ b/pjlib/src/pj/os_timestamp_common.c
@@ -65,16 +65,19 @@ static pj_highprec_t elapsed_msec( const pj_timestamp *start,
     freq += ts_freq.u32.lo;
 #endif
 
-    /* Avoid division by zero. */
-    if (freq == 0) freq = 1;
-
     /* Get elapsed time in cycles. */
     elapsed = get_elapsed(start, stop);
 
     /* usec = elapsed * MSEC / freq */
     pj_highprec_div(freq, MSEC);
-    pj_highprec_div(elapsed, freq);
-
+     
+    /* Avoid division by zero. */
+    if (freq == 0) {
+      /* Regard freq = 1 */
+      pj_highprec_mul(elapsed, MSEC);
+    } else {
+      pj_highprec_div(elapsed, freq);
+    }
     return elapsed;
 }
 

--- a/pjlib/src/pj/os_timestamp_common.c
+++ b/pjlib/src/pj/os_timestamp_common.c
@@ -72,7 +72,7 @@ static pj_highprec_t elapsed_msec( const pj_timestamp *start,
     elapsed = get_elapsed(start, stop);
 
     /* usec = elapsed * MSEC / freq */
-    pj_highprec_mul(elapsed, MSEC);
+    pj_highprec_div(freq, MSEC);
     pj_highprec_div(elapsed, freq);
 
     return elapsed;


### PR DESCRIPTION
If elapsed in elapsed_msec() reach 9223372036854776 which stands for around 106 days, after the calculation, the elapsed will overflow to -9223372036854775.
And this will cause troubles in timer calculation(refer to pj_gettickcount(), comparing monotonic tick with 0), the timer of upper-caller in pjsip will be postponed for 106 days.
Our software end users have to reboot the device every 3 months.