### PR TITLE
Fixed issues with event subscription regarding on_rx_refresh() and unsubscription

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1345,6 +1345,17 @@ int stdout_refresh_proc(void *arg)
     return 0;
 }
 
+static void on_call_tsx_state(pjsua_call_id call_id,
+                                 pjsip_transaction *tsx,
+                                 pjsip_event *e)
+{
+if (e->type == PJSIP_EVENT_TSX_STATE && e->body.tsx_state.type == PJSIP_EVENT_RX_MSG) {
+
+		pjsip_msg *msg = e->body.tsx_state.src.rdata->msg_info.msg;
+	printf("receive response %d\n", msg->line.status.code);
+
+}
+}
 
 static pj_status_t app_init(void)
 {
@@ -1380,6 +1391,7 @@ static pj_status_t app_init(void)
 
     /* Initialize application callbacks */
     app_config.cfg.cb.on_call_state = &on_call_state;
+    app_config.cfg.cb.on_call_tsx_state = &on_call_tsx_state;
     app_config.cfg.cb.on_stream_destroyed = &on_stream_destroyed;
     app_config.cfg.cb.on_call_media_state = &on_call_media_state;
     app_config.cfg.cb.on_incoming_call = &on_incoming_call;

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1345,17 +1345,6 @@ int stdout_refresh_proc(void *arg)
     return 0;
 }
 
-static void on_call_tsx_state(pjsua_call_id call_id,
-                                 pjsip_transaction *tsx,
-                                 pjsip_event *e)
-{
-if (e->type == PJSIP_EVENT_TSX_STATE && e->body.tsx_state.type == PJSIP_EVENT_RX_MSG) {
-
-		pjsip_msg *msg = e->body.tsx_state.src.rdata->msg_info.msg;
-	printf("receive response %d\n", msg->line.status.code);
-
-}
-}
 
 static pj_status_t app_init(void)
 {
@@ -1391,7 +1380,6 @@ static pj_status_t app_init(void)
 
     /* Initialize application callbacks */
     app_config.cfg.cb.on_call_state = &on_call_state;
-    app_config.cfg.cb.on_call_tsx_state = &on_call_tsx_state;
     app_config.cfg.cb.on_stream_destroyed = &on_stream_destroyed;
     app_config.cfg.cb.on_call_media_state = &on_call_media_state;
     app_config.cfg.cb.on_incoming_call = &on_incoming_call;

--- a/pjsip/include/pjsip-simple/evsub.h
+++ b/pjsip/include/pjsip-simple/evsub.h
@@ -124,13 +124,25 @@ struct pjsip_evsub_user
      * remote, along with additional headers and message body to be put 
      * in the response.
      *
-     * This callback is OPTIONAL.
+     * This callback is only applicable and required for UAS.
      *
-     * However, implementation MUST send NOTIFY request upon receiving this
-     * callback. The suggested behavior is to call 
-     * #pjsip_evsub_current_notify(), since this function takes care
-     * about unsubscription request and calculates the appropriate expiration
-     * interval.
+     * Upon receiving this callback, implementation MUST send NOTIFY request.
+     * The suggested behavior is to call  #pjsip_evsub_current_notify(),
+     * since this function takes care about unsubscription request and
+     * calculates the appropriate expiration interval.
+     *
+     * @param sub	The subscription instance.
+     * @param rdata	The received SUBSCRIBE request.
+     * @param p_st_code	Application MUST set the value of this argument with
+     *			final status code (200-699) upon returning from the
+     *			callback. Only applicable for refresh request. For
+     *			unsubscription, the library will always reply with
+     *			200.
+     * @param p_st_text	Custom status text, if any.
+     * @param res_hdr	Upon return, application can put additional headers 
+     *			to be sent in the response in this list.
+     * @param p_body	Application MAY specify message body to be sent in
+     *			the response.
      */
     void (*on_rx_refresh)( pjsip_evsub *sub, 
 			   pjsip_rx_data *rdata,

--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -2147,6 +2147,8 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 	sub->calling_on_rx_refresh = PJ_TRUE;
 
 	if (sub->expires->ivalue == 0) {
+	    PJ_LOG(4,(sub->obj_name, "Receiving unsubscription request "
+	    			     "(Expires=0)."));
 	    set_state(sub, PJSIP_EVSUB_STATE_TERMINATED, NULL, event, NULL);
 	} else  if (sub->state == PJSIP_EVSUB_STATE_NULL) {
 	    sub->state = PJSIP_EVSUB_STATE_ACCEPTED;

--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -2147,9 +2147,12 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 	sub->calling_on_rx_refresh = PJ_TRUE;
 
 	if (sub->expires->ivalue == 0) {
+	    pj_str_t timeout = { "timeout", 7};
+
 	    PJ_LOG(4,(sub->obj_name, "Receiving unsubscription request "
 	    			     "(Expires=0)."));
-	    set_state(sub, PJSIP_EVSUB_STATE_TERMINATED, NULL, event, NULL);
+	    set_state(sub, PJSIP_EVSUB_STATE_TERMINATED, NULL, event,
+	    	      &timeout);
 	} else  if (sub->state == PJSIP_EVSUB_STATE_NULL) {
 	    sub->state = PJSIP_EVSUB_STATE_ACCEPTED;
 	    sub->state_str = evsub_state_names[sub->state];
@@ -2211,7 +2214,9 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 	/* Send the pending NOTIFY sent by app from inside
 	 * on_rx_refresh() callback.
 	 */
+	pj_assert(sub->pending_notify);
 	status = pjsip_evsub_send_request(sub, sub->pending_notify);
+	sub->pending_notify = NULL;
 
     } else if (pjsip_method_cmp(&tsx->method, &pjsip_notify_method)==0) {
 

--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -235,6 +235,8 @@ struct pjsip_evsub
     int			  pending_tsx;	/**< Number of pending transactions.*/
     pjsip_transaction	 *pending_sub;	/**< Pending UAC SUBSCRIBE tsx.	    */
     pj_timer_entry	 *pending_sub_timer; /**< Stop pending sub timer.   */
+    pjsip_tx_data	 *pending_notify;/**< Pending NOTIFY to be sent.    */
+    pj_bool_t		  calling_on_rx_refresh;/**< Inside on_rx_refresh()?*/
     pj_grp_lock_t	 *grp_lock;	/* Session group lock	    */
 
     void		 *mod_data[PJSIP_MAX_MODULE];	/**< Module data.   */
@@ -631,7 +633,8 @@ static void set_state( pjsip_evsub *sub, pjsip_evsub_state state,
 	/* Kill any timer. */
 	set_timer(sub, TIMER_TYPE_NONE, 0);
 
-	if (sub->pending_tsx == 0) {
+	/* We must not destroy evsub if we're still calling the callback. */
+	if (sub->pending_tsx == 0 && !sub->calling_on_rx_refresh) {
 	    evsub_destroy(sub);
 	}
     }
@@ -1377,7 +1380,7 @@ PJ_DEF(pj_status_t) pjsip_evsub_current_notify( pjsip_evsub *sub,
 PJ_DEF(pj_status_t) pjsip_evsub_send_request( pjsip_evsub *sub,
 					      pjsip_tx_data *tdata)
 {
-    pj_status_t status;
+    pj_status_t status = PJ_SUCCESS;
 
     /* Must be request message. */
     PJ_ASSERT_RETURN(tdata->msg->type == PJSIP_REQUEST_MSG,
@@ -1385,6 +1388,18 @@ PJ_DEF(pj_status_t) pjsip_evsub_send_request( pjsip_evsub *sub,
 
     /* Lock */
     pjsip_dlg_inc_lock(sub->dlg);
+
+
+    /* Delay sending NOTIFY if we're inside on_rx_refresh() callback
+     * until we have sent the response to the incoming SUBSCRIBE.
+     */
+    if (sub->calling_on_rx_refresh &&
+        pjsip_method_cmp(&tdata->msg->line.req.method, 
+			 &pjsip_notify_method)==0)
+    {
+    	sub->pending_notify = tdata;
+    	goto on_return;
+    }
 
     /* Send the request. */
     status = pjsip_dlg_send_request(sub->dlg, tdata, -1, NULL);
@@ -1560,10 +1575,13 @@ static pjsip_evsub *on_new_transaction( pjsip_transaction *tsx,
     }
 
     /* Note: 
-     *  the second condition is for http://trac.pjsip.org/repos/ticket/911 
+     *  the second condition is for http://trac.pjsip.org/repos/ticket/911
+     * Take note that it could be us that is trying to send a final message,
+     * such as final NOTIFY upon unsubscription.
      */
     if (dlgsub == dlgsub_head ||
-	(dlgsub->sub && 
+	(dlgsub->sub &&
+	    tsx->role == PJSIP_ROLE_UAS &&
 	    pjsip_evsub_get_state(dlgsub->sub)==PJSIP_EVSUB_STATE_TERMINATED))
     {
 	const char *reason_msg = 
@@ -2117,13 +2135,19 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 
 	/* Save old state.
 	 * If application respond with non-2xx, revert to old state.
+	 * But if subscriber wants to unsubscribe, there is no
+	 * turning back.
 	 */
 	old_state = sub->state;
 	old_state_str = sub->state_str;
 
+	/* Must set this before calling set_state(), to prevent evsub
+	 * from being destroyed.
+	 */
+	sub->calling_on_rx_refresh = PJ_TRUE;
+
 	if (sub->expires->ivalue == 0) {
-	    sub->state = PJSIP_EVSUB_STATE_TERMINATED;
-	    sub->state_str = evsub_state_names[sub->state];
+	    set_state(sub, PJSIP_EVSUB_STATE_TERMINATED, NULL, event, NULL);
 	} else  if (sub->state == PJSIP_EVSUB_STATE_NULL) {
 	    sub->state = PJSIP_EVSUB_STATE_ACCEPTED;
 	    sub->state_str = evsub_state_names[sub->state];
@@ -2137,7 +2161,10 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 	if (sub->user.on_rx_refresh && sub->call_cb) {
 	    (*sub->user.on_rx_refresh)(sub, rdata, &st_code, &st_text, 
 				       &res_hdr, &body);
+	    /* We shouldn't fail an unsubscription request, should we? */
+	    if (sub->expires->ivalue == 0) st_code = 200;
 	}
+	sub->calling_on_rx_refresh = PJ_FALSE;
 
 	/* Application MUST specify final response! */
 	PJ_ASSERT_ON_FAIL(st_code >= 200, {st_code=200; });
@@ -2162,9 +2189,7 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 	/* Update state or revert state */
 	if (st_code/100==2) {
 	    
-	    if (sub->expires->ivalue == 0) {
-		set_state(sub, sub->state, NULL, event, &reason);
-	    } else  if (sub->state == PJSIP_EVSUB_STATE_NULL) {
+	    if (sub->state == PJSIP_EVSUB_STATE_NULL) {
 		set_state(sub, sub->state, NULL, event, &reason);
 	    }
 
@@ -2181,6 +2206,10 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
 	    sub->state_str = old_state_str;
 	}
 
+	/* Send the pending NOTIFY sent by app from inside
+	 * on_rx_refresh() callback.
+	 */
+	status = pjsip_evsub_send_request(sub, sub->pending_notify);
 
     } else if (pjsip_method_cmp(&tsx->method, &pjsip_notify_method)==0) {
 

--- a/tests/pjsua/scripts-sipp/uac-subscribe.xml
+++ b/tests/pjsua/scripts-sipp/uac-subscribe.xml
@@ -67,7 +67,7 @@
       SUBSCRIBE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
       From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
-      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
       Call-ID: [call_id]
       CSeq: 2 SUBSCRIBE
       Contact: sip:sipp@[local_ip]:[local_port]


### PR DESCRIPTION
There are several issues with the event subscription, in particular with the `on_rx_refresh()` callback and the unsubscription handling.
1. The doc specifies that `on_rx_refresh()` callback is optional, but it will trigger an assertion in `pjsip_evsub_create_uas()`:
  ```
    /* Package MUST implement on_rx_refresh */
    PJ_ASSERT_RETURN(user_cb->on_rx_refresh, PJ_EINVALIDOP);
  ```
We will fix the doc in this PR, and also add the missing parameter documentations.

2. A flow issue between SUBSCRIBE response and the NOTIFY.
   Upon incoming SUBSCRIBE, `on_rx_refresh()` will be called, and the doc says that app MUST send NOTIFY request inside the callback. The callback also provides a parameter `p_st_code` that will be used to send the response to the incoming SUBSCRIBE **after** the callback. This means that the NOTIFY will be sent first before the SUBSCRIBE response. While this is unlikely to cause any problem to the remote, which should be able to handle out-of-order messages, it's counterintuitive and goes against the [RFC 3265](https://datatracker.ietf.org/doc/html/rfc3265#section-3.1.6.2)'s recommendation in section 3.1.6.2:
```Note that a NOTIFY message is always sent immediately after any 200-class response to a SUBSCRIBE request```
  Even our sipp pjsua test `uac-subscribe.xml` will fail since it expects to receive the SUBSCRIBE response first:
```
  <send retrans="500">
    <![CDATA[
      SUBSCRIBE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      ....
    ]]>
  </send>
  <recv response="200" rtd="true"> </recv>
  <recv request="NOTIFY" crlf="true"> </recv>
```
The proposed fix in this PR is to delay sending the NOTIFY request when we're inside the callback.

3. Incorrect evsub state transition during unsubscription.
Upon receiving unsubscription request, evsub will set the state to TERMINATED before calling `on_rx_refresh()`:
```
	/* Save old state.
	 * If application respond with non-2xx, revert to old state.
	 */
	old_state = sub->state;
	old_state_str = sub->state_str;

	if (sub->expires->ivalue == 0) {
	    sub->state = PJSIP_EVSUB_STATE_TERMINATED;
 	    sub->state_str = evsub_state_names[sub->state];
        }
```
This is most likely done so that when enquiring the subscription state via `pjsip_evsub_get_state()` inside the callback, the app can easily differentiate between unsubscription (state TERMINATED) and refresh (otherwise). And the state setting is done without calling `set_state()` because there's a possibility the state can be reverted if the app rejects the SUBSCRIBE by specifying non-200 `p_st_code`. But this causes several issues:
a. The state never transitions smoothly to TERMINATED (the log will ouput`"Subscription state changed ACCEPTED --> ACTIVE"` followed by `"Subscription state changed TERMINATED --> TERMINATED"`). This causes timer to be still active, i.e. the following code in `set_state()` will never be executed:
```    
    if (state == PJSIP_EVSUB_STATE_TERMINATED &&
	prev_state != PJSIP_EVSUB_STATE_TERMINATED) 
    {
	/* Kill any timer. */
	set_timer(sub, TIMER_TYPE_NONE, 0);
```
As a result, timer, such as timeout timer, will still be triggered later (invoking `on_server_timeout()` callback), long after the subscription is deemed to have terminated.
b. When app tries to send the (final) NOTIFY request inside the callback, it's not handled properly. Instead it will get the log: `Subscription already terminated for NOTIFY, event=presence;id=`

It is quite complicated to fix the issue. The proposed fix in this PR is to always reply with success/200 upon unsubscription and therefore, disallow the state reversion. This is consistent with the behaviour of registration and call, where after sending unregistration or hanging up call, user is not going to stick around much longer and wait until it's accepted.
Behaviour change due to the patch: Upon unsubscription, app will now receive callback `on_evsub_state()` before `on_rx_refresh()`.

The PR also fixes a bug in `uac-subscribe.xml` missing the To tag that causes the unsubscription request to be treated as new subscription instead.
