### PR TITLE
Fixed failure to resume video when unholding the call

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2471,7 +2471,6 @@ pj_status_t pjsua_media_channel_init(pjsua_call_id call_id,
 	    /* Initialize default initial media direction as bidirectional */
 	    call_med->def_dir = PJMEDIA_DIR_ENCODING_DECODING;
 	}
-	call_med->dir = call_med->def_dir;
 
 	if (enabled) {
 	    call_med->enable_rtcp_mux = acc->cfg.enable_rtcp_mux;
@@ -2781,7 +2780,7 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
 
 	/* Ask pjmedia endpoint to create SDP media line */
 	pjmedia_endpt_create_sdp_param_default(&param);
-	param.dir = call_med->dir;
+	param.dir = call_med->def_dir;
 	switch (call_med->type) {
 	case PJMEDIA_TYPE_AUDIO:
 	    status = pjmedia_endpt_create_audio_sdp(pjsua_var.med_endpt, pool,


### PR DESCRIPTION
There is a regression caused by #2705.

Setting `call_med->dir` in `pjsua_call_media_init()` caused `is_media_changed()` detection to fail when unholding the call, causing the video to fail to resume.
