### PR TITLE
Pjsua test fix on multiple authentication header scenario

### DIFF
--- a/tests/pjsua/scripts-recvfrom/215_reg_good_multi_ok.py
+++ b/tests/pjsua/scripts-recvfrom/215_reg_good_multi_ok.py
@@ -16,10 +16,11 @@ req1 = sip.RecvfromTransaction("Initial registration", 401,
 
 req2 = sip.RecvfromTransaction("Registration retry with auth", 200,
 				include=["REGISTER sip", 
-					 "Authorization:[\\s\\S]+Authorization:", # Must have 2 Auth hdrs
-					 "realm=\"python1\"", "realm=\"python2\"", 
-					 "username=\"theuser1\"", "username=\"theuser2\"", 
-					 "nonce=\"1234\"", "nonce=\"6789\"", 
+					 # Must only have 1 Auth hdr since #2889
+					 "Authorization:", # [\\s\\S]+Authorization:"
+					 "realm=\"python1\"", # "realm=\"python2\"", 
+					 "username=\"theuser1\"", # "username=\"theuser2\"", 
+					 "nonce=\"1234\"", # "nonce=\"6789\"", 
 					 "response="],
 				expect="registration success"	     
 			  )

--- a/tests/pjsua/scripts-recvfrom/215_reg_good_multi_ok.py
+++ b/tests/pjsua/scripts-recvfrom/215_reg_good_multi_ok.py
@@ -16,7 +16,7 @@ req1 = sip.RecvfromTransaction("Initial registration", 401,
 
 req2 = sip.RecvfromTransaction("Registration retry with auth", 200,
 				include=["REGISTER sip", 
-					 # Must only have 1 Auth hdr since #2889
+					 # Must only have 1 Auth hdr since #2887
 					 "Authorization:", # [\\s\\S]+Authorization:"
 					 "realm=\"python1\"", # "realm=\"python2\"", 
 					 "username=\"theuser1\"", # "username=\"theuser2\"", 


### PR DESCRIPTION
Since #2887, when we receive multiple `WWW-Authenticate/Proxy-Authenticate` headers, we only reply with the top most supported authorization. This causes failing pjsua test `scripts-recvfrom_215_reg_good_multi_ok` that expects to get multiple `Authorization` header in such scenario.
```
Test completed with error: Pattern Authorization:[\s\S]+Authorization: not found in Registration retry with auth transaction
```
