### PR TITLE
Fix build failure when PJ_POOL_DEBUG is enabled

### DIFF
--- a/pjlib/include/pj/pool_alt.h
+++ b/pjlib/include/pj/pool_alt.h
@@ -56,8 +56,12 @@ struct pj_pool_t
  * This constant denotes the exception number that will be thrown by default
  * memory factory policy when memory allocation fails.
  */
-extern int PJ_NO_MEMORY_EXCEPTION;
+PJ_DECL_DATA(int) PJ_NO_MEMORY_EXCEPTION;
 
+/**
+ * Get #PJ_NO_MEMORY_EXCEPTION constant.
+ */
+PJ_DECL(int) pj_NO_MEMORY_EXCEPTION(void);
 
 
 /*
@@ -68,6 +72,8 @@ extern int PJ_NO_MEMORY_EXCEPTION;
 	pj_pool_create_imp(__FILE__, __LINE__, fc, nm, init, inc, cb)
 
 #define pj_pool_release(pool)		    pj_pool_release_imp(pool)
+#define pj_pool_safe_release(pool)	    pj_pool_safe_release_imp(pool)
+#define pj_pool_secure_release(pool)	    pj_pool_secure_release_imp(pool)
 #define pj_pool_getobjname(pool)	    pj_pool_getobjname_imp(pool)
 #define pj_pool_reset(pool)		    pj_pool_reset_imp(pool)
 #define pj_pool_get_capacity(pool)	    pj_pool_get_capacity_imp(pool)
@@ -97,6 +103,12 @@ PJ_DECL(pj_pool_t*) pj_pool_create_imp(const char *file, int line,
 
 /* Release pool */
 PJ_DECL(void) pj_pool_release_imp(pj_pool_t *pool);
+
+/* Safe release pool */
+PJ_DECL(void) pj_pool_safe_release_imp(pj_pool_t **pool);
+
+/* Secure release pool */
+PJ_DECL(void) pj_pool_secure_release_imp(pj_pool_t **pool);
 
 /* Get pool name */
 PJ_DECL(const char*) pj_pool_getobjname_imp(pj_pool_t *pool);

--- a/pjlib/src/pj/pool_dbg.c
+++ b/pjlib/src/pj/pool_dbg.c
@@ -44,7 +44,7 @@
 
 
 
-int PJ_NO_MEMORY_EXCEPTION;
+PJ_DEF_DATA(int) PJ_NO_MEMORY_EXCEPTION;
 
 
 PJ_DEF(int) pj_NO_MEMORY_EXCEPTION()
@@ -93,6 +93,24 @@ PJ_DEF(void) pj_pool_release_imp(pj_pool_t *pool)
 {
     pj_pool_reset(pool);
     free(pool);
+}
+
+/* Safe release pool */
+PJ_DEF(void) pj_pool_safe_release_imp( pj_pool_t **ppool )
+{
+    pj_pool_t *pool = *ppool;
+    *ppool = NULL;
+    if (pool)
+	pj_pool_release(pool);
+}
+
+/* Secure release pool */
+PJ_DEF(void) pj_pool_secure_release_imp( pj_pool_t **ppool )
+{
+    /* Secure release is not implemented, so we just call
+     * safe release.
+     */
+    pj_pool_safe_release_imp(ppool);
 }
 
 /* Get pool name */


### PR DESCRIPTION
When `PJ_POOL_DEBUG` is set to 1, PJSIP will fail to build with errors:
- undefined reference to `pj_pool_secure_release'
- undefined reference to `pj_pool_safe_release'
- implicit declaration of function 'pj_NO_MEMORY_EXCEPTION'
