### PR TITLE
Fixed build failure in Xamarin C# project

### DIFF
--- a/pjmedia/include/pjmedia/format.h
+++ b/pjmedia/include/pjmedia/format.h
@@ -227,7 +227,7 @@ typedef enum pjmedia_format_id
     PJMEDIA_FORMAT_MPEG2VIDEO = PJMEDIA_FORMAT_PACK('M', 'P', '2', 'V'),
     PJMEDIA_FORMAT_MPEG4    = PJMEDIA_FORMAT_PACK('M', 'P', 'G', '4'),
 
-    PJMEDIA_FORMAT_INVALID  = 0xFFFFFFFF
+    PJMEDIA_FORMAT_INVALID  = 0xFFFFFFF
 
 } pjmedia_format_id;
 

--- a/pjsip-apps/src/swig/csharp/Makefile
+++ b/pjsip-apps/src/swig/csharp/Makefile
@@ -46,6 +46,8 @@ $(LIBPJSUA2): $(OUT_DIR)/pjsua2_wrap.o
 ifeq ($(OS),android)
 	$(PJ_CXX) -shared -o $(LIBPJSUA2) $(OUT_DIR)/pjsua2_wrap.o \
 		$(MY_CFLAGS) $(MY_LDFLAGS)
+	# copy libc++_shared.so manually
+	cp -f ${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${TARGET_ARCH}/libc++_shared.so $(LIBPJSUA2_DIR)
 endif
 ifeq ($(OS),ios)
 	$(AR) $(LIBPJSUA2) $(AR_FLAGS) $(OUT_DIR)/pjsua2_wrap.o $(PJ_LIBXX_FILES)

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -464,7 +464,7 @@ typedef enum pjmedia_format_id
   PJMEDIA_FORMAT_MPEG1VIDEO = ((('V' << 24) | ('1' << 16)) | ('P' << 8)) | 'M',
   PJMEDIA_FORMAT_MPEG2VIDEO = ((('V' << 24) | ('2' << 16)) | ('P' << 8)) | 'M',
   PJMEDIA_FORMAT_MPEG4 = ((('4' << 24) | ('G' << 16)) | ('P' << 8)) | 'M',
-  PJMEDIA_FORMAT_INVALID = 0xFFFFFFFF
+  PJMEDIA_FORMAT_INVALID = 0xFFFFFFF
 } pjmedia_format_id;
 
 typedef enum pjmedia_vid_packing


### PR DESCRIPTION
If C enum is implemented as signed 32 bit-integer, the assignment of `PJMEDIA_FORMAT_INVALID` to max 32 bit unsigned may cause warning, or even worse, build error, such as in Xamarin C# project:
`pjmedia_format_id.cs(28,28): Error CS0266: Cannot implicitly convert type 'uint' to 'int'. An explicit conversion exists (are you missing a cast?) (CS0266) (pjsua2xamarin)`
The proposed solution is to change the value to max 32-bit signed integer instead.

Also in this PR, is to copy `libc++_shared.so` to the Xamarin Android C# project (similar to what's been done for Android Java app).
