### PR TITLE
Fixed OpenSSL server context initialization

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1008,6 +1008,9 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
     int rc;
     pj_status_t status;
 
+    if (ssock->param.proto == PJ_SSL_SOCK_PROTO_DEFAULT)
+	ssock->param.proto = PJ_SSL_SOCK_PROTO_SSL23;
+
     /* Determine SSL method to use */
     /* Specific version methods are deprecated since 1.1.0 */
 #if (USING_LIBRESSL && LIBRESSL_VERSION_NUMBER < 0x2020100fL)\

--- a/pjsip/src/test/multipart_test.c
+++ b/pjsip/src/test/multipart_test.c
@@ -277,11 +277,14 @@ static pj_status_t verify2(pj_pool_t *pool, pjsip_msg_body *body)
 	return (rc - rcbase);
     }
 
+    /* This will trigger assertion. */
+    /*
     rcbase += 10;
     rc = verify_cid_str(pool, body, pj_str(""), "has header4");
     if (!rc) {
 	return (rc - rcbase);
     }
+    */
 
     rcbase += 10;
     rc = verify_cid_str(pool, body, pj_str("<>"), "has header4");

--- a/pjsip/src/test/multipart_test.c
+++ b/pjsip/src/test/multipart_test.c
@@ -277,14 +277,11 @@ static pj_status_t verify2(pj_pool_t *pool, pjsip_msg_body *body)
 	return (rc - rcbase);
     }
 
-    /* This will trigger assertion. */
-    /*
     rcbase += 10;
     rc = verify_cid_str(pool, body, pj_str(""), "has header4");
     if (!rc) {
 	return (rc - rcbase);
     }
-    */
 
     rcbase += 10;
     rc = verify_cid_str(pool, body, pj_str("<>"), "has header4");


### PR DESCRIPTION
Re #2954 .

As the CI test showed, pjnath test will fail because of incorrect OpenSSL server context initialization when the protocol parameter is set as default.
```
15:15:59.245                   test Running turn_sock_test()...
15:15:59.246                          state progression tests - (IPv4) (TLS)
15:15:59.246                           without DNS SRV resolution
15:15:59.255                    SSL SSL_ERROR_SSL (Handshake): Level: 0 err: <337625156> <SSL routines-tls_setup_handshake-internal error> len: 0 peer: 127.0.0.1:56309
15:15:59.255         ssl0x138f11d20 Handshake failed in accepting 127.0.0.1:56309: internal error
```

