### PR TITLE
Find closest camera format when resolution is presented more than once

### DIFF
--- a/pjmedia/src/pjmedia/vid_port.c
+++ b/pjmedia/src/pjmedia/vid_port.c
@@ -352,16 +352,23 @@ static struct fmt_prop find_closest_fmt(pj_uint32_t req_fmt_id,
 	/* Fill the nearest width list. */
 	if (diff_width1 <= diff_width2) {
 	    int k = 1;
-	    pjmedia_rect_size tmp_size = vfd->size;
+	    while (((k < PJ_ARRAY_SIZE(nearest_width)) &&
+	    (!((vfd->size.w == nearest_width[k].w) && (vfd->size.h == nearest_width[k].h))))) {
+	        ++k;
+	    }
+	    if (k < PJ_ARRAY_SIZE(nearest_width)) {
+	        /* resolution was already processed */
+	        continue;
 
+	    }
+	    k = 1;
 	    while(((k < PJ_ARRAY_SIZE(nearest_width)) &&
-		   (GET_DIFF(tmp_size.w, req_fmt_size->w) <
-		   (GET_DIFF(nearest_width[k].w, req_fmt_size->w)))))
+		   (diff_width1 < (GET_DIFF(nearest_width[k].w, req_fmt_size->w)))))
 	    {
 		nearest_width[k-1] = nearest_width[k];
 		++k;
 	    }
-	    nearest_width[k-1] = tmp_size;
+	    nearest_width[k-1] = vfd->size;
 	}
     }
     /* No need to calculate ratio if exact match is found. */


### PR DESCRIPTION
Function find_closest_fmt searches for 3 resolutions from the possible resolutions of camera which width is closest to the width of the requested resolution. Then the function chooses the one with closest ratio comparing to ratio of requested resolution. But some cameras gives their possible resolutions with variants based on FPS. In such situation the function chooses not 3 but usually 2 different resolutions before checking the ratio (the one with two FPS variants is doubled in final table). This patch checks if such situation has occurred and solves it. 