### PR TITLE
Enable screensaver when using SDL 2.0.2

### DIFF
--- a/pjmedia/src/pjmedia-videodev/sdl_dev.c
+++ b/pjmedia/src/pjmedia-videodev/sdl_dev.c
@@ -295,6 +295,13 @@ static pj_status_t sdl_init(void * data)
 {
     PJ_UNUSED_ARG(data);
 
+#if SDL_VERSION_ATLEAST(2,0,2)
+    /* Since SDL 2.0.2, screensaver is disabled by default, to maintain
+     * the existing behavior, let's enable screensaver.
+     */
+    SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
+#endif
+
     if (SDL_Init(SDL_INIT_VIDEO)) {
         sdl_log_err("SDL_Init()");
         return PJMEDIA_EVID_INIT;


### PR DESCRIPTION
Since SDL 2.0.2, screensaver is disabled by default, and there has been a report that screensaver no longer working when an app using PJSIP is running.

In `SDL_video.c`:
```
    /* Disable the screen saver by default. This is a change from <= 2.0.1,
       but most things using SDL are games or media players; you wouldn't
       want a screensaver to trigger if you're playing exclusively with a
       joystick, or passively watching a movie. Things that use SDL but
       function more like a normal desktop app should explicitly reenable the
       screensaver. */
    if (!SDL_GetHintBoolean(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, SDL_FALSE)) {
        SDL_DisableScreenSaver();
    }
```
As generally SIP app is a 'normal' desktop app, we have been suggested to maintain the existing behavior, i.e: screensaver enabled.

Thanks to Wolfgang Wallhäuser for the suggestion and the patch.