### PR TITLE
Add additional unit test options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ tests/pjsua/wavs/tmp*.wav
 tests/pjsua/tools/cmp_wav
 tests/pjsua/tools/cmp_wav.dSYM
 tests/pjsua/logs
+# benchmark output
+*bench*.htm

--- a/pjlib-util/src/pjlib-util-test/main.c
+++ b/pjlib-util/src/pjlib-util-test/main.c
@@ -51,7 +51,7 @@ static void print_stack(int sig)
     exit(1);
 }
 
-static void init_signals()
+static void init_signals(void)
 {
     signal(SIGSEGV, &print_stack);
     signal(SIGABRT, &print_stack);
@@ -68,20 +68,33 @@ static void init_signals()
 int main(int argc, char *argv[])
 {
     int rc;
-
-    PJ_UNUSED_ARG(argc);
-    PJ_UNUSED_ARG(argv);
+    int interractive = 0;
+    int no_trap = 0;
 
     boost();
-    init_signals();
+
+    while (argc > 1) {
+        char *arg = argv[--argc];
+
+	if (*arg=='-' && *(arg+1)=='i') {
+	    interractive = 1;
+
+	} else if (*arg=='-' && *(arg+1)=='n') {
+	    no_trap = 1;
+	}
+    }
+
+    if (!no_trap) {
+	init_signals();
+    }
 
     rc = test_main();
 
-    if (argc==2 && pj_ansi_strcmp(argv[1], "-i")==0) {
+    if (interractive) {
 	char s[10];
-
-	puts("Press ENTER to quit");
-	if (fgets(s, sizeof(s), stdin) == NULL)
+	puts("");
+	puts("Press <ENTER> to exit");
+	if (!fgets(s, sizeof(s), stdin))
 	    return rc;
     }
 

--- a/pjlib/src/pjlib-test/main.c
+++ b/pjlib/src/pjlib-test/main.c
@@ -72,7 +72,7 @@ static void print_stack(int sig)
     exit(1);
 }
 
-static void init_signals()
+static void init_signals(void)
 {
     signal(SIGSEGV, &print_stack);
     signal(SIGABRT, &print_stack);
@@ -86,9 +86,9 @@ int main(int argc, char *argv[])
 {
     int rc;
     int interractive = 0;
+    int no_trap = 0;
 
     boost();
-    init_signals();
 
     while (argc > 1) {
         char *arg = argv[--argc];
@@ -96,6 +96,8 @@ int main(int argc, char *argv[])
 	if (*arg=='-' && *(arg+1)=='i') {
 	    interractive = 1;
 
+	} else if (*arg=='-' && *(arg+1)=='n') {
+	    no_trap = 1;
 	} else if (*arg=='-' && *(arg+1)=='p') {
             pj_str_t port = pj_str(argv[--argc]);
 
@@ -116,6 +118,10 @@ int main(int argc, char *argv[])
                 return 1;
             }
         }
+    }
+
+    if (!no_trap) {
+	init_signals();
     }
 
     rc = test_main();

--- a/pjmedia/src/test/main.c
+++ b/pjmedia/src/test/main.c
@@ -50,7 +50,7 @@ static void print_stack(int sig)
     exit(1);
 }
 
-static void init_signals()
+static void init_signals(void)
 {
     signal(SIGSEGV, &print_stack);
     signal(SIGABRT, &print_stack);
@@ -64,13 +64,31 @@ static void init_signals()
 static int main_func(int argc, char *argv[])
 {
     int rc;
-    char s[10];
+    int interractive = 0;
+    int no_trap = 0;
+
+    while (argc > 1) {
+        char *arg = argv[--argc];
+
+	if (*arg=='-' && *(arg+1)=='i') {
+	    interractive = 1;
+
+	} else if (*arg=='-' && *(arg+1)=='n') {
+	    no_trap = 1;
+	}
+    }
+
+    if (!no_trap) {
+	init_signals();
+    }
 
     rc = test_main();
 
-    if (argc == 2 && argv[1][0]=='-' && argv[1][1]=='i') {
-	puts("\nPress <ENTER> to quit");
-	if (fgets(s, sizeof(s), stdin) == NULL)
+    if (interractive) {
+	char s[10];
+	puts("");
+	puts("Press <ENTER> to exit");
+	if (!fgets(s, sizeof(s), stdin))
 	    return rc;
     }
 
@@ -79,6 +97,5 @@ static int main_func(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-    init_signals();
     return pj_run_app(&main_func, argc, argv, 0);
 }

--- a/pjnath/src/pjnath-test/main.c
+++ b/pjnath/src/pjnath-test/main.c
@@ -50,7 +50,7 @@ static void print_stack(int sig)
     exit(1);
 }
 
-static void init_signals()
+static void init_signals(void)
 {
     signal(SIGSEGV, &print_stack);
     signal(SIGABRT, &print_stack);
@@ -65,20 +65,33 @@ static void init_signals()
 int main(int argc, char *argv[])
 {
     int rc;
-
-    PJ_UNUSED_ARG(argc);
-    PJ_UNUSED_ARG(argv);
+    int interractive = 0;
+    int no_trap = 0;
 
     boost();
-    init_signals();
+
+    while (argc > 1) {
+        char *arg = argv[--argc];
+
+	if (*arg=='-' && *(arg+1)=='i') {
+	    interractive = 1;
+
+	} else if (*arg=='-' && *(arg+1)=='n') {
+	    no_trap = 1;
+	}
+    }
+
+    if (!no_trap) {
+	init_signals();
+    }
 
     rc = test_main();
 
-    if (argc == 2 && pj_ansi_strcmp(argv[1], "-i")==0) {
-	char buf[10];
-
+    if (interractive) {
+	char s[10];
+	puts("");
 	puts("Press <ENTER> to exit");
-	if (fgets(buf, sizeof(buf), stdin) == NULL)
+	if (!fgets(s, sizeof(s), stdin))
 	    return rc;
     }
 

--- a/pjsip/src/test/test.h
+++ b/pjsip/src/test/test.h
@@ -115,9 +115,10 @@ int transport_load_test(char *target_url);
 int inv_offer_answer_test(void);
 
 /* Test main entry */
-int  test_main(void);
+int  test_main(char *testlist);
 
 /* Test utilities. */
+void list_tests(void);
 void app_perror(const char *msg, pj_status_t status);
 int  init_msg_logger(void);
 int  msg_logger_set_enabled(pj_bool_t enabled);


### PR DESCRIPTION
All of the unit tests will now accept a '-n/--no-trap' option
that will prevent the test's main.c wrapper from intercepting the
SIGSEGV and SIGABRT signals.  This allows the OS to generate
a coredump which can be examined by gdb.

The pjsip unit test wrapper will now accept a '-t/--tests' option
that will take a list of tests to run.  If you're working on
a specific area, this makes it easier to just test that area
without having to comment out the defines in test.h. The default
is to run all tests.

Added *bench*.htm to .gitignore.