### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+---
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+TabWidth:   8
+UseTab: AlignWithSpaces
+BreakBeforeBraces: Linux
+ColumnLimit: 80
+IndentCaseLabels: false
+
+# Disable single line
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortBlocksOnASingleLine : false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false 
+AllowShortEnumsOnASingleLine: false
+
+# Function params
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackParameters: false
+
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 ---
+Language:        Cpp
 BasedOnStyle: LLVM
 
 IndentWidth: 4
@@ -7,7 +8,7 @@ TabWidth:   8
 UseTab: ForContinuationAndIndentation
 BreakBeforeBraces: Linux
 ColumnLimit: 80
-IndentCaseLabels: false
+#IndentCaseLabels: false
 
 # Disable single line
 AllowShortFunctionsOnASingleLine: None
@@ -15,10 +16,10 @@ AllowShortIfStatementsOnASingleLine: Never
 AllowShortBlocksOnASingleLine : false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false 
-AllowShortEnumsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
 
 # Function params
 AllowAllParametersOfDeclarationOnNextLine: false
 BinPackParameters: false
-
+PenaltyReturnTypeOnItsOwnLine: 2000
 

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,8 @@ BasedOnStyle: LLVM
 
 IndentWidth: 4
 TabWidth:   8
-UseTab: AlignWithSpaces
+#UseTab: AlignWithSpaces
+UseTab: ForContinuationAndIndentation
 BreakBeforeBraces: Linux
 ColumnLimit: 80
 IndentCaseLabels: false


### PR DESCRIPTION
Use clang-format  to help format code.
It could help contributors and avoid useless code style reviews.

According to [Coding Convention](https://www.pjsip.org/docs/latest/pjlib/docs/html/pjlib_coding_convention_page.htm).

This only contains basic functions, It can be expanded on this basis, add other features.

#3115 