### PR TITLE
Fix assertion after updating account contact

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3947,7 +3947,8 @@ static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
 	    if (acc->contact.slen < tmp_contact.slen) {
 		pj_strdup_with_null(acc->pool, &acc->contact, &tmp_contact);
 	    } else {
-		pj_strcpy(&acc->contact, &tmp_contact);
+		pj_strncpy_with_null(&acc->contact, &tmp_contact, 
+				     PJSIP_MAX_URL_SIZE);
 	    }
 	    update_regc_contact(acc);
 	    if (acc->regc)


### PR DESCRIPTION
Consider the scenario:
1. let the account do a successful registration using TCP/TLS.
2. after register is complete. terminate TCP/TLS from remote side, to disconnect the transport.
3. regc try's now to restart the registration
4. assertion ocours just after the respons is received (`pjsua_acc.c:1792`)
```
    contact_hdr = (pjsip_contact_hdr*)
		  pjsip_parse_hdr(pool, &STR_CONTACT, acc->contact.ptr, 
				  acc->contact.slen, NULL);
    pj_assert(contact_hdr != NULL);
```

This is because when regc retry the registration, it will copy the account contact with a new one.
```
if (acc->contact.slen < tmp_contact.slen) {
    pj_strdup_with_null(acc->pool, &acc->contact, &tmp_contact);
} else {
    pj_strcpy(&acc->contact, &tmp_contact);
}
```
When the new contact is shorter than the current contact, then the new contact will be copied without the NULL terminated data. The SIP parser itself require that the input string buffer MUST be NULL terminated.

