### PR TITLE
Update registration transport upon account's modification or transport setting

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3872,9 +3872,11 @@ PJ_DEF(pj_status_t) pjsua_acc_set_transport( pjsua_acc_id acc_id,
     PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id), PJ_EINVAL);
     acc = &pjsua_var.acc[acc_id];
 
-    PJ_ASSERT_RETURN(tp_id >= 0 && tp_id < (int)PJ_ARRAY_SIZE(pjsua_var.tpdata),
-		     PJ_EINVAL);
-    
+    PJ_ASSERT_RETURN(tp_id < (int)PJ_ARRAY_SIZE(pjsua_var.tpdata), PJ_EINVAL);
+
+    if (acc->cfg.transport_id == tp_id)
+    	return PJ_SUCCESS;
+
     acc->cfg.transport_id = tp_id;
 
     if (acc->cfg.transport_id != PJSUA_INVALID_ID) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3883,7 +3883,7 @@ PJ_DEF(pj_status_t) pjsua_acc_set_transport( pjsua_acc_id acc_id,
 	    /* Update client registration's transport. */
 	    pjsip_tpselector tp_sel;
 
-	    pjsua_init_tpselector(pjsua_var.acc[acc_id].cfg.transport_id, &tp_sel);
+	    pjsua_init_tpselector(acc->cfg.transport_id, &tp_sel);
 	    pjsip_regc_set_transport(acc->regc, &tp_sel);
 	}
     } else {


### PR DESCRIPTION
Currently, setting registration transport via `pjsip_regc_set_transport()` is only done in `pjsua_regc_init()`, so calling `pjsua_acc_modify()` or `pjsua_acc_set_transport()` won't change the transport.

This PR will fix this, and also allow `pjsua_acc_set_transport()` to be called with `PJSUA_INVALID_ID` to reset the account's transport (regc's transport will not be reset though).
