### PR TITLE
Update VAD docs/help

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -147,8 +147,8 @@ static void usage(void)
     puts  ("  --auto-rec          Automatically record conversation");
     puts  ("  --quality=N         Specify media quality (0-10, default="
     				  xstr(PJSUA_DEFAULT_CODEC_QUALITY) ")");
-    puts  ("  --ptime=MSEC        Override codec ptime to MSEC (default=specific)");
-    puts  ("  --no-vad            Disable VAD/silence detector (default=specific)");
+    puts  ("  --ptime=MSEC        Override codec ptime to MSEC (default=codec specific)");
+    puts  ("  --no-vad            Disable VAD/silence detector (default=codec specific)");
     puts  ("  --ec-tail=MSEC      Set echo canceller tail length (default="
 	   			  xstr(PJSUA_DEFAULT_EC_TAIL_LEN) ")");
     puts  ("  --ec-opt=OPT        Select echo canceller algorithm (0=default, ");

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -148,7 +148,7 @@ static void usage(void)
     puts  ("  --quality=N         Specify media quality (0-10, default="
     				  xstr(PJSUA_DEFAULT_CODEC_QUALITY) ")");
     puts  ("  --ptime=MSEC        Override codec ptime to MSEC (default=specific)");
-    puts  ("  --no-vad            Disable VAD/silence detector (default=vad enabled)");
+    puts  ("  --no-vad            Disable VAD/silence detector (default=specific)");
     puts  ("  --ec-tail=MSEC      Set echo canceller tail length (default="
 	   			  xstr(PJSUA_DEFAULT_EC_TAIL_LEN) ")");
     puts  ("  --ec-opt=OPT        Select echo canceller algorithm (0=default, ");

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6787,7 +6787,7 @@ struct pjsua_media_config
     /**
      * Disable VAD?
      *
-     * Default: 0 (no (meaning VAD is enabled))
+     * Default: 0 (codec specific)
      */
     pj_bool_t		no_vad;
 

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -923,7 +923,7 @@ public:
     /**
      * Disable VAD?
      *
-     * Default: 0 (no (meaning VAD is enabled))
+     * Default: 0 (codec specific)
      */
     bool		noVad;
 


### PR DESCRIPTION
The pjsua app help & PJSUA/PJSUA2 docs assume that VAD is always enabled for all codecs by default, while actually some codecs (e.g: Opus & SILK) have VAD disabled by default.

Thank you Liviu Andron for the report.