### PR TITLE
Perform async rendering in the main thread on Mac & iOS

### DIFF
--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -148,6 +148,9 @@ struct darwin_stream
     AVCaptureVideoPreviewLayer  *prev_layer;
     
 #if TARGET_OS_IPHONE
+    pj_bool_t		 is_running;
+    pj_bool_t		 is_rendering;
+    NSLock		*render_lock;
     void		*render_buf;
     pj_size_t		 render_buf_size;
     CGDataProviderRef    render_data_provider;
@@ -512,9 +515,11 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
 @implementation VOutDelegate
 #if TARGET_OS_IPHONE
 - (void)update_image
-{    
+{
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    [stream->render_lock lock];
+
     CGImageRef cgIm = CGImageCreate(stream->size.w, stream->size.h,
                                     8, 32, stream->bytes_per_row, colorSpace,
                                     kCGImageAlphaFirst |
@@ -524,10 +529,20 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
     CGColorSpaceRelease(colorSpace);
     
     stream->render_view.layer.contents = (__bridge id)(cgIm);
+    [stream->render_lock unlock];
     CGImageRelease(cgIm);
 
     [pool release];
+    stream->is_rendering = PJ_FALSE;
 }
+
+- (void)finish_render
+{
+    /* Do nothing. This function is serialized in the main thread, so when
+     * it is called, we can be sure that update_image() has completed.
+     */
+}
+
 #endif
 
 - (void)session_runtime_error:(NSNotification *)notification
@@ -962,6 +977,7 @@ static pj_status_t darwin_factory_create_stream(
 	    strm->vout_delegate->stream = strm;
 	}
         
+	strm->render_lock = [NSLock alloc];
 	strm->render_buf = pj_pool_alloc(pool, strm->frame_size);
 	strm->render_buf_size = strm->frame_size;
         strm->render_data_provider = CGDataProviderCreateWithData(NULL,
@@ -1311,14 +1327,14 @@ static pj_status_t darwin_stream_start(pjmedia_vid_dev_stream *strm)
 {
     struct darwin_stream *stream = (struct darwin_stream*)strm;
 
-    PJ_UNUSED_ARG(stream);
-
     PJ_LOG(4, (THIS_FILE, "Starting Darwin video stream"));
 
+    stream->is_running = PJ_TRUE;
+
     if (stream->cap_session) {
-        dispatch_sync_on_main_queue(^{
-            [stream->cap_session startRunning];
-        });
+        [stream->cap_session
+            performSelectorOnMainThread:@selector(startRunning)
+            withObject:nil waitUntilDone:YES];
     
 	if (![stream->cap_session isRunning]) {
 	    /* More info about the error should be reported in
@@ -1346,16 +1362,25 @@ static pj_status_t darwin_stream_put_frame(pjmedia_vid_dev_stream *strm,
      */
     if (frame->size==0 || frame->buf==NULL)
 	return PJ_SUCCESS;
-	
+
+    if (!stream->is_running)
+	return PJ_EINVALIDOP;
+    
+    /* Prevent more than one async rendering task. */
+    if (stream->is_rendering)
+    	return PJ_EIGNORED;
+
+    [stream->render_lock lock];
     if (stream->frame_size >= frame->size)
         pj_memcpy(stream->render_buf, frame->buf, frame->size);
     else
         pj_memcpy(stream->render_buf, frame->buf, stream->frame_size);
+    [stream->render_lock lock];
     
-    /* Perform video display in a background thread */
-    dispatch_sync_on_main_queue(^{
-        [stream->vout_delegate update_image];
-    });
+    /* Perform video display in the main thread */
+    stream->is_rendering = PJ_TRUE;
+    [stream->vout_delegate performSelectorOnMainThread:@selector(update_image)
+                           withObject:nil waitUntilDone:NO];
 #endif
 
     return PJ_SUCCESS;
@@ -1371,10 +1396,16 @@ static pj_status_t darwin_stream_stop(pjmedia_vid_dev_stream *strm)
     
     PJ_LOG(4, (THIS_FILE, "Stopping Darwin video stream"));
 
-    dispatch_sync_on_main_queue(^{
-        [stream->cap_session stopRunning];
-    });
+    [stream->cap_session performSelectorOnMainThread:@selector(stopRunning)
+                         withObject:nil waitUntilDone:YES];
     stream->has_image = PJ_FALSE;
+    stream->is_running = PJ_FALSE;
+
+#if TARGET_OS_IPHONE
+    /* Wait until the rendering finishes */
+    [stream->vout_delegate performSelectorOnMainThread:@selector(finish_render)
+                           withObject:nil waitUntilDone:YES];
+#endif
     
     return PJ_SUCCESS;
 }
@@ -1411,26 +1442,30 @@ static pj_status_t darwin_stream_destroy(pjmedia_vid_dev_stream *strm)
 
 #if TARGET_OS_IPHONE
     if (stream->prev_layer) {
-        CALayer *prev_layer = stream->prev_layer;
-        dispatch_sync_on_main_queue(^{
-            [prev_layer removeFromSuperlayer];
-            [prev_layer release];
-        });
+    	[stream->prev_layer
+    	    performSelectorOnMainThread:@selector(removeFromSuperlayer)
+            withObject:nil waitUntilDone:YES];
+        [stream->prev_layer release];
         stream->prev_layer = nil;
     }
     
     if (stream->render_view) {
-        UIView *view = stream->render_view;
-        dispatch_sync_on_main_queue(^{
-            [view removeFromSuperview];
-            [view release];
-        });
+    	[stream->render_view
+    	    performSelectorOnMainThread:@selector(removeFromSuperview)
+            withObject:nil waitUntilDone:YES];
+
+        [stream->render_view release];
         stream->render_view = nil;
     }
     
     if (stream->render_data_provider) {
         CGDataProviderRelease(stream->render_data_provider);
         stream->render_data_provider = nil;
+    }
+    
+    if (stream->render_lock) {
+    	[stream->render_lock release];
+    	stream->render_lock = nil;
     }
 #endif /* TARGET_OS_IPHONE */
 

--- a/pjsip-apps/src/pjsua/ios/ipjsua.xcodeproj/xcshareddata/xcschemes/ipjsua.xcscheme
+++ b/pjsip-apps/src/pjsua/ios/ipjsua.xcodeproj/xcshareddata/xcschemes/ipjsua.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Currently, worker thread will dispatch the rendering task synchronously to the main thread (while holding vid conf mutex lock), i.e.:
```
3   Foundation -[NSObject(NSThreadPerformAdditions) performSelector:onThread:withObject:waitUntilDone:modes:] + 784 (NSThread.m:1266)
4   Foundation -[NSObject(NSThreadPerformAdditions) performSelectorOnMainThread:withObject:waitUntilDone:] + 136 (NSThread.m:1284)
5   ios_sdk    iosgl_stream_put_frame + 2730932 (ios_opengl_dev.m:488)
6   ios_sdk    pjmedia_vid_dev_stream_put_frame + 2661692 (videodev.c:684)
7   ios_sdk    vid_pasv_port_put_frame + 2583192 (vid_port.c:1349)
8   ios_sdk    pjmedia_port_put_frame + 2398176 (port.c:117)
9   ios_sdk    on_clock_tick + 2611880 (vid_conf.c:803)
```
So if the main thread is trying to acquire vid conf mutex lock, such as by calling `pjsua_call_hangup()` or calling `pjsua_vid_conf_*()` APIs, a deadlock can occur.

The proposed solution in this PR is to perform the rendering asynchronously. A few notes:
- The renderer now requires its own frame buffer. Since the rendering is now async, the frame buffer (which was owned by the vid port) may have already changed, or in the process of being changed, when the rendering actually happens. Without its own frame buffer, the async rendering will cause flickers and artefacts.
- For efficiency, the async rendering task posted is limited to one. Since we only have one buffer, it's useless to post more than one tasks to draw the same buffer.
- In some places, `dispatch_sync()` is replaced by `performSelectorOnMainThread()`. According to the [doc](https://developer.apple.com/documentation/objectivec/nsobject/1414900-performselectoronmainthread), `performSelectorOnMainThread()` queues the message on the run loop of the main thread and then later dequeues the message and invokes the desired method (And multiple calls to this method from the same thread cause the corresponding selectors to be queued and performed in the same same order in which the calls were made.). While for `dispatch_sync()`, the [doc](https://developer.apple.com/documentation/dispatch/1452870-dispatch_sync) states that as a performance optimization, the function can execute blocks on the current thread whenever possible. So here we use the method queuing property of `performSelectorOnMainThread()` to make sure that the async rendering has completed when stopping the renderer.
