### PR TITLE
Fix issues in updating media dir to "none" in the middle of a call

### DIFF
--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -42,6 +42,7 @@ static const pj_str_t STR_SDP_NAME = { "pjmedia", 7 };
 static const pj_str_t STR_SENDRECV = { "sendrecv", 8 };
 static const pj_str_t STR_SENDONLY = { "sendonly", 8 };
 static const pj_str_t STR_RECVONLY = { "recvonly", 8 };
+static const pj_str_t STR_INACTIVE = { "inactive", 8 };
 
 
 /* Config to control rtpmap inclusion for static payload types */
@@ -405,17 +406,20 @@ static pj_status_t init_sdp_media(pjmedia_sdp_media *m,
     }
 #endif
 
-    /* Add sendrecv attribute. */
-    attr = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_attr);
-    if (dir == PJMEDIA_DIR_ENCODING) {
-    	attr->name = STR_SENDONLY;
-    } else if (dir == PJMEDIA_DIR_DECODING) {
-    	attr->name = STR_RECVONLY;
-    } else {
-    	attr->name = STR_SENDRECV;
+    /* Add direction attribute. */
+    if (m->desc.port != 0) {
+	attr = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_attr);
+	if (dir == PJMEDIA_DIR_ENCODING) {
+	    attr->name = STR_SENDONLY;
+	} else if (dir == PJMEDIA_DIR_DECODING) {
+	    attr->name = STR_RECVONLY;
+	} else if (dir == PJMEDIA_DIR_NONE) {
+	    attr->name = STR_INACTIVE;
+	} else {
+	    attr->name = STR_SENDRECV;
+	}
+	m->attr[m->attr_count++] = attr;
     }
-
-    m->attr[m->attr_count++] = attr;
 
     return PJ_SUCCESS;
 }

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -403,6 +403,10 @@ static void on_call_audio_state(pjsua_call_info *ci, unsigned mi,
 
 	call_conf_slot = ci->media[mi].stream.aud.conf_slot;
 
+	/* Make sure conf slot is valid (e.g: media dir is not "inactive") */
+	if (call_conf_slot == PJSUA_INVALID_ID)
+	    return;
+
 	/* Loopback sound, if desired */
 	if (app_config.auto_loop) {
 	    pjsua_conf_connect(call_conf_slot, call_conf_slot);

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -270,6 +270,10 @@ public:
 
 //////////////////////////////////////////////////////////////////////////////
 
+/** Array of media direction */
+typedef IntVector MediaDirVector;
+
+
 /**
  * Call settings.
  */
@@ -328,7 +332,7 @@ struct CallSetting
      *
      * Default: empty vector
      */
-    std::vector<pjmedia_dir> mediaDir;
+    MediaDirVector mediaDir;
 
     
 public:

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2472,9 +2472,6 @@ pj_status_t pjsua_media_channel_init(pjsua_call_id call_id,
 	    call_med->def_dir = PJMEDIA_DIR_ENCODING_DECODING;
 	}
 	call_med->dir = call_med->def_dir;
-	if (call_med->dir == PJMEDIA_DIR_NONE) {
-	    enabled = PJ_FALSE;
-	}
 
 	if (enabled) {
 	    call_med->enable_rtcp_mux = acc->cfg.enable_rtcp_mux;

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -259,7 +259,7 @@ pjsua_call_setting CallSetting::toPj() const
     setting.aud_cnt             = this->audioCount;
     setting.vid_cnt             = this->videoCount;
     for (mi = 0; mi < this->mediaDir.size(); mi++) {
-    	setting.media_dir[mi] = this->mediaDir[mi];
+	setting.media_dir[mi] = (pjmedia_dir)this->mediaDir[mi];
     }
     
     return setting;


### PR DESCRIPTION
Re #2705 (setting media direction in call initialization and update), some issues have been reported:
1. In this code :
    ```
   pjsua_call_setting opt;
   pjsua_call_setting_default(&opt);
   opt.flag = PJSUA_CALL_SET_MEDIA_DIR | PJSUA_CALL_REINIT_MEDIA;
   opt.media_dir[0] = PJMEDIA_DIR_NONE;
   pjsua_call_update2(call_id, &opt, NULL);
   ```
   - without `PJSUA_CALL_REINIT_MEDIA` flag, media direction is unaffected.
   - with `PJSUA_CALL_REINIT_MEDIA` flag, assertion is raised:
     ```
     ../src/pjmedia/endpoint.c:931: pj_status_t pjmedia_endpt_create_base_sdp(
          pjmedia_endpt *, pj_pool_t *, const pj_str_t *, const pj_sockaddr *, pjmedia_sdp_session **):
          assertion "!"Invalid address family"" failed
     ```
2. Missing SWIG interface for vector/array `CallSetting::mediaDir`.

Thanks to Christoph Gritschenberger for the reports.


