### PR TITLE
OpenSSL server-side enhancements to support session reuse and SNI

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -971,6 +971,9 @@ static pj_bool_t ssock_on_accept_complete (pj_ssl_sock_t *ssock_parent,
     if (status != PJ_SUCCESS)
 	goto on_return;
 
+    /* Set peer name */
+    ssl_set_peer_name(ssock);
+
     /* Prepare read buffer */
     ssock->asock_rbuf = (void**)pj_pool_calloc(ssock->pool, 
 					       ssock->param.async_cnt,

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2188,6 +2188,8 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
 
     /* Check if handshake has been completed */
     if (SSL_is_init_finished(ossock->ossl_ssl)) {
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     	if (ssock->is_server && ssock->ssl_state != SSL_STATE_ESTABLISHED) {
     	    enum {BUF_SIZE = 64};
 	    unsigned int len = 0, i;
@@ -2218,6 +2220,7 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
 	    buf[len] = '\0';
 	    PJ_LOG(5, (THIS_FILE, "Session id context: %s", buf));
     	}
+#endif
 
 	ssock->ssl_state = SSL_STATE_ESTABLISHED;
 	return PJ_SUCCESS;


### PR DESCRIPTION
In this PR, there are a few enhancements for server usage:
1. Support session reuse
We need to create only one SSL server context and maintain it if we want to reuse the SSL session created from that context.

2. Support Server Name Indication
Implement SNI callback which will check the server name passed by the client and fail the handshake upon mismatch (note that as per the [RFC3546](https://tools.ietf.org/html/rfc3546#section-3.1), server name must not be an IP address).

3. Add option to disable session tickets
SSL/TLS supports two mechanisms for resuming sessions: session ids and stateless session tickets. Here we provide an option to disable session tickets.

Client use should be unaffected by this PR.
