### PR TITLE
Fix build warnings related to <pj/limits.h>

### DIFF
--- a/pjlib/include/pj/compat/limits.h
+++ b/pjlib/include/pj/compat/limits.h
@@ -25,6 +25,8 @@
  * @brief Provides integer limits normally found in limits.h.
  */
 
+#include <pj/config.h>
+
 #if defined(PJ_HAS_LIMITS_H) && PJ_HAS_LIMITS_H != 0
 #  include <limits.h>
 #else

--- a/pjlib/include/pj/types.h
+++ b/pjlib/include/pj/types.h
@@ -362,13 +362,23 @@ PJ_INLINE(pj_int32_t) pj_swap32(pj_int32_t val32)
     return val32;
 }
 
-/* This is to check if uint32 var will overflow if converted to signed long */
-#define PJ_CHECK_OVERFLOW_UINT32_TO_LONG(uint32_var, exec_on_overflow) \
-	do { \
-	    if (uint32_var > PJ_MAXLONG) { \
-		exec_on_overflow; \
-	    } \
-	} while (0)
+
+/**
+ * Utility macro to check if uint32 var will overflow if converted to
+ * signed long.
+ */
+#if (PJ_MAXLONG <= 2147483647L)
+#  define PJ_CHECK_OVERFLOW_UINT32_TO_LONG(uint32_var, exec_on_overflow) \
+     do { \
+       if (uint32_var > PJ_MAXLONG) { \
+         exec_on_overflow; \
+       } \
+     } while (0)
+#else
+/* 'long' is longer than 32bit, uint32_var should never overflow */
+#  define PJ_CHECK_OVERFLOW_UINT32_TO_LONG(uint32_var, exec_on_overflow)
+#endif
+
 
 /**
  * @}


### PR DESCRIPTION
Warnings tried to be fixed:

```
In file included from ./deps/build/include/pj/limits.h:28,
                  from ./deps/build/include/pj/types.h:34,
                  from ./deps/build/include/pjsip/sip_config.h:27,
                  from ./deps/build/include/pjsip/sip_types.h:34,
                  from ./deps/build/include/pjsip.h:24,
                  from ./deps/build/include/pjsua-lib/pjsua.h:30,
                  from source/accounts.cpp:16:
./deps/build/include/pj/compat/limits.h:37:4: warning: #warning "limits.h is not found or not supported. LONG_MIN and LONG_MAX " "will be defined by the library
```

```
warning: result of comparison of constant 9223372036854775807 with expression of type 'unsigned int' is always false [-Wtautological-constant-out-of-range-compare]

        PJ_CHECK_OVERFLOW_UINT32_TO_LONG(ch.len - read, 

        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```