### PR TITLE
Some callbacks not invoked in call replace in PJSUA2

### DIFF
--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -72,7 +72,7 @@ public:
     
     virtual void onCallState(OnCallStateParam &prm);
     virtual void onCallTransferRequest(OnCallTransferRequestParam &prm);
-    virtual void onCallReplaced(OnCallReplacedParam &prm);
+    virtual void onCallReplaceRequest(OnCallReplaceRequestParam &prm);
     virtual void onCallMediaState(OnCallMediaStateParam &prm);
 };
 
@@ -190,10 +190,10 @@ void MyCall::onCallTransferRequest(OnCallTransferRequestParam &prm)
     prm.newCall = new MyCall(*myAcc);
 }
 
-void MyCall::onCallReplaced(OnCallReplacedParam &prm)
+void MyCall::onCallReplaceRequest(OnCallReplaceRequestParam &prm)
 {
     /* Create new Call for call replace */
-    prm.newCall = new MyCall(*myAcc, prm.newCallId);
+    prm.newCall = new MyCall(*myAcc);
 }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1599,6 +1599,12 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 				st_code, &st_text, NULL, NULL, NULL);
 	    goto on_return;
 	}
+
+	/* Set the user_data of the new call to the existing/parent call,
+	 * it is needed by PJSUA2 to update its states. While PJSUA app can
+	 * always override it anytime.
+	 */
+	pjsua_call_set_user_data(call_id, replaced_call->user_data);
     }
 
     if (!replaced_dlg) {
@@ -6071,7 +6077,11 @@ static void on_call_transferred( pjsip_inv_session *inv,
 	pj_list_push_back(&msg_data.hdr_list, dup);
     }
 
-    /* Now make the outgoing call. */
+    /* Now make the outgoing call.
+     * Note that the user_data of the new call is initialized to the
+     * original call, it is needed by PJSUA2 to update its states.
+     * While PJSUA app can always override it anytime.
+     */
     tmp = pj_str(uri);
     status = pjsua_call_make_call(existing_call->acc_id, &tmp, &call_opt,
 				  existing_call->user_data, &msg_data,

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -515,7 +515,11 @@ Call *Call::lookup(int call_id)
     Call *call = (Call*)pjsua_call_get_user_data(call_id);
     if (call && call_id != call->id) {
 	if (call->child && call->child->id == PJSUA_INVALID_ID) {
-	    /* This must be a new call from call transfer */
+	    /* This must be a new call from call transfer or call replace
+	     * which initially shares user_data with its parent (so the
+	     * user_data points to its parent's Call instance).
+	     * Let's update its user_data to its own Call instance.
+	     */
 	    call = call->child;
 	    pjsua_call_set_user_data(call_id, call);
 	}

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1398,6 +1398,10 @@ void Endpoint::on_call_transfer_request2(pjsua_call_id call_id,
     *opt = prm.opt.toPj();
     if (*code/100 <= 2) {
 	if (prm.newCall) {
+	    /* Sanity checks */
+	    pj_assert(prm.newCall->id == PJSUA_INVALID_ID);
+	    pj_assert(prm.newCall->acc.getId() == call->acc.getId());
+
 	    /* We don't manage (e.g: create, delete) the call child,
 	     * so let's just override any existing child.
 	     */


### PR DESCRIPTION
Currently in call replace scenario, the new PJSUA2 Call instance can only be created in `onCallReplaced()` callback, which cause application to miss some callbacks such as `onCallSdpCreated()` and `onCreateMediaTransport()`. This PR allows application to create the new Call instance earlier, i.e: in `onCallReplaceRequest()`, so it won't miss the `onCallSdpCreated()` & `onCreateMediaTransport()` callbacks.

Thanks to Johannes Westhuis for the report.

Note: this PR also bumps up log level of some warnings from 4 to 3 (when app does not create a new Call instance for call transfer & replace).