### PR TITLE
Fail sending periodic RTP transmission on silence

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1443,7 +1443,7 @@ static pj_status_t put_frame_imp( pjmedia_port *port,
 	       frame->buf == NULL &&
 	       stream->port.info.fmt.id == PJMEDIA_FORMAT_L16 &&
 	       (stream->dir & PJMEDIA_DIR_ENCODING) &&
-	       stream->enc_samples_per_pkt < PJ_ARRAY_SIZE(zero_frame))
+	       stream->enc_samples_per_pkt <= PJ_ARRAY_SIZE(zero_frame))
     {
 	pjmedia_frame silence_frame;
 


### PR DESCRIPTION
PR #2989 will re-enable RTP transmission on silence. Further test showed that the RTP transmission is not done on some codec due to this check:
```
else if (frame->type == PJMEDIA_FRAME_TYPE_AUDIO &&
	       frame->buf == NULL &&
	       stream->port.info.fmt.id == PJMEDIA_FORMAT_L16 &&
	       (stream->dir & PJMEDIA_DIR_ENCODING) &&
	       stream->enc_samples_per_pkt < PJ_ARRAY_SIZE(zero_frame))
```

Codec with 48000 clockrate, 1 channel and 20ms ptime, the `enc_samples_per_pkt` is 960. The same array size of `zero_frame`.
Hence failing the check and RTP transmission will be skipped. 
This issue should be noticeable when using opus codec which has the above settings.


