### PR TITLE
Fix crash when dumping call data during media deinit

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1011,6 +1011,7 @@ on_error:
     if (dlg) {
 	/* This may destroy the dialog */
 	pjsip_dlg_dec_lock(dlg);
+	call->async_call.dlg = NULL;
     }
 
     if (call_id != -1) {

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -570,7 +570,7 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
 	/* Upon failure to send first request, the invite
 	 * session would have been cleared.
 	 */
-	inv = NULL;
+	call->inv = inv = NULL;
 	goto on_error;
     }
 
@@ -599,10 +599,12 @@ on_error:
     if (dlg) {
 	/* This may destroy the dialog */
 	pjsip_dlg_dec_lock(dlg);
+	call->async_call.dlg = NULL;
     }
 
     if (inv != NULL) {
 	pjsip_inv_terminate(inv, PJSIP_SC_OK, PJ_FALSE);
+	call->inv = NULL;
     }
 
     if (call_id != -1) {

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3167,6 +3167,7 @@ on_return:
 pj_status_t pjsua_media_channel_deinit(pjsua_call_id call_id)
 {
     pjsua_call *call = &pjsua_var.calls[call_id];
+    pjsip_dialog *dlg;
     unsigned mi;
 
     for (mi=0; mi<call->med_cnt; ++mi) {
@@ -3185,7 +3186,9 @@ pj_status_t pjsua_media_channel_deinit(pjsua_call_id call_id)
     pj_log_push_indent();
 
     /* Print call dump first */
-    log_call_dump(call_id);
+    dlg = (call->inv? call->inv->dlg : call->async_call.dlg);
+    if (dlg)
+    	log_call_dump(call_id);
 
     stop_media_session(call_id);
 


### PR DESCRIPTION
When `pjsua_call_make_call()` fails, it will destroy the dialog then deinit the media:
```
on_error:
    if (dlg) {
	/* This may destroy the dialog */
	pjsip_dlg_dec_lock(dlg);
    }

    if (call_id != -1) {
	pjsua_media_channel_deinit(call_id);
	reset_call(call_id);
    }
```

After #2855,  we will call `pjsua_call_dump()` during media deinit. But since the dialog has been destroyed, it will cause crash:
```
9   pjsua-arm-apple-darwin20.6.0        0x000000010050e9fc pjsip_dlg_try_inc_lock + 44
10  pjsua-arm-apple-darwin20.6.0        0x000000010048f0ec acquire_call + 468
11  pjsua-arm-apple-darwin20.6.0        0x00000001004ad1a0 pjsua_call_dump + 220
12  pjsua-arm-apple-darwin20.6.0        0x00000001004a39d0 log_call_dump + 84
13  pjsua-arm-apple-darwin20.6.0        0x00000001004a3854 pjsua_media_channel_deinit + 220
14  pjsua-arm-apple-darwin20.6.0        0x000000010048bbec pjsua_call_make_call + 1580
```
