### PR TITLE
Fixed assertion in multipart test

### DIFF
--- a/pjsip/src/test/multipart_test.c
+++ b/pjsip/src/test/multipart_test.c
@@ -277,11 +277,14 @@ static pj_status_t verify2(pj_pool_t *pool, pjsip_msg_body *body)
 	return (rc - rcbase);
     }
 
+    /* This will trigger assertion. */
+    /*
     rcbase += 10;
     rc = verify_cid_str(pool, body, pj_str(""), "has header4");
     if (!rc) {
 	return (rc - rcbase);
     }
+    */
 
     rcbase += 10;
     rc = verify_cid_str(pool, body, pj_str("<>"), "has header4");


### PR DESCRIPTION
Re #2953 , multipart testing with `verify_cid_str(..., pj_str(""), ...);` will trigger assertion:
```
pjsip-test-x86_64-unknown-linux-gnu: ../src/pjsip/sip_multipart.c:594: pjsip_multipart_find_part_by_cid_str:
Assertion `pool && mp && cid && (pj_strlen(cid) > 0)' failed
```

since the length of the string is zero.

So I disable this.
