### PR TITLE
NAT64: handle special case where server put FQDN (resolved to IPv6 only) in SDP answer

### DIFF
--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -445,6 +445,14 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
     /* Set remote address: */
     status = pj_sockaddr_init(rem_af, &si->rem_addr, &rem_conn->addr,
 			      rem_m->desc.port);
+    if (status == PJ_ERESOLVE && rem_af == pj_AF_INET()) {
+	/* Handle special case in NAT64 scenario where for some reason, server
+	 * puts IPv6 (literal or FQDN) in SDP answer while indicating "IP4"
+	 * in its address type, let's retry resolving using AF_INET6.
+	 */
+	status = pj_sockaddr_init(pj_AF_INET6(), &si->rem_addr,
+				  &rem_conn->addr, rem_m->desc.port);
+    }
     if (status != PJ_SUCCESS) {
 	/* Invalid IP address. */
 	return PJMEDIA_EINVALIDIP;


### PR DESCRIPTION
Handle special case in NAT64 scenario where for some reason, the server puts IPv6 (literal or FQDN) in SDP answer while indicating "IP4" in its address type in SDP c= line. Perhaps the server knows that local endpoint is IPv6 from SIP signaling, so it replaces/puts IPv6 address in its SDP. While "IP4" in SDP c= line is just to match the SDP offer.