### PR TITLE
Improve performance for ioqueue_create (alloc memory)

### DIFF
--- a/pjlib/src/pj/ioqueue_kqueue.c
+++ b/pjlib/src/pj/ioqueue_kqueue.c
@@ -29,6 +29,7 @@
 #include <pj/log.h>
 #include <pj/os.h>
 #include <pj/pool.h>
+#include <pj/pool_buf.h>
 #include <pj/sock.h>
 #include <pj/string.h>
 
@@ -49,11 +50,27 @@
  */
 #include "ioqueue_common_abs.h"
 
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+#if defined(PJ_DARWINOS) && PJ_DARWINOS != 0
+#define TMP_BUF_SIZE 304
+#else
+#define TMP_BUF_SIZE 280
+#endif
+#endif
+
 /*
  * This describes each key.
  */
 struct pj_ioqueue_key_t {
     DECLARE_COMMON_KEY
+
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+#if PJ_DEBUG
+    char tmp_buf[TMP_BUF_SIZE + 48];
+#else
+    char tmp_buf[TMP_BUF_SIZE];
+#endif
+#endif
 };
 
 struct queue {
@@ -105,7 +122,10 @@ pj_ioqueue_create(pj_pool_t *pool, pj_size_t max_fd, pj_ioqueue_t **p_ioqueue)
     pj_ioqueue_t *ioqueue;
     pj_status_t rc;
     pj_lock_t *lock;
-    int i;
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+    pj_size_t i;
+    pj_ioqueue_key_t *array_keys;
+#endif
 
     /* Check that arguments are valid. */
     PJ_ASSERT_RETURN(pool != NULL && p_ioqueue != NULL && max_fd > 0,
@@ -142,12 +162,17 @@ pj_ioqueue_create(pj_pool_t *pool, pj_size_t max_fd, pj_ioqueue_t **p_ioqueue)
     pj_list_init(&ioqueue->closing_list);
 
     /* Pre-create all keys according to max_fd */
+    array_keys = (pj_ioqueue_key_t *)pj_pool_alloc(
+	pool, sizeof(pj_ioqueue_key_t) * max_fd);
     for (i = 0; i < max_fd; ++i) {
 	pj_ioqueue_key_t *key;
+	pj_pool_t *tmp_pool;
 
-	key = PJ_POOL_ALLOC_T(pool, pj_ioqueue_key_t);
+	key = array_keys + i;
 	key->ref_count = 0;
-	rc = pj_lock_create_recursive_mutex(pool, NULL, &key->lock);
+	tmp_pool =
+	    pj_pool_create_on_buf(NULL, key->tmp_buf, sizeof(key->tmp_buf));
+	rc = pj_lock_create_recursive_mutex(tmp_pool, NULL, &key->lock);
 	if (rc != PJ_SUCCESS) {
 	    key = ioqueue->free_list.next;
 	    while (key != &ioqueue->free_list) {

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -192,8 +192,11 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 {
     pj_ioqueue_t *ioqueue;
     pj_lock_t *lock;
-    unsigned i;
     pj_status_t rc;
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+    pj_size_t i;
+    pj_ioqueue_key_t *array_keys;
+#endif
 
     /* Check that arguments are valid. */
     PJ_ASSERT_RETURN(pool != NULL && p_ioqueue != NULL && 
@@ -239,10 +242,12 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 
 
     /* Pre-create all keys according to max_fd */
-    for (i=0; i<max_fd; ++i) {
+    array_keys = (pj_ioqueue_key_t *)pj_pool_alloc(
+	pool, sizeof(pj_ioqueue_key_t) * max_fd);
+    for (i = 0; i < max_fd; ++i) {
 	pj_ioqueue_key_t *key;
 
-	key = PJ_POOL_ALLOC_T(pool, pj_ioqueue_key_t);
+	key = array_keys + i;
 	key->ref_count = 0;
 	rc = pj_lock_create_recursive_mutex(pool, NULL, &key->lock);
 	if (rc != PJ_SUCCESS) {

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -328,8 +328,11 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 				       pj_ioqueue_t **p_ioqueue)
 {
     pj_ioqueue_t *ioqueue;
-    unsigned i;
     pj_status_t rc;
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+    pj_size_t i;
+    pj_ioqueue_key_t *array_keys;
+#endif
 
     PJ_UNUSED_ARG(max_fd);
     PJ_ASSERT_RETURN(pool && p_ioqueue, PJ_EINVAL);
@@ -367,10 +370,12 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
     /* Preallocate keys according to max_fd setting, and put them
      * in free_list.
      */
-    for (i=0; i<max_fd; ++i) {
+    array_keys = (pj_ioqueue_key_t *)pj_pool_alloc(
+	pool, sizeof(pj_ioqueue_key_t) * max_fd);
+    for (i = 0; i < max_fd; ++i) {
 	pj_ioqueue_key_t *key;
 
-	key = pj_pool_alloc(pool, sizeof(pj_ioqueue_key_t));
+	key = array_keys + i;
 
 	rc = pj_atomic_create(pool, 0, &key->ref_count);
 	if (rc != PJ_SUCCESS) {


### PR DESCRIPTION
When use epoll/kqueue, pj_ioqueue_create() 's param max_fd set to a large number (eg. 30000),
 it will take a long time to init.

The reason is that: 
It'll alloc max_fd  times memory (indeed 2 * max_fd,  alloc ioqueue_key_t and recursive_mutex), which is so slow.

It can be optimized to apply for contiguous memory only once.

Detail please see issue #3077 