### PR TITLE
Set SRTP context to NULL after deallocation

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -1087,6 +1087,8 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_stop(pjmedia_transport *srtp)
 		   "Failed to dealloc TX SRTP context: %s",
 		   get_libsrtp_errstr(err)));
     }
+    p_srtp->srtp_rx_ctx = NULL;
+    p_srtp->srtp_tx_ctx = NULL;
 
     p_srtp->session_inited = PJ_FALSE;
     pj_bzero(&p_srtp->rx_policy, sizeof(p_srtp->rx_policy));


### PR DESCRIPTION
Currently `pjmedia_transport_srtp_stop()` will deallocate the SRTP contexts but doesn't reset them to NULL. This can potentially cause crash in `pjmedia_transport_get_info()` which will call `srtp_get_stream_roc()` to the contexts.

```
 #00  pc 0000000000219c5c 
/data/app/~~3jcI6mCrsbub2EXvTHLuXQ==/split_config.arm64_v8a.apk!lib/arm64-v8a/libwwpjsua2.so 
(offset 0x331000) (srtp_get_stream_roc+28)
   #00  pc 00000000001e00a4 
/data/app/~~3jcI6mCrsbub2EXvTHLuXQ==/split_config.arm64_v8a.apk!lib/arm64-v8a/libwwpjsua2.so 
(offset 0x331000)
   #00  pc 0000000000182220 
/data/app/~~3jcI6mCrsbub2EXvTHLuXQ==/split_config.arm64_v8a.apk!lib/arm64-v8a/libwwpjsua2.so 
(offset 0x331000) (pjsua_call_dump+908)
   #00  pc 000000000017b8cc 
/data/app/~~3jcI6mCrsbub2EXvTHLuXQ==/split_config.arm64_v8a.apk!lib/arm64-v8a/libwwpjsua2.so 
(offset 0x331000) (pjsua_media_channel_deinit+280)
```
