### PR TITLE
Bug fixes and enhancements in pjlib ioq_perf.c

### DIFF
--- a/pjlib/include/pj/log.h
+++ b/pjlib/include/pj/log.h
@@ -217,12 +217,26 @@ PJ_DECL(unsigned) pj_log_get_decor(void);
 PJ_DECL(void) pj_log_add_indent(int indent);
 
 /**
- * Push indentation to the right by default value (PJ_LOG_INDENT).
+ * Set indentation to specific value.
+ *
+ * @param indent    The indentation value.
+ */
+PJ_DECL(void) pj_log_set_indent(int indent);
+
+/**
+ * Get current indentation value.
+ *
+ * @return 	    Current indentation value.
+ */
+PJ_DECL(int) pj_log_get_indent(void);
+
+/**
+ * Push indentation to the right by default value (PJ_LOG_INDENT_SIZE).
  */
 PJ_DECL(void) pj_log_push_indent(void);
 
 /**
- * Pop indentation (to the left) by default value (PJ_LOG_INDENT).
+ * Pop indentation (to the left) by default value (PJ_LOG_INDENT_SIZE).
  */
 PJ_DECL(void) pj_log_pop_indent(void);
 
@@ -304,12 +318,26 @@ pj_status_t pj_log_init(void);
 #  define pj_log_add_indent(indent)
 
 /**
- * Push indentation to the right by default value (PJ_LOG_INDENT).
+ * Set indentation to specific value.
+ *
+ * @param indent    The indentation value.
+ */
+#  define pj_log_set_indent(indent)
+
+/**
+ * Get current indentation value.
+ *
+ * @return 	    Current indentation value.
+ */
+#  define pj_log_get_indent()	0
+
+/**
+ * Push indentation to the right by default value (PJ_LOG_INDENT_SIZE).
  */
 #  define pj_log_push_indent()
 
 /**
- * Pop indentation (to the left) by default value (PJ_LOG_INDENT).
+ * Pop indentation (to the left) by default value (PJ_LOG_INDENT_SIZE).
  */
 #  define pj_log_pop_indent()
 

--- a/pjlib/src/pj/log.c
+++ b/pjlib/src/pj/log.c
@@ -101,7 +101,7 @@ static void logging_shutdown(void)
 #endif	/* PJ_HAS_THREADS */
 
 #if PJ_LOG_ENABLE_INDENT && PJ_HAS_THREADS
-static void log_set_indent(int indent)
+PJ_DEF(void) pj_log_set_indent(int indent)
 {
     if (indent < 0) indent = 0;
     pj_thread_local_set(thread_indent_tls_id, (void*)(pj_ssize_t)indent);
@@ -113,7 +113,7 @@ static int log_get_raw_indent(void)
 }
 
 #else
-static void log_set_indent(int indent)
+PJ_DEF(void) pj_log_set_indent(int indent)
 {
     log_indent = indent;
     if (log_indent < 0) log_indent = 0;
@@ -125,7 +125,7 @@ static int log_get_raw_indent(void)
 }
 #endif	/* PJ_LOG_ENABLE_INDENT && PJ_HAS_THREADS */
 
-static int log_get_indent(void)
+PJ_DEF(int) pj_log_get_indent(void)
 {
     int indent = log_get_raw_indent();
     return indent > LOG_MAX_INDENT ? LOG_MAX_INDENT : indent;
@@ -133,7 +133,7 @@ static int log_get_indent(void)
 
 PJ_DEF(void) pj_log_add_indent(int indent)
 {
-    log_set_indent(log_get_raw_indent() + indent);
+    pj_log_set_indent(log_get_raw_indent() + indent);
 }
 
 PJ_DEF(void) pj_log_push_indent(void)
@@ -338,7 +338,7 @@ PJ_DEF(void) pj_log( const char *sender, int level,
 #if PJ_LOG_USE_STACK_BUFFER
     char log_buffer[PJ_LOG_MAX_SIZE];
 #endif
-    int saved_level, len, print_len, indent;
+    int saved_level, len, print_len;
 
     PJ_CHECK_STACK();
 
@@ -444,7 +444,7 @@ PJ_DEF(void) pj_log( const char *sender, int level,
 
 #if PJ_LOG_ENABLE_INDENT
     if (log_decor & PJ_LOG_HAS_INDENT) {
-	indent = log_get_indent();
+	int indent = pj_log_get_indent();
 	if (indent > 0) {
 	    pj_memset(pre, PJ_LOG_INDENT_CHAR, indent);
 	    pre += indent;

--- a/pjlib/src/pjlib-test/test.h
+++ b/pjlib/src/pjlib-test/test.h
@@ -22,20 +22,22 @@
 
 #include <pj/types.h>
 
-#define GROUP_LIBC                  1
-#define GROUP_OS                    1
-#define GROUP_DATA_STRUCTURE        1
-#define GROUP_NETWORK               1
+#define TEST_DEFAULT		    1
+
+#define GROUP_LIBC                  TEST_DEFAULT
+#define GROUP_OS                    TEST_DEFAULT
+#define GROUP_DATA_STRUCTURE        TEST_DEFAULT
+#define GROUP_NETWORK               TEST_DEFAULT
 #if defined(PJ_SYMBIAN)
 #   define GROUP_FILE               0
 #else
-#   define GROUP_FILE               1
+#   define GROUP_FILE               TEST_DEFAULT
 #endif
 
 #if defined(PJ_EXCLUDE_BENCHMARK_TESTS) && (PJ_EXCLUDE_BENCHMARK_TESTS==1)
 #   define WITH_BENCHMARK	    0
 #else
-#   define WITH_BENCHMARK	    1
+#   define WITH_BENCHMARK	    TEST_DEFAULT
 #endif
 
 #define INCLUDE_ERRNO_TEST          GROUP_LIBC


### PR DESCRIPTION
## 1. Bug fixes in pjlib's `ioq_perf.c` tests

1. stopping condition that is too small and bug in duration calculation causing the test to complete very quickly (in about 1ms). This would cause bandwidth calculation to be inaccurate because threads haven't had chance to run properly yet.
2. bug in `total_received` calculation causing wrong bandwidth calculation (it only shows bandwidth of the last socket pair).

### Before and after results comparison

After the fix, we can see that bandwidth/throughput increases. as it should, with the increase of threads and socket pairs. Before the fix, the numbers were somewhat erratic.

#### epoll ioqueue

Before:
```
21:03:42.516 Running ioqueue_perf_test()...
21:08:22.813    Benchmarking epoll-exclusive ioqueue:
21:08:22.813    Testing with concurency=1
21:08:22.813    =======================================
21:08:22.813    Type  Threads  Skt.Pairs      Bandwidth
21:08:22.813    =======================================
21:08:32.815    udp     1         1         117333 KB/s
21:08:43.318    udp     2         2         157895 KB/s
21:08:53.820    udp     4         4          74576 KB/s
21:09:04.324    udp     8         8          93749 KB/s
21:09:14.829    udp    16        16          59979 KB/s
21:09:25.331    tcp     1         1          78638 KB/s
21:09:35.834    tcp     2         2          84022 KB/s
21:09:46.337    tcp     4         4          76040 KB/s
21:09:56.842    tcp     8         8          68366 KB/s
21:10:07.348    tcp    16        16          30451 KB/s
21:10:07.848    Best: Type=udp Threads=2, Skt.Pairs=2, Bandwidth=157895 KB/s
21:10:07.848    (Note: packet size=512, total errors=0)
21:10:07.848 ..success(0)
```

After:
```
19:04:00.276  Benchmarking epoll-exclusive ioqueue:
19:04:00.276    Testing with concurency=1
19:04:00.276    =======================================
19:04:00.276    Type  Threads  Skt.Pairs      Bandwidth
19:04:00.276    =======================================
19:04:05.278    udp     1         1         125746 KB/s
19:04:10.779    udp     2         2         277693 KB/s
19:04:16.281    udp     4         4         576932 KB/s
19:04:21.783    udp     8         8         948276 KB/s
19:04:27.286    udp    16        16        1061921 KB/s
19:04:32.788    tcp     1         1          83449 KB/s
19:04:38.290    tcp     2         2         177370 KB/s
19:04:43.792    tcp     4         4         365241 KB/s
19:04:49.295    tcp     8         8         605390 KB/s
19:04:54.799    tcp    16        16         421443 KB/s
19:04:55.299    Best: Type=udp Threads=16, Skt.Pairs=16, Bandwidth=1061921 KB/s
19:04:55.299    (Note: packet size=512, total errors=0)
```

#### select() ioqueue

Before:
```shell
19:02:13.751 Running ioqueue_perf_test()...
21:13:12.702    Benchmarking select ioqueue:
21:13:12.702    Testing with concurency=1
21:13:12.702    =======================================
21:13:12.702    Type  Threads  Skt.Pairs      Bandwidth
21:13:12.702    =======================================
21:13:22.703    udp     1         1          93851 KB/s
21:13:33.205    udp     2         2         196045 KB/s
21:13:43.708    udp     4         4         181632 KB/s
21:13:54.211    udp     8         8         110525 KB/s
21:14:04.714    udp    16        16          69549 KB/s
21:14:15.217    tcp     1         1          64289 KB/s
21:14:25.720    tcp     2         2         104252 KB/s
21:14:36.223    tcp     4         4          86293 KB/s
21:14:46.727    tcp     8         8          63276 KB/s
21:14:57.232    tcp    16        16          27767 KB/s
21:14:57.732    Best: Type=udp Threads=2, Skt.Pairs=2, Bandwidth=196045 KB/s
21:14:57.732    (Note: packet size=512, total errors=0)
21:14:57.732 ..success(0)

```

After:
```
19:14:55.662  Benchmarking select ioqueue:
19:14:55.662    Testing with concurency=1
19:14:55.662    =======================================
19:14:55.662    Type  Threads  Skt.Pairs      Bandwidth
19:14:55.662    =======================================
19:15:00.662    udp     1         1         108382 KB/s
19:15:06.164    udp     2         2         284524 KB/s
19:15:11.665    udp     4         4         617609 KB/s
19:15:17.166    udp     8         8        1146401 KB/s
19:15:22.669    udp    16        16        1308549 KB/s
19:15:28.171    tcp     1         1          73772 KB/s
19:15:33.673    tcp     2         2         172870 KB/s
19:15:39.174    tcp     4         4         308233 KB/s
19:15:44.676    tcp     8         8         527870 KB/s
19:15:50.181    tcp    16        16         580995 KB/s
19:15:50.681    Best: Type=udp Threads=16, Skt.Pairs=16, Bandwidth=1308549 KB/s
19:15:50.681    (Note: packet size=512, total errors=0)
```

## 2. Other enhancements

1. show statistics of each worker thread to see if threads are woken up equally.
2. show statistics of each socket pair to see if they have fair share of the bandwidth.

#### Sample output: worker thread analysis

*epoll* ioqueue performance is a lot better with `concurrency=1`, but interestingly it shows that only one thread is busy processing events. This will be subject to further investigation.

```
9:03:50.271  Detailed perf (concurrency=1):
19:03:55.274   udp 8 threads, 8 pairs
19:03:55.274   Elapsed  : 5000 msec
19:03:55.274   Bandwidth: 678035 KB/s
19:03:55.274   Threads statistics:
19:03:55.274     =============================
19:03:55.274     Thread  Loops  Events  Errors
19:03:55.274     =============================
19:03:55.274       0       2       2       0
19:03:55.274       1  422935  422935       0
19:03:55.274       2       3       3       0
19:03:55.274       3       1       1       0
19:03:55.274       4       1       1       0
19:03:55.274       5       3       3       0
19:03:55.274       6       1       1       0
19:03:55.274       7       1       1       0
19:03:55.274     =============================

19:03:55.274  Detailed perf (concurrency=0):
19:04:00.276   udp 8 threads, 8 pairs
19:04:00.276   Elapsed  : 5001 msec
19:04:00.276   Bandwidth: 214395 KB/s
19:04:00.276   Threads statistics:
19:04:00.276     =============================
19:04:00.276     Thread  Loops  Events  Errors
19:04:00.276     =============================
19:04:00.276       0   99012   97631       0
19:04:00.276       1  101853  100348       0
19:04:00.276       2   89097   87893       0
19:04:00.276       3   97414   96049       0
19:04:00.276       4   95655   94280       0
19:04:00.276       5   99624   98133       0
19:04:00.276       6  102123  100607       0
19:04:00.276       7  104908  103356       0
19:04:00.276     =============================

```

The same symptom is observed with **select ioqueue** as well:
```
19:14:45.658  Detailed perf (concurrency=1):
19:14:50.660   udp 8 threads, 8 pairs
19:14:50.660   Elapsed  : 5000 msec
19:14:50.660   Bandwidth: 958559 KB/s
19:14:50.660   Threads statistics:
19:14:50.660     =============================
19:14:50.660     Thread  Loops  Events  Errors
19:14:50.660     =============================
19:14:50.660       0      10      10       0
19:14:50.660       1      40      40       0
19:14:50.660       2       1       1       0
19:14:50.660       3       2       2       0
19:14:50.660       4       1       1       0
19:14:50.660       5  760441  760441       0
19:14:50.660       6       2       2       0
19:14:50.660       7       6       5       0

19:14:50.660  Detailed perf (concurrency=0):
19:14:55.662   udp 8 threads, 8 pairs
19:14:55.662   Elapsed  : 5001 msec
19:14:55.662   Bandwidth: 117050 KB/s
19:14:55.662   Threads statistics:
19:14:55.662     =============================
19:14:55.662     Thread  Loops  Events  Errors
19:14:55.662     =============================
19:14:55.662       0   66533   64923       0
19:14:55.662       1   68404   66805       0
19:14:55.662       2   66895   65183       0
19:14:55.662       3   66355   64749       0
19:14:55.662       4   64791   63351       0
19:14:55.662       5   62332   60887       0
19:14:55.662       6   67105   65419       0
19:14:55.662       7   63144   61640       0
19:14:55.662     =============================
```

#### Sample output: socket pair statistic

Below is sample output of socket pair statistics. It shows that all of them have their fair share of the bandwidth, as expected.

```
epoll with concurrency=1:
19:03:55.274   Socket-pair statistics:
19:03:55.274     ===================================
19:03:55.274     Pair     Sent     Recv    Pct total
19:03:55.274     ===================================
19:03:55.274        0  458.0 MB  458.0 MB     13.5%
19:03:55.274        1  430.6 MB  430.6 MB     12.7%
19:03:55.274        2  451.7 MB  451.7 MB     13.3%
19:03:55.274        3  216.5 MB  216.5 MB      6.4%
19:03:55.274        4  459.3 MB  459.3 MB     13.5%
19:03:55.274        5  443.2 MB  443.2 MB     13.1%
19:03:55.274        6  443.6 MB  443.6 MB     13.1%
19:03:55.274        7  487.9 MB  487.9 MB     14.4%

epoll with concurrency=0:
19:04:00.276   Socket-pair statistics:
19:04:00.276     ===================================
19:04:00.276     Pair     Sent     Recv    Pct total
19:04:00.276     ===================================
19:04:00.276        0  131.1 MB  131.1 MB     12.2%
19:04:00.276        1  134.4 MB  134.4 MB     12.5%
19:04:00.276        2  134.8 MB  134.8 MB     12.6%
19:04:00.276        3  134.5 MB  134.5 MB     12.5%
19:04:00.276        4  134.1 MB  134.1 MB     12.5%
19:04:00.276        5  135.0 MB  135.0 MB     12.6%
19:04:00.276        6  134.8 MB  134.8 MB     12.6%
19:04:00.276        7  133.4 MB  133.4 MB     12.4%
```

For comparison, below is the result of select ioqueue:
```
select with concurrency=1:
19:14:50.660   Socket-pair statistics:
19:14:50.660     ===================================
19:14:50.660     Pair     Sent     Recv    Pct total
19:14:50.660     ===================================
19:14:50.660        0  389.3 MB  389.3 MB      8.1%
19:14:50.660        1  640.8 MB  640.8 MB     13.4%
19:14:50.660        2  626.5 MB  626.5 MB     13.1%
19:14:50.660        3  629.4 MB  629.4 MB     13.1%
19:14:50.660        4  611.9 MB  611.9 MB     12.8%
19:14:50.660        5  614.1 MB  614.1 MB     12.8%
19:14:50.660        6  628.4 MB  628.4 MB     13.1%
19:14:50.660        7  653.0 MB  653.0 MB     13.6%

select with concurrency=0:
9:14:55.662   Socket-pair statistics:
19:14:55.662     ===================================
19:14:55.662     Pair     Sent     Recv    Pct total
19:14:55.662     ===================================
19:14:55.662        0   81.9 MB   81.9 MB     14.0%
19:14:55.662        1   77.7 MB   77.7 MB     13.3%
19:14:55.662        2   74.1 MB   74.1 MB     12.7%
19:14:55.662        3   71.9 MB   71.9 MB     12.3%
19:14:55.662        4   70.5 MB   70.5 MB     12.0%
19:14:55.662        5   70.1 MB   70.1 MB     12.0%
19:14:55.662        6   69.7 MB   69.7 MB     11.9%
19:14:55.662        7   69.4 MB   69.4 MB     11.9%

```

## 3. Logging enhancement

Add `pj_log_get_indent()` and `pj_log_set_indent()` to allow application to synchronize logging indentation across threads. 

Internally PJLIB stores current logging indentation as thread local value. When new thread is created however, this logging indentation is not populated to the new thread (note: it is subject to further discussion whether this is the desired behavior though). 

The new API allows application to control indentation in the threads.
