### PR TITLE
allow pj to build for arm64 under clang when not using autotools

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -255,7 +255,7 @@
 #   define PJ_IS_BIG_ENDIAN	1
 
 #elif defined(ARM) || defined(_ARM_) ||  defined(__arm__) || \
-       defined(_M_ARM) || defined(_M_ARM64)
+       defined(_M_ARM) || defined(_M_ARM64) || defined(__aarch64__)
 #   define PJ_HAS_PENTIUM	0
     /*
      * ARM, bi-endian, so raise error if endianness is not configured
@@ -271,7 +271,7 @@
 #	undef PJ_M_ARMV4
 #	define PJ_M_ARMV4		1
 #	define PJ_M_NAME		"armv4"
-#   elif defined (PJ_M_ARM64) || defined(ARM64)
+#   elif defined (PJ_M_ARM64) || defined(ARM64) || defined(__aarch64__)
 #	undef PJ_M_ARM64
 #	define PJ_M_ARM64		1
 #	define PJ_M_NAME		"arm64"


### PR DESCRIPTION
honoring __aarch64__ (clang's macro) as being equivalent to _M_ARM64 (MSVC's macro) to properly detect arm64 when compiling under clang (not using autotools).  This is necessary for multiarch builds (e.g. Apple Silicon).