### PR TITLE
Set thread display name

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -5714,6 +5714,10 @@ case $target in
 	printf "%s\n" "#define PJ_LINUX 1" >>confdefs.h
 
 	;;
+    *bsd*)
+	printf "%s\n" "#define PJ_BSD 1" >>confdefs.h
+
+	;;
     *rtems*)
 	printf "%s\n" "#define PJ_RTEMS 1" >>confdefs.h
 
@@ -5725,9 +5729,6 @@ case $target in
     *)
 	;;
 esac
-
-
-
 
 # Check whether --enable-floating-point was given.
 if test ${enable_floating_point+y}
@@ -10220,6 +10221,33 @@ case $target in
 
      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ** Setting non-blocking connect() retval to EINPROGRESS (please check)" >&5
 printf "%s\n" "** Setting non-blocking connect() retval to EINPROGRESS (please check)" >&6; }
+	;;
+esac
+
+
+case $target in
+  *linux* | *darwin* | *bsd*)
+	ac_fn_c_check_header_compile "$LINENO" "pthread_np.h" "ac_cv_header_pthread_np_h" "$ac_includes_default"
+if test "x$ac_cv_header_pthread_np_h" = xyes
+then :
+  printf "%s\n" "#define PJ_HAS_PTHREAD_NP_H 1" >>confdefs.h
+
+fi
+
+	ac_fn_c_check_func "$LINENO" "pthread_setname_np" "ac_cv_func_pthread_setname_np"
+if test "x$ac_cv_func_pthread_setname_np" = xyes
+then :
+  printf "%s\n" "#define PJ_HAS_PTHREAD_SETNAME_NP 1" >>confdefs.h
+
+fi
+
+	ac_fn_c_check_func "$LINENO" "pthread_set_name_np" "ac_cv_func_pthread_set_name_np"
+if test "x$ac_cv_func_pthread_set_name_np" = xyes
+then :
+  printf "%s\n" "#define PJ_HAS_PTHREAD_SET_NAME_NP 1" >>confdefs.h
+
+fi
+
 	;;
 esac
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -177,6 +177,9 @@ case $target in
     *linux*)
 	AC_DEFINE(PJ_LINUX,1)
 	;;
+    *bsd*)
+	AC_DEFINE(PJ_BSD,1)
+	;;
     *rtems*)
 	AC_DEFINE(PJ_RTEMS,1)
 	;;
@@ -186,9 +189,6 @@ case $target in
     *)
 	;;
 esac
-
-
-
 
 dnl # --disable-floating-point option
 AC_ARG_ENABLE(floating-point,
@@ -2479,6 +2479,20 @@ case $target in
 	;;
   *) AC_DEFINE(PJ_BLOCKING_CONNECT_ERROR_VAL,EINPROGRESS)
      AC_MSG_RESULT([** Setting non-blocking connect() retval to EINPROGRESS (please check)])
+	;;
+esac
+
+dnl
+dnl # Find set thread display name function
+dnl #   pthread_setname_np() in pthread.h on linux/darwin
+dnl #   pthread_setname_np()/pthread_set_name_np() in pthread_np.h on bsd
+dnl
+
+case $target in
+  *linux* | *darwin* | *bsd*)
+	AC_CHECK_HEADER(pthread_np.h,[AC_DEFINE(PJ_HAS_PTHREAD_NP_H,1)])
+	AC_CHECK_FUNC(pthread_setname_np,[AC_DEFINE(PJ_HAS_PTHREAD_SETNAME_NP,1)])
+	AC_CHECK_FUNC(pthread_set_name_np,[AC_DEFINE(PJ_HAS_PTHREAD_SET_NAME_NP,1)])
 	;;
 esac
 

--- a/pjlib/include/pj/compat/os_auto.h.in
+++ b/pjlib/include/pj/compat/os_auto.h.in
@@ -36,6 +36,7 @@
 #undef WIN32_LEAN_AND_MEAN
 #undef PJ_DARWINOS
 #undef PJ_LINUX
+#undef PJ_BSD
 #undef PJ_RTEMS
 #undef PJ_SUNOS
 #undef PJ_ANDROID
@@ -225,6 +226,13 @@
 #ifndef PJ_SSL_SOCK_IMP
 #undef PJ_SSL_SOCK_IMP
 #endif
+
+/* Has pthread_np.h ? */
+#undef PJ_HAS_PTHREAD_NP_H
+/* Has pthread_setname_np() ? */
+#undef PJ_HAS_PTHREAD_SETNAME_NP
+/* Has pthread_set_name_np() ? */
+#undef PJ_HAS_PTHREAD_SET_NAME_NP
 
 
 #endif	/* __PJ_COMPAT_OS_AUTO_H__ */

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -47,6 +47,10 @@
 #include <errno.h>	    // errno
 
 #include <pthread.h>
+#if defined(PJ_HAS_PTHREAD_NP_H) && PJ_HAS_PTHREAD_NP_H != 0
+#  include <pthread_np.h>
+#endif
+#include <pj/config.h>
 
 #define THIS_FILE   "os_core_unix.c"
 
@@ -616,6 +620,37 @@ pj_status_t pj_thread_init(void)
 }
 
 #if PJ_HAS_THREADS
+
+/*
+ * Set current thread display name
+ * This can be useful for debugging, as the name is displayed in the thread status
+ */
+static void set_thread_display_name(const char *name)
+{
+#if (defined(PJ_LINUX) && PJ_LINUX != 0) ||                                    \
+    (defined(PJ_ANDROID) && PJ_ANDROID != 0)
+    char xname[16];
+    // On linux, thread display name length is restricted to 16 (include '\0')
+    if (pj_ansi_strlen(name) >= 16) {
+	pj_ansi_snprintf(xname, 16, "%s", name);
+	name = xname;
+    }
+#endif
+
+#if defined(PJ_HAS_PTHREAD_SETNAME_NP) && PJ_HAS_PTHREAD_SETNAME_NP != 0
+#   if defined(PJ_DARWINOS) && PJ_DARWINOS != 0
+    pthread_setname_np(name);
+#   else
+    pthread_setname_np(pthread_self(), name);
+#   endif
+#elif defined(PJ_HAS_PTHREAD_SET_NAME_NP) && PJ_HAS_PTHREAD_SET_NAME_NP != 0
+    pthread_set_name_np(pthread_self(), name);
+#else
+#   warning "OS not support set thread display name"
+    PJ_UNUSED_ARG(name);
+#endif
+}
+
 /*
  * thread_main()
  *
@@ -644,6 +679,8 @@ static void *thread_main(void *param)
     }
 
     PJ_LOG(6,(rec->obj_name, "Thread started"));
+
+    set_thread_display_name(rec->obj_name);
 
     /* Call user's entry! */
     result = (void*)(long)(*rec->proc)(rec->arg);


### PR DESCRIPTION
This is an enhancement
when  pj_thread_create()  to setup  thread_name, also should set  thread display name
So that we can  see thread name use top command on linux/freebsd: 
```
top -H -p pid
```
also gdb debug cmd:
```
like this:
(gdb) info threads
  Id   Target Id         Frame 
  3   Thread 0x7ffff1521700 (LWP 24614) "worker_2" 0x00007ffff73e6
  2   Thread 0x7ffff1d22700 (LWP 24613) "worker_1" 0x00007ffff73e5
  1   Thread 0x7ffff2523700 (LWP 24612) "main" 0x00007ffff73e5eb3
```

win32 platform also supported now.

This is very useful for debugging.

#3157 