### PR TITLE
Add API pjsip_evsub_get_expires()

### DIFF
--- a/pjsip/include/pjsip-simple/evsub.h
+++ b/pjsip/include/pjsip-simple/evsub.h
@@ -280,7 +280,8 @@ PJ_DECL(pj_status_t) pjsip_evsub_register_pkg( pjsip_module *pkg_mod,
  *
  * @return		The Allow-Events header.
  */
-PJ_DECL(const pjsip_hdr*) pjsip_evsub_get_allow_events_hdr(pjsip_module *m);
+PJ_DECL(const pjsip_hdr*) pjsip_evsub_get_allow_events_hdr(
+			      const pjsip_module *m);
 
 
 /**
@@ -341,7 +342,7 @@ PJ_DECL(pj_status_t) pjsip_evsub_terminate( pjsip_evsub *sub,
  *
  * @return		Subscription state.
  */
-PJ_DECL(pjsip_evsub_state) pjsip_evsub_get_state(pjsip_evsub *sub);
+PJ_DECL(pjsip_evsub_state) pjsip_evsub_get_state(const pjsip_evsub *sub);
 
 
 /**
@@ -351,7 +352,7 @@ PJ_DECL(pjsip_evsub_state) pjsip_evsub_get_state(pjsip_evsub *sub);
  *
  * @return		NULL terminated string.
  */
-PJ_DECL(const char*) pjsip_evsub_get_state_name(pjsip_evsub *sub);
+PJ_DECL(const char*) pjsip_evsub_get_state_name(const pjsip_evsub *sub);
 
 
 /**
@@ -362,7 +363,18 @@ PJ_DECL(const char*) pjsip_evsub_get_state_name(pjsip_evsub *sub);
  *
  * @return		NULL terminated string.
  */
-PJ_DECL(const pj_str_t*) pjsip_evsub_get_termination_reason(pjsip_evsub *sub);
+PJ_DECL(const pj_str_t*) pjsip_evsub_get_termination_reason(
+			     const pjsip_evsub *sub);
+
+
+/**
+ * Get subscription expiration time.
+ *
+ * @param sub		Event subscription instance.
+ *
+ * @return		Subscription expiration time, in seconds.
+ */
+PJ_DECL(pj_uint32_t) pjsip_evsub_get_expires(const pjsip_evsub *sub);
 
 
 /**
@@ -478,7 +490,7 @@ PJ_DECL(pj_status_t) pjsip_evsub_send_request( pjsip_evsub *sub,
  * @return		The event subscription instance registered in the
  *			transaction, if any.
  */
-PJ_DECL(pjsip_evsub*) pjsip_tsx_get_evsub(pjsip_transaction *tsx);
+PJ_DECL(pjsip_evsub*) pjsip_tsx_get_evsub(const pjsip_transaction *tsx);
 
 
 /**
@@ -500,7 +512,8 @@ PJ_DECL(void) pjsip_evsub_set_mod_data( pjsip_evsub *sub, unsigned mod_id,
  *
  * @return		Data previously set at the specified id.
  */
-PJ_DECL(void*) pjsip_evsub_get_mod_data( pjsip_evsub *sub, unsigned mod_id );
+PJ_DECL(void*) pjsip_evsub_get_mod_data( const pjsip_evsub *sub,
+					 unsigned mod_id );
 
 
 /**
@@ -528,6 +541,10 @@ PJ_DEF(pj_status_t) pjsip_evsub_dec_ref(pjsip_evsub *sub);
  * If there is an existing timer, it is cancelled before any
  * other action. A timeout of 0 is ignored except that any
  * existing timer is cancelled.
+ *
+ * The API is intended to be used to restore UAS' subscription
+ * timer from backup in the case of failure, and should not be
+ * used to modify an ongoing subscription's timeout.
  *
  * @param sub           The server subscription instance.
  * @param seconds       The new timeout.

--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -356,7 +356,7 @@ PJ_DEF(pjsip_module*) pjsip_evsub_instance(void)
 /*
  * Get the event subscription instance in the transaction.
  */
-PJ_DEF(pjsip_evsub*) pjsip_tsx_get_evsub(pjsip_transaction *tsx)
+PJ_DEF(pjsip_evsub*) pjsip_tsx_get_evsub(const pjsip_transaction *tsx)
 {
     return (pjsip_evsub*) tsx->mod_data[mod_evsub.mod.id];
 }
@@ -376,7 +376,8 @@ PJ_DEF(void) pjsip_evsub_set_mod_data( pjsip_evsub *sub, unsigned mod_id,
 /*
  * Get event subscription's module data.
  */
-PJ_DEF(void*) pjsip_evsub_get_mod_data( pjsip_evsub *sub, unsigned mod_id )
+PJ_DEF(void*) pjsip_evsub_get_mod_data( const pjsip_evsub *sub,
+					unsigned mod_id )
 {
     PJ_ASSERT_RETURN(mod_id < PJSIP_MAX_MODULE, NULL);
     return sub->mod_data[mod_id];
@@ -476,7 +477,8 @@ PJ_DEF(pj_status_t) pjsip_evsub_register_pkg( pjsip_module *pkg_mod,
 /*
  * Retrieve Allow-Events header
  */
-PJ_DEF(const pjsip_hdr*) pjsip_evsub_get_allow_events_hdr(pjsip_module *m)
+PJ_DEF(const pjsip_hdr*) pjsip_evsub_get_allow_events_hdr(
+			     const pjsip_module *m)
 {
     struct mod_evsub *mod;
 
@@ -1048,7 +1050,7 @@ PJ_DEF(pj_status_t) pjsip_evsub_terminate( pjsip_evsub *sub,
 /*
  * Get subscription state.
  */
-PJ_DEF(pjsip_evsub_state) pjsip_evsub_get_state(pjsip_evsub *sub)
+PJ_DEF(pjsip_evsub_state) pjsip_evsub_get_state(const pjsip_evsub *sub)
 {
     return sub->state;
 }
@@ -1056,7 +1058,7 @@ PJ_DEF(pjsip_evsub_state) pjsip_evsub_get_state(pjsip_evsub *sub)
 /*
  * Get state name.
  */
-PJ_DEF(const char*) pjsip_evsub_get_state_name(pjsip_evsub *sub)
+PJ_DEF(const char*) pjsip_evsub_get_state_name(const pjsip_evsub *sub)
 {
     return sub->state_str.ptr;
 }
@@ -1064,9 +1066,18 @@ PJ_DEF(const char*) pjsip_evsub_get_state_name(pjsip_evsub *sub)
 /*
  * Get termination reason.
  */
-PJ_DEF(const pj_str_t*) pjsip_evsub_get_termination_reason(pjsip_evsub *sub)
+PJ_DEF(const pj_str_t*) pjsip_evsub_get_termination_reason(
+			    const pjsip_evsub *sub)
 {
     return &sub->term_reason;
+}
+
+/**
+ * Get subscription expiration time.
+ */
+PJ_DEF(pj_uint32_t) pjsip_evsub_get_expires(const pjsip_evsub *sub)
+{
+    return sub->expires->ivalue;
 }
 
 /*


### PR DESCRIPTION
Add a new API `pjsip_evsub_get_expires()` to get the current subscription's expiration time.

Also in this PR:
- Add const to the evsub parameter of its getter functions. 
- Clarify the doc for the API `pjsip_evsub_set_uas_timeout()`, added in #1998, since the API was added to recreate incoming subscriptions from a persistent storage and not to modify an existing subscription's timeout, which it can't do since it won't notify the client of such modification (if we are to support this, we probably need to implement #3129). 
