### PR TITLE
Set Oboe usage to voice communication

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -669,6 +669,8 @@ public:
 	sb.setChannelCount(stream->param.channel_count);
 	sb.setPerformanceMode(oboe::PerformanceMode::LowLatency);
 	sb.setFormat(oboe::AudioFormat::I16);
+	sb.setUsage(oboe::Usage::VoiceCommunication);
+	sb.setContentType(oboe::ContentType::Speech);
 	sb.setDataCallback(this);
 	sb.setErrorCallback(this);
 	sb.setFramesPerDataCallback(stream->param.samples_per_frame /


### PR DESCRIPTION
By default, Oboe usage is set to Media. According to the [doc](https://google.github.io/oboe/reference/namespaceoboe.html#a4477ed232b02e2694d9309baf55a8f06a5bad8854288c956062ec1d4d7c14fed6), `VoiceCommunication` should be better since it's for "voice over IP, telephony, etcetera."

Here we also set the [ContentType](https://google.github.io/oboe/reference/namespaceoboe.html#a2a3cec6f021c1a324df60273710c604b) to `Speech`.