### PR TITLE
Android - Create new ImageReader instance before opening camera

### DIFF
--- a/pjmedia/src/pjmedia-videodev/android/PjCamera2.java
+++ b/pjmedia/src/pjmedia-videodev/android/PjCamera2.java
@@ -50,8 +50,11 @@ public class PjCamera2
     private int camIdx;
     private final long userData;
     private final int fps;
+    private final int w;
+    private final int h;
+    private final int fmt;
 
-    private final ImageReader imageReader;
+    private ImageReader imageReader;
     private HandlerThread handlerThread = null;
     private Handler handler;
 
@@ -151,16 +154,16 @@ public class PjCamera2
 	}
     };
 
-    public PjCamera2(int idx, int w, int h, int fmt, int fps_,
+    public PjCamera2(int idx, int w_, int h_, int fmt_, int fps_,
 	    	    long userData_, SurfaceView surface)
     {
 	camIdx = idx;
+	w = w_;
+	h = h_;
+	fmt = fmt_;
 	userData = userData_;
 	fps = fps_;
 	surfaceView = surface;
-
-	/* Some say to put a larger maxImages to improve FPS */
-	imageReader = ImageReader.newInstance(w, h, fmt, 3);
     }
 
     public int SwitchDevice(int idx)
@@ -246,6 +249,9 @@ public class PjCamera2
 	handlerThread = new HandlerThread("Cam2HandlerThread");
 	handlerThread.start();
 	handler = new Handler(handlerThread.getLooper());
+
+	/* Some say to put a larger maxImages to improve FPS */
+	imageReader = ImageReader.newInstance(w, h, fmt, 3);
 	imageReader.setOnImageAvailableListener(imageAvailListener, handler);
 	isRunning = true;
 
@@ -294,6 +300,11 @@ public class PjCamera2
 	    } catch (InterruptedException e) {
 		e.printStackTrace();
 	    }
+	}
+
+	if (imageReader != null) {
+	    imageReader.close();
+	    imageReader = null;
 	}
 
 	/* Reset setting */


### PR DESCRIPTION
After testing a couple Android devices using pjsip 2.12 with PjCamera2, one device, a Kyocera E6910 on Android 9, failed to send video or show local playback after switching cameras (back to front) in an active video stream. 

It seems the underlying surface is being closed on camera switch. To resolve this, a new `ImageReader` instance can be created before opening the camera. After a discussion with Ming, it was suggested to close the `ImageReader` on `Stop()`.

With this change, testing shows video works well on the Kyocera and a Samsung Galaxy Note 9. 