### PR TITLE
Lock ordering issue in video conference bridge

### DIFF
--- a/pjlib/src/pj/lock.c
+++ b/pjlib/src/pj/lock.c
@@ -470,6 +470,7 @@ PJ_DEF(pj_status_t) pj_grp_lock_create_w_handler( pj_pool_t *pool,
 
     status = pj_grp_lock_create(pool, cfg, p_grp_lock);
     if (status == PJ_SUCCESS) {
+	pj_pool_t *pool = (*p_grp_lock)->pool;
         grp_lock_add_handler(*p_grp_lock, pool, member, handler, PJ_FALSE);
     }
     

--- a/pjmedia/include/pjmedia/port.h
+++ b/pjmedia/include/pjmedia/port.h
@@ -30,6 +30,7 @@
 #include <pjmedia/frame.h>
 #include <pjmedia/signatures.h>
 #include <pj/assert.h>
+#include <pj/lock.h>
 #include <pj/os.h>
 
 
@@ -387,6 +388,14 @@ typedef struct pjmedia_port
     } port_data;
 
     /**
+     * Group lock.
+     *
+     * This is optional, but if this port is registered to the audio/video
+     * conference bridge, the bridge will create one if the port has none.
+     */
+    pj_grp_lock_t	*grp_lock;
+
+    /**
      * Get clock source.
      * This should only be called by #pjmedia_port_get_clock_src().
      */
@@ -492,7 +501,10 @@ PJ_DECL(pj_status_t) pjmedia_port_put_frame( pjmedia_port *port,
 					     pjmedia_frame *frame );
 
 /**
- * Destroy port (and subsequent downstream ports)
+ * Destroy port (and subsequent downstream ports).
+ *
+ * Note that if the port has group lock, instead of destroying the port
+ * immediately, this function will just decrease the reference counter.
  *
  * @param port	    The media port.
  *
@@ -500,6 +512,48 @@ PJ_DECL(pj_status_t) pjmedia_port_put_frame( pjmedia_port *port,
  */
 PJ_DECL(pj_status_t) pjmedia_port_destroy( pjmedia_port *port );
 
+
+/**
+ * This is a helper function to initialize the port's group lock. This
+ * function will create the group lock if NULL is passed, add the port's
+ * destructor to the group lock handler list, and increment the reference
+ * counter.
+ *
+ * Application should call this function after on_destroy() function has
+ * been assigned.
+ *
+ * @param port		    The pjmedia port to be initialized.
+ * @param pool		    The pool, this can be a temporary pool as
+ *			    group lock will create and use its internal pool.
+ * @param grp_lock	    The group lock, or create a new one if NULL.
+ *
+ * @return		    PJ_SUCCESS on success, PJ_EEXISTS if group lock
+ *			    is already initialized, or the other appropriate
+ *			    error code.
+ */
+PJ_DECL(pj_status_t) pjmedia_port_init_glock( pjmedia_port *port,
+					      pj_pool_t *pool,
+					      pj_grp_lock_t *glock);
+
+
+/**
+ * This is a helper function to increase the port reference counter.
+ *
+ * @param port		    The PJMEDIA port.
+ *
+ * @return		    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_port_add_ref( pjmedia_port *port );
+
+
+/**
+ * This is a helper function to decrease the port reference counter.
+ *
+ * @param port		    The PJMEDIA port.
+ *
+ * @return		    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_port_dec_ref( pjmedia_port *port );
 
 
 PJ_END_DECL

--- a/pjmedia/include/pjmedia/port.h
+++ b/pjmedia/include/pjmedia/port.h
@@ -531,9 +531,9 @@ PJ_DECL(pj_status_t) pjmedia_port_destroy( pjmedia_port *port );
  *			    is already initialized, or the other appropriate
  *			    error code.
  */
-PJ_DECL(pj_status_t) pjmedia_port_init_glock( pjmedia_port *port,
-					      pj_pool_t *pool,
-					      pj_grp_lock_t *glock);
+PJ_DECL(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
+						 pj_pool_t *pool,
+						 pj_grp_lock_t *glock );
 
 
 /**

--- a/pjmedia/include/pjmedia/port.h
+++ b/pjmedia/include/pjmedia/port.h
@@ -525,7 +525,7 @@ PJ_DECL(pj_status_t) pjmedia_port_destroy( pjmedia_port *port );
  * @param port		    The pjmedia port to be initialized.
  * @param pool		    The pool, this can be a temporary pool as
  *			    group lock will create and use its internal pool.
- * @param grp_lock	    The group lock, or create a new one if NULL.
+ * @param glock		    The group lock, or create a new one if NULL.
  *
  * @return		    PJ_SUCCESS on success, PJ_EEXISTS if group lock
  *			    is already initialized, or the other appropriate

--- a/pjmedia/include/pjmedia/port.h
+++ b/pjmedia/include/pjmedia/port.h
@@ -515,12 +515,12 @@ PJ_DECL(pj_status_t) pjmedia_port_destroy( pjmedia_port *port );
 
 /**
  * This is a helper function to initialize the port's group lock. This
- * function will create the group lock if NULL is passed, add the port's
- * destructor to the group lock handler list, and increment the reference
- * counter.
+ * function will create a group lock if NULL is passed, initialize the group
+ * lock by adding the port's destructor to the group lock handler list, and
+ * increment the reference counter.
  *
- * Application should call this function after on_destroy() function has
- * been assigned.
+ * This function should only be called by a media port implementation and
+ * after port's on_destroy() function has been assigned.
  *
  * @param port		    The pjmedia port to be initialized.
  * @param pool		    The pool, this can be a temporary pool as

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -162,10 +162,16 @@ PJ_DEF(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
     PJ_ASSERT_RETURN(port->grp_lock == NULL, PJ_EEXISTS);
 
     /* We need to be caution on ports that do not have the on_destroy()!
-     * It can be uninitialized yet or it really does not have one.
-     * If it doesn't have one, then we'd expect a possible premature destroy!
+     * It is either uninitialized yet or the port does not have one.
+     * If the port doesn't have one, we'd expect a possible premature destroy!
      */
-    PJ_ASSERT_RETURN(port->on_destroy, PJ_EINVALIDOP);
+    if (port->on_destroy == NULL) {
+	PJ_LOG(3,(THIS_FILE, "Media port %s is using group lock but does not "
+			     "implement on_destroy()!",
+			     port->info.name.ptr));
+	pj_assert(!"Port using group lock should implement on_destroy()!");
+	return PJ_EINVALIDOP;
+    }
 
     if (!grp_lock) {
 	/* Create if not supplied */

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -159,18 +159,13 @@ PJ_DEF(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
     pj_status_t status;
 
     PJ_ASSERT_RETURN(port && pool, PJ_EINVAL);
+    PJ_ASSERT_RETURN(port->grp_lock == NULL, PJ_EEXISTS);
 
     /* We need to be caution on ports that do not have the on_destroy()!
      * It can be uninitialized yet or it really does not have one.
      * If it doesn't have one, then we'd expect a possible premature destroy!
      */
     PJ_ASSERT_RETURN(port->on_destroy, PJ_EINVALIDOP);
-
-    /* Check if it is already initialized */
-    if (port->grp_lock) {
-	pj_assert(glock == NULL || glock == port->grp_lock);
-	return PJ_EEXISTS;
-    }
 
     if (!grp_lock) {
 	/* Create if not supplied */

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -139,6 +139,7 @@ PJ_DEF(pj_status_t) pjmedia_port_destroy( pjmedia_port *port )
 }
 
 
+/* Group lock handler */
 static void port_on_destroy(void *arg)
 {
     pjmedia_port *port = (pjmedia_port*)arg;
@@ -150,9 +151,9 @@ static void port_on_destroy(void *arg)
 /**
  * Create and init group lock.
  */
-PJ_DEF(pj_status_t) pjmedia_port_init_glock(pjmedia_port *port,
-					    pj_pool_t *pool,
-					    pj_grp_lock_t *glock )
+PJ_DEF(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
+						pj_pool_t *pool,
+						pj_grp_lock_t *glock )
 {
     pj_grp_lock_t *grp_lock = glock;
     pj_status_t status;
@@ -189,6 +190,7 @@ PJ_DEF(pj_status_t) pjmedia_port_init_glock(pjmedia_port *port,
     if (status == PJ_SUCCESS) {
 	port->grp_lock = grp_lock;
     } else if (grp_lock && !glock) {
+	/* Something wrong, destroy group lock if it is created here */
 	pj_grp_lock_destroy(grp_lock);
     }
 

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2799,11 +2799,10 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
     att_param.rtcp_cb = &on_rx_rtcp;
 
     /* Only attach transport when stream is ready. */
+    stream->transport = tp;
     status = pjmedia_transport_attach2(tp, &att_param);
     if (status != PJ_SUCCESS)
 	goto err_cleanup;
-
-    stream->transport = tp;
 
 #if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
     /* Enable RTCP XR and update stream info/config to RTCP XR */

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -417,7 +417,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_add_port( pjmedia_vid_conf *vid_conf,
     pj_strdup_with_null(pool, &cport->name, name);
 
     /* Setup group lock */
-    status = pjmedia_port_init_glock(port, pool, NULL);
+    status = pjmedia_port_init_grp_lock(port, pool, NULL);
     if (status == PJ_EEXISTS) status = PJ_SUCCESS;
     if (status != PJ_SUCCESS)
 	goto on_error;

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -327,6 +327,8 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_destroy(pjmedia_vid_conf *vid_conf)
 
     PJ_ASSERT_RETURN(vid_conf, PJ_EINVAL);
 
+    PJ_LOG(5,(THIS_FILE, "Video conference bridge destroy requested"));
+
     /* Destroy clock */
     if (vid_conf->clock) {
 	pjmedia_clock_destroy(vid_conf->clock);
@@ -588,6 +590,8 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_remove_port( pjmedia_vid_conf *vid_conf,
 	return PJ_EINVAL;
     }
 
+    PJ_LOG(5,(THIS_FILE, "Video port %d remove requested", slot));
+
     /* Queue the operation */
     ope = get_free_op_entry(vid_conf);
     ope->type = OP_REMOVE_PORT;
@@ -767,6 +771,10 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_connect_port(
     /* Queue the operation */
     if (i == src_port->listener_cnt) {
 	op_entry *ope;
+
+	PJ_LOG(5,(THIS_FILE, "Video connect ports %d->%d requested",
+			     src_slot, sink_slot));
+
 	ope = get_free_op_entry(vid_conf);
 	ope->type = OP_CONNECT_PORTS;
 	ope->param.connect_ports.src = src_slot;
@@ -875,6 +883,10 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_disconnect_port(
 	/* Queue the operation */
 	if (i == src_port->listener_cnt) {
 	    op_entry *ope;
+
+	    PJ_LOG(5,(THIS_FILE, "Video disconnect ports %d->%d requested",
+				 src_slot, sink_slot));
+
 	    ope = get_free_op_entry(vid_conf);
 	    ope->type = OP_DISCONNECT_PORTS;
 	    ope->param.disconnect_ports.src = src_slot;

--- a/pjmedia/src/pjmedia/vid_port.c
+++ b/pjmedia/src/pjmedia/vid_port.c
@@ -147,6 +147,8 @@ static pj_status_t vid_pasv_port_put_frame(struct pjmedia_port *this_port,
 static pj_status_t vid_pasv_port_get_frame(struct pjmedia_port *this_port,
 					   pjmedia_frame *frame);
 
+static pj_status_t vid_pasv_port_on_destroy(struct pjmedia_port *this_port);
+
 
 PJ_DEF(void) pjmedia_vid_port_param_default(pjmedia_vid_port_param *prm)
 {
@@ -652,6 +654,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_port_create( pj_pool_t *pool,
 	    pp->base.get_frame = &vid_pasv_port_get_frame;
 	if (prm->vidparam.dir & PJMEDIA_DIR_RENDER)
 	    pp->base.put_frame = &vid_pasv_port_put_frame;
+	pp->base.on_destroy = &vid_pasv_port_on_destroy;
 	pjmedia_port_info_init2(&pp->base.info, &vp->dev_name,
 	                        PJMEDIA_SIG_VID_PORT,
 			        prm->vidparam.dir, &prm->vidparam.fmt);
@@ -1406,6 +1409,11 @@ static pj_status_t vid_pasv_port_get_frame(struct pjmedia_port *this_port,
     }
 
     return status;
+}
+
+
+static pj_status_t vid_pasv_port_on_destroy(struct pjmedia_port *this_port)
+{
 }
 
 

--- a/pjmedia/src/pjmedia/vid_port.c
+++ b/pjmedia/src/pjmedia/vid_port.c
@@ -118,6 +118,7 @@ struct vid_pasv_port
 {
     pjmedia_port	 base;
     pjmedia_vid_port	*vp;
+    pj_bool_t            is_destroying;
 };
 
 struct fmt_prop 
@@ -527,8 +528,9 @@ PJ_DEF(pj_status_t) pjmedia_vid_port_create( pj_pool_t *pool,
         return status;
 
     /* Allocate videoport */
+    pool = pj_pool_create(pool->factory, "video port", 500, 500, NULL);
     vp = PJ_POOL_ZALLOC_T(pool, pjmedia_vid_port);
-    vp->pool = pj_pool_create(pool->factory, "video port", 500, 500, NULL);
+    vp->pool = pool;
     vp->role = prm->active ? ROLE_ACTIVE : ROLE_PASSIVE;
     vp->dir = prm->vidparam.dir;
 //    vp->cap_size = vfd->size;
@@ -855,11 +857,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_port_stop(pjmedia_vid_port *vp)
     return status;
 }
 
-PJ_DEF(void) pjmedia_vid_port_destroy(pjmedia_vid_port *vp)
+static void vid_port_destroy(pjmedia_vid_port *vp)
 {
     PJ_ASSERT_ON_FAIL(vp, return);
 
-    PJ_LOG(4,(THIS_FILE, "Closing %s..", vp->dev_name.ptr));
+    PJ_LOG(4,(THIS_FILE, "Destroying %s..", vp->dev_name.ptr));
 
     /* Unsubscribe events first, otherwise the event callbacks can be called
      * and try to access already destroyed objects.
@@ -894,6 +896,22 @@ PJ_DEF(void) pjmedia_vid_port_destroy(pjmedia_vid_port *vp)
         vp->conv.conv = NULL;
     }
     pj_pool_release(vp->pool);
+}
+
+PJ_DEF(void) pjmedia_vid_port_destroy(pjmedia_vid_port *vp)
+{
+    PJ_ASSERT_ON_FAIL(vp, return);
+
+    PJ_LOG(4,(THIS_FILE, "Destroy request on %s..", vp->dev_name.ptr));
+
+    /* This is a passive port, destroy via PJMEDIA port API */
+    if (vp->pasv_port) {
+	vp->pasv_port->is_destroying = PJ_TRUE;
+	pjmedia_port_destroy(&vp->pasv_port->base);
+	return;
+    }
+
+    vid_port_destroy(vp);
 }
 
 /*
@@ -1339,6 +1357,9 @@ static pj_status_t vid_pasv_port_put_frame(struct pjmedia_port *this_port,
     struct vid_pasv_port *vpp = (struct vid_pasv_port*)this_port;
     pjmedia_vid_port *vp = vpp->vp;
 
+    if (vp->pasv_port->is_destroying)
+	return PJ_EGONE;
+
     if (vp->stream_role==ROLE_PASSIVE) {
         /* We are passive and the stream is passive.
          * The encoding counterpart is in vid_pasv_port_get_frame().
@@ -1386,6 +1407,9 @@ static pj_status_t vid_pasv_port_get_frame(struct pjmedia_port *this_port,
     pjmedia_vid_port *vp = vpp->vp;
     pj_status_t status = PJ_SUCCESS;
 
+    if (vp->pasv_port->is_destroying)
+	return PJ_EGONE;
+
     if (vp->stream_role==ROLE_PASSIVE) {
         /* We are passive and the stream is passive.
          * The decoding counterpart is in vid_pasv_port_put_frame().
@@ -1414,6 +1438,9 @@ static pj_status_t vid_pasv_port_get_frame(struct pjmedia_port *this_port,
 
 static pj_status_t vid_pasv_port_on_destroy(struct pjmedia_port *this_port)
 {
+    struct vid_pasv_port *vpp = (struct vid_pasv_port*)this_port;
+    vid_port_destroy(vpp->vp);
+    return PJ_SUCCESS;
 }
 
 

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -107,6 +107,7 @@ struct pjmedia_vid_stream
     pjmedia_endpt	    *endpt;	    /**< Media endpoint.	    */
     pjmedia_vid_codec_mgr   *codec_mgr;	    /**< Codec manager.		    */
     pjmedia_vid_stream_info  info;	    /**< Stream info.		    */
+    pj_grp_lock_t	    *grp_lock;	    /**< Stream lock.		    */
 
     pjmedia_vid_channel	    *enc;	    /**< Encoding channel.	    */
     pjmedia_vid_channel	    *dec;	    /**< Decoding channel.	    */
@@ -118,7 +119,6 @@ struct pjmedia_vid_stream
 
     pjmedia_transport	    *transport;	    /**< Stream transport.	    */
 
-    pj_mutex_t		    *jb_mutex;
     pjmedia_jbuf	    *jb;	    /**< Jitter buffer.		    */
     char		     jb_last_frm;   /**< Last frame type from jb    */
     unsigned		     jb_last_frm_cnt;/**< Last JB frame type counter*/
@@ -234,6 +234,10 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
 static void on_rx_rtcp( void *data,
                         void *pkt,
                         pj_ssize_t bytes_read);
+
+static void on_destroy(void *arg);
+
+static void channel_on_destroy(void *arg) { PJ_UNUSED_ARG(arg); }
 
 #if TRACE_JB
 
@@ -416,7 +420,7 @@ static pj_status_t stream_event_cb(pjmedia_event *event,
 	case PJMEDIA_EVENT_FMT_CHANGED:
 	    /* Copy the event to avoid deadlock if we publish the event
 	     * now. This happens because fmt_event may trigger restart
-	     * while we're still holding the jb_mutex.
+	     * while we're still holding the stream lock.
 	     */
 	    pj_memcpy(&stream->fmt_event, event, sizeof(*event));
 	    return PJ_SUCCESS;
@@ -516,6 +520,9 @@ static void send_keep_alive_packet(pjmedia_vid_stream *stream)
     pj_status_t status;
     void *pkt;
     int pkt_len;
+
+    if (!stream->transport)
+	return;
 
     TRC_((channel->port.info.name.ptr,
 	  "Sending keep-alive (RTCP and empty RTP)"));
@@ -909,7 +916,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 	}
     }
 
-    pj_mutex_lock( stream->jb_mutex );
+    pj_grp_lock_acquire( stream->grp_lock );
 
     /* Quickly see if there may be a full picture in the jitter buffer, and
      * decode them if so. More thorough check will be done in decode_frame().
@@ -975,7 +982,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 #endif
 
     }
-    pj_mutex_unlock( stream->jb_mutex );
+    pj_grp_lock_release( stream->grp_lock );
 
     /* Check if we need to send RTCP-FB generic NACK */
     if (stream->send_rtcp_fb_nack && seq_st.diff > 1 &&
@@ -1204,7 +1211,7 @@ static pj_status_t put_frame(pjmedia_port *port,
 	/* When the payload length is zero, we should not send anything,
 	 * but proceed the rest normally.
 	 */
-	if (frame_out.size != 0) {
+	if (frame_out.size != 0 && stream->transport) {
 	    /* Copy RTP header to the beginning of packet */
 	    pj_memcpy(channel->buf, rtphdr, sizeof(pjmedia_rtp_hdr));
 
@@ -1295,7 +1302,7 @@ static pj_status_t put_frame(pjmedia_port *port,
      * We only do this when stream direction is not "decoding only", because
      * when it is, check_tx_rtcp() will be handled by get_frame().
      */
-    if (stream->dir != PJMEDIA_DIR_DECODING) {
+    if (stream->dir != PJMEDIA_DIR_DECODING && stream->transport) {
 	check_tx_rtcp(stream);
     }
 
@@ -1543,7 +1550,7 @@ static pj_status_t get_frame(pjmedia_port *port,
     }
 
     /* Report pending events. Do not publish the event while holding the
-     * jb_mutex as that would lead to deadlock. It should be safe to
+     * stream lock as that would lead to deadlock. It should be safe to
      * operate on fmt_event without the mutex because format change normally
      * would only occur once during the start of the media.
      */
@@ -1587,7 +1594,7 @@ static pj_status_t get_frame(pjmedia_port *port,
 	stream->miss_keyframe_event.type = PJMEDIA_EVENT_NONE;
     }
 
-    pj_mutex_lock( stream->jb_mutex );
+    pj_grp_lock_acquire( stream->grp_lock );
 
     if (stream->dec_frame.size == 0) {
 	/* Don't have frame in buffer, try to decode one */
@@ -1613,7 +1620,7 @@ static pj_status_t get_frame(pjmedia_port *port,
 	stream->dec_frame.size = 0;
     }
 
-    pj_mutex_unlock( stream->jb_mutex );
+    pj_grp_lock_release( stream->grp_lock );
 
     return PJ_SUCCESS;
 }
@@ -1704,9 +1711,10 @@ static pj_status_t create_channel( pj_pool_t *pool,
 	pi->fmt.id = info->codec_param->dec_fmt.id;
 	channel->port.put_frame = &put_frame;
     }
-
-    /* Init port. */
     channel->port.port_data.pdata = stream;
+
+    /* Use stream group lock */
+    channel->port.grp_lock = stream->grp_lock;
 
     PJ_LOG(5, (name.ptr,
 	       "%s channel created %dx%d %s%s%.*s %d/%d(~%d)fps",
@@ -1832,9 +1840,15 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
     	stream->cname.slen = p - stream->cname.ptr;
     }
 
-    /* Create mutex to protect jitter buffer: */
+    /* Create group lock */
+    status = pj_grp_lock_create_w_handler(pool, NULL, stream, 
+					  &on_destroy,
+					  &stream->grp_lock);
+    if (status != PJ_SUCCESS)
+	goto err_cleanup;
 
-    status = pj_mutex_create_simple(pool, NULL, &stream->jb_mutex);
+    /* Add ref count of group lock */
+    status = pj_grp_lock_add_ref(stream->grp_lock);
     if (status != PJ_SUCCESS)
 	goto err_cleanup;
 
@@ -2140,6 +2154,14 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
 {
     PJ_ASSERT_RETURN(stream != NULL, PJ_EINVAL);
 
+    PJ_LOG(4,(THIS_FILE, "Destroy request on %s..", stream->name.ptr));
+
+    /* Stop the streaming */
+    if (stream->enc)
+	stream->enc->port.put_frame = NULL;
+    if (stream->dec)
+	stream->dec->port.get_frame = NULL;
+
 #if TRACE_RC
     {
 	unsigned total_time;
@@ -2153,7 +2175,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
     }
 #endif
 
-    /* Unsubscribe events from RTCP */
+    /* Unsubscribe from events */
+    if (stream->codec) {
+        pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream,
+                                  stream->codec);
+    }
     pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream, &stream->rtcp);
 
     /* Send RTCP BYE (also SDES) */
@@ -2170,27 +2196,38 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
 	stream->transport = NULL;
     }
 
-    /* This function may be called when stream is partly initialized. */
-    if (stream->jb_mutex)
-	pj_mutex_lock(stream->jb_mutex);
+    /* This function may be called when stream is partly initialized,
+     * i.e: group lock may not be created yet.
+     */
+    if (stream->grp_lock) {
+	return pj_grp_lock_dec_ref(stream->grp_lock);
+    } else {
+	on_destroy(stream);
+    }
 
+    return PJ_SUCCESS;
+}
+
+
+/*
+ * Destroy stream.
+ */
+static void on_destroy( void *arg )
+{
+    pjmedia_vid_stream *stream = (pjmedia_vid_stream*)arg;
+    pj_assert(stream);
+
+    PJ_LOG(4,(THIS_FILE, "Destroying %s..", stream->name.ptr));
 
     /* Free codec. */
     if (stream->codec) {
-        pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream,
-                                  stream->codec);
 	pjmedia_vid_codec_close(stream->codec);
 	pjmedia_vid_codec_mgr_dealloc_codec(stream->codec_mgr, stream->codec);
 	stream->codec = NULL;
     }
 
     /* Free mutex */
-
-    if (stream->jb_mutex) {
-	pj_mutex_unlock(stream->jb_mutex);
-	pj_mutex_destroy(stream->jb_mutex);
-	stream->jb_mutex = NULL;
-    }
+    stream->grp_lock = NULL;
 
     /* Destroy jitter buffer */
     if (stream->jb) {
@@ -2206,8 +2243,6 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
 #endif
 
     pj_pool_safe_release(&stream->own_pool);
-
-    return PJ_SUCCESS;
 }
 
 
@@ -2358,9 +2393,9 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_pause(pjmedia_vid_stream *stream,
 	stream->dec->paused = 1;
 
 	/* Also reset jitter buffer */
-	pj_mutex_lock( stream->jb_mutex );
+	pj_grp_lock_acquire( stream->grp_lock );
 	pjmedia_jbuf_reset(stream->jb);
-	pj_mutex_unlock( stream->jb_mutex );
+	pj_grp_lock_release( stream->grp_lock );
 
 	PJ_LOG(4,(stream->dec->port.info.name.ptr, "Decoder stream paused"));
     }

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -237,7 +237,6 @@ static void on_rx_rtcp( void *data,
 
 static void on_destroy(void *arg);
 
-static void channel_on_destroy(void *arg) { PJ_UNUSED_ARG(arg); }
 
 #if TRACE_JB
 

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -2502,7 +2502,7 @@ static pj_status_t cmd_vid_conf_list()
     }
 
     PJ_LOG(3,(THIS_FILE," Video conference has %d ports:\n", count));
-    PJ_LOG(3,(THIS_FILE," id name                   format               rx           tx    \n"));
+    PJ_LOG(3,(THIS_FILE," id name                   format               rx-from      tx-to \n"));
     PJ_LOG(3,(THIS_FILE," ------------------------------------------------------------------\n"));
     for (i=0; i<count; ++i) {
 	char li_list[PJSUA_MAX_CALLS*4];

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -618,7 +618,7 @@ static void vid_handle_menu(char *menuin)
 	    } else {
 		unsigned i;
 		printf(" Video conference has %d ports:\n", count);
-		printf(" id name                   format               rx           tx    \n");
+		printf(" id name                   format               rx-from      tx-to \n");
 		printf(" ------------------------------------------------------------------\n");
 		for (i=0; i<count; ++i) {
 		    char li_list[PJSUA_MAX_CALLS*4];


### PR DESCRIPTION
### Sample scenario
- Video conference (VC) worker thread: `put/get_frame()` publishes media event (synchronously), currently `put/get_frame()` is called while holding the VC mutex and app receiving the event invokes a SIP dialog API which tries to acquire the SIP dialog mutex.
- Other thread, app receives a SIP dialog callback (note: such callback is usually invoked while holding dialog mutex), it invokes a VC API which tries to acquire VC mutex.

The scenario involves non-uniform lock ordering between VC and SIP dialog mutexes which can cause deadlock.

### Proposed solution
The proposed solution is to avoid holding VC mutex while calling `put/get_frame()` in VC worker thread. To allow this, a couple major modifications are implemented in this PR:
1. VC internal states (such as port connection, rendering states) must not be changed when `put/get_frame()` is called, so some VC API operations (such as connect/disconnect ports, remove port, update port) must be queued or done asynchronously, the real operation will be performed in the VC worker thread context.
2. As remove port operation will be done asynchronously, media ports (especially video ports for now) need to have a reference counter (or group lock) to avoid premature destroy.

### Other fixes
This PR also contains a few minor other fixes such as:
- in `pj_grp_lock_create_w_handler()`: memory pool used for adding handler, updated to using group lock's memory pool itself, previously using app pool, was getting a premature destroy issue because of this (i.e: VC port added using PJSUA vidwin pool, the vidwin may get destroyed before the VC port, group lock crashed when iterating handlers).
- in PJMEDIA stream, somehow transport is accessed before the attach happens and it is still NULL, or it is accessed after set to NULL (in destructor), so put NULL transport check in some RTP/RTCP sending.
- in VC, fill buffer with black is performed when buffer is initially allocated and sink buffer after sink format changed, was every time render state is updated.
- add/modify logs in a few places including in app.
