### PR TITLE
"--version"  command line option does not work

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -649,6 +649,8 @@ static pj_status_t parse_args(int argc, char *argv[],
 	    return PJ_EINVAL;
 
 	case OPT_VERSION:   /* version */
+	    if (pj_log_get_level() < 3)
+	        pj_log_set_level(3);
 	    pj_dump_config();
 	    return PJ_EINVAL;
 


### PR DESCRIPTION
"--version"  command line option (OPT_VERSION) requires log level 3