### PR TITLE
Fixed call hangup crash when ending session fails

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2833,7 +2833,11 @@ static pj_status_t call_inv_end_session(pjsua_call *call,
     }
     
 on_return:
-    if (status != PJ_SUCCESS) {
+    /* Failure in pjsip_inv_send_msg() can cause
+     * pjsua_call_on_state_changed() to be called and call to be reset,
+     * so we need to check for call->inv as well.
+     */
+    if (status != PJ_SUCCESS && call->inv) {
     	pj_time_val delay;
 
     	/* Schedule a retry */


### PR DESCRIPTION
To fix #2970.

From the gdb log provided in the issue:
```
(gdb) p call->inv
$2 = (pjsip_inv_session *) 0x7ffff000b858
(gdb) n
2827        status = pjsip_inv_send_msg(call->inv, tdata);
(gdb) 
PJ| debug2 |      inv0x7ffff0003b68  Sending Request msg BYE/cseq=6909 (tdta0x7ffff0000ed8)
PJ| debug2 |      dlg0x7ffff0003b68  Sending Request msg BYE/cseq=6909 (tdta0x7ffff0000ed8)
PJ| debug2 |      tsx0x7ffff0001ee8  Transaction created for Request msg BYE/cseq=6908 (tdta0x7ffff0000ed8)
PJ| debug2 |      tsx0x7ffff0001ee8  Sending Request msg BYE/cseq=6908 (tdta0x7ffff0000ed8) in state Null
PJ| debug2 |          sip_resolve.c  Target '10.137.15.2:5061' type=Unspecified resolved to '10.137.15.2:5061' type=UDP (UDP transport)
PJ| info |      tsx0x7ffff0001ee8  Failed to send Request msg BYE/cseq=6908 (tdta0x7ffff0000ed8)! err=171060 (Unsupported transport (PJSIP_EUNSUPTRANSPORT))
PJ| debug2 |      tsx0x7ffff0001ee8  State changed from Null to Terminated, event=TRANSPORT_ERROR
PJ| debug2 |      dlg0x7ffff0003b68  Transaction tsx0x7ffff0001ee8 state changed to Terminated
PJ| debug2 |     tdta0x7fffe800cf98  Destroying txdata Request msg ACK/cseq=6907 (tdta0x7fffe800cf98)
PJ| debug2 |     tdta0x7ffff000db88  Destroying txdata Request msg INVITE/cseq=6907 (tdta0x7ffff000db88)
PJ| debug2 |      dlg0x7ffff0003b68  Session count dec to 3 by mod-invite
2828        if (status != PJ_SUCCESS) {
(gdb) p call->inv
$3 = (pjsip_inv_session *) 0x0
```
In `call_inv_end_session()` (called by `pjsua_call_hangup()`) in `pjsua_call.c`, when `pjsip_inv_send_msg()` fails, `call->inv` can be reset to NULL, potentially causing crash.

The flow is as follows:
- `sip_transaction`:  `Failed to send Request msg BYE`, will call: `tsx_set_state( tsx, PJSIP_TSX_STATE_TERMINATED, PJSIP_EVENT_TRANSPORT_ERROR, ...)`
- `sip_dialog`: `pjsip_dlg_on_tsx_state()`
- `sip_inv`: `mod_inv_on_tsx_state()` -> `inv_on_state_confirmed()` -> `inv_set_state(inv, PJSIP_INV_STATE_DISCONNECTED, e)`
- `pjsua_call`: `pjsua_call_on_state_changed` -> `call->inv = NULL`
