### PR TITLE
Deprecate PJ_ENABLE_EXTRA_CHECK macro

### DIFF
--- a/pjlib/include/pj/assert.h
+++ b/pjlib/include/pj/assert.h
@@ -55,21 +55,29 @@
  * If the expression yields false, assertion will be triggered
  * and the current function will return with the specified return value.
  */
+// #if defined(PJ_ENABLE_EXTRA_CHECK) && PJ_ENABLE_EXTRA_CHECK != 0
 #define PJ_ASSERT_RETURN(expr,retval)    \
 	    do { \
 		if (!(expr)) { pj_assert(expr); return retval; } \
 	    } while (0)
+//#else
+//#   define PJ_ASSERT_RETURN(expr,retval)    pj_assert(expr)
+//#endif
 
 /**
  * @hideinitializer
  * If the expression yields false, assertion will be triggered
  * and @a exec_on_fail will be executed.
  */
+//#if defined(PJ_ENABLE_EXTRA_CHECK) && PJ_ENABLE_EXTRA_CHECK != 0
 #define PJ_ASSERT_ON_FAIL(expr,exec_on_fail)    \
 	    do { \
 		pj_assert(expr); \
 		if (!(expr)) exec_on_fail; \
 	    } while (0)
+//#else
+//#   define PJ_ASSERT_ON_FAIL(expr,exec_on_fail)    pj_assert(expr)
+//#endif
 
 /** @} */
 

--- a/pjlib/include/pj/assert.h
+++ b/pjlib/include/pj/assert.h
@@ -52,42 +52,24 @@
 
 /**
  * @hideinitializer
- * If #PJ_ENABLE_EXTRA_CHECK is declared and the value is non-zero, then 
- * #PJ_ASSERT_RETURN macro will evaluate the expression in @a expr during
- * run-time. If the expression yields false, assertion will be triggered
+ * If the expression yields false, assertion will be triggered
  * and the current function will return with the specified return value.
- *
- * If #PJ_ENABLE_EXTRA_CHECK is not declared or is zero, then no run-time
- * checking will be performed. The macro simply evaluates to pj_assert(expr).
  */
-#if defined(PJ_ENABLE_EXTRA_CHECK) && PJ_ENABLE_EXTRA_CHECK != 0
-#   define PJ_ASSERT_RETURN(expr,retval)    \
+#define PJ_ASSERT_RETURN(expr,retval)    \
 	    do { \
 		if (!(expr)) { pj_assert(expr); return retval; } \
 	    } while (0)
-#else
-#   define PJ_ASSERT_RETURN(expr,retval)    pj_assert(expr)
-#endif
 
 /**
  * @hideinitializer
- * If #PJ_ENABLE_EXTRA_CHECK is declared and non-zero, then 
- * #PJ_ASSERT_ON_FAIL macro will evaluate the expression in @a expr during
- * run-time. If the expression yields false, assertion will be triggered
+ * If the expression yields false, assertion will be triggered
  * and @a exec_on_fail will be executed.
- *
- * If #PJ_ENABLE_EXTRA_CHECK is not declared or is zero, then no run-time
- * checking will be performed. The macro simply evaluates to pj_assert(expr).
  */
-#if defined(PJ_ENABLE_EXTRA_CHECK) && PJ_ENABLE_EXTRA_CHECK != 0
-#   define PJ_ASSERT_ON_FAIL(expr,exec_on_fail)    \
+#define PJ_ASSERT_ON_FAIL(expr,exec_on_fail)    \
 	    do { \
 		pj_assert(expr); \
 		if (!(expr)) exec_on_fail; \
 	    } while (0)
-#else
-#   define PJ_ASSERT_ON_FAIL(expr,exec_on_fail)    pj_assert(expr)
-#endif
 
 /** @} */
 

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -921,7 +921,7 @@
  *
  * PJ_ENABLE_EXTRA_CHECK has been deprecated in 2.13.
  */
-#if defined(PJ_ENABLE_EXTRA_CHECK)
+#if defined(PJ_ENABLE_EXTRA_CHECK) && PJ_ENABLE_EXTRA_CHECK==0
 #   ifdef _MSC_VER
 #	pragma message("Warning: PJ_ENABLE_EXTRA_CHECK macro is deprecated"\
 		       " and has no effect")

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -334,7 +334,6 @@
 #   undef FD_SETSIZE
 #   undef PJ_HAS_SEMAPHORE
 #   undef PJ_HAS_EVENT_OBJ
-#   undef PJ_ENABLE_EXTRA_CHECK
 #   undef PJ_EXCEPTION_USE_WIN32_SEH
 #   undef PJ_HAS_ERROR_STRING
 
@@ -841,22 +840,6 @@
 
 
 /**
- * Enable library's extra check.
- * If this macro is enabled, #PJ_ASSERT_RETURN macro will expand to
- * run-time checking. If this macro is disabled, #PJ_ASSERT_RETURN
- * will simply evaluate to #pj_assert().
- *
- * You can disable this macro to reduce size, at the risk of crashes
- * if invalid value (e.g. NULL) is passed to the library.
- *
- * Default: 1
- */
-#ifndef PJ_ENABLE_EXTRA_CHECK
-#   define PJ_ENABLE_EXTRA_CHECK    1
-#endif
-
-
-/**
  * Enable name registration for exceptions with #pj_exception_id_alloc().
  * If this feature is enabled, then the library will keep track of
  * names associated with each exception ID requested by application via
@@ -931,6 +914,20 @@
  */
 #ifndef PJ_HAS_STRICMP_ALNUM
 #   define PJ_HAS_STRICMP_ALNUM	    0
+#endif
+
+/*
+ * Warn about obsolete macros.
+ *
+ * PJ_ENABLE_EXTRA_CHECK has been deprecated in 2.13.
+ */
+#if defined(PJ_ENABLE_EXTRA_CHECK)
+#   ifdef _MSC_VER
+#	pragma message("Warning: PJ_ENABLE_EXTRA_CHECK macro is deprecated"\
+		       " and has no effect")
+#   else
+#	warning "PJ_ENABLE_EXTRA_CHECK macro is deprecated and has no effect"
+#   endif
 #endif
 
 

--- a/pjlib/include/pj/config_site_sample.h
+++ b/pjlib/include/pj/config_site_sample.h
@@ -447,7 +447,6 @@
 #   undef PJ_OS_HAS_CHECK_STACK
 #   define PJ_OS_HAS_CHECK_STACK	0
 #   define PJ_LOG_MAX_LEVEL		0
-#   define PJ_ENABLE_EXTRA_CHECK	0
 #   define PJ_HAS_ERROR_STRING		0
 #   undef PJ_IOQUEUE_MAX_HANDLES
 /* Putting max handles to lower than 32 will make pj_fd_set_t size smaller
@@ -466,7 +465,6 @@
 #   undef PJ_OS_HAS_CHECK_STACK
 #   define PJ_OS_HAS_CHECK_STACK	0
 #   define PJ_LOG_MAX_LEVEL		3
-#   define PJ_ENABLE_EXTRA_CHECK	0
 #   define PJ_IOQUEUE_MAX_HANDLES	5000
 #   define PJSIP_MAX_TSX_COUNT		((640*1024)-1)
 #   define PJSIP_MAX_DIALOG_COUNT	((640*1024)-1)

--- a/pjlib/src/pj/config.c
+++ b/pjlib/src/pj/config.c
@@ -78,7 +78,6 @@ PJ_DEF(void) pj_dump_config(void)
     PJ_LOG(3, (id, " PJ_LOG_USE_STACK_BUFFER   : %d", PJ_LOG_USE_STACK_BUFFER));
     PJ_LOG(3, (id, " PJ_HAS_SEMAPHORE          : %d", PJ_HAS_SEMAPHORE));
     PJ_LOG(3, (id, " PJ_HAS_EVENT_OBJ          : %d", PJ_HAS_EVENT_OBJ));
-    PJ_LOG(3, (id, " PJ_ENABLE_EXTRA_CHECK     : %d", PJ_ENABLE_EXTRA_CHECK));
     PJ_LOG(3, (id, " PJ_HAS_EXCEPTION_NAMES    : %d", PJ_HAS_EXCEPTION_NAMES));
     PJ_LOG(3, (id, " PJ_MAX_EXCEPTION_ID       : %d", PJ_MAX_EXCEPTION_ID));
     PJ_LOG(3, (id, " PJ_EXCEPTION_USE_WIN32_SEH: %d", PJ_EXCEPTION_USE_WIN32_SEH));


### PR DESCRIPTION
This ticket will deprecate `PJ_ENABLE_EXTRA_CHECK` macro. Initially, it is intended to reduce size on assertion checks.