### PR TITLE
Fixed build failure on clang 13

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -184,6 +184,8 @@ static pj_status_t circ_write(circ_buf_t *cb,
  *******************************************************************
  */
 
+#ifndef SSL_SOCK_IMP_USE_OWN_NETWORK
+
 /* Check IP address version. */
 static int get_ip_addr_ver(const pj_str_t *host)
 {
@@ -202,7 +204,6 @@ static int get_ip_addr_ver(const pj_str_t *host)
     return 0;
 }
 
-#ifndef SSL_SOCK_IMP_USE_OWN_NETWORK
 /* Close sockets */
 static void ssl_close_sockets(pj_ssl_sock_t *ssock)
 {
@@ -919,8 +920,8 @@ static pj_bool_t ssock_on_accept_complete (pj_ssl_sock_t *ssock_parent,
     pj_ssl_sock_t *ssock;
 #ifndef SSL_SOCK_IMP_USE_OWN_NETWORK
     pj_activesock_cb asock_cb;
-#endif
     pj_activesock_cfg asock_cfg;
+#endif
     unsigned i;
     pj_status_t status;
 

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -706,7 +706,7 @@ static pj_ssize_t print_attr(const pjmedia_sdp_attr *attr,
     return p-buf;
 }
 
-static int print_media_desc( pjmedia_sdp_media *m, char *buf, int len)
+static int print_media_desc(const pjmedia_sdp_media *m, char *buf, int len)
 {
     char *p = buf;
     char *end = buf+len;

--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -1315,11 +1315,11 @@ static pj_status_t dtls_encode_sdp( pjmedia_transport *tp,
             	}
                 if (pj_sockaddr_has_addr(&ds->rem_addr) &&
 		    pj_sockaddr_has_addr(&rem_rtp) &&
-		    pj_sockaddr_cmp(&ds->rem_addr, &rem_rtp) ||
-                    (!use_rtcp_mux &&
-		     pj_sockaddr_has_addr(&ds->rem_rtcp) &&
-		     pj_sockaddr_has_addr(&rem_rtcp) &&
-                     pj_sockaddr_cmp(&ds->rem_rtcp, &rem_rtcp)))
+		    (pj_sockaddr_cmp(&ds->rem_addr, &rem_rtp) ||
+                     (!use_rtcp_mux &&
+		      pj_sockaddr_has_addr(&ds->rem_rtcp) &&
+		      pj_sockaddr_has_addr(&rem_rtcp) &&
+                      pj_sockaddr_cmp(&ds->rem_rtcp, &rem_rtcp))))
                 {
                     rem_addr_changed = PJ_TRUE;
                 }

--- a/third_party/speex/libspeex/bits.c
+++ b/third_party/speex/libspeex/bits.c
@@ -106,7 +106,7 @@ EXPORT void speex_bits_rewind(SpeexBits *bits)
    bits->overflow=0;
 }
 
-EXPORT void speex_bits_read_from(SpeexBits *bits, char *chars, int len)
+EXPORT void speex_bits_read_from(SpeexBits *bits, const char *chars, int len)
 {
    int i;
    int nchars = len / BYTES_PER_CHAR;
@@ -153,7 +153,7 @@ static void speex_bits_flush(SpeexBits *bits)
    bits->charPtr=0;
 }
 
-EXPORT void speex_bits_read_whole_bytes(SpeexBits *bits, char *chars, int nbytes)
+EXPORT void speex_bits_read_whole_bytes(SpeexBits *bits, const char *chars, int nbytes)
 {
    int i,pos;
    int nchars = nbytes/BYTES_PER_CHAR;


### PR DESCRIPTION
Upgrading to the latest Clang 13 (the current exact version used: `(clang-1300.0.29.30)`), PJSIP will fail to build with the following errors:
```
./../speex/libspeex/bits.c:109:13: error: conflicting types for 'speex_bits_read_from'
EXPORT void speex_bits_read_from(SpeexBits *bits, char *chars, int len)
            ^
/opt/local/include/speex/speex_bits.h:80:6: note: previous declaration is here
void speex_bits_read_from(SpeexBits *bits, const char *bytes, int len);
     ^
../../speex/libspeex/bits.c:156:13: error: conflicting types for 'speex_bits_read_whole_bytes'
EXPORT void speex_bits_read_whole_bytes(SpeexBits *bits, char *chars, int nbytes)
            ^
/opt/local/include/speex/speex_bits.h:88:6: note: previous declaration is here
void speex_bits_read_whole_bytes(SpeexBits *bits, const char *bytes, int len);
     ^
2 errors generated.
```

Also in this PR: suppress some compilation warnings
