### PR TITLE
Add OpenSSL version check for SSL_SESSION_is_resumable()

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2303,7 +2303,11 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
 	    PJ_LOG(5, (THIS_FILE, "Session info: reused=%d, resumable=%d, "
 		       "timeout=%d",
 		       SSL_session_reused(ossock->ossl_ssl),
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
 		       SSL_SESSION_is_resumable(sess),
+#else
+		       -1,
+#endif
 		       SSL_SESSION_get_timeout(sess)));
 
 	    sid = SSL_SESSION_get_id(sess, &len);


### PR DESCRIPTION
The function is only available in OpenSSL 1.1.1 (instead of 1.1.0).
https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_is_resumable.html

Thanks to @formater for the info.
