### PR TITLE
Fix decode issue on FFMpeg 4.3.2

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1599,6 +1599,12 @@ static pj_status_t ffmpeg_codec_encode_whole(pjmedia_vid_codec *codec,
         p += ff->enc_vafp.plane_bytes[i[0]];
     }
 
+#if LIBAVCODEC_VER_AT_LEAST(58,134)
+    avframe.height = ff->enc_ctx->height;
+    avframe.width = ff->enc_ctx->width;
+    avframe.format = ff->enc_ctx->pix_fmt;
+#endif
+
     /* Force keyframe */
     if (opt && opt->force_keyframe) {
 #if LIBAVCODEC_VER_AT_LEAST(53,20)


### PR DESCRIPTION
When using FFMPeg 4.3.2 and onwards, the codec failed with these information on the log:
```
ffmpeg_vid_codecs.c        clock  ffmpeg err -22: Invalid argument
vstenc0x7fb7f401b8b8        clock  Codec encode_begin() error: Codec internal creation error (PJMEDIA_CODEC_EFAILED)
```
This ticket will fix such issue.

