### PR TITLE
Update media event poll timeout

### DIFF
--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -345,7 +345,7 @@ static int PJ_THREAD_FUNC worker_proc(void *arg)
     pjmedia_endpt *endpt = (pjmedia_endpt*) arg;
 
     while (!endpt->quit_flag) {
-	pj_time_val timeout = { 0, 500 };
+	pj_time_val timeout = { 0, 10 };
 	pj_ioqueue_poll(endpt->ioqueue, &timeout);
     }
 


### PR DESCRIPTION
Currently it is 500ms (perhaps for power/battery saving reason?). This may cause issues, e.g: a newly added socket may need to wait for ~500ms to start polled.

The new timeout, 10ms, is quite far from 500ms, but considering PJSUA is also using 10ms for polling SIP events (code [here](https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsua-lib/pjsua_core.c#L779)), it should not introduce any issue.