### PR TITLE
Avoid memory bloat on ICE restart

### DIFF
--- a/pjlib/include/pj/lock.h
+++ b/pjlib/include/pj/lock.h
@@ -195,6 +195,15 @@ typedef struct pj_grp_lock_config
 
 
 /**
+ * The group lock destroy handler, a destructor function called when
+ * a group lock is about to be destroyed.
+ *
+ * @param member	A pointer to be passed to the handler.
+ */
+typedef void (*pj_grp_lock_handler)(void *member);
+
+
+/**
  * Initialize the config with the default values.
  *
  * @param cfg		The config to be initialized.
@@ -235,7 +244,7 @@ PJ_DECL(pj_status_t) pj_grp_lock_create(pj_pool_t *pool,
 PJ_DECL(pj_status_t) pj_grp_lock_create_w_handler(pj_pool_t *pool,
                                         	  const pj_grp_lock_config *cfg,
                                         	  void *member,
-                                                  void (*handler)(void *member),
+                                                  pj_grp_lock_handler handler,
                                         	  pj_grp_lock_t **p_grp_lock);
 
 /**
@@ -303,7 +312,7 @@ PJ_DECL(pj_status_t) pj_grp_lock_release( pj_grp_lock_t *grp_lock);
 PJ_DECL(pj_status_t) pj_grp_lock_add_handler(pj_grp_lock_t *grp_lock,
                                              pj_pool_t *pool,
                                              void *member,
-                                             void (*handler)(void *member));
+                                             pj_grp_lock_handler handler);
 
 /**
  * Remove previously registered handler. All parameters must be the same
@@ -317,7 +326,7 @@ PJ_DECL(pj_status_t) pj_grp_lock_add_handler(pj_grp_lock_t *grp_lock,
  */
 PJ_DECL(pj_status_t) pj_grp_lock_del_handler(pj_grp_lock_t *grp_lock,
                                              void *member,
-                                             void (*handler)(void *member));
+                                             pj_grp_lock_handler handler);
 
 /**
  * Increment reference counter to prevent the group lock grom being destroyed.

--- a/pjnath/include/pjnath/ice_session.h
+++ b/pjnath/include/pjnath/ice_session.h
@@ -861,6 +861,27 @@ PJ_DECL(pj_status_t) pj_ice_sess_get_options(pj_ice_sess *ice,
 PJ_DECL(pj_status_t) pj_ice_sess_set_options(pj_ice_sess *ice,
 					     const pj_ice_sess_options *opt);
 
+
+/**
+ * Detach ICE session from group lock. This will delete ICE session group lock
+ * handler.
+ *
+ * This function is useful when application creates an ICE session with
+ * group lock and later it needs to recreate ICE session (e.g: for ICE
+ * restart) so the previous ICE session resources can be released manually
+ * (by calling the group lock handler) without waiting for the group lock
+ * destroy to avoid memory bloat.
+ *
+ * @param ice		ICE session instance.
+ * @param handler	Pointer to receive the group lock handler of
+ *			this ICE session.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pj_ice_sess_detach_grp_lock(pj_ice_sess *ice,
+						 pj_grp_lock_handler *handler);
+
+
 /**
  * Destroy ICE session. This will cancel any connectivity checks currently
  * running, if any, and any other events scheduled by this session, as well

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -536,6 +536,22 @@ PJ_DEF(pj_status_t) pj_ice_sess_destroy(pj_ice_sess *ice)
 
 
 /*
+ * Detach ICE session from group lock.
+ */
+PJ_DEF(pj_status_t) pj_ice_sess_detach_grp_lock(pj_ice_sess *ice,
+						pj_grp_lock_handler *handler)
+{
+    PJ_ASSERT_RETURN(ice && handler, PJ_EINVAL);
+
+    pj_grp_lock_acquire(ice->grp_lock);
+    pj_grp_lock_del_handler(ice->grp_lock, ice, &ice_on_destroy);
+    *handler = &ice_on_destroy;
+    pj_grp_lock_release(ice->grp_lock);
+    return PJ_SUCCESS;
+}
+
+
+/*
  * Change session role. 
  */
 PJ_DEF(pj_status_t) pj_ice_sess_change_role(pj_ice_sess *ice,

--- a/pjnath/src/pjnath/ice_strans.c
+++ b/pjnath/src/pjnath/ice_strans.c
@@ -1024,10 +1024,9 @@ static void destroy_ice_st(pj_ice_strans *ice_st)
 
     /* Destroy ICE if we have ICE */
     if (ice_st->ice) {
-	ice_st->ice_prev = ice_st->ice;
+	pj_ice_sess *ice = ice_st->ice;
 	ice_st->ice = NULL;
-	pj_ice_sess_detach_grp_lock(ice_st->ice_prev, &ice_st->ice_prev_hndlr);
-	pj_ice_sess_destroy(ice_st->ice_prev);
+	pj_ice_sess_destroy(ice);
     }
 
     /* Destroy all components */


### PR DESCRIPTION
On ICE restart, ICE session will be recreated. However the ICE session's pool will not be released immediately, it will only be released when the ICE stream transport is destroyed, this is due to group lock.

Similar issue also occurs on ICE transport reuse scenario (#2901).