### PR TITLE
Fix darwin_dev build failure on Mac

### DIFF
--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -147,8 +147,8 @@ struct darwin_stream
     dispatch_queue_t 		 queue;
     AVCaptureVideoPreviewLayer  *prev_layer;
     
-#if TARGET_OS_IPHONE
     pj_bool_t		 is_running;
+#if TARGET_OS_IPHONE
     pj_bool_t		 is_rendering;
     void		*render_buf;
     pj_size_t		 render_buf_size;


### PR DESCRIPTION
The change in the latest PR #3166 causes a build failure on Mac since `is_running` variable declaration is within the macro `TARGET_OS_IPHONE`.