### PR TITLE
Add option to use default settings when switching sound device

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7790,7 +7790,8 @@ PJ_DECL(pj_bool_t) pjsua_snd_is_active(void);
  * 
  * Note that in case the setting is kept for future use, it will be applied
  * to any devices, even when application has changed the sound device to be
- * used.
+ * used. To reset the setting, application can call #pjsua_set_snd_dev2()
+ * with \a use_default_settings set to PJ_TRUE.
  *
  * Note also that the echo cancellation setting should be set with 
  * #pjsua_set_ec() API instead.

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7195,10 +7195,12 @@ typedef struct pjsua_snd_dev_param
     unsigned		mode;
 
     /*
-     * When opening the sound device, the settings set from
-     * #pjsua_snd_set_setting() will be applied to any sound device.
-     * This might be undesirable, e.g: output volume changes when switching
-     * sound device due to the use of previously set volume settings.
+     * The library will maintain the global sound device settings set when
+     * opening the sound device for the first time and later can be modified
+     * using #pjsua_snd_set_setting(). These setings are then applied to any
+     * sound device when opening. This might be undesirable,
+     * e.g: output volume changes when switching sound device due to the
+     * use of previously set volume settings.
      *
      * To avoid such case, application can set this to PJ_TRUE and let the
      * sound device use default settings when opening. This will also reset

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7194,6 +7194,20 @@ typedef struct pjsua_snd_dev_param
      */
     unsigned		mode;
 
+    /*
+     * When opening the sound device, the settings set from
+     * #pjsua_snd_set_setting() will be applied to any sound device.
+     * This might be undesirable, e.g: output volume changes when switching
+     * sound device due to the use of previously set volume settings.
+     *
+     * To avoid such case, application can set this to PJ_TRUE and let the
+     * sound device use default settings when opening. This will also reset
+     * the global sound device settings.
+     *
+     * Default: PJ_FALSE
+     */
+    pj_bool_t		use_default_settings;
+
 } pjsua_snd_dev_param;
 
 

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1813,7 +1813,8 @@ static pj_status_t update_initial_aud_param()
     pjmedia_aud_param param;
     pj_status_t status;
 
-    PJ_ASSERT_RETURN(pjsua_var.snd_port != NULL, PJ_EBUG);    
+    PJ_ASSERT_RETURN(pjsua_var.snd_port != NULL, PJ_EBUG);
+
     strm = pjmedia_snd_port_get_snd_stream(pjsua_var.snd_port);
 
     status = pjmedia_aud_stream_get_param(strm, &param);


### PR DESCRIPTION
The sound device settings used in ```pjsua_snd_set_setting()/pjsua_snd_get_setting()``` are global settings and not device specific.
It will be applied to any devices, even when application has changed the sound device to be used.
This might raise in an unwanted issue:
- First sound device opened is the main speaker. The settings will be retrieve and stored
- User switch the sound device to a headphone. The volume might changes because it is using the volume settings from the main speaker.

This patch will allow to switch the sound device and use the default settings and ignore the previously stored settings.
When the option is used, the current sound device settings will be reset and reinitialize based on the sound device used.