### PR TITLE
Fix multicast problems on Windows

### DIFF
--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -60,11 +60,11 @@ const pj_uint16_t PJ_SOCK_RDM	= SOCK_RDM;
  * Socket level values.
  */
 const pj_uint16_t PJ_SOL_SOCKET	= SOL_SOCKET;
-#ifdef SOL_IP
-const pj_uint16_t PJ_SOL_IP	= SOL_IP;
-#elif (defined(PJ_WIN32) && PJ_WIN32) || (defined(PJ_WIN64) && PJ_WIN64) || \
+#if (defined(PJ_WIN32) && PJ_WIN32) || (defined(PJ_WIN64) && PJ_WIN64) || \
       (defined (IPPROTO_IP))
 const pj_uint16_t PJ_SOL_IP	= IPPROTO_IP;
+#elif defined(SOL_IP)
+const pj_uint16_t PJ_SOL_IP	= SOL_IP;
 #else
 const pj_uint16_t PJ_SOL_IP	= 0;
 #endif /* SOL_IP */


### PR DESCRIPTION
Reported that setting up a multicast socket like:
```
pj_sock_setsockopt(..., pj_SOL_IP(), pj_IP_ADD_MEMBERSHIP(), ...);
```
will return error `WSAEINVAL`.

Looks like it is caused by the recent Windows build toolsets (e.g: v143) that defines `SOL_IP` to a 'bad' value so `pj_SOL_IP()` will be resolved to that 'bad' value. In previous/older build toolsets `SOL_IP` is undefined so `pj_SOL_IP()` will be resolved to `IPPROTO_IP`.

The patch is tested on Windows, Linux Ubuntu, MacOS.

Thanks to Adam Wientzek for the report.