### PR TITLE
wrong documentation about default jbInit

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -983,9 +983,10 @@ public:
 
     /**
      * Jitter buffer initial prefetch delay in msec. The value must be
-     * between jb_min_pre and jb_max_pre below.
+     * between jb_min_pre and jb_max_pre below. If the value is 0,
+     * prefetching will be disabled.
      *
-     * Default: -1 (to use default stream settings, currently 150 msec)
+     * Default: -1 (to use default stream settings, currently 0)
      */
     int			jbInit;
 


### PR DESCRIPTION
"updated wrong documentation about default jb_init value in pjsua. The default is 0, not 150."

Duplicates
commit 2f2de4cc3ba0b186713447c3e993a09543253b56
Author: Benny Prijono <bennylp@teluu.com>
Date:   Tue Dec 3 05:22:10 2013 +0000