### PR TITLE
Make sure AccountMediaConfig params are set to false in constructor

### DIFF
--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -1046,7 +1046,10 @@ public:
      */
     AccountMediaConfig() : srtpUse(PJSUA_DEFAULT_USE_SRTP),
 			   ipv6Use(PJSUA_IPV6_DISABLED)
-    {}
+    {
+        useLoopMedTp = false;
+        enableLoopback = false;
+    }
 
     /**
      * Read this object from a container node.


### PR DESCRIPTION
Hi,

After upgrading to pjsip 2.12 I noticed occasional call failures. In the case of call failure it was noticed the call sdp shows the client stating its IP address as 127.0.0.1. After a discussion with @nanangizz over email it was mentioned the client seemed to be using loop transport. I was able to verify the client was using loop transport, but only sometimes. Looking further, `AccountMediaConfig#setUseLoopMedTp(...)`  was recently added in #2900 

This proposed change makes sure the two parameters `useLoopMedTp` and `enableLoopback` are set to `false` in the `AccountMediaConfig` constructor. I am seeing expected behavior with this change.

This brings the question, should other fields in `AccountMediaConfig` have default values set in the constructor like `rtcpMuxEnabled`, `srtpSecureSignaling`, etc?

