### PR TITLE
Add documentation on how port_range is used

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3001,6 +3001,13 @@ typedef struct pjsua_transport_config
      * port number specified in \a port. Note that this setting is only
      * applicable when the start port number is non zero.
      *
+     * Example: \a port=5000, \a port_range=4
+     * - Available ports: 5000, 5001, 5002, 5003, 5004 (SIP transport)
+     * - Available ports: 5000, 5002, 5004 (Media/RTP transport)
+     *                    5001, 5003, 5005 (Media/RTCP transport)
+     * 
+     * Available ports are in the range of [\a port, \a port + \a port_range]. 
+     * 
      * Default value is zero.
      */
     unsigned		port_range;

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3003,8 +3003,6 @@ typedef struct pjsua_transport_config
      *
      * Example: \a port=5000, \a port_range=4
      * - Available ports: 5000, 5001, 5002, 5003, 5004 (SIP transport)
-     * - Available ports: 5000, 5002, 5004 (Media/RTP transport)
-     *                    5001, 5003, 5005 (Media/RTCP transport)
      * 
      * Available ports are in the range of [\a port, \a port + \a port_range]. 
      * 
@@ -4089,6 +4087,12 @@ typedef struct pjsua_acc_config
 
     /**
      * Media transport config.
+     * 
+     * For \a port and \a port_range settings, RTCP port is selected as 
+     * RTP port+1.
+     * Example: \a port=5000, \a port_range=4
+     * - Available ports: 5000, 5002, 5004 (Media/RTP transport)
+     *                    5001, 5003, 5005 (Media/RTCP transport)
      */
     pjsua_transport_config rtp_cfg;
 

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -953,6 +953,12 @@ struct AccountMediaConfig : public PersistentObject
 {
     /**
      * Media transport (RTP) configuration.
+     * 
+     * For \a port and \a portRange settings, RTCP port is selected as 
+     * RTP port+1.
+     * Example: \a port=5000, \a portRange=4
+     * - Available ports: 5000, 5002, 5004 (Media/RTP transport)
+     *                    5001, 5003, 5005 (Media/RTCP transport)
      */
     TransportConfig	transportConfig;
 

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -318,8 +318,6 @@ struct TransportConfig : public PersistentObject
      * 
      * Example: \a port=5000, \a portRange=4
      * - Available ports: 5000, 5001, 5002, 5003, 5004 (SIP transport)
-     * - Available ports: 5000, 5002, 5004 (Media/RTP transport)
-     *                    5001, 5003, 5005 (Media/RTCP transport)
      * 
      * Available ports are in the range of [\a port, \a port + \a portRange]. 
      *

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -315,6 +315,13 @@ struct TransportConfig : public PersistentObject
      * Specify the port range for socket binding, relative to the start
      * port number specified in \a port. Note that this setting is only
      * applicable when the start port number is non zero.
+     * 
+     * Example: \a port=5000, \a portRange=4
+     * - Available ports: 5000, 5001, 5002, 5003, 5004 (SIP transport)
+     * - Available ports: 5000, 5002, 5004 (Media/RTP transport)
+     *                    5001, 5003, 5005 (Media/RTCP transport)
+     * 
+     * Available ports are in the range of [\a port, \a port + \a portRange]. 
      *
      * Default value is zero.
      */


### PR DESCRIPTION
This ticket will add some documentation on how `port_range` is used by providing example.
This way user will have a better understanding of what to expect.