### PR TITLE
Fixed assertion in Apple SSL when verification is retried

### DIFF
--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -675,6 +675,9 @@ static pj_status_t verify_cert(applessl_sock_t *assock, pj_ssl_cert_t *cert)
         
         err = SecTrustGetTrustResult(trust, &trust_result);
         if (err == noErr) {
+#if SSL_DEBUG
+            PJ_LOG(3, (THIS_FILE, "SSL trust evaluation: %d", trust_result));
+#endif
     	    switch (trust_result) {
     		case kSecTrustResultInvalid:
 		    ssock->verify_status |= PJ_SSL_CERT_EINVALID_FORMAT;
@@ -1027,7 +1030,7 @@ static pj_status_t network_create_params(pj_ssl_sock_t * ssock,
 	      sec_protocol_metadata_get_negotiated_tls_ciphersuite(metadata);
 
 	    /* For client, call on_connect_complete() callback first. */
-	    if (!ssock->is_server) {
+	    if (!ssock->is_server && ssock->ssl_state == SSL_STATE_NULL) {
 	    	if (!assock->connection)
 	    	    complete(false);
 


### PR DESCRIPTION
To fix #2930.

It is reported that initiating SSL connection can trigger an assertion:
`Assertion failed: (ssock->send_buf.max_len == 0), function ssock_on_connect_complete, file ../src/pj/ssl_sock_imp_common.c, line 1134.`

Upon investigation, it turns out that server can retry the client verification, i.e. invoke the client's verification block more than once. This causes client to receive duplicate `EVENT_CONNECT`, which triggers the assertion. The proposed solution is to issue `EVENT_CONNECT` only if the SSL state is NULL, to prevent it being called more than once.

Also in this PR is to add more logging to print the trust evaluation result, so we can know whether cert verification can potentially be retried by server.
