### PR TITLE
Fix documentation and usage of txdata ref counter

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1174,8 +1174,12 @@ static void simple_registrar(pjsip_rx_data *rdata)
     srv->hvalue = pj_str("pjsua simple registrar");
     pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)srv);
 
-    pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
+    status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
 		       rdata, tdata, NULL, NULL);
+	if (status != PJ_SUCCESS) {
+	    pjsip_tx_data_dec_ref(tdata);
+	}
+
 }
 
 /*****************************************************************************
@@ -1249,8 +1253,9 @@ static pj_bool_t default_mod_on_rx_request(pjsip_rx_data *rdata)
 	pjsip_msg_add_hdr(tdata->msg, h);
     }
 
-    pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(), rdata, tdata, 
+    status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(), rdata, tdata, 
 			       NULL, NULL);
+	    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 
     return PJ_TRUE;
 }

--- a/pjsip-apps/src/samples/pjsip-perf.c
+++ b/pjsip-apps/src/samples/pjsip-perf.c
@@ -460,11 +460,10 @@ static pj_bool_t mod_call_on_rx_request(pjsip_rx_data *rdata)
 		pjsip_response_addr res_addr;
 
 		pjsip_get_response_addr(tdata->pool, rdata, &res_addr);
-		pjsip_endpt_send_response(app.sip_endpt, &res_addr, tdata, 
+		status = pjsip_endpt_send_response(app.sip_endpt, &res_addr, tdata, 
 					  NULL, NULL);
-
+		if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 	    } else {
-
 		/* Respond with 500 (Internal Server Error) */
 		pjsip_endpt_respond_stateless(app.sip_endpt, rdata, 500, NULL,
 					      NULL, NULL);

--- a/pjsip-apps/src/samples/siprtp.c
+++ b/pjsip-apps/src/samples/siprtp.c
@@ -623,8 +623,9 @@ static void process_incoming_call(pjsip_rx_data *rdata)
 	    pjsip_response_addr res_addr;
 	    
 	    pjsip_get_response_addr(tdata->pool, rdata, &res_addr);
-	    pjsip_endpt_send_response(app.sip_endpt, &res_addr, tdata,
+	    pj_status_t status = pjsip_endpt_send_response(app.sip_endpt, &res_addr, tdata,
 		NULL, NULL);
+	    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 	    
 	} else {
 	    

--- a/pjsip-apps/src/samples/stateful_proxy.c
+++ b/pjsip-apps/src/samples/stateful_proxy.c
@@ -346,6 +346,7 @@ static pj_bool_t proxy_on_rx_response( pjsip_rx_data *rdata )
     status = pjsip_endpt_send_response(global.endpt, &res_addr, tdata,
 				       NULL, NULL);
     if (status != PJ_SUCCESS) {
+	pjsip_tx_data_dec_ref(tdata);
 	app_perror("Error forwarding response", status);
 	return PJ_TRUE;
     }

--- a/pjsip-apps/src/samples/stateless_proxy.c
+++ b/pjsip-apps/src/samples/stateless_proxy.c
@@ -163,6 +163,7 @@ static pj_bool_t on_rx_response( pjsip_rx_data *rdata )
     status = pjsip_endpt_send_response(global.endpt, &res_addr, tdata, 
 				       NULL, NULL);
     if (status != PJ_SUCCESS) {
+	pjsip_tx_data_dec_ref(tdata);
 	app_perror("Error forwarding response", status);
 	return PJ_TRUE;
     }

--- a/pjsip-apps/src/vidgui/vidgui.cpp
+++ b/pjsip-apps/src/vidgui/vidgui.cpp
@@ -659,8 +659,9 @@ static void simple_registrar(pjsip_rx_data *rdata)
     srv->hvalue = pj_str((char*)"pjsua simple registrar");
     pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)srv);
 
-    pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
+    pj_status_t status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
                                rdata, tdata, NULL, NULL);
+    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 }
 
 /* Notification on incoming request */

--- a/pjsip/include/pjsip-ua/sip_replaces.h
+++ b/pjsip/include/pjsip-ua/sip_replaces.h
@@ -128,11 +128,14 @@
     if (status != PJ_SUCCESS) {
 	// Something wrong with Replaces request.
 	//
+	pj_status_t status;
 	if (response) {
-	    pjsip_endpt_send_response(endpt, rdata, response, NULL, NULL);
+	    status = pjsip_endpt_send_response(endpt, rdata, response, NULL, NULL);
+	    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 	} else {
 	    // Respond with 500 (Internal Server Error)
-	    pjsip_endpt_respond_stateless(endpt, rdata, 500, NULL, NULL, NULL);
+	    status = pjsip_endpt_respond_stateless(endpt, rdata, 500, NULL, NULL, NULL);
+	    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 	}
     }
 

--- a/pjsip/include/pjsip/sip_util.h
+++ b/pjsip/include/pjsip/sip_util.h
@@ -322,7 +322,7 @@ pjsip_endpt_create_request_from_hdr( pjsip_endpoint *endpt,
  * will construct all the Via, Record-Route, Call-ID, From, To, CSeq, and 
  * Call-ID headers from the request.
  *
- * Note: the txdata reference counter is set to ZERO!.
+ * Once a transmit data is created, the reference counter is initialized to 1.
  *
  * @param endpt	    The endpoint.
  * @param rdata	    The request receive data.
@@ -344,6 +344,8 @@ PJ_DECL(pj_status_t) pjsip_endpt_create_response( pjsip_endpoint *endpt,
  * an ACK request to 3xx-6xx final response.
  * The generation of ACK message for 2xx final response is different than
  * this one.
+ *
+ * Once a transmit data is created, the reference counter is initialized to 1.
  * 
  * @param endpt	    The endpoint.
  * @param tdata	    This contains the original INVITE request
@@ -360,6 +362,8 @@ PJ_DECL(pj_status_t) pjsip_endpt_create_ack( pjsip_endpoint *endpt,
 
 /**
  * Construct CANCEL request for the previously sent request.
+ *
+ * Once a transmit data is created, the reference counter is initialized to 1.
  *
  * @param endpt	    The endpoint.
  * @param tdata	    The transmit buffer for the request being cancelled.

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1498,9 +1498,9 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 	    pjsip_response_addr res_addr;
 
 	    pjsip_get_response_addr(response->pool, rdata, &res_addr);
-	    pjsip_endpt_send_response(pjsua_var.endpt, &res_addr, response,
+	    status = pjsip_endpt_send_response(pjsua_var.endpt, &res_addr, response,
 				      NULL, NULL);
-
+	    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(response);
 	} else {
 
 	    /* Respond with 500 (Internal Server Error) */
@@ -1696,8 +1696,9 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 	    pjsip_response_addr res_addr;
 
 	    pjsip_get_response_addr(response->pool, rdata, &res_addr);
-	    pjsip_endpt_send_response(pjsua_var.endpt, &res_addr, response,
+	    pj_status_t status = pjsip_endpt_send_response(pjsua_var.endpt, &res_addr, response,
 				      NULL, NULL);
+	    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(response);
 
 	} else {
 	    /* Respond with 500 (Internal Server Error) */

--- a/pjsip/src/test/tsx_uac_test.c
+++ b/pjsip/src/test/tsx_uac_test.c
@@ -563,7 +563,8 @@ static void send_response_callback( pj_timer_heap_t *timer_heap,
 
     PJ_UNUSED_ARG(timer_heap);
 
-    pjsip_endpt_send_response(endpt, &r->res_addr, r->tdata, NULL, NULL);
+    pj_status_t status = pjsip_endpt_send_response(endpt, &r->res_addr, r->tdata, NULL, NULL);
+    if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(r->tdata);
     if (tp)
 	pjsip_transport_dec_ref(tp);
 }


### PR DESCRIPTION
The documentation is not according to `pjsip/src/pjsip/sip_util.c:513`.
The Statful Proxy should handle one error case, similar to rest of the code.