### PR TITLE
Misleading log when answering a call in CONFIRMED state

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2611,6 +2611,12 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
     if (status != PJ_SUCCESS)
 	goto on_return;
 
+    if (call->inv->state == PJSIP_INV_STATE_CONFIRMED) {
+	PJ_LOG(3,(THIS_FILE, "Can not answer call that has been confirmed"));
+	status = PJSIP_ESESSIONSTATE;
+	goto on_return;
+    }
+
     /* Apply call setting, only if status code is 1xx or 2xx. */
     if (opt && code < 300) {
 	/* Check if it has not been set previously or it is different to

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2611,7 +2611,7 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
     if (status != PJ_SUCCESS)
 	goto on_return;
 
-    if (call->inv->state == PJSIP_INV_STATE_CONFIRMED) {
+    if (call->inv->state >= PJSIP_INV_STATE_CONFIRMED) {
 	PJ_LOG(3,(THIS_FILE, "Can not answer call that has been confirmed"));
 	status = PJSIP_ESESSIONSTATE;
 	goto on_return;


### PR DESCRIPTION
After #2350, we will get an error when we try to call pjsua_call_answer() successively.
```
18:32:19.051           pjsua_call.c  ..Answering call 0: code=200
18:32:19.051            pjsua_app.c  .........Call 0 state changed to CONNECTING
18:32:19.051           pjsua_call.c  ..Answering call 0: code=100
18:32:19.051           pjsua_call.c  ...Error sending response: Invalid operation (PJ_EINVALIDOP) [status=70013]
```
However, if ACK is received in between, this causes `call->inv->last_answer` to be cleared. As a result, we will get a log which says that the answer is pending:
```
18:41:41.750           pjsua_call.c  ..Answering call 0: code=200
18:41:42.270           pjsua_core.c  .RX 514 bytes Request msg ACK/cseq=30228 (rdata0x1209c0828) from UDP 139.162.62.29:5060:
18:41:42.270            pjsua_app.c  ...Call 0 state changed to CONFIRMED
18:41:43.258           pjsua_call.c !Answering call 0: code=100
18:41:43.258           pjsua_call.c  .Pending answering call 0 upon completion of media transport
```
Functionality wise, it doesn't seem to negatively affect anything since it only queues the answer to `call->async_call.call_var.inc_call.answers`, but the log is obviously misleading.
