### PR TITLE
pjsua: Return earlier when handling of rx offer is async

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5402,6 +5402,11 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
 	call->opt = opt;
     }
 
+    if (async) {
+	call->rx_reinv_async = async;
+	goto on_return;
+    }
+
     /* Re-init media for the new remote offer before creating SDP */
     status = apply_call_setting(call, &call->opt, offer);
     if (status != PJ_SUCCESS)
@@ -5412,11 +5417,6 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
 					    offer, &answer, NULL);
     if (status != PJ_SUCCESS) {
 	pjsua_perror(THIS_FILE, "Unable to create local SDP", status);
-	goto on_return;
-    }
-
-    if (async) {
-	call->rx_reinv_async = async;
 	goto on_return;
     }
 


### PR DESCRIPTION
This avoids having to make a useless call to `pjsua_media_channel_create_sdp()` and the like if we know we're responding to the offer asynchronously (especially with `pjsua_call_answer_with_sdp()`).

I'm not 100% sure if this has the potential to cause any issues (e.g. if answering the call at a later point *without* an SDP), but all of the pjsua tests pass before and after this change for me so :man_shrugging: