### PR TITLE
Assertion due to bad rtpmap attribute generated by pjmedia_endpt_create_audio_sdp()

### DIFF
--- a/pjmedia/include/pjmedia/sdp.h
+++ b/pjmedia/include/pjmedia/sdp.h
@@ -246,7 +246,8 @@ PJ_DECL(pj_status_t) pjmedia_sdp_attr_to_rtpmap(pj_pool_t *pool,
  * Get the rtpmap representation of the same SDP attribute.
  *
  * @param attr		Generic attribute to be converted to rtpmap, which
- *			name must be "rtpmap".
+ *			name must be "rtpmap". Attribute value must be
+ *			terminated with a NULL, '\r', or '\n' character.
  * @param rtpmap	SDP \a rtpmap attribute to be initialized.
  *
  * @return		PJ_SUCCESS if the attribute can be successfully

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -699,7 +699,8 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
 	    attr->name = pj_str("rtpmap");
 	    pj_ansi_snprintf(buf, sizeof(buf), "%d telephone-event/%d",
 			     pt, televent_clockrates[i]);
-	    attr->value = pj_strdup3(pool, buf);
+	    /* Must be NULL terminated for pjmedia_sdp_attr_get_rtpmap() */
+	    pj_strdup2_with_null(pool, &attr->value, buf);
 	    m->attr[m->attr_count++] = attr;
 
 	    /* Add fmtp */


### PR DESCRIPTION
The function `pjmedia_sdp_attr_get_rtpmap()` checks for string termination by `null` byte, `\r`, or `\n`, and it asserts if the string is not properly terminated. However, `pjmedia_endpt_create_audio_sdp()` creates an unterminated telephone-event rtpmap attribute, which leads to an assert on some platforms.

Fix it by using an appropriate string duplication function that adds a string terminator.

Thanks to Justin Maggard for the patch.