### PR TITLE
Reenable periodic RTP transmission on silence

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1470,8 +1470,6 @@ static pj_status_t put_frame_imp( pjmedia_port *port,
 					 (const void**)&rtphdr,
 					 &rtphdrlen);
 
-	return PJ_SUCCESS;
-
     /* Encode audio frame */
     } else if ((frame->type == PJMEDIA_FRAME_TYPE_AUDIO &&
 	        frame->buf != NULL) ||


### PR DESCRIPTION
Re-enable periodic RTP transmission on silence (old feature from #56) that was accidentally disabled in #2878.
