### PR TITLE
Add option to randomize RTP starting port

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3011,6 +3011,16 @@ typedef struct pjsua_transport_config
     unsigned		port_range;
 
     /**
+     * Specify whether to randomly pick the starting port number from
+     * the range of [\a port, \a port + \a port_range]. This setting is
+     * used only if both port and port_range are non-zero, and only
+     * applicable for the port selection of UDP and loop media transport.
+     * 
+     * Default is PJ_FALSE.
+     */
+    pj_bool_t		randomize_port;
+
+    /**
      * Optional address to advertise as the address of this transport.
      * Application can specify any address or hostname for this field,
      * for example it can point to one of the interface address in the

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -336,6 +336,16 @@ struct TransportConfig : public PersistentObject
     unsigned		portRange;
 
     /**
+     * Specify whether to randomly pick the starting port number from
+     * the range of [\a port, \a port + \a port_range]. This setting is
+     * used only if both port and port_range are non-zero, and only
+     * applicable for the port selection of UDP and loop media transport.
+     * 
+     * Default is PJ_FALSE.
+     */
+    bool		randomizePort;
+
+    /**
      * Optional address to advertise as the address of this transport.
      * Application can specify any address or hostname for this field,
      * for example it can point to one of the interface address in the

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1358,6 +1358,13 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     acc->cfg.vid_stream_rc_cfg = cfg->vid_stream_rc_cfg;
 
     /* Media settings */
+    if (acc->cfg.rtp_cfg.port != cfg->rtp_cfg.port) {
+    	/* Note that changing port range only changes the calculation of
+    	 * the next rtp port but doesn't reset it.
+    	 */
+    	acc->next_rtp_port = 0;
+    }
+
     if (pj_stricmp(&acc->cfg.rtp_cfg.public_addr, &cfg->rtp_cfg.public_addr) ||
 	pj_stricmp(&acc->cfg.rtp_cfg.bound_addr, &cfg->rtp_cfg.bound_addr))
     {

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -290,6 +290,15 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
     if (acc->next_rtp_port == 0 || cfg->port == 0)
 	acc->next_rtp_port = (pj_uint16_t)cfg->port;
 
+    if (acc->next_rtp_port == 0) {
+        if (cfg->port != 0 && cfg->port_range != 0 && cfg->randomize_port) {
+            unsigned offset = ((pj_rand() % (cfg->port_range)) / 2) * 2;
+ 	    acc->next_rtp_port = (pj_uint16_t)cfg->port + offset;
+        } else {
+	    acc->next_rtp_port = (pj_uint16_t)cfg->port;
+	}
+    }
+
     for (i=0; i<2; ++i)
 	sock[i] = PJ_INVALID_SOCKET;
 
@@ -678,8 +687,14 @@ static pj_status_t create_loop_media_transport(
     if (cfg->bound_addr.slen)
         opt.addr = cfg->bound_addr;
 
-    if (acc->next_rtp_port == 0 || cfg->port == 0)
-	acc->next_rtp_port = (pj_uint16_t)cfg->port;
+    if (acc->next_rtp_port == 0) {
+        if (cfg->port != 0 && cfg->port_range != 0 && cfg->randomize_port) {
+            unsigned offset = ((pj_rand() % (cfg->port_range)) / 2) * 2;
+ 	    acc->next_rtp_port = (pj_uint16_t)cfg->port + offset;
+        } else {
+	    acc->next_rtp_port = (pj_uint16_t)cfg->port;
+	}
+    }
 
     if (cfg->port > 0 && cfg->port_range > 0 &&
         (acc->next_rtp_port > cfg->port + cfg->port_range ||

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -287,10 +287,7 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
 	}
     }
 
-    if (acc->next_rtp_port == 0 || cfg->port == 0)
-	acc->next_rtp_port = (pj_uint16_t)cfg->port;
-
-    if (acc->next_rtp_port == 0) {
+    if (acc->next_rtp_port == 0 || cfg->port == 0) {
         if (cfg->port != 0 && cfg->port_range != 0 && cfg->randomize_port) {
             unsigned offset = ((pj_rand() % (cfg->port_range)) / 2) * 2;
  	    acc->next_rtp_port = (pj_uint16_t)cfg->port + offset;
@@ -687,7 +684,7 @@ static pj_status_t create_loop_media_transport(
     if (cfg->bound_addr.slen)
         opt.addr = cfg->bound_addr;
 
-    if (acc->next_rtp_port == 0) {
+    if (acc->next_rtp_port == 0 || cfg->port == 0) {
         if (cfg->port != 0 && cfg->port_range != 0 && cfg->randomize_port) {
             unsigned offset = ((pj_rand() % (cfg->port_range)) / 2) * 2;
  	    acc->next_rtp_port = (pj_uint16_t)cfg->port + offset;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -288,10 +288,10 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
     }
 
     if (acc->next_rtp_port == 0 || cfg->port == 0) {
-        if (cfg->port != 0 && cfg->port_range != 0 && cfg->randomize_port) {
-            unsigned offset = ((pj_rand() % (cfg->port_range)) / 2) * 2;
- 	    acc->next_rtp_port = (pj_uint16_t)cfg->port + offset;
-        } else {
+	if (cfg->port != 0 && cfg->port_range != 0 && cfg->randomize_port) {
+	    unsigned offset = ((pj_rand() % (cfg->port_range)) / 2) * 2;
+	    acc->next_rtp_port = (pj_uint16_t)cfg->port + offset;
+	} else {
 	    acc->next_rtp_port = (pj_uint16_t)cfg->port;
 	}
     }

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -292,6 +292,7 @@ void TransportConfig::fromPj(const pjsua_transport_config &prm)
 {
     this->port 		= prm.port;
     this->portRange	= prm.port_range;
+    this->randomizePort	= PJ2BOOL(prm.randomize_port);
     this->publicAddress = pj2Str(prm.public_addr);
     this->boundAddress	= pj2Str(prm.bound_addr);
     this->tlsConfig.fromPj(prm.tls_setting);
@@ -306,6 +307,7 @@ pjsua_transport_config TransportConfig::toPj() const
 
     tc.port		= this->port;
     tc.port_range	= this->portRange;
+    tc.randomize_port	= this->randomizePort;
     tc.public_addr	= str2Pj(this->publicAddress);
     tc.bound_addr	= str2Pj(this->boundAddress);
     tc.tls_setting	= this->tlsConfig.toPj();


### PR DESCRIPTION
To implement #2998.

Also change the behavior of `pjsua_acc_modify()` to reset `acc->next_rtp_port` if `rtp_cfg.port` is changed.
