### PR TITLE
Remove epoll back-off timeout

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -815,13 +815,6 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 	                            "ioqueue", 0);
     }
 
-    /* Special case:
-     * When epoll returns > 0 but no descriptors are actually set!
-     */
-    if (count > 0 && !event_cnt && msec > 0) {
-	pj_thread_sleep(msec);
-    }
-
     TRACE_((THIS_FILE, "     poll: count=%d events=%d processed=%d",
 		       count, event_cnt, processed_cnt));
 


### PR DESCRIPTION
Hi!

Does anyone remember the reason for adding this sleep to the worker thread(s)? My prio is not to get this merged if it has implications, I'm mostly interested why it came to place. :)

I have for some time been trying to understand why there are a fair amount of discards in the jitter buffers even though the network looks fine (i.e. a steady RTP cadence). What I discovered is that my worker threads (8 to 16 depending on hardware) are spending lots of time sleeping on the job. The result is that the incoming socket buffers are filling up because there are not enough workers to dispatch packets up the stack in a timely manner, and when the workers polls the events they get multiple packets which will overflow the jitter buffers (set to handle 40 ms delay).

If the sleep is removed according to this PR the discards drops by a factor of about 10 to 15, even when there are hundreds of simultaneous streams.

BR
Martin