### PR TITLE
Fixed failed pjsua test due to incorrect SRTP ROC check

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3231,11 +3231,13 @@ pj_status_t pjsua_media_channel_deinit(pjsua_call_id call_id)
     	    	       pjmedia_transport_info_get_spc_info(
 	            	   &tpinfo, PJMEDIA_TRANSPORT_TYPE_ICE);
 
-	    call_med->prev_srtp_use = (srtp_info? PJ_TRUE: PJ_FALSE);
-	    if (srtp_info)
+	    call_med->prev_srtp_use = (srtp_info && srtp_info->active)?
+	    			      PJ_TRUE: PJ_FALSE;
+	    if (call_med->prev_srtp_use)
 	    	call_med->prev_srtp_info = *srtp_info;
-	    call_med->prev_ice_use = (ice_info? PJ_TRUE: PJ_FALSE);
-	    if (ice_info)
+	    call_med->prev_ice_use = (ice_info && ice_info->active)?
+	    			     PJ_TRUE: PJ_FALSE;
+	    if (call_med->prev_ice_use)
 	    	call_med->prev_ice_info = *ice_info;
 
     	    /* Try to sync recent changes to provisional media */
@@ -3367,8 +3369,9 @@ static void check_srtp_roc(pjsua_call *call,
     } else {
     	call_med->prev_srtp_use = PJ_TRUE;
 	call_med->prev_srtp_info = *srtp_info;
-	call_med->prev_ice_use = (ice_info? PJ_TRUE: PJ_FALSE);
-	if (ice_info)
+	call_med->prev_ice_use = (ice_info && ice_info->active)?
+	    			 PJ_TRUE: PJ_FALSE;
+	if (call_med->prev_ice_use)
 	    call_med->prev_ice_info = *ice_info;
 
     	if (call_med->type == PJMEDIA_TYPE_AUDIO) {


### PR DESCRIPTION
Pjsua test `scripts-call/330_ice_trickle_full_vs_no_ice` currently fails with assertion in:
```
  * frame #1: 0x00000001000436a8 pjsua-arm-apple-darwin21.2.0`check_srtp_roc(call=0x00000001002b6ea0, med_idx=0, new_si_=0x00000001702e48b0, local_sdp=0x0000000107810c28, remote_sdp=0x000000010780fc28) at pjsua_media.c:3436:11
    frame #2: 0x0000000100042394 pjsua-arm-apple-darwin21.2.0`pjsua_media_channel_update(call_id=0, local_sdp=0x0000000107810828, remote_sdp=0x000000010780e828) at pjsua_media.c:3901:6
    frame #3: 0x000000010002500c pjsua-arm-apple-darwin21.2.0`pjsua_call_on_media_update(inv=0x000000012080dc28, status=0) at pjsua_call.c:5200:14
```

In the above scenario, the ICE will be rejected because the callee doesn't support ICE, but `call_med->prev_ice_use` is still `PJ_TRUE` because it doesn't check for `ice_info->active`.
