### PR TITLE
Random crash due to invoking SRTP APIs on custom media transport instance

### DIFF
--- a/pjmedia/include/pjmedia/transport.h
+++ b/pjmedia/include/pjmedia/transport.h
@@ -539,6 +539,11 @@ typedef struct pjmedia_transport_specific_info
      */
     char		     buffer[PJMEDIA_TRANSPORT_SPECIFIC_INFO_MAXSIZE];
 
+    /**
+     * The media transport instance.
+     */
+    pjmedia_transport	    *tp;
+
 } pjmedia_transport_specific_info;
 
 
@@ -714,6 +719,29 @@ PJ_INLINE(void*) pjmedia_transport_info_get_spc_info(
     for (i = 0; i < info->specific_info_cnt; ++i) {
 	if (info->spc_info[i].type == type)
 	    return (void*)info->spc_info[i].buffer;
+    }
+    return NULL;
+}
+
+
+/**
+ * Utility API to get the transport instance from the specified media
+ * transport info.
+ *
+ * @param info	    Media transport info.
+ * @param type	    Media transport type.
+ *
+ * @return	    The media transport instance, or NULL if
+ * 		    the transport type is not found.
+ */
+PJ_INLINE(pjmedia_transport*) pjmedia_transport_info_get_transport(
+						pjmedia_transport_info *info,
+						pjmedia_transport_type type)
+{
+    unsigned i;
+    for (i = 0; i < info->specific_info_cnt; ++i) {
+	if (info->spc_info[i].type == type)
+	    return info->spc_info[i].tp;
     }
     return NULL;
 }

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -2345,6 +2345,7 @@ static pj_status_t transport_get_info(pjmedia_transport *tp,
 	pj_assert(sizeof(*ii) <= sizeof(tsi->buffer));
 	tsi = &info->spc_info[info->specific_info_cnt++];
 	tsi->type = PJMEDIA_TRANSPORT_TYPE_ICE;
+	tsi->tp = tp;
 	tsi->cbsize = sizeof(*ii);
 
 	ii = (pjmedia_ice_transport_info*) tsi->buffer;

--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -1199,6 +1199,7 @@ static pj_status_t transport_get_info(pjmedia_transport *tp,
 
     spc_info_idx = info->specific_info_cnt++;
     info->spc_info[spc_info_idx].type = PJMEDIA_TRANSPORT_TYPE_SRTP;
+    info->spc_info[spc_info_idx].tp = tp;
     info->spc_info[spc_info_idx].cbsize = sizeof(srtp_info);
     pj_memcpy(&info->spc_info[spc_info_idx].buffer, &srtp_info,
 	      sizeof(srtp_info));

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3344,7 +3344,7 @@ static void check_srtp_roc(pjsua_call *call,
     srtp = pjmedia_transport_info_get_transport(&tpinfo,
 						PJMEDIA_TRANSPORT_TYPE_SRTP);
 
-    /* We are not using SRTP. */
+    /* Just return if there is no SRTP transport in the transport stack. */
     if (!srtp_info || !srtp)
     	return;
 

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3326,6 +3326,7 @@ static void check_srtp_roc(pjsua_call *call,
     pjsua_call_media *call_med = &call->media[med_idx];
     pjmedia_transport_info tpinfo;
     pjmedia_srtp_info *srtp_info;
+    pjmedia_transport *srtp;
     pjmedia_ice_transport_info *ice_info;
     const pjmedia_stream_info *prev_aud_si = NULL;
     pjmedia_stream_info aud_si;
@@ -3340,8 +3341,11 @@ static void check_srtp_roc(pjsua_call *call,
     pjmedia_transport_get_info(call_med->tp, &tpinfo);
     srtp_info = (pjmedia_srtp_info *) pjmedia_transport_info_get_spc_info(
 	            &tpinfo, PJMEDIA_TRANSPORT_TYPE_SRTP);
+    srtp = pjmedia_transport_info_get_transport(&tpinfo,
+						PJMEDIA_TRANSPORT_TYPE_SRTP);
+
     /* We are not using SRTP. */
-    if (!srtp_info)
+    if (!srtp_info || !srtp)
     	return;
 
     ice_info = (pjmedia_ice_transport_info*)
@@ -3469,7 +3473,7 @@ static void check_srtp_roc(pjsua_call *call,
 	 }	    
     }
 
-    pjmedia_transport_srtp_get_setting(call_med->tp, &setting);
+    pjmedia_transport_srtp_get_setting(srtp, &setting);
     setting.tx_roc = call_med->prev_srtp_info.tx_roc;
     setting.rx_roc = call_med->prev_srtp_info.rx_roc;
     if (local_change) {
@@ -3500,7 +3504,7 @@ static void check_srtp_roc(pjsua_call *call,
  	}
 #endif 
     }
-    pjmedia_transport_srtp_modify_setting(call_med->tp, &setting);
+    pjmedia_transport_srtp_modify_setting(srtp, &setting);
 }
 #endif
 


### PR DESCRIPTION
There were reports that `pjmedia_transport_srtp_get_setting()` inside `check_srtp_roc()` ([code](https://github.com/pjsip/pjproject/blob/8daf5a9216f846cd2a2866e48b17810915ba3c92/pjsip/src/pjsua-lib/pjsua_media.c#L3405) was added in #2846) is called on custom media transport instance instead of SRTP transport instance:
```
    pjmedia_transport_srtp_get_setting(call_med->tp, &setting);
```
When custom media transport is not used and SRTP is not disabled in compile-time, `call_med->tp` is normally an SRTP media transport, so the function call above is executed fine. But when custom media transport is used, it may introduce problems as there is no check whether the `call_med->tp` is really an SRTP instance.

Actually the `check_srtp_roc()` has a check whether SRTP is being used:
```
    srtp_info = (pjmedia_srtp_info *) pjmedia_transport_info_get_spc_info(
	            &tpinfo, PJMEDIA_TRANSPORT_TYPE_SRTP);
    /* We are not using SRTP. */
    if (!srtp_info)
    	return;
```
But when the custom media transport is stacked on top of the PJSUA-precreated SRTP+UDP/ICE transports (i.e: custom transport adapter -> SRTP -> ICE/UDP), it will pass the above check.

This PR will make sure that `pjmedia_transport_srtp_get_setting()` is called on SRTP transport. For this purpose, the media transport instance info is now added to media transport specific info structure.