### PR TITLE
Check for tdata when ending inv session

### DIFF
--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -584,7 +584,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
 
 	/* Send 500 response */
 	status = pjsip_inv_end_session(dd->inv, 500, &reason, &tdata);
-	if (status == PJ_SUCCESS) {
+	if (status == PJ_SUCCESS && tdata) {
 	    pjsip_dlg_send_response(dd->inv->dlg, 
 				    dd->inv->invite_tsx,
 				    tdata);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5056,7 +5056,7 @@ static void call_disconnect( pjsip_inv_session *inv,
     pj_status_t status;
 
     status = pjsip_inv_end_session(inv, code, NULL, &tdata);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS || !tdata)
 	return;
 
 #if DISABLED_FOR_TICKET_1185

--- a/pjsip/src/test/inv_offer_answer_test.c
+++ b/pjsip/src/test/inv_offer_answer_test.c
@@ -498,8 +498,10 @@ static int perform_test(inv_test_param_t *param)
     status = pjsip_inv_end_session(inv_test.uas, PJSIP_SC_DECLINE, 0, &tdata);
     pj_assert(status == PJ_SUCCESS);
 
-    status = pjsip_inv_send_msg(inv_test.uas, tdata);
-    pj_assert(status == PJ_SUCCESS);
+    if (tdata) {
+    	status = pjsip_inv_send_msg(inv_test.uas, tdata);
+    	pj_assert(status == PJ_SUCCESS);
+    }
 
     flush_events(500);
 


### PR DESCRIPTION
To fix #2935 and #2761

From the doc of `pjsip_inv_end_session()`:
```
 * If no provisional response has been received, the
 * function will not create CANCEL request (the function will return 
 * PJ_SUCCESS but the \a p_tdata will contain NULL) because we cannot send
 * CANCEL before receiving provisional response.
```