### PR TITLE
Fix incorrect pjmedia_sdp_neg_state in case of SDP parsing error

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2066,6 +2066,14 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
 	return PJMEDIA_SDP_EINSDP;
     }
 
+    /* Process the SDP body. */
+    if (sdp_info->sdp_err) {
+        PJ_PERROR(4,(THIS_FILE, sdp_info->sdp_err,
+             "Error parsing SDP in %s",
+             pjsip_rx_data_get_info(rdata)));
+        return PJMEDIA_SDP_EINSDP;
+    }
+
     /* Get/attach invite session's transaction data */
     tsx_inv_data = (struct tsx_inv_data*) tsx->mod_data[mod_inv.mod.id];
     if (tsx_inv_data == NULL) {
@@ -2162,14 +2170,6 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
 	    }
 	    return PJ_SUCCESS;
 	}
-    }
-
-    /* Process the SDP body. */
-    if (sdp_info->sdp_err) {
-	PJ_PERROR(4,(THIS_FILE, sdp_info->sdp_err,
-		     "Error parsing SDP in %s",
-		     pjsip_rx_data_get_info(rdata)));
-	return PJMEDIA_SDP_EINSDP;
     }
 
     pj_assert(sdp_info->sdp != NULL);


### PR DESCRIPTION
This is try to fix sip forking issue:
`**** pjsip (uac)********************voip phone 1 *** voip phone 2`
`----> INVITE ------------------------------>------------->`
`<---- 183 PROGRESSING (with correct SDP) <--`
`<---- 183 PROGRESSING (with incorrect SDP) <--------------`
`<---- 200 OK (with correct SDP) <------------------------- `

when processing 200 OK, the assert https://github.com/pjsip/pjproject/blob/05cad67f52f715b385699b366e351491ae9a6f0e/pjmedia/src/pjmedia/sdp_neg.c#L314 will occur