### PR TITLE
Add run time settings to enable/disable RTCP-XR in account config

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2972,7 +2972,11 @@ PJ_DEF(pj_status_t) pjmedia_stream_destroy( pjmedia_stream *stream )
 
     /* Send RTCP BYE (also SDES & XR) */
     if (stream->transport && !stream->rtcp_sdes_bye_disabled) {
-	send_rtcp(stream, PJ_TRUE, PJ_TRUE, PJ_TRUE, PJ_FALSE);
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+	send_rtcp(stream, PJ_TRUE, PJ_TRUE, stream->rtcp.xr_enabled, PJ_FALSE);
+#else
+	send_rtcp(stream, PJ_TRUE, PJ_TRUE, PJ_FALSE, PJ_FALSE);
+#endif
     }
 
     /* If we're in the middle of transmitting DTMF digit, send one last

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4329,14 +4329,12 @@ typedef struct pjsua_acc_config
      */
     pjmedia_rtcp_fb_setting rtcp_fb_cfg;
 
-#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
     /**
      * Enable RTCP Extended Report (RTCP XR).
      *
      * Default: PJMEDIA_STREAM_ENABLE_XR
      */
     pj_bool_t		enable_rtcp_xr;
-#endif
 
 } pjsua_acc_config;
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4329,6 +4329,15 @@ typedef struct pjsua_acc_config
      */
     pjmedia_rtcp_fb_setting rtcp_fb_cfg;
 
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    /**
+     * Enable RTCP Extended Report (RTCP XR).
+     *
+     * Default: PJMEDIA_STREAM_ENABLE_XR
+     */
+    pj_bool_t		enable_rtcp_xr;
+#endif
+
 } pjsua_acc_config;
 
 

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -1023,6 +1023,13 @@ struct AccountMediaConfig : public PersistentObject
     RtcpFbConfig	rtcpFbConfig;
 
     /**
+     * Enable RTCP Extended Report (RTCP XR).
+     *
+     * Default: PJMEDIA_STREAM_ENABLE_XR
+     */
+    bool		rtcpXrEnabled;
+
+    /**
      * Use loopback media transport. This may be useful if application
      * doesn't want PJSUA2 to create real media transports/sockets, such as
      * when using third party media.

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1379,9 +1379,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     acc->cfg.ipv6_media_use = cfg->ipv6_media_use;
     acc->cfg.enable_rtcp_mux = cfg->enable_rtcp_mux;
     acc->cfg.lock_codec = cfg->lock_codec;
-#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
     acc->cfg.enable_rtcp_xr = cfg->enable_rtcp_xr;
-#endif
 
     /* STUN and Media customization */
     if (acc->cfg.sip_stun_use != cfg->sip_stun_use) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1379,6 +1379,9 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     acc->cfg.ipv6_media_use = cfg->ipv6_media_use;
     acc->cfg.enable_rtcp_mux = cfg->enable_rtcp_mux;
     acc->cfg.lock_codec = cfg->lock_codec;
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    acc->cfg.enable_rtcp_xr = cfg->enable_rtcp_xr;
+#endif
 
     /* STUN and Media customization */
     if (acc->cfg.sip_stun_use != cfg->sip_stun_use) {

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -379,9 +379,7 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
     cfg->ip_change_cfg.reinvite_flags = PJSUA_CALL_REINIT_MEDIA |
 					PJSUA_CALL_UPDATE_CONTACT |
 					PJSUA_CALL_UPDATE_VIA;
-#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
-    cfg->enable_rtcp_xr = PJMEDIA_STREAM_ENABLE_XR;
-#endif
+    cfg->enable_rtcp_xr = (PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR);
 }
 
 PJ_DEF(void) pjsua_buddy_config_default(pjsua_buddy_config *cfg)

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -379,6 +379,9 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
     cfg->ip_change_cfg.reinvite_flags = PJSUA_CALL_REINIT_MEDIA |
 					PJSUA_CALL_UPDATE_CONTACT |
 					PJSUA_CALL_UPDATE_VIA;
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    cfg->enable_rtcp_xr = PJMEDIA_STREAM_ENABLE_XR;
+#endif
 }
 
 PJ_DEF(void) pjsua_buddy_config_default(pjsua_buddy_config *cfg)

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3826,6 +3826,11 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		goto on_check_med_status;
 	    }
 
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+	    /* Enable/disable RTCP XR based on account setting. */
+	    si->rtcp_xr_enabled = acc->cfg.enable_rtcp_xr;
+#endif
+
 	    /* Check if remote wants RTP and RTCP multiplexing,
 	     * but we don't enable it.
 	     */

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -465,6 +465,7 @@ void AccountMediaConfig::readObject(const ContainerNode &node)
     NODE_READ_BOOL    ( this_node, rtcpMuxEnabled);
     NODE_READ_BOOL    ( this_node, useLoopMedTp);
     NODE_READ_BOOL    ( this_node, enableLoopback);
+    NODE_READ_BOOL    ( this_node, rtcpXrEnabled);
 }
 
 void AccountMediaConfig::writeObject(ContainerNode &node) const
@@ -482,6 +483,7 @@ void AccountMediaConfig::writeObject(ContainerNode &node) const
     NODE_WRITE_BOOL    ( this_node, rtcpMuxEnabled);
     NODE_WRITE_BOOL    ( this_node, useLoopMedTp);
     NODE_WRITE_BOOL    ( this_node, enableLoopback);
+    NODE_WRITE_BOOL    ( this_node, rtcpXrEnabled);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -691,6 +693,9 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     ret.rtcp_fb_cfg		= mediaConfig.rtcpFbConfig.toPj();
     ret.use_loop_med_tp		= mediaConfig.useLoopMedTp;
     ret.enable_loopback		= mediaConfig.enableLoopback;
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    ret.enable_rtcp_xr		= mediaConfig.rtcpXrEnabled;
+#endif
 
     // AccountVideoConfig
     ret.vid_in_auto_show	= videoConfig.autoShowIncoming;
@@ -883,6 +888,11 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     mediaConfig.rtcpFbConfig.fromPj(prm.rtcp_fb_cfg);
     mediaConfig.useLoopMedTp	= PJ2BOOL(prm.use_loop_med_tp);
     mediaConfig.enableLoopback	= PJ2BOOL(prm.enable_loopback);
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    mediaConfig.rtcpXrEnabled	= PJ2BOOL(prm.enable_rtcp_xr);
+#else
+    mediaConfig.rtcpXrEnabled	= false;
+#endif
 
     // AccountVideoConfig
     videoConfig.autoShowIncoming 	= PJ2BOOL(prm.vid_in_auto_show);

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -693,9 +693,7 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     ret.rtcp_fb_cfg		= mediaConfig.rtcpFbConfig.toPj();
     ret.use_loop_med_tp		= mediaConfig.useLoopMedTp;
     ret.enable_loopback		= mediaConfig.enableLoopback;
-#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
     ret.enable_rtcp_xr		= mediaConfig.rtcpXrEnabled;
-#endif
 
     // AccountVideoConfig
     ret.vid_in_auto_show	= videoConfig.autoShowIncoming;
@@ -888,11 +886,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     mediaConfig.rtcpFbConfig.fromPj(prm.rtcp_fb_cfg);
     mediaConfig.useLoopMedTp	= PJ2BOOL(prm.use_loop_med_tp);
     mediaConfig.enableLoopback	= PJ2BOOL(prm.enable_loopback);
-#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
     mediaConfig.rtcpXrEnabled	= PJ2BOOL(prm.enable_rtcp_xr);
-#else
-    mediaConfig.rtcpXrEnabled	= false;
-#endif
 
     // AccountVideoConfig
     videoConfig.autoShowIncoming 	= PJ2BOOL(prm.vid_in_auto_show);


### PR DESCRIPTION
Currently RTCP-XR can be enabled/disabled via compile time settings only, i.e: `PJMEDIA_HAS_RTCP_XR` & `PJMEDIA_STREAM_ENABLE_XR`. This PR adds run time settings:
- PJSUA: `pjsua_acc_config.enable_rtcp_xr`
- PJSUA2: `AccountMediaConfig.rtcpXrEnabled`

Default is `PJMEDIA_STREAM_ENABLE_XR`.