### PR TITLE
sip_transport_tls: Allow wildcard certifcates

### DIFF
--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -269,6 +269,18 @@ typedef struct pjsip_tls_setting
     pj_str_t		entropy_path;
 
     /**
+     * Specifies whether or not to allow a certificate to be verified against
+     * names that start with a wildcard, i.e. '*.'.
+     * - If \allow_wildcard_certs is disabled (set to PJ_FALSE), then in accordance
+     *   with RFC5922 wildcard verification is not done.
+     * - If \allow_wildcard_certs is enabled (set to PJ_TRUE), then noncompliant
+     *   with RFC5922 wildcard verification is permitted.
+     *
+     * Default value is PJ_FALSE.
+     */
+    pj_bool_t	allow_wildcard_certs;
+
+    /**
      * Specifies TLS transport behavior on the server TLS certificate 
      * verification result:
      * - If \a verify_server is disabled (set to PJ_FALSE), TLS transport 


### PR DESCRIPTION
Rightly the use of wildcards in certificates is disallowed in accordance
with RFC5922. However, RFC2818 does make some allowances with regards to
their use when using subject alt names with DNS name types.

As such this patch creates a new setting for TLS transports called
'allow_wildcard_certs', which when enabled allows DNS name types, as
well as the common name that start with '*.' to match as a wildcard.

For instance: *.example.com
will match for: foo.example.com

Partial matching is not allowed, e.g. f*.example.com, foo.*.com, etc...
And the starting wildcard only matches for a single levels

For instance: *.example.com
will NOT match for: foo.bar.example.com

The new setting is disabled by default.