### PR TITLE
Fixed iOS ipjsua app inability to auto answer

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -308,8 +308,7 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
 	current_call = call_id;
 
 #ifdef USE_GUI
-    if (!showNotification(call_id))
-	return;
+    showNotification(call_id);
 #endif
 
     /* Start ringback */


### PR DESCRIPTION
When passing `--auto-answer` option to ipjsua sample app, the app will ignore it. This is because previously, in order to answer a call, user needs to press "accept call" button in the GUI, but since the app is now telnet based and with Apple's switching to PushKit, that's no longer applicable.
