### PR TITLE
win32 unicode: prevent buffer overflow when using FormatMessage()

### DIFF
--- a/pjlib/src/pj/os_error_win32.c
+++ b/pjlib/src/pj/os_error_win32.c
@@ -181,7 +181,7 @@ int platform_strerror( pj_os_err_type os_errcode,
 			     os_errcode,
 			     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
 			     wbuf,
-			     sizeof(wbuf),
+			     PJ_ARRAY_SIZE(wbuf),
 			     NULL);
 	if (len) {
 	    pj_unicode_to_ansi(wbuf, len, buf, bufsize);


### PR DESCRIPTION
The Unicode variant expects the number of characters that can be put in the output buffer supplied by the user
and not the size in bytes.
See: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagew

I found this by accident as I was scrolling through the code, the editor would underline the call to FormatMessage()
and the tooltip informed me about the possible overflow.
I didn't see any warning when I compiled the unit...