### PR TITLE
Avoid assertions when using PJ_HAS_THREADS 0

### DIFF
--- a/pjlib/src/pj/lock.c
+++ b/pjlib/src/pj/lock.c
@@ -260,17 +260,25 @@ PJ_DEF(void) pj_grp_lock_config_default(pj_grp_lock_config *cfg)
 static void grp_lock_set_owner_thread(pj_grp_lock_t *glock)
 {
     if (!glock->owner) {
+#if PJ_HAS_THREADS
 	glock->owner = pj_thread_this();
+#else
+        glock->owner = (pj_thread_t *) -1;
+#endif
 	glock->owner_cnt = 1;
     } else {
+#if PJ_HAS_THREADS
 	pj_assert(glock->owner == pj_thread_this());
+#endif
 	glock->owner_cnt++;
     }
 }
 
 static void grp_lock_unset_owner_thread(pj_grp_lock_t *glock)
 {
+#if PJ_HAS_THREADS
     pj_assert(glock->owner == pj_thread_this());
+#endif
     pj_assert(glock->owner_cnt > 0);
     if (--glock->owner_cnt <= 0) {
 	glock->owner = NULL;

--- a/pjlib/src/pj/log.c
+++ b/pjlib/src/pj/log.c
@@ -167,12 +167,28 @@ pj_status_t pj_log_init(void)
     }
 #endif
     g_last_thread = NULL;
+
+    /* Normalize log decor, e.g: unset thread flags when threading is
+     * disabled.
+     */
+    pj_log_set_decor(pj_log_get_decor());
+
     return PJ_SUCCESS;
 }
 
 PJ_DEF(void) pj_log_set_decor(unsigned decor)
 {
     log_decor = decor;
+
+#if !PJ_HAS_THREADS
+    /* Unset thread related flags */
+    if (log_decor & PJ_LOG_HAS_THREAD_ID) {
+       log_decor &= ~(PJ_LOG_HAS_THREAD_ID);
+    }
+    if (log_decor & PJ_LOG_HAS_THREAD_SWC) {
+       log_decor &= ~(PJ_LOG_HAS_THREAD_SWC);
+    }
+#endif
 }
 
 PJ_DEF(unsigned) pj_log_get_decor(void)


### PR DESCRIPTION
This fixes assertions occuring when using PJSIP without thread support. The assertions get triggered when `pj_thread_this` gets called.

Please be aware that in additon to this patch you will also need to exclude `PJ_LOG_HAS_THREAD_ID` and `PJ_LOG_HAS_THREAD_SWC `from your logging decor.

This patch sets the `grp lock owner` pointer to a constant invalid value. While this is ugly, the lock owner should not equal `NULL` while locked and a constant seemed the simplest solution to achieve this.