### PR TITLE
Handle crash when converting std::string with non UTF-8 character on Android

### DIFF
--- a/pjsip-apps/src/swig/and_string.i
+++ b/pjsip-apps/src/swig/and_string.i
@@ -1,0 +1,57 @@
+#if defined(SWIGJAVA) && defined(__ANDROID__)
+%typemap(out) std::string
+%{
+    jsize $1_len = (jsize)$1.length();
+    jbyteArray bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1.c_str());
+    jclass strClass = jenv->FindClass("java/lang/String");
+    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring encoding = jenv->NewStringUTF("UTF-8");
+    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
+    jenv->DeleteLocalRef(encoding);
+    jenv->DeleteLocalRef(bytes);
+    $result = jstr;
+%}
+
+%typemap(directorin,descriptor="Ljava/lang/String;") std::string
+%{
+    jsize $1_len = (jsize)$1.length();
+    jbyteArray bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1.c_str());
+    jclass strClass = jenv->FindClass("java/lang/String");
+    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring encoding = jenv->NewStringUTF("UTF-8");
+    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
+    jenv->DeleteLocalRef(encoding);
+    jenv->DeleteLocalRef(bytes);
+    $input = jstr;
+%}
+
+%typemap(directorin,descriptor="Ljava/lang/String;") const std::string &
+%{
+    jsize $1_len = (jsize)$1.length();
+    jbyteArray bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1.c_str());
+    jclass strClass = jenv->FindClass("java/lang/String");
+    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring encoding = jenv->NewStringUTF("UTF-8");
+    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
+    jenv->DeleteLocalRef(encoding);
+    jenv->DeleteLocalRef(bytes);
+    $input = jstr;
+%}
+
+%typemap(out) const std::string &
+%{
+    jsize $1_len = (jsize)$1->length();
+    jbyteArray bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1->c_str());
+    jclass strClass = jenv->FindClass("java/lang/String");
+    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring encoding = jenv->NewStringUTF("UTF-8");
+    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
+    jenv->DeleteLocalRef(encoding);
+    jenv->DeleteLocalRef(bytes);
+    $result = jstr;
+%}
+#endif

--- a/pjsip-apps/src/swig/and_string.i
+++ b/pjsip-apps/src/swig/and_string.i
@@ -2,56 +2,137 @@
 %typemap(out) std::string
 %{
     jsize $1_len = (jsize)$1.length();
-    jbyteArray bytes = jenv->NewByteArray($1_len);
-    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1.c_str());
-    jclass strClass = jenv->FindClass("java/lang/String");
-    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
-    jstring encoding = jenv->NewStringUTF("UTF-8");
-    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
-    jenv->DeleteLocalRef(encoding);
-    jenv->DeleteLocalRef(bytes);
-    $result = jstr;
+    jbyteArray $1_bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion($1_bytes, 0, $1_len, (jbyte *) $1.c_str());
+    jclass $1_strClass = jenv->FindClass("java/lang/String");
+    jmethodID $1_ctorID = jenv->GetMethodID($1_strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring $1_encoding = jenv->NewStringUTF("UTF-8");
+    jstring $1_jstr = (jstring) jenv->NewObject($1_strClass, $1_ctorID, $1_bytes, $1_encoding);
+    jenv->DeleteLocalRef($1_encoding);
+    jenv->DeleteLocalRef($1_bytes);
+    $result = $1_jstr;
 %}
 
 %typemap(directorin,descriptor="Ljava/lang/String;") std::string
 %{
     jsize $1_len = (jsize)$1.length();
-    jbyteArray bytes = jenv->NewByteArray($1_len);
-    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1.c_str());
-    jclass strClass = jenv->FindClass("java/lang/String");
-    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
-    jstring encoding = jenv->NewStringUTF("UTF-8");
-    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
-    jenv->DeleteLocalRef(encoding);
-    jenv->DeleteLocalRef(bytes);
-    $input = jstr;
+    jbyteArray $1_bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion($1_bytes, 0, $1_len, (jbyte *) $1.c_str());
+    jclass $1_strClass = jenv->FindClass("java/lang/String");
+    jmethodID $1_ctorID = jenv->GetMethodID($1_strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring $1_encoding = jenv->NewStringUTF("UTF-8");
+    jstring $1_jstr = (jstring) jenv->NewObject($1_strClass, $1_ctorID, $1_bytes, $1_encoding);
+    jenv->DeleteLocalRef($1_encoding);
+    jenv->DeleteLocalRef($1_bytes);
+    $input = $1_jstr;
 %}
 
 %typemap(directorin,descriptor="Ljava/lang/String;") const std::string &
 %{
     jsize $1_len = (jsize)$1.length();
-    jbyteArray bytes = jenv->NewByteArray($1_len);
-    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1.c_str());
-    jclass strClass = jenv->FindClass("java/lang/String");
-    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
-    jstring encoding = jenv->NewStringUTF("UTF-8");
-    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
-    jenv->DeleteLocalRef(encoding);
-    jenv->DeleteLocalRef(bytes);
-    $input = jstr;
+    jbyteArray $1_bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion($1_bytes, 0, $1_len, (jbyte *) $1.c_str());
+    jclass $1_strClass = jenv->FindClass("java/lang/String");
+    jmethodID $1_ctorID = jenv->GetMethodID($1_strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring $1_encoding = jenv->NewStringUTF("UTF-8");
+    jstring $1_jstr = (jstring) jenv->NewObject($1_strClass, $1_ctorID, $1_bytes, $1_encoding);
+    jenv->DeleteLocalRef($1_encoding);
+    jenv->DeleteLocalRef($1_bytes);
+    $input = $1_jstr;
 %}
 
 %typemap(out) const std::string &
 %{
     jsize $1_len = (jsize)$1->length();
-    jbyteArray bytes = jenv->NewByteArray($1_len);
-    jenv->SetByteArrayRegion(bytes, 0, $1_len, (jbyte *) $1->c_str());
-    jclass strClass = jenv->FindClass("java/lang/String");
-    jmethodID ctorID = jenv->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
-    jstring encoding = jenv->NewStringUTF("UTF-8");
-    jstring jstr = (jstring) jenv->NewObject(strClass, ctorID, bytes, encoding);
-    jenv->DeleteLocalRef(encoding);
-    jenv->DeleteLocalRef(bytes);
-    $result = jstr;
+    jbyteArray $1_bytes = jenv->NewByteArray($1_len);
+    jenv->SetByteArrayRegion($1_bytes, 0, $1_len, (jbyte *) $1->c_str());
+    jclass $1_strClass = jenv->FindClass("java/lang/String");
+    jmethodID $1_ctorID = jenv->GetMethodID($1_strClass, "<init>", "([BLjava/lang/String;)V");
+    jstring $1_encoding = jenv->NewStringUTF("UTF-8");
+    jstring $1_jstr = (jstring) jenv->NewObject($1_strClass, $1_ctorID, $1_bytes, $1_encoding);
+    jenv->DeleteLocalRef($1_encoding);
+    jenv->DeleteLocalRef($1_bytes);
+    $result = $1_jstr;
 %}
+
+%typemap(in) std::string 
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+    }
+    const jclass $1_strClass = jenv->GetObjectClass($input);
+    const jmethodID $1_getBytes = jenv->GetMethodID($1_strClass, "getBytes", "(Ljava/lang/String;)[B");
+    const jbyteArray $1_strJbytes = (jbyteArray) jenv->CallObjectMethod($input, $1_getBytes, jenv->NewStringUTF("UTF-8"));
+
+    size_t $1_length = (size_t) jenv->GetArrayLength($1_strJbytes);
+    jbyte* $1_pBytes = jenv->GetByteArrayElements($1_strJbytes, NULL);
+
+    if (!$1_pBytes) return $null;
+    $1.assign((char *)$1_pBytes, $1_length);
+    jenv->ReleaseByteArrayElements($1_strJbytes, $1_pBytes, JNI_ABORT);
+    jenv->DeleteLocalRef($1_strJbytes);
+    jenv->DeleteLocalRef($1_strClass);
+%}
+
+%typemap(directorout) std::string 
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+   }
+   const jclass $1_strClass = jenv->GetObjectClass($input);
+   const jmethodID $1_getBytes = jenv->GetMethodID($1_strClass, "getBytes", "(Ljava/lang/String;)[B");
+   const jbyteArray $1_strJbytes = (jbyteArray) jenv->CallObjectMethod($input, $1_getBytes, jenv->NewStringUTF("UTF-8"));
+
+   size_t $1_length = (size_t) jenv->GetArrayLength($1_strJbytes);
+   jbyte* $1_pBytes = jenv->GetByteArrayElements($1_strJbytes, NULL);
+
+   if (!$1_pBytes) return $null;
+   $result.assign((char *)$1_pBytes, $1_length);
+   jenv->ReleaseByteArrayElements($1_strJbytes, $1_pBytes, JNI_ABORT);
+   jenv->DeleteLocalRef($1_strJbytes);
+   jenv->DeleteLocalRef($1_strClass);       
+%}
+
+%typemap(in) const std::string &
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+   }
+   const jclass $1_strClass = jenv->GetObjectClass($input);
+   const jmethodID $1_getBytes = jenv->GetMethodID($1_strClass, "getBytes", "(Ljava/lang/String;)[B");
+   const jbyteArray $1_strJbytes = (jbyteArray) jenv->CallObjectMethod($input, $1_getBytes, jenv->NewStringUTF("UTF-8"));
+
+   size_t $1_length = (size_t) jenv->GetArrayLength($1_strJbytes);
+   jbyte* $1_pBytes = jenv->GetByteArrayElements($1_strJbytes, NULL);
+
+   if (!$1_pBytes) return $null;
+   $*1_ltype $1_str((char *)$1_pBytes, $1_length);
+   $1 = &$1_str;   
+   jenv->ReleaseByteArrayElements($1_strJbytes, $1_pBytes, JNI_ABORT);
+   jenv->DeleteLocalRef($1_strJbytes);
+   jenv->DeleteLocalRef($1_strClass);
+%}
+
+%typemap(directorout,warning=SWIGWARN_TYPEMAP_THREAD_UNSAFE_MSG) const std::string &
+%{ if(!$input) {
+     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+     return $null;
+   }
+   const jclass $1_strClass = jenv->GetObjectClass($input);
+   const jmethodID $1_getBytes = jenv->GetMethodID($1_strClass, "getBytes", "(Ljava/lang/String;)[B");
+   const jbyteArray $1_strJbytes = (jbyteArray) jenv->CallObjectMethod($input, $1_getBytes, jenv->NewStringUTF("UTF-8"));
+
+   size_t $1_length = (size_t) jenv->GetArrayLength($1_strJbytes);
+   jbyte* $1_pBytes = jenv->GetByteArrayElements($1_strJbytes, NULL);
+
+   if (!$1_pBytes) return $null;
+   /* possible thread/reentrant code problem */
+   static $*1_ltype $1_str;
+   $1_str = (char *)$1_pBytes;
+   $result = &$1_str;
+   jenv->ReleaseByteArrayElements($1_strJbytes, $1_pBytes, JNI_ABORT);
+   jenv->DeleteLocalRef($1_strJbytes);
+   jenv->DeleteLocalRef($1_strClass);
+%}
+
 #endif

--- a/pjsip-apps/src/swig/java/Makefile
+++ b/pjsip-apps/src/swig/java/Makefile
@@ -182,7 +182,7 @@ $(OUT_DIR)/pjsua2_wrap.o: $(OUT_DIR)/pjsua2_wrap.cpp Makefile
 	$(PJ_CXX) -c $(OUT_DIR)/pjsua2_wrap.cpp -o $(OUT_DIR)/pjsua2_wrap.o \
 		$(MY_CFLAGS)
 
-$(OUT_DIR)/pjsua2_wrap.cpp: ../pjsua2.i ../symbols.i $(SRCS)
+$(OUT_DIR)/pjsua2_wrap.cpp: ../pjsua2.i ../symbols.i ../and_string.i $(SRCS)
 	mkdir -p $(MY_PACKAGE_PATH)
 	mkdir -p $(OUT_DIR)
 	swig $(SWIG_FLAGS) -java  -package $(MY_PACKAGE_NAME) \

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -112,6 +112,9 @@ using namespace pj;
 %include "std_vector.i"
 %include "std_map.i"
 
+// Android string handling
+%include "and_string.i"
+
 %template(StringVector)			std::vector<std::string>;
 %template(IntVector) 			std::vector<int>;
 %template(StringToStringMap) 			std::map<string, string>;


### PR DESCRIPTION
PJSUA2 (C++) API uses std::string to store string information. If the string contains non UTF-8 character, then on Android it will lead to a crash.
```
JNI WARNING: NewStringUTF input is not valid Modified UTF-8
```
The swig will use `NewStringUTF()` JNI call to convert the std::string, and it will crash if it contains non UTF-8 characters.

Reference:
- https://github.com/swig/swig/issues/1174