### PR TITLE
Fix aviplay crash when using ffmpeg video codec

### DIFF
--- a/pjmedia/src/pjmedia/avi_player.c
+++ b/pjmedia/src/pjmedia/avi_player.c
@@ -897,10 +897,17 @@ static pj_status_t avi_get_frame(pjmedia_port *this_port,
 
 on_error2:
     if (status == AVI_EOF) {
+        fport->eof = PJ_TRUE;
+
         size_to_read -= size_read;
+        if (size_to_read == frame->size) {
+            /* Frame is empty */
+ 	    frame->type = PJMEDIA_FRAME_TYPE_NONE;
+	    frame->size = 0;
+	    return PJ_EEOF;           
+        }
         pj_bzero((char *)frame->buf + frame->size - size_to_read,
                  size_to_read);
-        fport->eof = PJ_TRUE;
 
         return PJ_SUCCESS;
     }

--- a/pjsip-apps/src/samples/aviplay.c
+++ b/pjsip-apps/src/samples/aviplay.c
@@ -311,9 +311,14 @@ static int aviplay(pj_pool_t *pool, const char *fname)
 	    
             /* Alloc encoding buffer */
             enc_buf_size =  codec_param.dec_fmt.det.vid.size.w *
-	    codec_param.dec_fmt.det.vid.size.h * 4
-	    + 16; /*< padding, just in case */
-            enc_buf = pj_pool_alloc(pool,enc_buf_size);
+	    codec_param.dec_fmt.det.vid.size.h * 4;
+            enc_buf = pj_pool_alloc(pool, enc_buf_size +
+            			    128 /*< padding, required for vid codecs
+            			    	    such as ffmpeg. Must be >=
+            			    	    AV_INPUT_BUFFER_PADDING_SIZE.
+            			    	    And must not be included in
+            			    	    the enc_buf_size calculation
+            			    	    above. */);
 	    
             /* Init codec port */
             pj_bzero(&codec_port, sizeof(codec_port));


### PR DESCRIPTION
Reported in #2870.

In our ffmpeg codec wrapper implementation, https://github.com/pjsip/pjproject/blob/master/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c#L1832:
```
    /* ffmpeg warns:
     * - input buffer padding, at least FF_INPUT_BUFFER_PADDING_SIZE
     * - null terminated
     * Normally, encoded buffer is allocated more than needed, so lets just
     * bzero the input buffer end/pad, hope it will be just fine.
     */
#if LIBAVCODEC_VER_AT_LEAST(56,35)
    pj_bzero(avpacket.data+avpacket.size, AV_INPUT_BUFFER_PADDING_SIZE);
```

So when the input frame size is already at the maximum, which is the case of AVI_EOF in `avi_player.c`, the `pj_bzero()` above will cause buffer overwrite. In my test, it will overwrite the vid_port's stream to `NULL` and cause the crash in `pjmedia_vid_dev_stream_put_frame(strm, ...)` since `strm` has become `NULL`, exactly as reported in #2870.

The fix here is to allocate the frame buffer larger than needed, to accommodate the padding. Note that this is not ideal for two reasons:
- It puts the burden of padding allocation on the applications, which may not realise this.
- The padding size may also increase in the future (in my testing, it is 64 bytes, 4 times larger than the currently used 16 bytes).
