### PR TITLE
pjsip-apps: Set initial log level to 1

### DIFF
--- a/pjsip-apps/src/pjsua/main.c
+++ b/pjsip-apps/src/pjsua/main.c
@@ -157,5 +157,7 @@ int main_func(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+    pj_log_set_level(1);
+
     return pj_run_app(&main_func, argc, argv, 0);
 }

--- a/pjsip-apps/src/pjsystest/main_console.c
+++ b/pjsip-apps/src/pjsystest/main_console.c
@@ -133,6 +133,8 @@ void gui_sleep(unsigned sec)
 
 int main()
 {
+    pj_log_set_level(1);
+
     if (systest_init() != PJ_SUCCESS)
 	return 1;
 

--- a/pjsip-apps/src/python/_pjsua.c
+++ b/pjsip-apps/src/python/_pjsua.c
@@ -4434,7 +4434,8 @@ init_pjsua(void)
     PyObject* m = NULL;
 #define ADD_CONSTANT(mod,name)	PyModule_AddIntConstant(mod,#name,name)
 
-    
+    pj_log_set_level(1);
+
     PyEval_InitThreads();
 
     if (PyType_Ready(&PyTyp_pjsua_callback) < 0)


### PR DESCRIPTION
When pjsua is started or when the python bindings are initialized
tons of debug log messages are emitted before the command line
"log-level" arguments are processed.  This causes quite a bit
of unnecessary log space to be used.  To combat this,
pj_log_set_level(1) is now called before anything else.  The
command line arguments can, of course, still set any level
later on.