### PR TITLE
Implement verify callback to TLS connection

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -671,7 +671,8 @@ typedef struct pj_ssl_sock_cb
     
     /**
      * This callback is called when certificate verification is being done.
-     * Certification info can be obtained from #pj_ssl_sock_info.
+     * Certification info can be obtained from #pj_ssl_sock_info. Currently
+     * it's only implemented for OpenSSL backend.
      *
      * @param ssock	The secure socket.
      * @param is_server	PJ_TRUE to indicate an incoming connection.

--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -668,6 +668,20 @@ typedef struct pj_ssl_sock_cb
      */
     pj_bool_t (*on_connect_complete)(pj_ssl_sock_t *ssock,
 				     pj_status_t status);
+    
+    /**
+     * This callback is called when certificate verification is being done.
+     * Certification info can be obtained from #pj_ssl_sock_info.
+     *
+     * @param ssock	The secure socket.
+     * @param is_server	PJ_TRUE to indicate an incoming connection.
+     *
+     * @return		Return PJ_TRUE if verification is successful. 
+     *                  If verification failed, then the connection will be 
+     *			dropped immediately.
+     * 
+     */
+    pj_bool_t (*on_verify_cb)(pj_ssl_sock_t *ssock, pj_bool_t is_server);
 
 } pj_ssl_sock_cb;
 

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1527,16 +1527,17 @@ PJ_DEF(pj_status_t) pj_ssl_sock_get_info (pj_ssl_sock_t *ssock,
 
     /* Local address */
     pj_sockaddr_cp(&info->local_addr, &ssock->local_addr);
+
+    /* Certificates info */
+    info->local_cert_info = &ssock->local_cert_info;
+    info->remote_cert_info = &ssock->remote_cert_info;
+
+    /* Remote address */
+    if (pj_sockaddr_has_addr(&ssock->rem_addr))
+	pj_sockaddr_cp(&info->remote_addr, &ssock->rem_addr);
     
     if (info->established) {
 	info->cipher = ssl_get_cipher(ssock);
-
-	/* Remote address */
-	pj_sockaddr_cp(&info->remote_addr, &ssock->rem_addr);
-
-	/* Certificates info */
-	info->local_cert_info = &ssock->local_cert_info;
-	info->remote_cert_info = &ssock->remote_cert_info;
 
 	/* Verification status */
 	info->verify_status = ssock->verify_status;

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -138,6 +138,7 @@ static void update_certs_info(pj_ssl_sock_t* ssock,
 #elif !USING_LIBRESSL
 #  define SSL_CIPHER_get_id(c)	    (c)->id
 #  define SSL_set_session(ssl, s)   (ssl)->session = (s)
+#  define X509_STORE_CTX_get0_cert(ctx) ((ctx)->cert)
 #endif
 
 

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -121,6 +121,11 @@ static unsigned get_nid_from_cid(unsigned cid)
 
 #endif
 
+static void update_certs_info(pj_ssl_sock_t* ssock,
+			      X509_STORE_CTX* ctx,
+			      pj_ssl_cert_info *local_cert_info,
+			      pj_ssl_cert_info *remote_cert_info,
+			      pj_bool_t is_verify);
 
 #if !USING_LIBRESSL && OPENSSL_VERSION_NUMBER >= 0x10100000L
 #  define OPENSSL_NO_SSL2	    /* seems to be removed in 1.1.0 */
@@ -856,6 +861,15 @@ static int verify_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
 	PJ_LOG(1,(THIS_FILE,
 		  "SSL verification callback failed to get SSL socket "
 		  "instance (sslsock_idx=%d).", sslsock_idx));
+	goto on_return;
+    }
+
+    if (ssock->param.cb.on_verify_cb) {
+	update_certs_info(ssock, x509_ctx, &ssock->local_cert_info, 
+			  &ssock->remote_cert_info, PJ_TRUE);
+	preverify_ok = (*ssock->param.cb.on_verify_cb)(ssock, 
+						       ssock->is_server);
+
 	goto on_return;
     }
 
@@ -1980,39 +1994,60 @@ static void ssl_update_remote_cert_chain_info(pj_pool_t *pool,
  */
 static void ssl_update_certs_info(pj_ssl_sock_t *ssock)
 {
-    ossl_sock_t *ossock = (ossl_sock_t *)ssock;
-    X509 *x;
-    STACK_OF(X509) *chain;
-
     pj_assert(ssock->ssl_state == SSL_STATE_ESTABLISHED);
+
+    update_certs_info(ssock, NULL, &ssock->local_cert_info, 
+		      &ssock->remote_cert_info, PJ_FALSE);
+}
+
+
+static void update_certs_info(pj_ssl_sock_t* ssock,
+			      X509_STORE_CTX* ctx,
+			      pj_ssl_cert_info *local_cert_info,
+			      pj_ssl_cert_info *remote_cert_info,
+			      pj_bool_t is_verify)
+{
+    ossl_sock_t* ossock = (ossl_sock_t*)ssock;
+    X509* x;
+    STACK_OF(X509)* chain;
 
     /* Active local certificate */
     x = SSL_get_certificate(ossock->ossl_ssl);
     if (x) {
-	get_cert_info(ssock->pool, &ssock->local_cert_info, x, PJ_FALSE);
+	get_cert_info(ssock->pool, local_cert_info, x, PJ_FALSE);
 	/* Don't free local's X509! */
     } else {
-	pj_bzero(&ssock->local_cert_info, sizeof(pj_ssl_cert_info));
+	pj_bzero(local_cert_info, sizeof(pj_ssl_cert_info));
     }
 
     /* Active remote certificate */
-    x = SSL_get_peer_certificate(ossock->ossl_ssl);
-    if (x) {
-	get_cert_info(ssock->pool, &ssock->remote_cert_info, x, PJ_TRUE);
-	/* Free peer's X509 */
-	X509_free(x);
+    if (is_verify) {
+	x = X509_STORE_CTX_get0_cert(ctx);
     } else {
-	pj_bzero(&ssock->remote_cert_info, sizeof(pj_ssl_cert_info));
+	x = SSL_get_peer_certificate(ossock->ossl_ssl);
+    }
+    if (x) {
+	get_cert_info(ssock->pool, remote_cert_info, x, PJ_TRUE);
+	if (!is_verify) {
+	    /* Free peer's X509 */
+	    X509_free(x);
+	}
+    } else {
+	pj_bzero(remote_cert_info, sizeof(pj_ssl_cert_info));
     }
 
-    chain = SSL_get_peer_cert_chain(ossock->ossl_ssl);
+    if (is_verify) {
+	chain = X509_STORE_CTX_get1_chain(ctx);
+    } else {
+	chain = SSL_get_peer_cert_chain(ossock->ossl_ssl);
+    }
     if (chain) {
 	pj_pool_reset(ssock->info_pool);
 	ssl_update_remote_cert_chain_info(ssock->info_pool,
-       					  &ssock->remote_cert_info,
+       					  remote_cert_info,
        					  chain, PJ_TRUE);
     } else {
-	ssock->remote_cert_info.raw_chain.cnt = 0;
+	remote_cert_info->raw_chain.cnt = 0;
     }
 }
 

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -377,7 +377,8 @@ typedef struct pjsip_tls_setting
     void(*on_accept_fail_cb)(const pjsip_tls_on_accept_fail_param *param);
 
     /**
-     * Callback to be called to verify a new connection.
+     * Callback to be called to verify a new connection.  Currently it's only 
+     * implemented for OpenSSL backend.
      *
      * @param param         The parameter to the callback.
      * 

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -105,6 +105,38 @@ typedef struct pjsip_tls_on_accept_fail_param {
 
 
 /**
+ * This structure describe the parameter passed from #on_verify_cb().
+ */
+typedef struct pjsip_tls_on_verify_param {
+    /**
+     * Describes local address.
+     */
+    const pj_sockaddr_t *local_addr;
+
+    /**
+     * Describes remote address.
+     */
+    const pj_sockaddr_t *remote_addr;
+
+    /**
+     * Describes transport direction.
+     */
+    pjsip_transport_dir tp_dir;
+
+    /**
+     * Describes active local certificate info.
+     */
+    pj_ssl_cert_info *local_cert_info;
+   
+    /**
+     * Describes active remote certificate info.
+     */
+    pj_ssl_cert_info *remote_cert_info;
+
+} pjsip_tls_on_verify_param;
+
+
+/**
  * TLS transport settings.
  */
 typedef struct pjsip_tls_setting
@@ -343,6 +375,18 @@ typedef struct pjsip_tls_setting
      * @param param         The parameter to the callback.
      */
     void(*on_accept_fail_cb)(const pjsip_tls_on_accept_fail_param *param);
+
+    /**
+     * Callback to be called to verify a new connection.
+     *
+     * @param param         The parameter to the callback.
+     * 
+     * @return              Return PJ_TRUE if succesfully verified. 
+     *			    If verification failed, connection will be dropped
+     *			    immediately.
+     *
+     */
+    pj_bool_t(*on_verify_cb)(const pjsip_tls_on_verify_param *param);
 
 } pjsip_tls_setting;
 

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -113,6 +113,9 @@ struct tls_transport
 
     /* Group lock to be used by TLS transport and ioqueue key */
     pj_grp_lock_t	    *grp_lock;
+
+    /* Verify callback. */
+    pj_bool_t(*on_verify_cb)(const pjsip_tls_on_verify_param *param);
 };
 
 
@@ -138,6 +141,8 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
 static pj_bool_t on_data_sent(pj_ssl_sock_t *ssock,
 			      pj_ioqueue_op_key_t *send_key,
 			      pj_ssize_t sent);
+
+static pj_bool_t on_verify_cb(pj_ssl_sock_t *ssock, pj_bool_t is_server);
 
 /* This callback is called by transport manager to destroy listener */
 static pj_status_t lis_destroy(pjsip_tpfactory *factory);
@@ -304,6 +309,9 @@ static void set_ssock_param(pj_ssl_sock_param *ssock_param,
     pj_ssl_sock_param_default(ssock_param);
     ssock_param->sock_af = af;
     ssock_param->cb.on_accept_complete2 = &on_accept_complete2;
+    if (listener->tls_setting.on_verify_cb)
+	ssock_param->cb.on_verify_cb = &on_verify_cb;
+
     ssock_param->async_cnt = listener->async_cnt;
     ssock_param->ioqueue = pjsip_endpt_get_ioqueue(listener->endpt);
     ssock_param->timer_heap = pjsip_endpt_get_timer_heap(listener->endpt);
@@ -885,6 +893,7 @@ static pj_status_t tls_create( struct tls_listener *listener,
     tls->base.factory = &listener->factory;
 
     tls->ssock = ssock;
+    tls->on_verify_cb = listener->tls_setting.on_verify_cb;
 
     /* Set up the group lock */
     tls->grp_lock = tls->base.grp_lock = glock;
@@ -1182,6 +1191,8 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
     ssock_param.cb.on_connect_complete = &on_connect_complete;
     ssock_param.cb.on_data_read = &on_data_read;
     ssock_param.cb.on_data_sent = &on_data_sent;
+    if (listener->tls_setting.on_verify_cb)
+	ssock_param.cb.on_verify_cb = &on_verify_cb;
     ssock_param.async_cnt = 1;
     ssock_param.ioqueue = pjsip_endpt_get_ioqueue(listener->endpt);
     ssock_param.timer_heap = pjsip_endpt_get_timer_heap(listener->endpt);
@@ -1572,6 +1583,40 @@ static pj_bool_t on_data_sent(pj_ssl_sock_t *ssock,
 	return PJ_FALSE;
     }
     
+    return PJ_TRUE;
+}
+
+static pj_bool_t on_verify_cb(pj_ssl_sock_t* ssock, pj_bool_t is_server)
+{
+    pj_bool_t(*verify_cb)(const pjsip_tls_on_verify_param * param) = NULL;
+
+    if (is_server) {
+	struct tls_listener* tls;
+
+	tls = (struct tls_listener*)pj_ssl_sock_get_user_data(ssock);
+	verify_cb = tls->tls_setting.on_verify_cb;
+    } else {
+	struct tls_transport* tls;
+
+	tls = (struct tls_transport*)pj_ssl_sock_get_user_data(ssock);
+	verify_cb = tls->on_verify_cb;
+    }
+
+    if (verify_cb) {
+	pjsip_tls_on_verify_param param;
+	pj_ssl_sock_info info;
+
+	pj_bzero(&param, sizeof(param));
+	pj_ssl_sock_get_info(ssock, &info);
+
+	param.local_addr = &info.local_addr;
+	param.remote_addr = &info.remote_addr;
+	param.local_cert_info = info.local_cert_info;
+	param.remote_cert_info = info.remote_cert_info;
+	param.tp_dir = is_server?PJSIP_TP_DIR_INCOMING:PJSIP_TP_DIR_OUTGOING;
+	
+	return (*verify_cb)(&param);
+    }
     return PJ_TRUE;
 }
 


### PR DESCRIPTION
This patch will allow application to specify it's verification to a new TLS connection.
Currently, application can do the verification via `pjsip_tp_state_callback` (e.g: shutdown the connection when verification failed). This will allow remote to send data during application verification. 
The callback will allow connection disconnection immediately if verification failed.