### PR TITLE
Get note from root presence element if not found in tuple RPID

### DIFF
--- a/pjsip/src/pjsip-simple/rpid.c
+++ b/pjsip/src/pjsip-simple/rpid.c
@@ -204,6 +204,10 @@ static pj_status_t get_tuple_note(const pjpidf_pres *pres,
 	return PJSIP_SIMPLE_EBADRPID;
 
     nd_note = find_node(nd_tuple, "note");
+    /* If we cannot find <note> inside <tuple>, try to get it from root. */
+    if (!nd_note)
+    	nd_note = find_node(pres, "note");
+
     if (nd_note) {
 	pj_strdup(pool, &elem->note, &nd_note->content);
 	return PJ_SUCCESS;


### PR DESCRIPTION
In #2639, one of the changes is to find the note inside `<tuple>`. But if not found, this will result in an empty note, such as in the message below:
```
<?xml version="1.0" encoding="UTF-8"?>
<presence>
  <note>Ready</note>
  <tuple id="800">
   <status>
    <basic>open</basic>
   </status>
  </tuple>
</presence>
```

So in this PR, we add a failover to find the note in the root `<presence>` element if not found inside the tuple.
