### PR TITLE
Add account id parameter checking in pjsua im APIs

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_im.c
+++ b/pjsip/src/pjsua-lib/pjsua_im.c
@@ -545,6 +545,9 @@ PJ_DEF(pj_status_t) pjsua_im_send( pjsua_acc_id acc_id,
     pj_bool_t content_in_msg_data;
     pj_status_t status;
 
+    PJ_ASSERT_RETURN(acc_id>=0 && acc_id<(int)PJ_ARRAY_SIZE(pjsua_var.acc),
+		     PJ_EINVAL);
+
     content_in_msg_data = msg_data && (msg_data->msg_body.slen ||
 				       msg_data->multipart_ctype.type.slen);
 
@@ -672,6 +675,9 @@ PJ_DEF(pj_status_t) pjsua_im_typing( pjsua_acc_id acc_id,
     pjsip_tx_data *tdata;
     pjsua_acc *acc;
     pj_status_t status;
+
+    PJ_ASSERT_RETURN(acc_id>=0 && acc_id<(int)PJ_ARRAY_SIZE(pjsua_var.acc),
+		     PJ_EINVAL);
 
     acc = &pjsua_var.acc[acc_id];
 


### PR DESCRIPTION
Compared to `pjsua_acc` APIs which already have account id parameter checking, `pjsua_im` APIs noticeably lack those, which may cause out-of-bound array access if app passes invalid id.
So this PR is to add those safety checks.

Thanks to WangZhong ([Cossack9989](https://github.com/Cossack9989)) for the report.
