### PR TITLE
Hangup call in crossover scenario between CANCEL and 200 response

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -4843,6 +4843,14 @@ static void pjsua_call_on_state_changed(pjsip_inv_session *inv,
 		       sizeof(call->last_text_buf_));
 	    break;
 	case PJSIP_INV_STATE_CONFIRMED:
+	    if (call->hanging_up) {
+	    	/* This can happen if there is a crossover between
+	    	 * our CANCEL request and the remote's 200 response.
+	    	 * So we send BYE here.
+	    	 */
+	    	call_inv_end_session(call, 200, NULL, NULL);
+	    	return;
+	    }
 	    pj_gettimeofday(&call->conn_time);
 
 	    if (call->trickle_ice.enabled) {


### PR DESCRIPTION
To fix #2992.

Some references:
https://datatracker.ietf.org/doc/html/rfc5407#page-52
https://lists.cs.columbia.edu/pipermail/sip-implementors/2008-December/021162.html

There doesn't seem to be a specific recommendation as to whether we MUST hangup the call, but since in pjsua-lib we have consider the call to be disconnected, we need to send BYE to clear up the call.
