### PR TITLE
pjturn-srv enhancement:  support CreatePermission request and make TCP work well

### DIFF
--- a/pjnath/src/pjturn-srv/allocation.c
+++ b/pjnath/src/pjturn-srv/allocation.c
@@ -932,18 +932,6 @@ PJ_DEF(void) pj_turn_allocation_on_rx_client_pkt(pj_turn_allocation *alloc,
 					   &pkt->src.clt_addr,
 					   pkt->src_addr_len);
 
-	if (pkt->transport->listener->tp_type == PJ_TURN_TP_UDP) {
-	    pkt->len = 0;
-	} else if (parsed_len > 0) {
-	    if (parsed_len == pkt->len) {
-		pkt->len = 0;
-	    } else {
-		pj_memmove(pkt->pkt, pkt->pkt+parsed_len,
-			   pkt->len - parsed_len);
-		pkt->len -= parsed_len;
-	    }
-	}
-
 	if (status != PJ_SUCCESS) {
 	    alloc_err(alloc, "Error handling STUN packet", status);
 	    goto on_return;
@@ -959,12 +947,13 @@ PJ_DEF(void) pj_turn_allocation_on_rx_client_pkt(pj_turn_allocation *alloc,
 
 	pj_assert(sizeof(*cd)==4);
 
-	/* For UDP check the packet length */
-	if (alloc->transport->listener->tp_type == PJ_TURN_TP_UDP) {
-	    if (pkt->len < pj_ntohs(cd->length)+sizeof(*cd)) {
+	/* For UDP/TCP check the packet length */
+	if (alloc->transport->listener->tp_type == PJ_TURN_TP_UDP ||
+		alloc->transport->listener->tp_type == PJ_TURN_TP_TCP) {
+		if (pkt->len < pj_ntohs(cd->length)+sizeof(*cd)) {
 		PJ_LOG(4,(alloc->obj_name,
-			  "ChannelData from %s discarded: UDP size error",
-			  alloc->info));
+			  "ChannelData from %s discarded: %s size error",
+			  alloc->info, pj_turn_tp_type_name(alloc->transport->listener->tp_type)));
 		goto on_return;
 	    }
 	} else {
@@ -1038,6 +1027,10 @@ static void handle_peer_pkt(pj_turn_allocation *alloc,
 
 	/* Copy data */
 	pj_memcpy(rel->tp.tx_pkt+sizeof(pj_turn_channel_data), pkt, len);
+
+	/* 4 byte alignment */
+	while (len & 0x3)
+		len++;
 
 	/* Send to client */
 	alloc->transport->sendto(alloc->transport, rel->tp.tx_pkt,

--- a/pjnath/src/pjturn-srv/allocation.c
+++ b/pjnath/src/pjturn-srv/allocation.c
@@ -1193,7 +1193,7 @@ static pj_status_t stun_on_rx_request(pj_stun_session *sess,
 
 	    /* Update lifetime */
 	    if (lifetime) {
-		alloc->relay.lifetime = lifetime->value;
+		alloc->relay.lifetime = PJ_MIN(lifetime->value, MAX_LIFETIME);
 	    }
 
 	    /* Update bandwidth */

--- a/pjnath/src/pjturn-srv/listener_tcp.c
+++ b/pjnath/src/pjturn-srv/listener_tcp.c
@@ -325,10 +325,20 @@ static void tcp_destroy(struct tcp_transport *tcp)
     if (tcp->key) {
 	pj_ioqueue_unregister(tcp->key);
 	tcp->key = NULL;
-	tcp->sock = 0;
-    } else if (tcp->sock) {
+	tcp->sock = PJ_INVALID_SOCKET;
+    } else if (tcp->sock != PJ_INVALID_SOCKET) {
 	pj_sock_close(tcp->sock);
-	tcp->sock = 0;
+	tcp->sock = PJ_INVALID_SOCKET;
+    }
+
+    if (tcp->timer.id != TIMER_NONE) {
+        pj_timer_heap_cancel(tcp->base.listener->server->core.timer_heap,
+                             &tcp->timer);
+        tcp->timer.id = TIMER_NONE;
+    }
+
+    if (tcp->recv_op.pkt.pool) {
+	pj_pool_release(tcp->recv_op.pkt.pool);
     }
 
     if (tcp->pool) {
@@ -355,6 +365,7 @@ static void tcp_on_read_complete(pj_ioqueue_key_t *key,
     struct tcp_transport *tcp;
     struct recv_op *recv_op = (struct recv_op*) op_key;
     pj_status_t status;
+    pj_turn_pkt *pkt = &recv_op->pkt;
 
     tcp = (struct tcp_transport*) pj_ioqueue_get_user_data(key);
 
@@ -362,21 +373,62 @@ static void tcp_on_read_complete(pj_ioqueue_key_t *key,
 	/* Report to server or allocation, if we have allocation */
 	if (bytes_read > 0) {
 
-	    recv_op->pkt.len = bytes_read;
-	    pj_gettimeofday(&recv_op->pkt.rx_time);
+	    pkt->len += bytes_read;
+	    pj_gettimeofday(&pkt->rx_time);
 
 	    tcp_add_ref(&tcp->base, NULL);
 
-	    if (tcp->alloc) {
-		pj_turn_allocation_on_rx_client_pkt(tcp->alloc, &recv_op->pkt);
-	    } else {
-		pj_turn_srv_on_rx_pkt(tcp->base.listener->server, &recv_op->pkt);
-	    }
+        pj_size_t left_len = pkt->len;
+
+        for (;;) {
+        if (left_len < 4)
+            break;
+
+        pj_uint16_t typ = pj_ntohs(*(pj_uint16_t *)pkt->pkt); // message type
+        pj_size_t len = pj_ntohs(*(pj_uint16_t *)(pkt->pkt + 2)); // message length
+
+        if (typ < 0x4000) {
+            len += sizeof(pj_stun_msg_hdr);
+        }
+        else if (typ < 0x8000) {
+            len += sizeof(pj_turn_channel_data);
+            /* 4 byte alignment */
+            while (len & 0x3)
+                len++;
+        }
+        else {
+            PJ_LOG(2, ("TCP", "Bad msg typ: 0x%04x", typ));
+            pkt->len = 0; //reset pkt
+            break;
+        }
+
+        /* check data size */
+        if (left_len < len) {
+            // no enough, wait more ..
+            break;
+        }
+
+        /* Parse a whole msg */
+        pkt->len = len;
+        if (tcp->alloc) {
+            pj_turn_allocation_on_rx_client_pkt(tcp->alloc, pkt);
+        }
+        else {
+            pj_turn_srv_on_rx_pkt(tcp->base.listener->server, pkt);
+        }
+
+        /* Continue to parse */
+        left_len -= len;
+        pkt->len = left_len;
+        if (left_len > 0)
+            pj_memmove(pkt->pkt, pkt->pkt + len, left_len);
+
+        }
 
 	    pj_assert(tcp->ref_cnt > 0);
 	    tcp_dec_ref(&tcp->base, NULL);
 
-	} else if (bytes_read != -PJ_EPENDING) {
+	} else if (bytes_read != -PJ_EPENDING && bytes_read != -PJ_STATUS_FROM_OS(PJ_BLOCKING_ERROR_VAL)) {
 	    /* TCP connection closed/error. Notify client and then destroy 
 	     * ourselves.
 	     * Note: the -PJ_EPENDING is the value passed during init.

--- a/pjnath/src/pjturn-srv/main.c
+++ b/pjnath/src/pjturn-srv/main.c
@@ -148,16 +148,20 @@ int main()
     if (status != PJ_SUCCESS)
 	return err("Error creating UDP listener", status);
 
+    status = pj_turn_srv_add_listener(srv, listener);
+    if (status != PJ_SUCCESS)
+	return err("Error adding UDP listener", status);
+
 #if PJ_HAS_TCP
     status = pj_turn_listener_create_tcp(srv, pj_AF_INET(), NULL, 
 					 TURN_PORT, 1, 0, &listener);
     if (status != PJ_SUCCESS)
-	return err("Error creating listener", status);
-#endif
+	return err("Error creating TCP listener", status);
 
     status = pj_turn_srv_add_listener(srv, listener);
     if (status != PJ_SUCCESS)
-	return err("Error adding listener", status);
+	return err("Error adding TCP listener", status);
+#endif
 
     puts("Server is running");
 


### PR DESCRIPTION
Two main functions:
1. CreatePermission request support
    - Current version always response 400 Bad request
    - Should discard Indication  if no permission
2. Make tcp work well
   - Cache a whole message  before parse or relay
   - Should CHECK channel data message length 4-byte alignment
     (Because the  data that client send may not 4-byte alignment, in this case we should add padding)

   ```
   RFC5766 11.5  Sending a ChannelData Message

   the ChannelData message MUST be padded to
   a multiple of four bytes in order to ensure the alignment of
   subsequent messages.  The padding is not reflected in the length
   field of the ChannelData message, so the actual size of a ChannelData
   message (including padding) is (4 + Length) rounded up to the nearest
   multiple of 4.
   ```

PS : This  pull request also include some code fix

Ref to #3048 