### PR TITLE
Add configure option to disable srtp

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -657,6 +657,7 @@ ac_webrtc_cflags
 ac_webrtc_instset
 ac_no_webrtc
 ac_no_yuv
+ac_no_srtp
 ac_no_bcg729
 opus_present
 opus_h_present
@@ -878,6 +879,7 @@ with_opus
 enable_opus
 with_bcg729
 enable_bcg729
+enable_libsrtp
 enable_libyuv
 enable_libwebrtc
 enable_libwebrtc_aec3
@@ -1563,6 +1565,7 @@ Optional Features:
                           autodetect)
 
   --disable-bcg729        Disable bcg729 (default: not disabled)
+  --disable-libsrtp       Exclude libsrtp in the build
   --disable-libyuv        Exclude libyuv in the build
   --disable-libwebrtc     Exclude libwebrtc in the build
   --enable-libwebrtc-aec3 Build libwebrtc-aec3 that's included in PJSIP
@@ -9854,6 +9857,23 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
 
+fi
+
+
+
+
+# Check whether --enable-libsrtp was given.
+if test ${enable_libsrtp+y}
+then :
+  enableval=$enable_libsrtp; if test "$enable_libsrtp" = "no"; then
+		ac_no_srtp=1
+		CFLAGS="$CFLAGS -DPJMEDIA_HAS_SRTP=0"
+		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Checking if libsrtp is disabled...yes" >&5
+printf "%s\n" "Checking if libsrtp is disabled...yes" >&6; }
+	       fi
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Checking if libsrtp is disabled...no" >&5
+printf "%s\n" "Checking if libsrtp is disabled...no" >&6; }
 fi
 
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -2183,6 +2183,19 @@ AC_ARG_ENABLE(bcg729,
 	      ])
 		  
 
+dnl # Include libsrtp
+AC_SUBST(ac_no_srtp)
+AC_ARG_ENABLE(libsrtp,
+	      AS_HELP_STRING([--disable-libsrtp],
+			     [Exclude libsrtp in the build]),
+	      [if test "$enable_libsrtp" = "no"; then
+		[ac_no_srtp=1]
+		CFLAGS="$CFLAGS -DPJMEDIA_HAS_SRTP=0"
+		AC_MSG_RESULT([Checking if libsrtp is disabled...yes])
+	       fi],
+	      AC_MSG_RESULT([Checking if libsrtp is disabled...no]))
+
+
 dnl # Include libyuv
 AC_SUBST(ac_no_yuv)
 AC_ARG_ENABLE(libyuv,

--- a/build.mak.in
+++ b/build.mak.in
@@ -41,6 +41,7 @@ export APP_THIRD_PARTY_EXT :=
 export APP_THIRD_PARTY_LIBS :=
 export APP_THIRD_PARTY_LIB_FILES :=
 
+ifneq (@ac_no_srtp@,1)
 ifneq (@ac_external_srtp@,0)
 # External SRTP library
 APP_THIRD_PARTY_EXT += -l@ac_external_srtp_lib@
@@ -51,6 +52,7 @@ APP_THIRD_PARTY_LIBS += -lsrtp-$(TARGET_NAME)
 else
 APP_THIRD_PARTY_LIBS += -lsrtp
 APP_THIRD_PARTY_LIB_FILES += $(PJ_DIR)/third_party/lib/libsrtp.$(SHLIB_SUFFIX).$(PJ_VERSION_MAJOR) $(PJ_DIR)/third_party/lib/libsrtp.$(SHLIB_SUFFIX)
+endif
 endif
 endif
 

--- a/third_party/build/os-auto.mak.in
+++ b/third_party/build/os-auto.mak.in
@@ -43,10 +43,12 @@ ifneq ($(findstring windows_os,@ac_pjmedia_video@),)
 DIRS += baseclasses
 endif
 
+ifneq (@ac_no_srtp@,1)
 ifneq (@ac_external_srtp@,0)
 # External SRTP
 else
 DIRS += srtp
+endif
 
 ifeq (@ac_ssl_has_aes_gcm@,0)
 CIPHERS_SRC = crypto/cipher/aes.o crypto/cipher/aes_icm.o       \


### PR DESCRIPTION
Usually we offer an option to disable the building of any third party library located in `third_party` folder, but currently it's lacking the option to disable `libsrtp`. So the PR will add that option.
