### PR TITLE
Fix missing event unsubscription in pjsua video

### DIFF
--- a/pjmedia/include/pjmedia/vid_port.h
+++ b/pjmedia/include/pjmedia/vid_port.h
@@ -168,6 +168,18 @@ PJ_DECL(pj_status_t) pjmedia_vid_port_subscribe_event(
 						pjmedia_port *port);
 
 /**
+ * Unsubscribe media event notifications from the specified media port.
+ *
+ * @param vid_port	The video port.
+ * @param port		The media port whose events to be unsubscribed.
+ *
+ * @return		PJ_SUCCESS on success or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjmedia_vid_port_unsubscribe_event(
+						pjmedia_vid_port *vid_port,
+						pjmedia_port *port);
+
+/**
  * Connect the video port to a downstream (slave) media port. This operation
  * is only valid for video ports created with active interface selected.
  * Connecting a passive video port may raise an assertion.

--- a/pjmedia/src/pjmedia/vid_port.c
+++ b/pjmedia/src/pjmedia/vid_port.c
@@ -742,6 +742,18 @@ PJ_DEF(pj_status_t) pjmedia_vid_port_subscribe_event(
     return pjmedia_event_subscribe(NULL, &client_port_event_cb, vp, port);
 }
 
+
+PJ_DEF(pj_status_t) pjmedia_vid_port_unsubscribe_event(
+						pjmedia_vid_port *vp,
+						pjmedia_port *port)
+{
+    PJ_ASSERT_RETURN(vp && port, PJ_EINVAL);
+
+    /* Unsubscribe to port's events */
+    return pjmedia_event_unsubscribe(NULL, &client_port_event_cb, vp, port);
+}
+
+
 PJ_DEF(pj_status_t) pjmedia_vid_port_connect(pjmedia_vid_port *vp,
 					      pjmedia_port *port,
 					      pj_bool_t destroy)


### PR DESCRIPTION
Currently there are a couple missing event unsubscriptions found in `pjsua_vid`. Besides causing the obvious leak (i.e. event list will keep growing), this may also cause other unexpected issues, such as:
- Rogue event called with invalid user data. Example log:
```
09:52:32.520  pjsua_media.c  ..Call 1: initializing media..
09:52:35.919     vid_conf.c  ......Added port 1 (vstdec0x84d2c814)
...
09:52:40.087  dlg0x84cc5864  ......Sending Response msg 200/BYE/cseq=25373 (tdta0x8495c064)
09:52:40.088  pjsua_media.c  ......Call 1: deinitializing media..
Call 1 disconnected
...

09:52:55.365  pjsua_media.c  ..Call 3: initializing media..
09:52:58.262     vid_conf.c  ......Added port 1 (vstdec0x84d2c814)
09:52:58.973   openh264.cpp !Frame size changed: 1456x1456 --> 720x480
09:52:58.974 vstdec0x84d2c8  Decoding format changed: 720x480 I420<- 30/1(~30)fps
09:52:58.974  pjsua_media.c !Call 1: Media 1: Received media event, type=FMCH, src=0x7b6b0c64, epub=0x84d2d1b8
09:52:58.974 android_opengl  Stopping Android opengl stream
09:52:58.974 android_opengl !Re-initializing OpenGL due to format change: Success
09:52:58.974 android_opengl  Starting Android opengl stream
09:52:58.974  pjsua_media.c  Call 3: Media 1: Received media event, type=FMCH, src=0x7b6b0c64, epub=0x84c09264
```
From the log, we could see that call 1 still received media event even though it had long been disconnected.

- Wrong order of event distribution.
Since new subscribers are inserted at the back of the subscriber list, the dangling subscribers will be called first. During events such as format change, this causes video components to receive the event in the wrong order, causing cross-component format change checking to fail (for example, vid_conf performs update based on vid_stream's format since vid_stream is expected to have received the event, but the update will fail if vid_conf receives the event first and vid_stream hasn't). Consequently, this may cause the video to never show up due to incorrect format.
