### PR TITLE
Fixed missing field in CodecParam

### DIFF
--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2431,6 +2431,8 @@ struct CodecParamInfo
     unsigned	maxBps;			/**< Maximum bandwidth in bits/sec  */
     unsigned    maxRxFrameSize;		/**< Maximum frame size             */
     unsigned 	frameLen;		/**< Decoder frame ptime in msec.   */
+    unsigned 	encFrameLen;		/**< Encoder ptime, or zero if it's
+					     equal to decoder ptime.	    */
     unsigned  	pcmBitsPerSample;	/**< Bits/sample in the PCM side    */
     unsigned  	pt;			/**< Payload type.		    */
     pjmedia_format_id fmtId;		/**< Source format, it's format of

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1824,6 +1824,7 @@ void CodecParam::fromPj(const pjmedia_codec_param &param)
     info.maxBps = param.info.max_bps;
     info.maxRxFrameSize = param.info.max_rx_frame_size;
     info.frameLen = param.info.frm_ptime;
+    info.encFrameLen = param.info.enc_ptime;
     info.pcmBitsPerSample = param.info.pcm_bits_per_sample;
     info.pt = param.info.pt;
     info.fmtId = param.info.fmt_id;
@@ -1850,6 +1851,7 @@ pjmedia_codec_param CodecParam::toPj() const
     param.info.max_bps= (pj_uint32_t)info.maxBps;
     param.info.max_rx_frame_size = info.maxRxFrameSize;
     param.info.frm_ptime = (pj_uint16_t)info.frameLen;
+    param.info.enc_ptime = (pj_uint16_t)info.encFrameLen;
     param.info.pcm_bits_per_sample = (pj_uint8_t)info.pcmBitsPerSample;
     param.info.pt = (pj_uint8_t)info.pt;
     param.info.fmt_id = info.fmtId;


### PR DESCRIPTION
Add missing field in pjsua2 `CodecParam` for `pjmedia_codec_param.info.enc_ptime`. This missing field can cause undefined behavior when calling `Endpoint::codecSetParam()` (since the field can be any value), which can later trigger various assertions such as:
`../src/pjmedia/stream.c:1276: void rebuffer(pjmedia_stream *, pjmedia_frame *): assertion "stream->enc_buf_count + (frame->size >> 1) < stream->enc_buf_size" failed`
or
`'../src/pjmedia-codec/g722.c:560: pj_status_t g722_codec_encode(pjmedia_codec *, const struct pjmedia_frame *, unsigned int, struct pjmedia_frame *): assertion "(input->size >> 2) <= output_buf_len" failed'`
