### PR TITLE
Add ioqueue wakeup mechanism to avoid new socket delay

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -682,6 +682,21 @@
 #   define PJ_IOQUEUE_MAX_HANDLES	(64)
 #endif
 
+/**
+ *
+ * When add new socket to ioqueue, poll maybe blocked waiting,
+ * new socket's events can't be real-time caught.
+ *
+ * Wakeup mechanism will make ioqueue exit poll blocked waiting state
+ * immediately, to poll sockets event again, which make it less delay for newly
+ * added socket.
+ *
+ * Default: 0
+ */
+
+#ifndef PJ_IOQUEUE_HAS_WAKEUP
+#   define PJ_IOQUEUE_HAS_WAKEUP 	0
+#endif
 
 /**
  * If PJ_IOQUEUE_HAS_SAFE_UNREG macro is defined, then ioqueue will do more

--- a/pjlib/include/pj/ioqueue.h
+++ b/pjlib/include/pj/ioqueue.h
@@ -363,6 +363,15 @@ PJ_DECL(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 PJ_DECL(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioque );
 
 /**
+ * Wakeup the I/O queue.
+ *
+ * @param ioque	        The I/O Queue to be wakeuped
+ *
+ * @return              PJ_SUCCESS if success.
+ */
+PJ_DECL(pj_status_t) pj_ioqueue_wakeup( pj_ioqueue_t *ioque );
+
+/**
  * Set the lock object to be used by the I/O Queue. This function can only
  * be called right after the I/O queue is created, before any handle is
  * registered to the I/O queue.

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -1529,6 +1529,27 @@ PJ_DECL(char *) pj_addr_str_print( const pj_str_t *host_str, int port,
 
 
 /**
+ * Create socket pair
+ * @param family    Specifies a communication domain; this selects the
+ *		    protocol family which will be used for communication.
+ * @param type	    The socket has the indicated type, which specifies the 
+ *		    communication semantics.
+ * @param protocol  Specifies  a  particular  protocol  to  be used with the
+ *		    socket.  Normally only a single protocol exists to support 
+ *		    a particular socket  type  within  a given protocol family, 
+ *		    in which a case protocol can be specified as 0.
+ * @param sv	    The new sockets vector
+ *
+ * @return	    Zero on success.
+ *
+ */
+PJ_DECL(pj_status_t) pj_sock_socketpair(int family,
+				    int type,
+				    int protocol,
+				    pj_sock_t sv[2]);
+
+
+/**
  * @}
  */
 

--- a/pjlib/src/pj/config.c
+++ b/pjlib/src/pj/config.c
@@ -74,6 +74,7 @@ PJ_DEF(void) pj_dump_config(void)
     PJ_LOG(3, (id, " ioqueue type              : %s", pj_ioqueue_name()));
     PJ_LOG(3, (id, " PJ_IOQUEUE_MAX_HANDLES    : %d", PJ_IOQUEUE_MAX_HANDLES));
     PJ_LOG(3, (id, " PJ_IOQUEUE_HAS_SAFE_UNREG : %d", PJ_IOQUEUE_HAS_SAFE_UNREG));
+    PJ_LOG(3, (id, " PJ_IOQUEUE_HAS_WAKEUP     : %d", PJ_IOQUEUE_HAS_WAKEUP));
     PJ_LOG(3, (id, " PJ_HAS_THREADS            : %d", PJ_HAS_THREADS));
     PJ_LOG(3, (id, " PJ_LOG_USE_STACK_BUFFER   : %d", PJ_LOG_USE_STACK_BUFFER));
     PJ_LOG(3, (id, " PJ_HAS_SEMAPHORE          : %d", PJ_HAS_SEMAPHORE));

--- a/pjlib/src/pj/ioqueue_common_abs.h
+++ b/pjlib/src/pj/ioqueue_common_abs.h
@@ -117,10 +117,22 @@ union operation_key
     UNREG_FIELDS
 
 
+
+#if PJ_IOQUEUE_HAS_WAKEUP
 #define DECLARE_COMMON_IOQUEUE                      \
+    pj_sock_t          wakeup_fd[2];                \
+    char               wakeup_buf[8];               \
+    pj_pool_t          *pool;                       \
     pj_lock_t          *lock;                       \
     pj_bool_t           auto_delete_lock;	    \
     pj_bool_t		default_concurrency;
+#else
+#define DECLARE_COMMON_IOQUEUE                      \
+    pj_pool_t          *pool;                       \
+    pj_lock_t          *lock;                       \
+    pj_bool_t           auto_delete_lock;	    \
+    pj_bool_t		default_concurrency;
+#endif
 
 
 enum ioqueue_event_type

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -861,9 +861,11 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
     /* Special case:
      * When epoll returns > 0 but no descriptors are actually set!
      */
+#if 0
     if (count > 0 && !event_cnt && msec > 0) {
-	pj_thread_sleep(msec);
+	pj_thread_sleep(msec); // Is this necessary?
     }
+#endif
 
     TRACE_((THIS_FILE, "     poll: count=%d events=%d processed=%d",
 		       count, event_cnt, processed_cnt));

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -677,14 +677,12 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
     enum { MAX_EVENTS = PJ_IOQUEUE_MAX_CAND_EVENTS };
     struct epoll_event events[MAX_EVENTS];
     struct queue queue[MAX_EVENTS];
-    pj_timestamp t1, t2;
     
     PJ_CHECK_STACK();
 
     msec = timeout ? PJ_TIME_VAL_MSEC(*timeout) : 9000;
 
     TRACE_((THIS_FILE, "start os_epoll_wait, msec=%d", msec));
-    pj_get_timestamp(&t1);
  
     //count = os_epoll_wait( ioqueue->epfd, events, ioqueue->max, msec);
     count = os_epoll_wait( ioqueue->epfd, events, MAX_EVENTS, msec);
@@ -706,10 +704,6 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 	TRACE_((THIS_FILE, "os_epoll_wait error"));
 	return -pj_get_netos_error();
     }
-
-    pj_get_timestamp(&t2);
-    TRACE_((THIS_FILE, "os_epoll_wait returns %d, time=%d usec",
-		       count, pj_elapsed_usec(&t1, &t2)));
 
     /* Lock ioqueue. */
     pj_lock_acquire(ioqueue->lock);
@@ -869,10 +863,6 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 
     TRACE_((THIS_FILE, "     poll: count=%d events=%d processed=%d",
 		       count, event_cnt, processed_cnt));
-
-    pj_get_timestamp(&t1);
-    TRACE_((THIS_FILE, "ioqueue_poll() returns %d, time=%d usec",
-		       processed_cnt, pj_elapsed_usec(&t2, &t1)));
 
     return processed_cnt;
 }

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -979,9 +979,13 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 #endif
 	pj_lock_release(ioqueue->lock);
 	TRACE__((THIS_FILE, "     poll: no fd is set"));
-        if (timeout)
-            pj_thread_sleep(PJ_TIME_VAL_MSEC(*timeout));
-        return 0;
+	if (timeout) {
+	    int msec = PJ_TIME_VAL_MSEC(*timeout);
+	    if (msec > 10)
+		msec = 10; // Limit sleep value to avoid long time delay
+	    pj_thread_sleep(msec);
+	}
+	return 0;
     }
 
     /* Copy ioqueue's pj_fd_set_t to local variables. */

--- a/pjlib/src/pj/ioqueue_symbian.cpp
+++ b/pjlib/src/pj/ioqueue_symbian.cpp
@@ -482,6 +482,14 @@ PJ_DEF(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioq )
     return PJ_SUCCESS;
 }
 
+/*
+ * Wakeup ioqueue.
+ */
+PJ_DEF(pj_status_t) pj_ioqueue_wakeup(pj_ioqueue_t *ioq )
+{
+    PJ_UNUSED_ARG(ioq);
+    return PJ_SUCCESS;
+}
 
 /*
  * Set the lock object to be used by the I/O Queue. 

--- a/pjlib/src/pj/ioqueue_uwp.cpp
+++ b/pjlib/src/pj/ioqueue_uwp.cpp
@@ -212,6 +212,14 @@ PJ_DEF(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioq )
     return ioqueue_destroy(ioq);
 }
 
+/*
+ * Wakeup ioqueue.
+ */
+PJ_DEF(pj_status_t) pj_ioqueue_wakeup(pj_ioqueue_t *ioq )
+{
+    PJ_UNUSED_ARG(ioq);
+    return PJ_SUCCESS;
+}
 
 /*
  * Register a socket to the I/O queue framework. 

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -463,6 +463,14 @@ PJ_DEF(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioqueue )
     return PJ_SUCCESS;
 }
 
+/*
+ * pj_ioqueue_wakeup
+ */
+PJ_DEF(pj_status_t) pj_ioqueue_wakeup(pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return PJ_SUCCESS;
+}
 
 PJ_DEF(pj_status_t) pj_ioqueue_set_default_concurrency(pj_ioqueue_t *ioqueue,
 						       pj_bool_t allow)


### PR DESCRIPTION
This is an enhancement for ioqueue framework.
For detail reason, please see discussion in #3086 

Describe:
When poll_wait(),  if no any event, which will wait till timeout.
During this waiting period, If add a new socket to ioqueue, 
it will has delay to catch new socket's read/write events

Solution:
Socketpair create  a 'pipe', register pipe's read fd to ioqueue first.
When a new socket register to ioqueue,  write 1 byte to 'pipe',
which will wakeup ioqueue (exit poll_wait)  immediately
 to get pipe's read event.
And then ioqueue can start watching new socket's events quickly,
which make it less delay.
(set poll_wait()'s timeout  to a big value, will be more obvious)

