### PR TITLE
Avoid confusion in CSeq generation for request within dialog

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1227,9 +1227,9 @@ PJ_DEF(pj_status_t) pjsip_dlg_create_request( pjsip_dialog *dlg,
     /* Lock dialog. */
     pjsip_dlg_inc_lock(dlg);
 
-    /* Use outgoing CSeq and increment it by one. */
+    /* Use outgoing CSeq, if set to -1 (other than ACK/CANCEL). */
     if (cseq < 0)
-	cseq = dlg->local.cseq + 1;
+	cseq = dlg->local.cseq;
 
     /* Keep compiler happy */
     status = PJ_EBUG;


### PR DESCRIPTION
When creating a (non-ACK/CANCEL) request within dialog, the `cseq` is assigned to `local.cseq+1` [here](https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip/sip_dialog.c#L1230), but later in sending [here](https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip/sip_dialog.c#L1314) it is reassigned to `local.cseq`. The sent messages are just fine, but it can be confusing in the logs, e.g:
```
18:25:39.103               endpoint  ..Request msg BYE/cseq=22059 (tdta0x10880c8a8) created.
18:25:39.103         inv0x1098260a8  ..Sending Request msg BYE/cseq=22059 (tdta0x10880c8a8)
18:25:39.103         dlg0x1098260a8  ...Sending Request msg BYE/cseq=22059 (tdta0x10880c8a8)
18:25:39.103         tsx0x10883d8a8  ....Transaction created for Request msg BYE/cseq=22058 (tdta0x10880c8a8)
18:25:39.103         tsx0x10883d8a8  ...Sending Request msg BYE/cseq=22058 (tdta0x10880c8a8) in state Null
```
Note that there is actually only one BYE message generated & sent, and it has CSeq=22058 on the wire.
