### PR TITLE
Build SWIG python wrapper with multithreading support

### DIFF
--- a/pjsip-apps/src/swig/python/Makefile
+++ b/pjsip-apps/src/swig/python/Makefile
@@ -41,7 +41,7 @@ gcc.exe: cc_mingw.c
 	cp gcc.exe g++.exe
 
 pjsua2_wrap.cpp: ../pjsua2.i ../symbols.i Makefile $(SRCS)
-	swig $(SWIG_FLAGS) -python -o pjsua2_wrap.cpp ../pjsua2.i
+	swig $(SWIG_FLAGS) -python -threads -o pjsua2_wrap.cpp ../pjsua2.i
 
 clean distclean realclean:
 	rm -rf $(PYTHON_SO) pjsua2_wrap.cpp pjsua2_wrap.h pjsua2.py build *.pyc


### PR DESCRIPTION
Segmentation fault when trying to get an `AudioMediaPlayer.onEof2` callback:
```
Thread 4 "python" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff1e16700 (LWP 1524)]
PyErr_Restore (traceback=0x0, value=0x0, type=0x0) at Python/errors.c:42
42          oldtype = tstate->curexc_type;
(gdb) bt
#0  PyErr_Restore (traceback=0x0, value=0x0, type=0x0) at Python/errors.c:42
#1  PyErr_Clear () at Python/errors.c:356
#2  0x000055555564cb8d in PyDict_GetItem (op=op@entry=0x7ffff05fd5e8, key=key@entry=0x7ffff4ae77a0) at Objects/dictobject.c:1418
#3  0x0000555555657988 in _PyObject_GenericGetAttrWithDict (dict=0x7ffff05fd5e8, name=0x7ffff4ae77a0, obj=0x7ffff4b67828) at Objects/object.c:1126
#4  PyObject_GenericGetAttr (name=0x7ffff4ae77a0, obj=0x7ffff4b67828) at Objects/object.c:1158
#5  PyObject_GetAttr (v=0x7ffff4b67828, name=0x7ffff4ae77a0) at Objects/object.c:928
#6  0x000055555562d754 in PyObject_CallMethodObjArgs (callable=<optimized out>, name=<optimized out>) at Objects/abstract.c:2745
#7  0x00007ffff43877bd in SwigDirector_AudioMediaPlayer::onEof2 (this=0x5555562a7ce0) at pjsua2_wrap.cpp:2977
#8  0x00007ffff3d89b99 in file_on_event () from /usr/local/lib/libpjmedia.so.2
#9  0x00007ffff3d63fcb in event_mgr_distribute_events () from /usr/local/lib/libpjmedia.so.2
#10 0x00007ffff3d6403d in event_worker_thread () from /usr/local/lib/libpjmedia.so.2
#11 0x00007ffff3cf66be in thread_main () from /usr/local/lib/libpj.so.2
#12 0x00007ffff7f9b609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#13 0x00007ffff7d66163 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Disabling multithreading (https://github.com/pjsip/pjproject/blob/master/pjsip-apps/src/pygui/application.py#L88) does not solve the problem.

You need to force multithreading to be enabled: https://www.swig.org/Doc4.0/Python.html#Python_thread_UI