### PR TITLE
Add option to check if UPDATE sent during EARLY inv state has completed SDP nego using reliable prov response

### DIFF
--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -441,6 +441,8 @@ struct pjsip_inv_session
     pjsip_status_code	 cause;			    /**< Disconnect cause.  */
     pj_str_t		 cause_text;		    /**< Cause text.	    */
     pj_bool_t		 notify;		    /**< Internal.	    */
+    pj_bool_t		 sdp_done_early_rel;	    /**< Nego done in early
+    							 med was reliable?  */
     unsigned		 cb_called;		    /**< Cb has been called */
     pjsip_dialog	*dlg;			    /**< Underlying dialog. */
     pjsip_role_e	 role;			    /**< Invite role.	    */

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1470,6 +1470,20 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #   define PJSIP_INV_ACCEPT_UNKNOWN_BODY    PJ_FALSE
 #endif
 
+/** 
+ * Specify whether to check if UPDATE sent in EARLY state has already
+ * completed SDP negotiation using reliable provisional responses, as
+ * specified in RFC3311 section 5.1.
+ *
+ * By default, the library will disable the check and allow the UPDATE
+ * to be sent for backward compatibility.
+ *
+ * Default: 0 (disabled)
+ */
+#ifndef PJSIP_INV_UPDATE_EARLY_CHECK_RELIABLE
+#   define PJSIP_INV_UPDATE_EARLY_CHECK_RELIABLE    0
+#endif
+
 /**
  * Dump configuration to log with verbosity equal to info(3).
  */

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -4159,15 +4159,18 @@ static pj_status_t process_pending_reinvite(pjsua_call *call)
 	return PJ_EINVALIDOP;
     }
 
-    /* Delay this when the SDP negotiation done in call state EARLY and
-     * remote does not support UPDATE method.
-     */
-    if (inv->state == PJSIP_INV_STATE_EARLY &&
-	pjsip_dlg_remote_has_cap(inv->dlg, PJSIP_H_ALLOW, NULL, &ST_UPDATE)!=
-	PJSIP_DIALOG_CAP_SUPPORTED)
-    {
-        call->reinv_pending = PJ_TRUE;
-        return PJ_EPENDING;
+    if (inv->state == PJSIP_INV_STATE_EARLY) {
+    	if (pjsip_dlg_remote_has_cap(inv->dlg, PJSIP_H_ALLOW, NULL,
+    	        &ST_UPDATE) == PJSIP_DIALOG_CAP_SUPPORTED &&
+    	    inv->sdp_done_early_rel)
+    	{
+    	    /* Yes, remote supports UPDATE and SDP negotiation was done
+    	     * using reliable provisional responses. We can proceed.
+    	     */
+    	} else {
+            call->reinv_pending = PJ_TRUE;
+            return PJ_EPENDING;
+        }
     }
 
     /* Check if ICE setup is complete and if it needs reinvite */

--- a/pjsip/src/test/inv_offer_answer_test.c
+++ b/pjsip/src/test/inv_offer_answer_test.c
@@ -650,6 +650,7 @@ static inv_test_param_t test_params[] =
     ACK	-->
 */
 #if 1
+#if !PJSIP_INV_UPDATE_EARLY_CHECK_RELIABLE
     {
 	"INVITE and UPDATE by UAC",
 	0,
@@ -658,9 +659,10 @@ static inv_test_param_t test_params[] =
 	{ OFFERER_UAC, OFFERER_UAC },
 	PJ_FALSE
     },
+#endif
     {
-	"INVITE and UPDATE by UAC, with Multipart",
-	0,
+	"INVITE and UPDATE by UAC, with Multipart, with 100rel",
+	PJSIP_INV_REQUIRE_100REL,
 	PJ_TRUE,
 	2,
 	{ OFFERER_UAC, OFFERER_UAC },
@@ -691,16 +693,17 @@ static inv_test_param_t test_params[] =
     ACK			-->
 
  */
+
     {
-	"INVITE and many UPDATE by UAC and UAS",
-	0,
+	"INVITE and many UPDATE by UAC and UAS, with 100rel",
+	PJSIP_INV_REQUIRE_100REL,
 	PJ_TRUE,
 	4,
 	{ OFFERER_UAC, OFFERER_UAS, OFFERER_UAC, OFFERER_UAS }
     },
     {
-	"INVITE and many UPDATE by UAC and UAS, with Multipart",
-	0,
+	"INVITE and many UPDATE by UAC and UAS, with Multipart, with 100rel",
+	PJSIP_INV_REQUIRE_100REL,
 	PJ_TRUE,
 	4,
 	{ OFFERER_UAC, OFFERER_UAS, OFFERER_UAC, OFFERER_UAS },


### PR DESCRIPTION
[RFC section 5.1](https://datatracker.ietf.org/doc/html/rfc3311#section-5.1) stipulates that UPDATE being sent during EARLY invite state needs to have completed SDP negotiation using reliable provisional response mechanism, such as:
```
If the UPDATE is being sent before completion of the initial
         INVITE transaction, and the initial INVITE contained an offer,
         the UPDATE can contain an offer if the callee generated an
         answer in a reliable provisional response, and the caller has
         received answers to any other offers it sent in either PRACK or
         UPDATE, and has generated answers for any offers it received in
         an UPDATE from the callee.
...
```
(the above is just a snippet, for a complete detail that includes other scenario, please refer to the RFC).

Currently PJSIP doesn't enforce this and since the behaviour has existed since the beginning of PJSIP and it doesn't seem to cause any adverse effect, we opt to provide a compile-time setting `PJSIP_INV_UPDATE_EARLY_CHECK_RELIABLE` to enforce the check as mandated by the RFC with the default currently set to 0 (false/disabled) to maintain backward compatibility.

Impact:
- Applications using the higher level PJSUA/PJSUA2 API will notice that UPDATE normally sent during EARLY state (for the purpose of codec locking or ICE update) may be delayed until provisional response is received, or until the INVITE is confirmed (this behaviour is not affected by the above compile-time setting). But there shouldn't be any negative effect to the functionality, and nothing needs to be done on the application side.
- Applications that call `Call::update()/pjsua_call_update()`, or apps that directly use PJSIP API and call `pjsip_inv_update()` are recommended to anticipate the potential error status returned by the function in the above scenario and handle it accordingly (such as by retrying the UPDATE at a later timing until provisional response is received or INVITE is confirmed).

The patch passed pjsip `inv_offer_answer` test for either setting values (enabled/disabled).
