### PR TITLE
Initialize pj logging earlier in pj_init()

### DIFF
--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -175,6 +175,9 @@ PJ_DEF(pj_status_t) pj_init(void)
 	return PJ_SUCCESS;
     }
 
+    /* Init logging */
+    pj_log_init();
+
 #if PJ_HAS_THREADS
     /* Init this thread's TLS. */
     if ((rc=pj_thread_init()) != 0) {
@@ -186,9 +189,6 @@ PJ_DEF(pj_status_t) pj_init(void)
 	return rc;
 
 #endif
-
-    /* Init logging */
-    pj_log_init();
 
     /* Initialize exception ID for the pool.
      * Must do so after critical section is configured.


### PR DESCRIPTION
To fix #2948.
In `pj_init()`, `init_mutex()` will call `PJ_LOG(6, (mutex->obj_name, "Mutex created"))` before `pj_log_init()`.

This can cause undefined behavior in `pj_log()`->`log_get_indent()`->`log_get_raw_indent()`->`pj_thread_local_get(thread_indent_tls_id)` since `thread_indent_tls_id` has not been initialized yet.
