### PR TITLE
Patch to improve epoll implementation

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -744,6 +744,15 @@
 #endif
 
 
+/* Setting to determine whether to enable epoll exclusive/oneshot feature.
+ *
+ * Default: 1 (enabled)
+ */
+#ifndef PJ_IOQUEUE_EPOLL_ENABLE_EXCLUSIVE_ONESHOT
+#   define PJ_IOQUEUE_EPOLL_ENABLE_EXCLUSIVE_ONESHOT 1
+#endif
+
+
 /**
  * Determine if FD_SETSIZE is changeable/set-able. If so, then we will
  * set it to PJ_IOQUEUE_MAX_HANDLES. Currently we detect this by checking

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -493,10 +493,17 @@ PJ_DEF(pj_status_t) pj_ioqueue_unregister( pj_ioqueue_key_t *key)
     ev.epoll_data = (epoll_data_type)key;
     status = os_epoll_ctl( ioqueue->epfd, EPOLL_CTL_DEL, key->fd, &ev);
     if (status != 0) {
-	pj_status_t rc = pj_get_os_error();
-	pj_lock_release(ioqueue->lock);
-	pj_ioqueue_unlock_key(key);
-	return rc;
+        // pj_status_t rc = pj_get_os_error();
+        TRACE_((THIS_FILE,
+                "pj_ioqueue_unregister error: os_epoll_ctl rc=%d",
+                pj_get_os_error()));
+        /* From epoll doc: "Closing a file descriptor cause it to be
+         * removed from all epoll interest lists". So we should just
+         * proceed instead of returning failure here.
+         */
+        // pj_lock_release(ioqueue->lock);
+        // pj_ioqueue_unlock_key(key);
+        // return rc;
     }
 
     /* Destroy the key. */


### PR DESCRIPTION
It's been reported that there is a performance issue with epoll backend (increased delay of packet received during heavy load, and CPU load not dropping back to normal state afterward).

The PR is an **EXPERIMENTAL(!)** attempt to address the issue, as well as to improve the current epoll implementation:
- Modify the fix of #2747 and #3018 since the rearming was done in `remove_from_set()`, which doesn't seem like the proper place to do so. It is suspected that the early rearming may cause other polling threads to be notified of the same events before they're even processed, potentially causing performance inefficiency. So the rearming is now moved to `add_to_set()` and performed after dispatch instead.
- Modify the sleep period in the special case when `epoll_wait()` returns > 0 but we don't process it. Previously, the sleep period is always using the timeout period provided by the user, disregarding how much time we have spent in `epoll_wait()`, which means that total duration spent inside `pj_ioqueue_poll()` can potentially be up to double of the `timeout` parameter passed by the user (example: `pj_ioqueue_poll(timeout=500 msec) -> os_epoll_wait() returns > 0 after 400 msec -> event_cnt = 0 -> pj_thread_sleep(500)`). Also add some more explanation about this special case.
- Currently socket unregistration will fail if `os_epoll_ctl(EPOLL_CTL_DEL, ...)` fails. This may cause the socket to be in the interest list forever, potentially causing performance issue and failure to properly cleanup and return to the initial state.
- Add compile-time setting to enable/disable exclusive/oneshot feature, which can be useful for app that only use a single thread to poll ioq and therefore, doesn't need the feature.
