### PR TITLE
Fix potential buffer overrun when printing SIP header/message

### DIFF
--- a/pjsip/src/pjsip/sip_auth_msg.c
+++ b/pjsip/src/pjsip/sip_auth_msg.c
@@ -125,14 +125,14 @@ static int pjsip_authorization_hdr_print( pjsip_authorization_hdr *hdr,
 {
     int printed;
     char *startbuf = buf;
-    char *endbuf = buf + size;
+    char *endbuf = buf + size - 1; // Need to minus one for NULL terminator
 
     copy_advance(buf, hdr->name);
-    *buf++ = ':';
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ':');
+    copy_advance_char_check(buf, ' ');
 
     copy_advance(buf, hdr->scheme);
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ' ');
 
     if (pj_stricmp(&hdr->scheme, &pjsip_DIGEST_STR) == 0)
     {
@@ -291,14 +291,14 @@ static int pjsip_www_authenticate_hdr_print( pjsip_www_authenticate_hdr *hdr,
 {
     int printed;
     char *startbuf = buf;
-    char *endbuf = buf + size;
+    char *endbuf = buf + size - 1; // Need to minus one for NULL terminator
 
     copy_advance(buf, hdr->name);
-    *buf++ = ':';
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ':');
+    copy_advance_char_check(buf, ' ');
 
     copy_advance(buf, hdr->scheme);
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ' ');
 
     if (pj_stricmp2(&hdr->scheme, "digest") == 0)
 	printed = print_digest_challenge(&hdr->challenge.digest, buf, endbuf - buf);

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -1573,8 +1573,8 @@ static int pjsip_fromto_hdr_print( pjsip_fromto_hdr *hdr,
     const pjsip_parser_const_t *pc = pjsip_parser_const();
 
     copy_advance(buf, (*hname));
-    *buf++ = ':';
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ':');
+    copy_advance_char_check(buf, ' ');
 
     printed = pjsip_uri_print(PJSIP_URI_IN_FROMTO_HDR, hdr->uri, 
 			      buf, endbuf-buf);
@@ -1777,8 +1777,8 @@ static int pjsip_routing_hdr_print( pjsip_routing_hdr *hdr,
     /* Route and Record-Route don't compact forms */
 
     copy_advance(buf, hdr->name);
-    *buf++ = ':';
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ':');
+    copy_advance_char_check(buf, ' ');
 
     printed = pjsip_uri_print(PJSIP_URI_IN_ROUTING_HDR, &hdr->name_addr, buf, 
 			      endbuf-buf);
@@ -2051,8 +2051,8 @@ static int pjsip_via_hdr_print( pjsip_via_hdr *hdr,
 
     /* pjsip_hdr_names */
     copy_advance(buf, (*hname));
-    *buf++ = ':';
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ':');
+    copy_advance_char_check(buf, ' ');
 
     /* SIP/2.0/transport host:port */
     pj_memcpy(buf, sip_ver.ptr, sip_ver.slen);
@@ -2066,7 +2066,7 @@ static int pjsip_via_hdr_print( pjsip_via_hdr *hdr,
 	}
     }
     buf += hdr->transport.slen;
-    *buf++ = ' ';
+    copy_advance_char_check(buf, ' ');
 
     /* Check if host contains IPv6 */
     if (pj_strchr(&hdr->sent_by.host, ':')) {
@@ -2076,7 +2076,7 @@ static int pjsip_via_hdr_print( pjsip_via_hdr *hdr,
     }
 
     if (hdr->sent_by.port != 0) {
-	*buf++ = ':';
+	copy_advance_char_check(buf, ':');
 	printed = pj_utoa(hdr->sent_by.port, buf);
 	buf += printed;
     }
@@ -2097,7 +2097,7 @@ static int pjsip_via_hdr_print( pjsip_via_hdr *hdr,
 	pj_memcpy(buf, ";rport", 6);
 	buf += 6;
 	if (hdr->rport_param > 0) {
-	    *buf++ = '=';
+	    copy_advance_char_check(buf, '=');
 	    buf += pj_utoa(hdr->rport_param, buf);
 	}
     }

--- a/pjsip/src/pjsip/sip_tel_uri.c
+++ b/pjsip/src/pjsip/sip_tel_uri.c
@@ -182,14 +182,14 @@ static pj_ssize_t tel_uri_print( pjsip_uri_context_e context,
 {
     int printed;
     char *startbuf = buf;
-    char *endbuf = buf+size-1;
+    char *endbuf = buf+size-1; // Need to minus one for NULL terminator
     const pjsip_parser_const_t *pc = pjsip_parser_const();
 
     PJ_UNUSED_ARG(context);
 
     /* Print scheme. */
     copy_advance(buf, pc->pjsip_TEL_STR);
-    *buf++ = ':';
+    copy_advance_char_check(buf, ':');
 
     /* Print number. */
     copy_advance_escape(buf, uri->number, pjsip_TEL_NUMBER_SPEC);

--- a/pjsip/src/pjsip/sip_uri.c
+++ b/pjsip/src/pjsip/sip_uri.c
@@ -256,10 +256,11 @@ static pj_ssize_t pjsip_url_print(  pjsip_uri_context_e context,
 {
     int printed;
     char *startbuf = buf;
-    char *endbuf = buf+size;
+    char *endbuf = buf+size-1; // Need to minus one for NULL terminator
     const pj_str_t *scheme;
     const pjsip_parser_const_t *pc = pjsip_parser_const();
 
+    if (endbuf < startbuf) return -1;
     *buf = '\0';
 
     /* Print scheme ("sip:" or "sips:") */
@@ -558,7 +559,7 @@ static pj_ssize_t pjsip_name_addr_print(pjsip_uri_context_e context,
 {
     int printed;
     char *startbuf = buf;
-    char *endbuf = buf + size;
+    char *endbuf = buf + size - 1; // Need to minus one for NULL terminator
     pjsip_uri *uri;
 
     uri = (pjsip_uri*) pjsip_uri_get_uri(name->uri);
@@ -575,7 +576,7 @@ static pj_ssize_t pjsip_name_addr_print(pjsip_uri_context_e context,
 	copy_advance_char_check(buf, '<');;
     }
 
-    printed = pjsip_uri_print(context,uri, buf, size-(buf-startbuf));
+    printed = pjsip_uri_print(context,uri, buf, endbuf - buf);
     if (printed < 1)
 	return -1;
     buf += printed;
@@ -687,7 +688,7 @@ static pj_ssize_t other_uri_print(pjsip_uri_context_e context,
 
     /* Print scheme. */
     copy_advance(buf, uri->scheme);
-    *buf++ = ':';
+    copy_advance_char_check(buf, ':');
     
     /* Print content. */
     copy_advance(buf, uri->content);

--- a/pjsip/src/pjsip/sip_uri.c
+++ b/pjsip/src/pjsip/sip_uri.c
@@ -679,7 +679,7 @@ static pj_ssize_t other_uri_print(pjsip_uri_context_e context,
 				  char *buf, pj_size_t size)
 {
     char *startbuf = buf;
-    char *endbuf = buf + size;
+    char *endbuf = buf + size - 1; // Need to minus one for NULL terminator
     
     PJ_UNUSED_ARG(context);
     
@@ -693,6 +693,7 @@ static pj_ssize_t other_uri_print(pjsip_uri_context_e context,
     /* Print content. */
     copy_advance(buf, uri->content);
     
+    *buf = '\0';
     return (buf - startbuf);
 }
 


### PR DESCRIPTION
As reported in #3173, when printing a SIP header/message, the NULL terminator character may go beyond the provided buffer.

This PR also fixes several buffer assignment that doesn't check against the end buffer. The solution is to use `copy_advance_char_check()` consistently.

Special thanks to @BeardedSkunk for the original report.
