### PR TITLE
Fix declaration of pjsip_auth_deinit_parser()

### DIFF
--- a/pjsip/include/pjsip/sip_auth_parser.h
+++ b/pjsip/include/pjsip/sip_auth_parser.h
@@ -44,7 +44,7 @@ PJ_DECL(pj_status_t) pjsip_auth_init_parser(void);
 /**
  * DeInitialize authorization parser module.
  */
-PJ_DECL(void) pjsip_auth_deinit_parser();
+PJ_DECL(void) pjsip_auth_deinit_parser(void);
 
 
 


### PR DESCRIPTION
pjsip_auth_deinit_parser is declared in sip_auth_parser.h as follows:
PJ_DECL(void) pjsip_auth_deinit_parser();

Since there's no parameter list, projects compiled against
pjproject after commit cc680d2 (when sip_auth_parser.h was added to
pjsip.h) will fail if they use "-Werror=strict-prototypes".

Simply changing the declaration from:
PJ_DECL(void) pjsip_auth_deinit_parser();
to:
PJ_DECL(void) pjsip_auth_deinit_parser(void);
fixes the issue.

Fixes #2913