### PR TITLE
Don't schedule re-Registration on IP change case

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4038,8 +4038,6 @@ static void schedule_reregistration(pjsua_acc *acc)
     acc->auto_rereg.timer.id = PJ_TRUE;
     if (pjsua_schedule_timer(&acc->auto_rereg.timer, &delay) != PJ_SUCCESS)
 	acc->auto_rereg.timer.id = PJ_FALSE;
-
-    return;
 }
 
 


### PR DESCRIPTION
The call to `pjsua_handle_ip_change()` might trigger Registration to update Contact.
On some cases when it fails, the library will schedule a retry. 
Currently, when this happen the the library will end the IP change progress ignoring the retry.
The reschedule will use `pjsua_acc_config::reg_retry_interval` (default: 5minutes) as the interval, which is not desirable for IP change case.
The patch will disable scheduling re-Registration on IP change and let application retry manually.
