### PR TITLE
Release wav player and recorder pool to clean up when calling pjsua_destroy()

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -2068,16 +2068,14 @@ static pj_status_t app_destroy(void)
     }
 
     /* Close wav player */
-    if (app_config.wav_id != PJSUA_INVALID_ID) 
-    {
+    if (app_config.wav_id != PJSUA_INVALID_ID) {
 	pjsua_player_destroy(app_config.wav_id);
 	app_config.wav_id = PJSUA_INVALID_ID;
 	app_config.wav_port = PJSUA_INVALID_ID;
     }
 
-    /* Close wav recorder */    
-    if (app_config.rec_id != PJSUA_INVALID_ID) 
-    {
+    /* Close wav recorder */
+    if (app_config.rec_id != PJSUA_INVALID_ID) {
 	pjsua_recorder_destroy(app_config.rec_id);
 	app_config.rec_id = PJSUA_INVALID_ID;
 	app_config.rec_port = PJSUA_INVALID_ID;

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -2067,6 +2067,22 @@ static pj_status_t app_destroy(void)
 	app_config.ring_port = NULL;
     }
 
+    /* Close wav player */
+    if (app_config.wav_id != PJSUA_INVALID_ID) 
+    {
+	pjsua_player_destroy(app_config.wav_id);
+	app_config.wav_id = PJSUA_INVALID_ID;
+	app_config.wav_port = PJSUA_INVALID_ID;
+    }
+
+    /* Close wav recorder */    
+    if (app_config.rec_id != PJSUA_INVALID_ID) 
+    {
+	pjsua_recorder_destroy(app_config.rec_id);
+	app_config.rec_id = PJSUA_INVALID_ID;
+	app_config.rec_port = PJSUA_INVALID_ID;
+    }
+
     /* Close tone generators */
     for (i=0; i<app_config.tone_count; ++i) {
 	pjsua_conf_remove_port(app_config.tone_slots[i]);
@@ -2089,6 +2105,8 @@ static pj_status_t app_destroy(void)
 
     /* Reset config */
     pj_bzero(&app_config, sizeof(app_config));
+    app_config.wav_id = PJSUA_INVALID_ID;
+    app_config.rec_id = PJSUA_INVALID_ID;
 
     if (use_cli) {    
 	app_config.use_cli = use_cli;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -472,7 +472,6 @@ pj_status_t pjsua_aud_subsys_destroy()
 	if (pjsua_var.player[i].port) {
 	    PJ_LOG(2,(THIS_FILE, "Destructor for player id=%d is not called"));
 	    pjsua_player_destroy(i);
-	    pjsua_var.player[i].port = NULL;
 	}
     }
 
@@ -481,8 +480,7 @@ pj_status_t pjsua_aud_subsys_destroy()
 	if (pjsua_var.recorder[i].port) {
 	    PJ_LOG(2,(THIS_FILE, "Destructor for recorder id=%d "
 		      "is not called"));
-	    pjsua_recorder_destroy(i);	    
-	    pjsua_var.recorder[i].port = NULL;
+	    pjsua_recorder_destroy(i);
 	}
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -479,6 +479,9 @@ pj_status_t pjsua_aud_subsys_destroy()
 
     /* Destroy file players */
     for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.player); ++i) {
+	if (pjsua_var.player[i].pool) {
+	    PJ_LOG(2,(THIS_FILE, "Pool for player id=%d is not released"));
+	}
 	if (pjsua_var.player[i].port) {
 	    pjmedia_port_destroy(pjsua_var.player[i].port);
 	    pjsua_var.player[i].port = NULL;
@@ -487,6 +490,9 @@ pj_status_t pjsua_aud_subsys_destroy()
 
     /* Destroy file recorders */
     for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.recorder); ++i) {
+	if (pjsua_var.recorder[i].pool) {
+	    PJ_LOG(2,(THIS_FILE, "Pool for recorder id=%d is not released"));
+	}
 	if (pjsua_var.recorder[i].port) {
 	    pjmedia_port_destroy(pjsua_var.recorder[i].port);
 	    pjsua_var.recorder[i].port = NULL;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -467,6 +467,25 @@ pj_status_t pjsua_aud_subsys_destroy()
 
     close_snd_dev();
 
+    /* Destroy file players */
+    for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.player); ++i) {
+	if (pjsua_var.player[i].port) {
+	    PJ_LOG(2,(THIS_FILE, "Destructor for player id=%d is not called"));
+	    pjsua_player_destroy(i);
+	    pjsua_var.player[i].port = NULL;
+	}
+    }
+
+    /* Destroy file recorders */
+    for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.recorder); ++i) {
+	if (pjsua_var.recorder[i].port) {
+	    PJ_LOG(2,(THIS_FILE, "Destructor for recorder id=%d "
+		      "is not called"));
+	    pjsua_recorder_destroy(i);	    
+	    pjsua_var.recorder[i].port = NULL;
+	}
+    }
+
     if (pjsua_var.mconf) {
 	pjmedia_conf_destroy(pjsua_var.mconf);
 	pjsua_var.mconf = NULL;
@@ -475,28 +494,6 @@ pj_status_t pjsua_aud_subsys_destroy()
     if (pjsua_var.null_port) {
 	pjmedia_port_destroy(pjsua_var.null_port);
 	pjsua_var.null_port = NULL;
-    }
-
-    /* Destroy file players */
-    for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.player); ++i) {
-	if (pjsua_var.player[i].pool) {
-	    PJ_LOG(2,(THIS_FILE, "Pool for player id=%d is not released"));
-	}
-	if (pjsua_var.player[i].port) {
-	    pjmedia_port_destroy(pjsua_var.player[i].port);
-	    pjsua_var.player[i].port = NULL;
-	}
-    }
-
-    /* Destroy file recorders */
-    for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.recorder); ++i) {
-	if (pjsua_var.recorder[i].pool) {
-	    PJ_LOG(2,(THIS_FILE, "Pool for recorder id=%d is not released"));
-	}
-	if (pjsua_var.recorder[i].port) {
-	    pjmedia_port_destroy(pjsua_var.recorder[i].port);
-	    pjsua_var.recorder[i].port = NULL;
-	}
     }
 
     return PJ_SUCCESS;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -2033,6 +2033,22 @@ PJ_DEF(pj_status_t) pjsua_destroy2(unsigned flags)
 		pjsua_var.acc[i].pool = NULL;
 	    }
 	}
+
+	/* Destroy pool in the wav player object */
+        for (i = 0; i < (int)PJ_ARRAY_SIZE(pjsua_var.player); ++i) {
+	    if (pjsua_var.player[i].pool != NULL) {
+		pj_pool_release(pjsua_var.player[i].pool);
+		pjsua_var.player[i].pool = NULL;
+	    }
+        }
+
+	/* Destroy pool in the wav writer object */
+        for (i = 0; i < (int)PJ_ARRAY_SIZE(pjsua_var.recorder); ++i) {
+	    if (pjsua_var.recorder[i].pool != NULL) {
+		pj_pool_release(pjsua_var.recorder[i].pool);
+		pjsua_var.recorder[i].pool = NULL;
+	    }
+        }
     }
 
     /* Destroy mutex */

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -2033,22 +2033,6 @@ PJ_DEF(pj_status_t) pjsua_destroy2(unsigned flags)
 		pjsua_var.acc[i].pool = NULL;
 	    }
 	}
-
-	/* Destroy pool in the wav player object */
-        for (i = 0; i < (int)PJ_ARRAY_SIZE(pjsua_var.player); ++i) {
-	    if (pjsua_var.player[i].pool != NULL) {
-		pj_pool_release(pjsua_var.player[i].pool);
-		pjsua_var.player[i].pool = NULL;
-	    }
-        }
-
-	/* Destroy pool in the wav writer object */
-        for (i = 0; i < (int)PJ_ARRAY_SIZE(pjsua_var.recorder); ++i) {
-	    if (pjsua_var.recorder[i].pool != NULL) {
-		pj_pool_release(pjsua_var.recorder[i].pool);
-		pjsua_var.recorder[i].pool = NULL;
-	    }
-        }
     }
 
     /* Destroy mutex */


### PR DESCRIPTION
This patch will call `pjsua_player_destroy()`/`pjsua_recorder_destroy()` if app haven't prior to `pjsua_destroy()` / `pjsua_destroy2()`.
To make sure that the resources are released properly.

