### PR TITLE
Prevent OOB read for RTCP XR block

### DIFF
--- a/pjmedia/src/pjmedia/rtcp_xr.c
+++ b/pjmedia/src/pjmedia/rtcp_xr.c
@@ -417,7 +417,7 @@ void pjmedia_rtcp_xr_rx_rtcp_xr( pjmedia_rtcp_xr_session *sess,
     const pjmedia_rtcp_xr_rb_voip_mtc *rb_voip_mtc = NULL;
     const pjmedia_rtcp_xr_rb_header   *rb_hdr = (pjmedia_rtcp_xr_rb_header*) 
 						rtcp_xr->buf;
-    unsigned pkt_len, rb_len, ck_len;
+    unsigned pkt_len, rb_len;
 
     if (rtcp_xr->common.pt != RTCP_XR)
 	return;
@@ -427,38 +427,39 @@ void pjmedia_rtcp_xr_rx_rtcp_xr( pjmedia_rtcp_xr_session *sess,
     if ((pkt_len + 1) > (size / 4))
 	return;
 
-    ck_len = pkt_len - 1;
-
     /* Parse report rpt_types */
     while ((pj_int32_t*)rb_hdr < (pj_int32_t*)pkt + pkt_len)
     {	
-	unsigned bl_len;
 	rb_len = pj_ntohs((pj_uint16_t)rb_hdr->length);
 
 	/* Just skip any block with length == 0 (no report content) */
 	if (rb_len) {
 	    switch (rb_hdr->bt) {
 		case BT_RR_TIME:
-		    bl_len = sizeof(*rb_rr_time) / 4;
-		    if (ck_len >= bl_len) {
+		    if ((char*)rb_hdr + sizeof(*rb_rr_time) <=
+			(char*)pkt + size) 
+		    {
 			rb_rr_time = (pjmedia_rtcp_xr_rb_rr_time*)rb_hdr;
 		    }
 		    break;
 		case BT_DLRR:
-		    bl_len = sizeof(*rb_dlrr) / 4;
-		    if (ck_len >= bl_len) {
+		    if ((char*)rb_hdr + sizeof(*rb_dlrr) <=
+			(char*)pkt + size)
+		    {
 			rb_dlrr = (pjmedia_rtcp_xr_rb_dlrr*)rb_hdr;
 		    }
 		    break;
 		case BT_STATS:
-		    bl_len = sizeof(*rb_stats) / 4;
-		    if (ck_len >= bl_len) {
+		    if ((char*)rb_hdr + sizeof(*rb_stats) <=
+			(char*)pkt + size)
+		    {
 			rb_stats = (pjmedia_rtcp_xr_rb_stats*)rb_hdr;
 		    }
 		    break;
 		case BT_VOIP_METRICS:
-		    bl_len = sizeof(*rb_voip_mtc) / 4;
-		    if (ck_len >= bl_len) {
+		    if ((char*)rb_hdr + sizeof(*rb_voip_mtc) <=
+			(char*)pkt + size)
+		    {
 			rb_voip_mtc = (pjmedia_rtcp_xr_rb_voip_mtc*)rb_hdr;
 		    }
 		    break;
@@ -466,10 +467,8 @@ void pjmedia_rtcp_xr_rx_rtcp_xr( pjmedia_rtcp_xr_session *sess,
 		    break;
 	    }
 	}
-	++rb_len;
-	ck_len = ((rb_len) >= ck_len) ? 0 : (ck_len - rb_len);
 	rb_hdr = (pjmedia_rtcp_xr_rb_header*)
-		 ((pj_int32_t*)rb_hdr + rb_len);
+		 ((pj_int32_t*)rb_hdr + rb_len + 1);
     }
 
     /* Receiving RR Time */


### PR DESCRIPTION
When receiving RTCP XR block, the packet will be parsed by using cast
``` c
switch (rb_hdr->bt) {
case BT_RR_TIME:
    rb_rr_time = (pjmedia_rtcp_xr_rb_rr_time*) rb_hdr;
    break;
case BT_DLRR:
    rb_dlrr = (pjmedia_rtcp_xr_rb_dlrr*) rb_hdr;
    break;
case BT_STATS:
    rb_stats = (pjmedia_rtcp_xr_rb_stats*) rb_hdr;
    break;
case BT_VOIP_METRICS:
    rb_voip_mtc = (pjmedia_rtcp_xr_rb_voip_mtc*) rb_hdr;
    break;
default:
    break;
}
```
Without checking the length, this can lead to out of bound read.
This ticket will prevent such issue by checking the packet length.