### PR TITLE
wrong default value for jitter buffer max

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1006,7 +1006,7 @@ public:
     /**
      * Set maximum delay that can be accomodated by the jitter buffer msec.
      *
-     * Default: -1 (to use default stream settings, currently 360 msec)
+     * Default: -1 (to use default stream settings, currently 500 msec)
      */
     int			jbMax;
 


### PR DESCRIPTION
jitter buffer max is 500 ms, as seen in pjsua.h and pjmedia_stream_create (jb_max = 500 / stream->codec_param.info.frm_ptime;)