### PR TITLE
Fixed ice session assertion when there's no checklist

### DIFF
--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -2505,8 +2505,8 @@ PJ_DEF(pj_status_t) pj_ice_sess_start_check(pj_ice_sess *ice)
     PJ_ASSERT_RETURN(ice, PJ_EINVAL);
 
     /* Checklist must have been created */
-    PJ_ASSERT_RETURN(ice->clist.count > 0 || ice->is_trickling,
-		     PJ_EINVALIDOP);
+    if (ice->clist.count == 0 && !ice->is_trickling)
+    	return PJ_EINVALIDOP;
 
     /* Lock session */
     pj_grp_lock_acquire(ice->grp_lock);


### PR DESCRIPTION
To fix #2952.

When remote responds with invalid candidates, ice session will fail with an assertion:
```PJ_ASSERT_RETURN(ice->clist.count > 0 || ice->is_trickling, PJ_EINVALIDOP);```
when calling  `pj_ice_strans_start_ice()` which will then call `pj_ice_sess_start_check()`.

The proposed fix here is to change the assertion to regular error checking.
