### PR TITLE
Fix compiler warning C4819 (Unicode character in ANSI file)

### DIFF
--- a/pjnath/include/pjnath/turn_session.h
+++ b/pjnath/include/pjnath/turn_session.h
@@ -922,7 +922,7 @@ PJ_DECL(pj_status_t) pj_turn_session_connection_bind(
  *
  * According to RFC 6062, a control connection must be a TCP connection,
  * and application must send TCP Allocate request
- * (with pj_turn_session_alloc()，set TURN allocation parameter peer_conn_type
+ * (with pj_turn_session_alloc(), set TURN allocation parameter peer_conn_type
  * to PJ_TURN_TP_TCP) before calling this function.
  *
  * @param sess		The TURN client session.

--- a/pjnath/include/pjnath/turn_sock.h
+++ b/pjnath/include/pjnath/turn_sock.h
@@ -630,7 +630,7 @@ PJ_DECL(pj_status_t) pj_turn_sock_bind_channel(pj_turn_sock *turn_sock,
  *
  * According to RFC 6062, the TURN transport instance must be created with
  * connection type are set to PJ_TURN_TP_TCP, application must send TCP
- * Allocate request (with pj_turn_session_alloc()，set TURN allocation
+ * Allocate request (with pj_turn_session_alloc(), set TURN allocation
  * parameter peer_conn_type to PJ_TURN_TP_TCP) before calling this function.
  *
  *


### PR DESCRIPTION
The files `turn_session.h` and `turn_sock.h` each contained 1 Unicode character (it looks like a comma but it is NOT the ANSI comma).

When compiling with VisualStudio 2022 on a Japanese Windows machine, this would cause the following compile warnings:

```
> pjsiplib\include\pjnath\include\pjnath\turn_sock.h(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss

> pjsiplib\include\pjnath\include\pjnath\turn_session.h(812,1): warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss
```

Fix: replace non-ANSI comma with ANSI comma