### PR TITLE
Add ioqueue wakeup mechanism

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -6220,6 +6220,32 @@ printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if socketpair() is available" >&5
+printf %s "checking if socketpair() is available... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <sys/types.h>
+				     #include <sys/socket.h>
+int
+main (void)
+{
+socketpair(0, 0, 0, 0);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  printf "%s\n" "#define PJ_SOCK_HAS_SOCKETPAIR 1" >>confdefs.h
+
+		   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if sockaddr_in has sin_len member" >&5
 printf %s "checking if sockaddr_in has sin_len member... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -344,6 +344,15 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
 		   AC_MSG_RESULT(yes)],
 		  [AC_MSG_RESULT(no)])
 
+dnl # Determine if socketpair() is available
+AC_MSG_CHECKING([if socketpair() is available])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+				     #include <sys/socket.h>]],
+		    		  [socketpair(0, 0, 0, 0);])],
+		  [AC_DEFINE(PJ_SOCK_HAS_SOCKETPAIR,1)
+		   AC_MSG_RESULT(yes)],
+		  [AC_MSG_RESULT(no)])
+
 dnl # Determine if sockaddr_in has sin_len member
 AC_MSG_CHECKING([if sockaddr_in has sin_len member])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>

--- a/pjlib/include/pj/compat/os_auto.h.in
+++ b/pjlib/include/pj/compat/os_auto.h.in
@@ -91,6 +91,7 @@
 #undef PJ_SOCK_HAS_INET_PTON
 #undef PJ_SOCK_HAS_INET_NTOP
 #undef PJ_SOCK_HAS_GETADDRINFO
+#undef PJ_SOCK_HAS_SOCKETPAIR
 
 /* On these OSes, semaphore feature depends on semaphore.h */
 #if defined(PJ_HAS_SEMAPHORE_H) && PJ_HAS_SEMAPHORE_H!=0

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -682,6 +682,15 @@
 #   define PJ_IOQUEUE_MAX_HANDLES	(64)
 #endif
 
+/**
+ * Enable ioqueue wakeup mechanism
+ *
+ * Default: 0
+ */
+
+#ifndef PJ_IOQUEUE_HAS_WAKEUP
+#   define PJ_IOQUEUE_HAS_WAKEUP 	0
+#endif
 
 /**
  * If PJ_IOQUEUE_HAS_SAFE_UNREG macro is defined, then ioqueue will do more

--- a/pjlib/include/pj/ioqueue.h
+++ b/pjlib/include/pj/ioqueue.h
@@ -362,6 +362,17 @@ PJ_DECL(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
  */
 PJ_DECL(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioque );
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+/**
+ * Wakeup the I/O queue.
+ *
+ * @param ioque	        The I/O Queue to be wakeuped
+ *
+ * @return              PJ_SUCCESS if success.
+ */
+PJ_DECL(pj_status_t) pj_ioqueue_wakeup( pj_ioqueue_t *ioque );
+#endif
+
 /**
  * Set the lock object to be used by the I/O Queue. This function can only
  * be called right after the I/O queue is created, before any handle is

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -1527,6 +1527,25 @@ PJ_DECL(pj_status_t) pj_sock_shutdown( pj_sock_t sockfd,
 PJ_DECL(char *) pj_addr_str_print( const pj_str_t *host_str, int port, 
 				   char *buf, int size, unsigned flag);
 
+/**
+ * Create socket pair
+ * @param family    Specifies a communication domain; this selects the
+ *		    protocol family which will be used for communication.
+ * @param type	    The socket has the indicated type, which specifies the 
+ *		    communication semantics.
+ * @param protocol  Specifies  a  particular  protocol  to  be used with the
+ *		    socket.  Normally only a single protocol exists to support 
+ *		    a particular socket  type  within  a given protocol family, 
+ *		    in which a case protocol can be specified as 0.
+ * @param sv	    The new sockets vector
+ *
+ * @return	    Zero on success.
+ *
+ */
+PJ_DECL(pj_status_t) pj_sock_socketpair(int family,
+				    int type,
+				    int protocol,
+				    pj_sock_t sv[2]);
 
 /**
  * @}

--- a/pjlib/include/pj/timer.h
+++ b/pjlib/include/pj/timer.h
@@ -183,6 +183,16 @@ PJ_DECL(pj_status_t) pj_timer_heap_create( pj_pool_t *pool,
  */
 PJ_DECL(void) pj_timer_heap_destroy( pj_timer_heap_t *ht );
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+/**
+ * Bind the timer heap to an ioqueue
+ *
+ * @param ht        The timer heap.
+ * @param ioq       The ioqueue to bind.
+ *
+ */
+PJ_DECL(void) pj_timer_heap_bind(pj_timer_heap_t *ht, pj_ioqueue_t *ioq);
+#endif
 
 /**
  * Set lock object to be used by the timer heap. By default, the timer heap

--- a/pjlib/src/pj/config.c
+++ b/pjlib/src/pj/config.c
@@ -74,6 +74,7 @@ PJ_DEF(void) pj_dump_config(void)
     PJ_LOG(3, (id, " ioqueue type              : %s", pj_ioqueue_name()));
     PJ_LOG(3, (id, " PJ_IOQUEUE_MAX_HANDLES    : %d", PJ_IOQUEUE_MAX_HANDLES));
     PJ_LOG(3, (id, " PJ_IOQUEUE_HAS_SAFE_UNREG : %d", PJ_IOQUEUE_HAS_SAFE_UNREG));
+    PJ_LOG(3, (id, " PJ_IOQUEUE_HAS_WAKEUP     : %d", PJ_IOQUEUE_HAS_WAKEUP));
     PJ_LOG(3, (id, " PJ_HAS_THREADS            : %d", PJ_HAS_THREADS));
     PJ_LOG(3, (id, " PJ_LOG_USE_STACK_BUFFER   : %d", PJ_LOG_USE_STACK_BUFFER));
     PJ_LOG(3, (id, " PJ_HAS_SEMAPHORE          : %d", PJ_HAS_SEMAPHORE));

--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -29,16 +29,31 @@
  */
 
 #define PENDING_RETRY	2
+#include "ioqueue_common_wakeup.c"
 
-static void ioqueue_init( pj_ioqueue_t *ioqueue )
+static void ioqueue_init( pj_ioqueue_t *ioqueue, pj_pool_t *pool)
 {
+    ioqueue->pool = pool;
     ioqueue->lock = NULL;
     ioqueue->auto_delete_lock = 0;
     ioqueue->default_concurrency = PJ_IOQUEUE_DEFAULT_ALLOW_CONCURRENCY;
 }
 
+static void ioqueue_init_done( pj_ioqueue_t *ioqueue)
+{
+#if PJ_IOQUEUE_HAS_WAKEUP
+    /* wakeup init */
+    ioqueue_wakeup_init(ioqueue);
+#endif
+}
+
 static pj_status_t ioqueue_destroy(pj_ioqueue_t *ioqueue)
 {
+#if PJ_IOQUEUE_HAS_WAKEUP
+    /* wakeup deinit */
+    ioqueue_wakeup_deinit(ioqueue);
+#endif
+
     if (ioqueue->auto_delete_lock && ioqueue->lock ) {
 	pj_lock_release(ioqueue->lock);
         return pj_lock_destroy(ioqueue->lock);

--- a/pjlib/src/pj/ioqueue_common_abs.h
+++ b/pjlib/src/pj/ioqueue_common_abs.h
@@ -117,10 +117,21 @@ union operation_key
     UNREG_FIELDS
 
 
-#define DECLARE_COMMON_IOQUEUE                      \
+#if PJ_IOQUEUE_HAS_WAKEUP
+#   define DECLARE_COMMON_IOQUEUE                   \
+    pj_sock_t          wakeup_fd[2];                \
+    char               wakeup_buf[8];               \
+    pj_pool_t          *pool;                       \
     pj_lock_t          *lock;                       \
     pj_bool_t           auto_delete_lock;	    \
     pj_bool_t		default_concurrency;
+#else
+#   define DECLARE_COMMON_IOQUEUE                   \
+    pj_pool_t          *pool;                       \
+    pj_lock_t          *lock;                       \
+    pj_bool_t           auto_delete_lock;	    \
+    pj_bool_t		default_concurrency;
+#endif
 
 
 enum ioqueue_event_type

--- a/pjlib/src/pj/ioqueue_common_wakeup.c
+++ b/pjlib/src/pj/ioqueue_common_wakeup.c
@@ -1,0 +1,130 @@
+/* 
+ * Copyright (C) 2022 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+ */
+
+/*
+ * ioqueue_common_wakeup.c
+ *
+ * This contains common functionalities to implement the feature wakeup
+ * mechanisms
+ *
+ * This file will be included by the appropriate ioqueue implementation.
+ * This file is NOT supposed to be compiled as stand-alone source.
+ */
+
+#if PJ_IOQUEUE_HAS_WAKEUP
+#if 0
+#define TRACE_WAKEUP(expr) PJ_LOG(3, expr)
+#else
+#define TRACE_WAKEUP(expr)
+#endif
+
+static void wakeup_on_read_complete(pj_ioqueue_key_t *key,
+				    pj_ioqueue_op_key_t *op_key,
+				    pj_ssize_t bytes_read)
+{
+    pj_status_t status;
+    pj_ioqueue_t *ioqueue = (pj_ioqueue_t *)pj_ioqueue_get_user_data(key);
+
+    if (bytes_read > 0) {
+	TRACE_WAKEUP((THIS_FILE, "ioqueue:%p, hanle wakeup event", ioqueue));
+    } else if (bytes_read != -PJ_EPENDING &&
+	       bytes_read != -PJ_STATUS_FROM_OS(PJ_BLOCKING_ERROR_VAL)) {
+	return;
+    }
+    bytes_read = sizeof(ioqueue->wakeup_buf);
+    pj_ioqueue_recv(key, op_key, ioqueue->wakeup_buf, &bytes_read,
+		    PJ_IOQUEUE_ALWAYS_ASYNC);
+}
+
+static pj_status_t ioqueue_wakeup_init(pj_ioqueue_t *ioqueue)
+{
+    pj_status_t rc;
+    pj_pool_t *pool = ioqueue->pool;
+    pj_ioqueue_callback cb;
+    pj_ioqueue_key_t *read_key;
+    pj_ioqueue_op_key_t *read_op;
+    char errmsg[PJ_ERR_MSG_SIZE];
+
+    TRACE_WAKEUP((THIS_FILE, "ioqueue:%p, wakeup init", ioqueue));
+
+    /* create socket pair */
+    rc = pj_sock_socketpair(pj_AF_UNIX(), pj_SOCK_DGRAM(), 0,
+			    ioqueue->wakeup_fd);
+    if (rc != PJ_SUCCESS) {
+	pj_strerror(rc, errmsg, sizeof(errmsg));
+	PJ_LOG(1, (THIS_FILE, "wakeup init, socketpair: %s(%d)", errmsg, rc));
+	ioqueue->wakeup_fd[0] = ioqueue->wakeup_fd[1] = PJ_INVALID_SOCKET;
+	return rc;
+    }
+
+    /* Add read fd: wakeup_fd[0] to ioqueue */
+    pj_bzero(&cb, sizeof(cb));
+    cb.on_read_complete = wakeup_on_read_complete;
+    rc = pj_ioqueue_register_sock(pool, ioqueue, ioqueue->wakeup_fd[0], ioqueue,
+				  &cb, &read_key);
+    if (rc != PJ_SUCCESS) {
+	pj_strerror(rc, errmsg, sizeof(errmsg));
+	PJ_LOG(1, (THIS_FILE, "wakeup init, register: %s(%d)", errmsg, rc));
+	pj_sock_close(ioqueue->wakeup_fd[0]);
+	pj_sock_close(ioqueue->wakeup_fd[1]);
+	ioqueue->wakeup_fd[0] = ioqueue->wakeup_fd[1] = PJ_INVALID_SOCKET;
+	return rc;
+    }
+
+    /* start read */
+    read_op = PJ_POOL_ZALLOC_T(pool, pj_ioqueue_op_key_t);
+    wakeup_on_read_complete(read_key, read_op, -PJ_EPENDING);
+
+    return PJ_SUCCESS;
+}
+
+static void ioqueue_wakeup_deinit(pj_ioqueue_t *ioqueue)
+{
+    TRACE_WAKEUP((THIS_FILE, "ioqueue:%p, wakeup deinit", ioqueue));
+    if (ioqueue->wakeup_fd[0] != PJ_INVALID_SOCKET) {
+	pj_sock_close(ioqueue->wakeup_fd[0]);
+	ioqueue->wakeup_fd[0] = PJ_INVALID_SOCKET;
+    }
+
+    if (ioqueue->wakeup_fd[1] != PJ_INVALID_SOCKET) {
+	pj_sock_close(ioqueue->wakeup_fd[1]);
+	ioqueue->wakeup_fd[1] = PJ_INVALID_SOCKET;
+    }
+}
+
+static pj_status_t ioqueue_wakeup_notify(pj_ioqueue_t *ioqueue)
+{
+    pj_ssize_t len = 1;
+    PJ_ASSERT_RETURN(ioqueue->wakeup_fd[1] != PJ_INVALID_SOCKET, PJ_EINVALIDOP);
+    if (ioqueue->wakeup_fd[1] == PJ_INVALID_SOCKET)
+	return PJ_EINVALIDOP;
+
+    TRACE_WAKEUP((THIS_FILE, "ioqueue:%p, send wakeup event", ioqueue));
+    return pj_sock_send(ioqueue->wakeup_fd[1], "1", &len, 0);
+}
+
+/*
+ * pj_ioqueue_wakeup()
+ *
+ * Wakeup ioqueue.
+ */
+PJ_DEF(pj_status_t) pj_ioqueue_wakeup(pj_ioqueue_t *ioqueue)
+{
+    return ioqueue_wakeup_notify(ioqueue);
+}
+#endif

--- a/pjlib/src/pj/ioqueue_common_wakeup.c
+++ b/pjlib/src/pj/ioqueue_common_wakeup.c
@@ -37,7 +37,6 @@ static void wakeup_on_read_complete(pj_ioqueue_key_t *key,
 				    pj_ioqueue_op_key_t *op_key,
 				    pj_ssize_t bytes_read)
 {
-    pj_status_t status;
     pj_ioqueue_t *ioqueue = (pj_ioqueue_t *)pj_ioqueue_get_user_data(key);
 
     if (bytes_read > 0) {

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -228,7 +228,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 
     ioqueue = pj_pool_alloc(pool, sizeof(pj_ioqueue_t));
 
-    ioqueue_init(ioqueue);
+    ioqueue_init(ioqueue, pool);
 
     ioqueue->max = max_fd;
     ioqueue->count = 0;
@@ -299,6 +299,9 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
     detect_epoll_exclusive_oneshot(ioqueue);
 
     PJ_LOG(4, ("pjlib", "%s I/O Queue created (%p)", pj_ioqueue_name(), ioqueue));
+
+    /* Do some stuffs after ioqueue init */
+    ioqueue_init_done(ioqueue);
 
     *p_ioqueue = ioqueue;
     return PJ_SUCCESS;

--- a/pjlib/src/pj/ioqueue_kqueue.c
+++ b/pjlib/src/pj/ioqueue_kqueue.c
@@ -570,11 +570,11 @@ PJ_DEF(int) pj_ioqueue_poll(pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 
     if (timeout) {
 	xtimeout.tv_sec = timeout->sec;
-	xtimeout.tv_nsec = timeout->msec * 1000;
+	xtimeout.tv_nsec = timeout->msec * 1000000;
     }
 
     TRACE_((THIS_FILE, "start kqueue wait, msec=%d",
-	    xtimeout.tv_sec * 1000 + xtimeout.tv_nsec / 1000));
+	    xtimeout.tv_sec * 1000 + xtimeout.tv_nsec / 1000000));
     count =
 	os_kqueue_wait(ioqueue->kfd, NULL, 0, events, MAX_EVENTS, &xtimeout);
     if (count == 0) {

--- a/pjlib/src/pj/ioqueue_kqueue.c
+++ b/pjlib/src/pj/ioqueue_kqueue.c
@@ -118,7 +118,7 @@ pj_ioqueue_create(pj_pool_t *pool, pj_size_t max_fd, pj_ioqueue_t **p_ioqueue)
 
     ioqueue = pj_pool_alloc(pool, sizeof(pj_ioqueue_t));
 
-    ioqueue_init(ioqueue);
+    ioqueue_init(ioqueue, pool);
 
     ioqueue->max = max_fd;
     ioqueue->count = 0;
@@ -180,6 +180,9 @@ pj_ioqueue_create(pj_pool_t *pool, pj_size_t max_fd, pj_ioqueue_t **p_ioqueue)
 
     PJ_LOG(4,
 	   ("pjlib", "%s I/O Queue created (%p)", pj_ioqueue_name(), ioqueue));
+
+    /* Do some stuffs after ioqueue init */
+    ioqueue_init_done(ioqueue);
 
     *p_ioqueue = ioqueue;
     return PJ_SUCCESS;

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -958,9 +958,6 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 #if defined(PJ_HAS_TCP) && PJ_HAS_TCP!=0
         && PJ_FD_COUNT(&ioqueue->xfdset)==0
 #endif
-#if PJ_IOQUEUE_HAS_WAKEUP
-        && ioqueue->wakeup_fd[0] == PJ_INVALID_SOCKET
-#endif
 	)
     {
 #if PJ_IOQUEUE_HAS_SAFE_UNREG
@@ -992,17 +989,6 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 #endif
 
     nfds = ioqueue->nfds;
-
-#if PJ_IOQUEUE_HAS_WAKEUP && PJ_HAS_THREADS
-    /*
-     * Make sure that wakeupfd always be added to rfdset
-     * When multi-thread polling,  wakeupfd may has been removed
-     * (ioqueue_remove_from_set) by other thread
-     */
-    if (ioqueue->wakeup_fd[0] != PJ_INVALID_SOCKET) {
-	PJ_FD_SET(ioqueue->wakeup_fd[0], &rfdset);
-    }
-#endif
 
     /* Unlock ioqueue before select(). */
     pj_lock_release(ioqueue->lock);

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -973,9 +973,14 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 #endif
 	pj_lock_release(ioqueue->lock);
 	TRACE__((THIS_FILE, "     poll: no fd is set"));
-        if (timeout)
-            pj_thread_sleep(PJ_TIME_VAL_MSEC(*timeout));
-        return 0;
+	const pj_uint32_t MAX_MSEC = 50;
+	pj_uint32_t msec = timeout ? PJ_TIME_VAL_MSEC(*timeout) : MAX_MSEC;
+	if (msec > MAX_MSEC) {
+	    // Avoid sleep too long time
+	    msec = MAX_MSEC;
+	}
+	pj_thread_sleep(msec);
+	return 0;
     }
 
     /* Copy ioqueue's pj_fd_set_t to local variables. */

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -206,7 +206,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
 
     /* Create and init common ioqueue stuffs */
     ioqueue = PJ_POOL_ALLOC_T(pool, pj_ioqueue_t);
-    ioqueue_init(ioqueue);
+    ioqueue_init(ioqueue, pool);
 
     ioqueue->max = (unsigned)max_fd;
     ioqueue->count = 0;
@@ -269,6 +269,9 @@ PJ_DEF(pj_status_t) pj_ioqueue_create( pj_pool_t *pool,
         return rc;
 
     PJ_LOG(4, ("pjlib", "select() I/O Queue created (%p)", ioqueue));
+
+    /* Do some stuffs after ioqueue init */
+    ioqueue_init_done(ioqueue);
 
     *p_ioqueue = ioqueue;
     return PJ_SUCCESS;
@@ -404,6 +407,11 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
 
     /* Rescan fdset to get max descriptor */
     rescan_fdset(ioqueue);
+
+#if PJ_IOQUEUE_HAS_WAKEUP
+    /* wakeup ioqueue */
+    pj_ioqueue_wakeup(ioqueue);
+#endif
 
 on_return:
     /* On error, socket may be left in non-blocking mode. */
@@ -568,6 +576,11 @@ PJ_DEF(pj_status_t) pj_ioqueue_unregister( pj_ioqueue_key_t *key)
     }
 
     pj_lock_destroy(key->lock);
+#endif
+
+#if PJ_IOQUEUE_HAS_WAKEUP
+    /* wakeup ioqueue */
+    pj_ioqueue_wakeup(ioqueue);
 #endif
 
     return PJ_SUCCESS;
@@ -950,6 +963,9 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 #if defined(PJ_HAS_TCP) && PJ_HAS_TCP!=0
         && PJ_FD_COUNT(&ioqueue->xfdset)==0
 #endif
+#if PJ_IOQUEUE_HAS_WAKEUP
+        && ioqueue->wakeup_fd[0] == PJ_INVALID_SOCKET
+#endif
 	)
     {
 #if PJ_IOQUEUE_HAS_SAFE_UNREG
@@ -976,6 +992,17 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 #endif
 
     nfds = ioqueue->nfds;
+
+#if PJ_IOQUEUE_HAS_WAKEUP && PJ_HAS_THREADS
+    /*
+     * Make sure that wakeupfd always be added to rfdset
+     * When multi-thread polling,  wakeupfd may has been removed
+     * (ioqueue_remove_from_set) by other thread
+     */
+    if (ioqueue->wakeup_fd[0] != PJ_INVALID_SOCKET) {
+	PJ_FD_SET(ioqueue->wakeup_fd[0], &rfdset);
+    }
+#endif
 
     /* Unlock ioqueue before select(). */
     pj_lock_release(ioqueue->lock);

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -578,11 +578,6 @@ PJ_DEF(pj_status_t) pj_ioqueue_unregister( pj_ioqueue_key_t *key)
     pj_lock_destroy(key->lock);
 #endif
 
-#if PJ_IOQUEUE_HAS_WAKEUP
-    /* wakeup ioqueue */
-    pj_ioqueue_wakeup(ioqueue);
-#endif
-
     return PJ_SUCCESS;
 }
 

--- a/pjlib/src/pj/ioqueue_symbian.cpp
+++ b/pjlib/src/pj/ioqueue_symbian.cpp
@@ -482,6 +482,16 @@ PJ_DEF(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioq )
     return PJ_SUCCESS;
 }
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+/*
+ * Wakeup ioqueue.
+ */
+PJ_DEF(pj_status_t) pj_ioqueue_wakeup(pj_ioqueue_t *ioq )
+{
+    PJ_UNUSED_ARG(ioq);
+    return PJ_ENOTSUP;
+}
+#endif
 
 /*
  * Set the lock object to be used by the I/O Queue. 

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -463,6 +463,16 @@ PJ_DEF(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioqueue )
     return PJ_SUCCESS;
 }
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+/*
+ * pj_ioqueue_wakeup
+ */
+PJ_DEF(pj_status_t) pj_ioqueue_wakeup(pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return PJ_ENOTSUP;
+}
+#endif
 
 PJ_DEF(pj_status_t) pj_ioqueue_set_default_concurrency(pj_ioqueue_t *ioqueue,
 						       pj_bool_t allow)

--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -905,7 +905,25 @@ PJ_DEF(pj_status_t) pj_sock_accept( pj_sock_t serverfd,
 }
 #endif	/* PJ_HAS_TCP */
 
-#if defined(PJ_WIN32) || defined(PJ_WIN64)
+#if defined(PJ_SOCK_HAS_SOCKETPAIR) && PJ_SOCK_HAS_SOCKETPAIR != 0
+PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
+				    int type,
+				    int protocol,
+				    pj_sock_t sv[2])
+{
+    int status;
+    int tmp_sv[2];
+
+    status = socketpair(family, type, protocol, tmp_sv);
+    if (status != PJ_SUCCESS) {
+	status = PJ_RETURN_OS_ERROR(pj_get_native_netos_error());
+	return status;
+    }
+    sv[0] = tmp_sv[0];
+    sv[1] = tmp_sv[1];
+    return PJ_SUCCESS;
+}
+#else
 PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
 				    int type,
 				    int protocol,
@@ -982,23 +1000,5 @@ PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
     if (cfd != PJ_INVALID_SOCKET)
 	pj_sock_close(cfd);
     return status;
-}
-#else
-PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
-				    int type,
-				    int protocol,
-				    pj_sock_t sv[2])
-{
-    int status;
-    int tmp_sv[2];
-
-    status = socketpair(family, type, protocol, tmp_sv);
-    if (status != PJ_SUCCESS) {
-	status = PJ_RETURN_OS_ERROR(pj_get_native_netos_error());
-	return status;
-    }
-    sv[0] = tmp_sv[0];
-    sv[1] = tmp_sv[1];
-    return PJ_SUCCESS;
 }
 #endif

--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -940,8 +940,12 @@ PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
     pj_sockaddr sa;
     int salen;
 
+#if PJ_HAS_TCP
     PJ_ASSERT_RETURN(type == pj_SOCK_DGRAM() || type == pj_SOCK_STREAM(),
 		     PJ_EINVAL);
+#else
+    PJ_ASSERT_RETURN(type == pj_SOCK_DGRAM(), PJ_EINVAL);
+#endif
     family = pj_AF_INET(); // Always inet
 
     do {
@@ -960,11 +964,13 @@ PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
 	if (status != PJ_SUCCESS)
 	    break;
 
+#if PJ_HAS_TCP
 	if (type == pj_SOCK_STREAM()) {
 	    status = pj_sock_listen(lfd, 1);
 	    if (status != PJ_SUCCESS)
 		break;
 	}
+#endif
 
 	/* connect to listen fd */
 	status = pj_sock_socket(family, type, protocol, &cfd);
@@ -983,7 +989,9 @@ PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
 		break;
 	    sv[0] = lfd;
 	    sv[1] = cfd;
-	} else if (type == pj_SOCK_STREAM()) {
+	}
+#if PJ_HAS_TCP
+	else if (type == pj_SOCK_STREAM()) {
 	    pj_sock_t newfd = PJ_INVALID_SOCKET;
 	    status = pj_sock_accept(lfd, &newfd, NULL, NULL);
 	    if (status != PJ_SUCCESS)
@@ -992,6 +1000,7 @@ PJ_DEF(pj_status_t) pj_sock_socketpair(int family,
 	    sv[0] = newfd;
 	    sv[1] = cfd;
 	}
+#endif
 	return PJ_SUCCESS;
     } while (0);
 

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -666,7 +666,7 @@ PJ_DEF(void) pj_timer_heap_destroy( pj_timer_heap_t *ht )
 #if PJ_IOQUEUE_HAS_WAKEUP
 PJ_DEF(void) pj_timer_heap_bind(pj_timer_heap_t *ht, pj_ioqueue_t *ioq)
 {
-    pj_assert(ht && ioq);
+    pj_assert(ht);
     ht->ioq = ioq;
 }
 #endif

--- a/pjlib/src/pj/timer_symbian.cpp
+++ b/pjlib/src/pj/timer_symbian.cpp
@@ -473,3 +473,11 @@ PJ_DEF(pj_status_t) pj_timer_heap_earliest_time( pj_timer_heap_t * ht,
     return PJ_SUCCESS;
 }
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+PJ_DEF(void) pj_timer_heap_bind( pj_timer_heap_t *ht, pj_ioqueue_t *ioq)
+{
+    PJ_UNUSED_ARG(ht);
+    PJ_UNUSED_ARG(ioq);
+    // Not support
+}
+#endif

--- a/pjlib/src/pjlib-test/ioq_perf.c
+++ b/pjlib/src/pjlib-test/ioq_perf.c
@@ -256,7 +256,11 @@ static int perform_test(pj_bool_t allow_concur,
     	     pj_pool_alloc(pool, thread_cnt*sizeof(pj_thread_t*));
 
     TRACE_((THIS_FILE, "     creating ioqueue.."));
+#if PJ_IOQUEUE_HAS_WAKEUP
+    rc = pj_ioqueue_create(pool, sockpair_cnt*2 + 2, &ioqueue);
+#else
     rc = pj_ioqueue_create(pool, sockpair_cnt*2, &ioqueue);
+#endif
     if (rc != PJ_SUCCESS) {
         app_perror("...error: unable to create ioqueue", rc);
         return -15;

--- a/pjnath/src/pjturn-srv/server.c
+++ b/pjnath/src/pjturn-srv/server.c
@@ -120,6 +120,11 @@ PJ_DEF(pj_status_t) pj_turn_srv_create(pj_pool_factory *pf,
     if (status != PJ_SUCCESS)
 	goto on_error;
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+    /* Bind the timer heap to the ioqueue */
+    pj_timer_heap_bind(srv->core.timer_heap, srv->core.ioqueue);
+#endif
+
     /* Configure lock for the timer heap */
     pj_timer_heap_set_lock(srv->core.timer_heap, srv->core.lock, PJ_FALSE);
 

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -511,6 +511,11 @@ PJ_DEF(pj_status_t) pjsip_endpt_create(pj_pool_factory *pf,
 	goto on_error;
     }
 
+#if PJ_IOQUEUE_HAS_WAKEUP
+    /* Bind the timer heap to the ioqueue */
+    pj_timer_heap_bind(endpt->timer_heap, endpt->ioqueue);
+#endif
+
     /* Create transport manager. */
     status = pjsip_tpmgr_create( endpt->pool, endpt,
 			         &endpt_on_rx_msg,


### PR DESCRIPTION
Why add this feature, please go to #3160 for detail.

Set macro PJ_IOQUEUE_HAS_WAKEUP =1 to enable feature.

If enable wakeup-mechanism, the ioqueue poll timeout can be a large value ( eg. 9 seconds),
which can reduce cpu usage to 0% in idle state.

I have already added this feature support in pjsip and pjmedia modules,  so can test it use pjsua app.


PS:
This feature is supported in ioqueue frameworks select/epoll/kqueue,  
other ioqueue frameworks uwp/winnt/symbian not support now.