### PR TITLE
Add ability in stream to modify Opus codec parameters on the fly

### DIFF
--- a/pjmedia/include/pjmedia/codec.h
+++ b/pjmedia/include/pjmedia/codec.h
@@ -150,7 +150,7 @@ PJ_BEGIN_DECL
     pjmedia_codec_param param;
 
     // Retrieve default codec param for the specified codec.
-    pjmedia_codec_mgr_get_default_param(codec_mgr, codec_info
+    pjmedia_codec_mgr_get_default_param(codec_mgr, codec_info,
 					&param);
 
     // Application may change the "settings" part of codec param,
@@ -269,7 +269,7 @@ typedef struct pjmedia_codec_param
 {
     /**
      * The "info" part of codec param describes the capability of the codec,
-     * and the value should NOT be changed by application.
+     * and is recommended not to be modified unless necessary.
      */
     struct {
        unsigned	   clock_rate;		/**< Sampling rate in Hz	    */
@@ -294,7 +294,7 @@ typedef struct pjmedia_codec_param
      * of the codec. Any features that are supported by the codec (e.g. vad
      * or plc) will be turned on, so that application can query which 
      * capabilities are supported by the codec. Application may change the
-     * settings here before instantiating the codec/stream.
+     * settings here before instantiating or modifying the codec.
      */
     struct {
 	pj_uint8_t  frm_per_pkt;    /**< Number of frames per packet.	*/
@@ -305,6 +305,9 @@ typedef struct pjmedia_codec_param
 	unsigned    reserved:1;	    /**< Reserved, must be zero.	*/
 	pjmedia_codec_fmtp enc_fmtp;/**< Encoder's fmtp params.		*/
 	pjmedia_codec_fmtp dec_fmtp;/**< Decoder's fmtp params.		*/
+    	unsigned   packet_loss;     /**< Encoder's expected pkt loss %.	*/
+    	unsigned   complexity;      /**< Encoder complexity, 0-10(max). */
+    	pj_bool_t  cbr;             /**< Constant bit rate?		*/
     } setting;
 } pjmedia_codec_param;
 

--- a/pjmedia/include/pjmedia/codec.h
+++ b/pjmedia/include/pjmedia/codec.h
@@ -383,13 +383,11 @@ typedef struct pjmedia_codec_op
     pj_status_t (*close)(pjmedia_codec *codec);
 
     /** 
-     * Modify the codec parameter after the codec is open. 
-     * Note that not all codec parameters can be modified during run-time. 
-     * When the parameter cannot be changed, this function will return 
-     * non-PJ_SUCCESS, and the original parameters will not be changed.
-     *
-     * Application can expect changing trivial codec settings such as
-     * changing VAD setting to succeed.
+     * Modify the codec parameter after the codec is open.
+     * Note that not all codec parameters can be modified during run-time.
+     * Currently, only Opus codec supports changing key codec parameters
+     * such as bitrate and bandwidth, while other codecs may only be able to
+     * modify minor settings such as VAD or PLC.
      *
      * Application should call #pjmedia_codec_modify() instead of 
      * calling this function directly.
@@ -1001,13 +999,11 @@ PJ_INLINE(pj_status_t) pjmedia_codec_close( pjmedia_codec *codec )
 
 
 /** 
- * Modify the codec parameter after the codec is open. 
- * Note that not all codec parameters can be modified during run-time. 
- * When the parameter cannot be changed, this function will return 
- * non-PJ_SUCCESS, and the original parameters will not be changed.
- *
- * Application can expect changing trivial codec settings such as
- * changing VAD setting to succeed.
+ * Modify the codec parameter after the codec is open.
+ * Note that not all codec parameters can be modified during run-time.
+ * Currently, only Opus codec supports changing key codec parameters
+ * such as bitrate and bandwidth, while other codecs may only be able to
+ * modify minor settings such as VAD or PLC.
  *
  * @param codec	    The codec instance.
  * @param param	    The new codec parameter.

--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -299,6 +299,25 @@ PJ_DECL(pj_status_t) pjmedia_stream_start(pjmedia_stream *stream);
 
 
 /**
+ * Modify the stream's codec parameter after the codec is opened.
+ * Note that not all codec parameters can be modified during run-time.
+ * When the parameter cannot be changed, this function will return
+ * non-PJ_SUCCESS, and the original parameters will not be changed.
+ *
+ * Currently, only Opus codec supports changing key codec parameters
+ * such as bitrate and bandwidth, while other codecs may only be able to
+ * modify minor settings such as VAD.
+ *
+ * @param stream	The media stream.
+ * @param param		The new codec parameter.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_modify_codec_param(pjmedia_stream *stream,
+			  	  const pjmedia_codec_param *param);
+
+/**
  * Get the stream info.
  *
  * @param stream	The media stream.

--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -301,12 +301,9 @@ PJ_DECL(pj_status_t) pjmedia_stream_start(pjmedia_stream *stream);
 /**
  * Modify the stream's codec parameter after the codec is opened.
  * Note that not all codec parameters can be modified during run-time.
- * When the parameter cannot be changed, this function will return
- * non-PJ_SUCCESS, and the original parameters will not be changed.
- *
  * Currently, only Opus codec supports changing key codec parameters
  * such as bitrate and bandwidth, while other codecs may only be able to
- * modify minor settings such as VAD.
+ * modify minor settings such as VAD or PLC.
  *
  * @param stream	The media stream.
  * @param param		The new codec parameter.

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -847,8 +847,7 @@ static pj_status_t  codec_modify( pjmedia_codec *codec,
     PJ_LOG(4, (THIS_FILE, "Modifying Opus encoder, sample rate: %d, "
     			  "avg bitrate: %d%s, vad: %d, plc: %d, pkt loss: %d, "
     			  "complexity: %d, constant bit rate: %d",
-               		  get_opus_bw_constant(
-    					    attr->info.clock_rate),
+    			  attr->info.clock_rate,
                		  (attr->info.avg_bps? attr->info.avg_bps: 0),
                		  (attr->info.avg_bps? "": "(auto)"),
                		  attr->setting.vad?1:0,

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -508,6 +508,9 @@ static pj_status_t factory_default_attr( pjmedia_codec_factory *factory,
     attr->info.pcm_bits_per_sample = 16;
     attr->setting.vad      	   = OPUS_DEFAULT_VAD;
     attr->setting.plc      	   = OPUS_DEFAULT_PLC;
+    attr->setting.packet_loss	   = opus_cfg.packet_loss;
+    attr->setting.complexity	   = opus_cfg.complexity;
+    attr->setting.cbr		   = opus_cfg.cbr;
 
     /* Set max RX frame size to 1275 (max Opus frame size) to anticipate
      * possible ptime change on the fly.
@@ -752,11 +755,13 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     opus_encoder_ctl(opus_data->enc,
     		     OPUS_SET_VBR(opus_data->cfg.cbr ? 0 : 1));
 
-    PJ_LOG(5, (THIS_FILE, "Initialize Opus encoder, sample rate: %d, "
-    			  "avg bitrate: %d, vad: %d, plc: %d, pkt loss: %d, "
+    PJ_LOG(4, (THIS_FILE, "Initialize Opus encoder, sample rate: %d, "
+    			  "avg bitrate: %d%s, vad: %d, plc: %d, pkt loss: %d, "
     			  "complexity: %d, constant bit rate: %d",
                		  opus_data->cfg.sample_rate,
-               		  attr->info.avg_bps, attr->setting.vad?1:0,
+               		  (auto_bit_rate? 0: attr->info.avg_bps),
+               		  (auto_bit_rate? "(auto)": ""),
+               		  attr->setting.vad?1:0,
                		  attr->setting.plc?1:0,
                		  opus_data->cfg.packet_loss,
                		  opus_data->cfg.complexity,
@@ -824,6 +829,33 @@ static pj_status_t  codec_modify( pjmedia_codec *codec,
     /* Set PLC */
     opus_encoder_ctl(opus_data->enc,
     		     OPUS_SET_INBAND_FEC(attr->setting.plc ? 1 : 0));
+
+    /* Set bandwidth */
+    opus_encoder_ctl(opus_data->enc,
+    		     OPUS_SET_MAX_BANDWIDTH(get_opus_bw_constant(
+    					    attr->info.clock_rate)));
+    /* Set expected packet loss */
+    opus_encoder_ctl(opus_data->enc,
+    		     OPUS_SET_PACKET_LOSS_PERC(attr->setting.packet_loss));
+    /* Set complexity */
+    opus_encoder_ctl(opus_data->enc,
+		     OPUS_SET_COMPLEXITY(attr->setting.complexity));
+    /* Set constant bit rate */
+    opus_encoder_ctl(opus_data->enc,
+    		     OPUS_SET_VBR(attr->setting.cbr ? 0 : 1));
+
+    PJ_LOG(4, (THIS_FILE, "Modifying Opus encoder, sample rate: %d, "
+    			  "avg bitrate: %d%s, vad: %d, plc: %d, pkt loss: %d, "
+    			  "complexity: %d, constant bit rate: %d",
+               		  get_opus_bw_constant(
+    					    attr->info.clock_rate),
+               		  (attr->info.avg_bps? attr->info.avg_bps: 0),
+               		  (attr->info.avg_bps? "": "(auto)"),
+               		  attr->setting.vad?1:0,
+               		  attr->setting.plc?1:0,
+               		  attr->setting.packet_loss,
+               		  attr->setting.complexity,
+               		  attr->setting.cbr?1:0));
 
     pj_mutex_unlock (opus_data->mutex);
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -3128,6 +3128,18 @@ PJ_DEF(pj_status_t) pjmedia_stream_start(pjmedia_stream *stream)
     return PJ_SUCCESS;
 }
 
+/*
+ * Modify codec parameter.
+ */
+PJ_DEF(pj_status_t)
+pjmedia_stream_modify_codec_param(pjmedia_stream *stream,
+			  	  const pjmedia_codec_param *param)
+{
+    PJ_ASSERT_RETURN(stream && param, PJ_EINVAL);
+
+    return pjmedia_codec_modify(stream->codec, param);
+}
+
 
 PJ_DEF(pj_status_t) pjmedia_stream_get_info( const pjmedia_stream *stream,
 					     pjmedia_stream_info *info)

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -581,6 +581,15 @@ typedef struct pjsua_stream_info
 	pjmedia_vid_stream_info	vid;
     } info;
 
+    /** Stream instance (union). */
+    union {
+	/** Audio stream */
+	pjmedia_stream 	       *aud_strm;
+
+	/** Video stream */
+	pjmedia_vid_stream     *vid_strm;
+    } strm;
+
 } pjsua_stream_info;
 
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -581,15 +581,6 @@ typedef struct pjsua_stream_info
 	pjmedia_vid_stream_info	vid;
     } info;
 
-    /** Stream instance (union). */
-    union {
-	/** Audio stream */
-	pjmedia_stream 	       *aud_strm;
-
-	/** Video stream */
-	pjmedia_vid_stream     *vid_strm;
-    } strm;
-
 } pjsua_stream_info;
 
 
@@ -6111,6 +6102,24 @@ PJ_DECL(pj_status_t) pjsua_call_set_vid_strm (
 				pjsua_call_vid_strm_op op,
 				const pjsua_call_vid_strm_op_param *param);
 
+/**
+ * Modify the audio stream's codec parameter after the codec is opened.
+ * Note that not all codec parameters can be modified during run-time.
+ * Currently, only Opus codec supports changing key codec parameters
+ * such as bitrate and bandwidth, while other codecs may only be able to
+ * modify minor settings such as VAD or PLC.
+ *
+ * @param call_id	Call identification.
+ * @param med_idx	Media stream index, or -1 to specify default audio
+ * 			media.
+ * @param param		The new codec parameter.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjsua_call_aud_stream_modify_codec_param(pjsua_call_id call_id,
+                                         int med_idx,
+			  	  	 const pjmedia_codec_param *param);
 
 /**
  * Get media stream info for the specified media index.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -47,7 +47,7 @@ using std::vector;
 //////////////////////////////////////////////////////////////////////////////
 
 /**
- * Media stream, corresponds to pjmedia_stream or pjmedia_vid_stream
+ * Media stream, corresponds to pjmedia_stream
  */
 typedef void *MediaStream;
 
@@ -562,11 +562,6 @@ public:
  */
 struct StreamInfo
 {
-    /**
-     * Media stream instance, either audio or video.
-     */
-    MediaStream		stream;
-
     /**
      * Media type of this stream.
      */
@@ -1763,6 +1758,22 @@ public:
      */
     void vidSetStream(pjsua_call_vid_strm_op op,
                       const CallVidSetStreamParam &param) PJSUA2_THROW(Error);
+
+    /**
+     * Modify the audio stream's codec parameter after the codec is opened.
+     * Note that not all codec parameters can be modified during run-time.
+     * Currently, only Opus codec supports changing key codec parameters
+     * such as bitrate and bandwidth, while other codecs may only be able to
+     * modify minor settings such as VAD or PLC.
+     *
+     * @param med_idx	    Media stream index, or -1 to specify default audio
+     * 			    media.
+     * @param param	    The new codec parameter.
+     *
+     * @return		    PJ_SUCCESS on success.
+     */
+    void audStreamModifyCodecParam(int med_idx, const CodecParam &param)
+    				   PJSUA2_THROW(Error);
 
     /**
      * Get media stream info for the specified media index.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -47,7 +47,7 @@ using std::vector;
 //////////////////////////////////////////////////////////////////////////////
 
 /**
- * Media stream, corresponds to pjmedia_stream
+ * Media stream, corresponds to pjmedia_stream or pjmedia_vid_stream
  */
 typedef void *MediaStream;
 
@@ -562,6 +562,11 @@ public:
  */
 struct StreamInfo
 {
+    /**
+     * Media stream instance, either audio or video.
+     */
+    MediaStream		stream;
+
     /**
      * Media type of this stream.
      */

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2459,6 +2459,9 @@ struct CodecParamSetting
     bool	reserved;	    /**< Reserved, must be zero.	*/
     CodecFmtpVector encFmtp;	    /**< Encoder's fmtp params.		*/
     CodecFmtpVector decFmtp;	    /**< Decoder's fmtp params.		*/
+    unsigned   	packetLoss;         /**< Encoder's expected pkt loss %.	*/
+    unsigned   	complexity;         /**< Encoder complexity, 0-10(max). */
+    bool  	cbr;                /**< Constant bit rate?		*/
 };
 
 /**

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -115,11 +115,13 @@ PJ_DEF(pj_status_t) pjsua_call_get_stream_info( pjsua_call_id call_id,
     psi->type = call_med->type;
     switch (call_med->type) {
     case PJMEDIA_TYPE_AUDIO:
+    	psi->strm.aud_strm = call_med->strm.a.stream;
 	status = pjmedia_stream_get_info(call_med->strm.a.stream,
 					 &psi->info.aud);
 	break;
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
     case PJMEDIA_TYPE_VIDEO:
+    	psi->strm.vid_strm = call_med->strm.v.stream;
 	status = pjmedia_vid_stream_get_info(call_med->strm.v.stream,
 					     &psi->info.vid);
 	break;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -116,7 +116,7 @@ pjsua_call_aud_stream_modify_codec_param(pjsua_call_id call_id,
 
     /* Verify if the media is audio */
     call_med = &call->media[med_idx];
-    if (call_med->type == PJMEDIA_TYPE_AUDIO && call_med->strm.a.stream) {
+    if (call_med->type != PJMEDIA_TYPE_AUDIO || !call_med->strm.a.stream) {
 	PJSUA_UNLOCK();
 	return PJ_EINVALIDOP;
     }

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -875,6 +875,14 @@ void Call::vidSetStream(pjsua_call_vid_strm_op op,
 #endif
 }
 
+void Call::audStreamModifyCodecParam(int med_idx, const CodecParam &param)
+    				     PJSUA2_THROW(Error)
+{
+    pjmedia_codec_param prm = param.toPj();
+    PJSUA2_CHECK_EXPR( pjsua_call_aud_stream_modify_codec_param(id, med_idx,
+    								&prm) );
+}
+
 StreamInfo Call::getStreamInfo(unsigned med_idx) const PJSUA2_THROW(Error)
 {
     pjsua_stream_info pj_si;

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -335,6 +335,7 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
 
     type = info.type;
     if (type == PJMEDIA_TYPE_AUDIO) {
+    	stream = info.strm.aud_strm;
         proto = info.info.aud.proto;
         dir = info.info.aud.dir;
         pj_sockaddr_print(&info.info.aud.rem_addr, straddr, sizeof(straddr), 3);
@@ -356,6 +357,7 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
 #endif
         rtcpSdesByeDisabled = PJ2BOOL(info.info.aud.rtcp_sdes_bye_disabled);
     } else if (type == PJMEDIA_TYPE_VIDEO) {
+    	stream = info.strm.vid_strm;
         proto = info.info.vid.proto;
         dir = info.info.vid.dir;
         pj_sockaddr_print(&info.info.vid.rem_addr, straddr, sizeof(straddr), 3);

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -335,7 +335,6 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
 
     type = info.type;
     if (type == PJMEDIA_TYPE_AUDIO) {
-    	stream = info.strm.aud_strm;
         proto = info.info.aud.proto;
         dir = info.info.aud.dir;
         pj_sockaddr_print(&info.info.aud.rem_addr, straddr, sizeof(straddr), 3);
@@ -357,7 +356,6 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
 #endif
         rtcpSdesByeDisabled = PJ2BOOL(info.info.aud.rtcp_sdes_bye_disabled);
     } else if (type == PJMEDIA_TYPE_VIDEO) {
-    	stream = info.strm.vid_strm;
         proto = info.info.vid.proto;
         dir = info.info.vid.dir;
         pj_sockaddr_print(&info.info.vid.rem_addr, straddr, sizeof(straddr), 3);

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1838,6 +1838,9 @@ void CodecParam::fromPj(const pjmedia_codec_param &param)
     setting.reserved = param.setting.reserved;
     CodecFmtpUtil::fromPj(param.setting.enc_fmtp, setting.encFmtp);
     CodecFmtpUtil::fromPj(param.setting.dec_fmtp, setting.decFmtp);
+    setting.packetLoss = param.setting.packet_loss;
+    setting.complexity = param.setting.complexity;
+    setting.cbr = PJ2BOOL(param.setting.cbr);
 }
 
 pjmedia_codec_param CodecParam::toPj() const
@@ -1865,6 +1868,9 @@ pjmedia_codec_param CodecParam::toPj() const
     param.setting.reserved = setting.reserved;
     CodecFmtpUtil::toPj(setting.encFmtp, param.setting.enc_fmtp);
     CodecFmtpUtil::toPj(setting.decFmtp, param.setting.dec_fmtp);
+    param.setting.packet_loss = setting.packetLoss;
+    param.setting.complexity = setting.complexity;
+    param.setting.cbr = setting.cbr;
     return param;
 }
 


### PR DESCRIPTION
As described in [RFC 6176](https://datatracker.ietf.org/doc/html/rfc6716):
```
The Opus codec includes a number of control parameters that can be
   changed dynamically during regular operation of the codec, without
   interrupting the audio stream from the encoder to the decoder. These
   parameters only affect the encoder since any impact they have on the
   bitstream is signaled in-band such that a decoder can decode any Opus
   stream without any out-of-band signaling.
```

Typically, the adjusted parameters are the bitrate, bandwidth, and frame duration, in order to adapt to the changes in network condition. For example, in a slower network, sender can increase the frame duration and reduce the bitrate&bandwidth.
```
Opus can encode frames of 2.5, 5, 10, 20, 40, or 60 ms.  It can also
   combine multiple frames into packets of up to 120 ms.  For real-time
   applications, sending fewer packets per second reduces the bitrate,
   since it reduces the overhead from IP, UDP, and RTP headers.
```

For the receiving direction, most of the hard work has been done in #2089 that handles the frame duration change. While for bitrate and bandwidth changes, as the above RFC text says, they will be internally taken care of by the Opus decoder itself.

But for the outgoing direction, currently there's no mechanism for PJSIP to modify the codec parameters, so this PR will add `pjmedia_stream_modify_codec_param()`. Applications monitoring network conditions can thus use this API to modify the current codec's settings, in particular when using Opus codec.
