### PR TITLE
Update third party media sample implementation

### DIFF
--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
@@ -327,6 +327,16 @@ PJ_DEF(pjsua_conf_port_id) pjsua_call_get_conf_port(pjsua_call_id call_id)
     return PJSUA_INVALID_ID;
 }
 
+/* Modify audio stream's codec parameters. */
+PJ_DEF(pj_status_t)
+pjsua_call_aud_stream_modify_codec_param(pjsua_call_id call_id,
+                                         int med_idx,
+			  	  	 const pjmedia_codec_param *param)
+{
+    UNIMPLEMENTED(pjsua_call_aud_stream_modify_codec_param)
+    return PJ_ENOTSUP;
+}
+
 /* Get media stream info for the specified media index. */
 PJ_DEF(pj_status_t) pjsua_call_get_stream_info( pjsua_call_id call_id,
                                                 unsigned med_idx,

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
@@ -362,6 +362,11 @@ PJ_DEF(pj_status_t) pjsua_call_dial_dtmf( pjsua_call_id call_id,
  * with the other media stack)
  */
 
+PJ_DEF(void) pjsua_conf_connect_param_default(pjsua_conf_connect_param *prm)
+{
+    UNIMPLEMENTED(pjsua_conf_connect_param_default)
+}
+
 /* Get maximum number of conference ports. */
 PJ_DEF(unsigned) pjsua_conf_get_max_ports(void)
 {
@@ -418,6 +423,18 @@ PJ_DEF(pj_status_t) pjsua_conf_connect( pjsua_conf_port_id source,
 					pjsua_conf_port_id sink)
 {
     UNIMPLEMENTED(pjsua_conf_connect)
+    return PJ_ENOTSUP;
+}
+
+/*
+ * Establish unidirectional media flow from souce to sink, with signal
+ * level adjustment.
+ */
+PJ_DEF(pj_status_t) pjsua_conf_connect2( pjsua_conf_port_id source,
+					 pjsua_conf_port_id sink,
+					 const pjsua_conf_connect_param *prm)
+{
+    UNIMPLEMENTED(pjsua_conf_connect2)
     return PJ_ENOTSUP;
 }
 
@@ -597,6 +614,23 @@ PJ_DEF(pj_status_t) pjsua_get_snd_dev(int *capture_dev, int *playback_dev)
     return PJ_ENOTSUP;
 }
 
+/* Get sound dev parameters such as playback & capture device IDs and mode. */
+PJ_DEF(pj_status_t) pjsua_get_snd_dev2(pjsua_snd_dev_param *snd_param)
+{
+    UNIMPLEMENTED(pjsua_get_snd_dev2)
+    return PJ_ENOTSUP;
+}
+
+/*
+ * Select or change sound device. Application may call this function at
+ * any time to replace current sound device.
+ */
+PJ_DEF(pj_status_t) pjsua_set_snd_dev2(const pjsua_snd_dev_param *snd_param)
+{
+    UNIMPLEMENTED(pjsua_set_snd_dev2)
+    return PJ_SUCCESS;
+}
+
 /* Use null sound device. */
 PJ_DEF(pj_status_t) pjsua_set_null_snd_dev(void)
 {
@@ -645,4 +679,35 @@ PJ_DEF(pj_status_t) pjsua_snd_get_setting(pjmedia_aud_dev_cap cap, void *pval)
 {
     UNIMPLEMENTED(pjsua_snd_get_setting)
     return PJ_ENOTSUP;
+}
+
+/* Create an extra sound device and register it to conference bridge. */
+PJ_DEF(pj_status_t) pjsua_ext_snd_dev_create( pjmedia_snd_port_param *param,
+					      pjsua_ext_snd_dev **p_snd)
+{
+    UNIMPLEMENTED(pjsua_ext_snd_dev_create)
+    return PJ_ENOTSUP;
+}
+
+/* Destroy an extra sound device and unregister it from conference bridge. */
+PJ_DEF(pj_status_t) pjsua_ext_snd_dev_destroy(pjsua_ext_snd_dev *snd)
+{
+    UNIMPLEMENTED(pjsua_ext_snd_dev_destroy)
+    return PJ_ENOTSUP;
+}
+
+/* Get sound port instance of an extra sound device. */
+PJ_DEF(pjmedia_snd_port*) pjsua_ext_snd_dev_get_snd_port(
+					    pjsua_ext_snd_dev *snd)
+{
+    UNIMPLEMENTED(pjsua_ext_snd_dev_get_snd_port)
+    return NULL;
+}
+
+/* Get conference port ID of an extra sound device. */
+PJ_DEF(pjsua_conf_port_id) pjsua_ext_snd_dev_get_conf_port(
+					    pjsua_ext_snd_dev *snd)
+{
+    UNIMPLEMENTED(pjsua_ext_snd_dev_get_conf_port)
+    return PJSUA_INVALID_ID;
 }

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
@@ -386,6 +386,14 @@ PJ_DEF(pjsua_vid_win_id) pjsua_vid_preview_get_win(pjmedia_vid_dev_index id)
     return PJSUA_INVALID_ID;
 }
 
+/* Get video conference slot ID of the specified capture device. */
+PJ_DEF(pjsua_conf_port_id) pjsua_vid_preview_get_vid_conf_port(
+						    pjmedia_vid_dev_index id)
+{
+    UNIMPLEMENTED(pjsua_vid_preview_get_vid_conf_port)
+    return PJSUA_INVALID_ID;
+}
+
 /* Reset internal window structure. Not sure if this is needed?. */
 PJ_DEF(void) pjsua_vid_win_reset(pjsua_vid_win_id wid)
 {
@@ -449,6 +457,31 @@ PJ_DEF(pj_status_t) pjsua_vid_enum_devs(pjmedia_vid_dev_info info[],
     return PJ_ENOTSUP;
 }
 
+/* Check whether the video device is currently active. */
+PJ_DEF(pj_bool_t) pjsua_vid_dev_is_active(pjmedia_vid_dev_index id)
+{
+    UNIMPLEMENTED(pjsua_vid_dev_is_active)
+    return PJ_FALSE;
+}
+
+/* Set the capability of the video device. */
+PJ_DEF(pj_status_t) pjsua_vid_dev_set_setting( pjmedia_vid_dev_index id,
+					       pjmedia_vid_dev_cap cap,
+					       const void *pval,
+					       pj_bool_t keep)
+{
+    UNIMPLEMENTED(pjsua_vid_dev_set_setting)
+    return PJ_ENOTSUP;
+}
+
+/* Get the value of the video device capability. */
+PJ_DEF(pj_status_t) pjsua_vid_dev_get_setting( pjmedia_vid_dev_index id,
+					       pjmedia_vid_dev_cap cap,
+					       void *pval)
+{
+    UNIMPLEMENTED(pjsua_vid_dev_get_setting)
+    return PJ_ENOTSUP;
+}
 
 /*****************************************************************************
  * Codecs.
@@ -561,6 +594,23 @@ PJ_DEF(pj_status_t) pjsua_vid_win_set_size( pjsua_vid_win_id wid,
     return PJ_ENOTSUP;
 }
 
+/* Set video window fullscreen. */
+PJ_DEF(pj_status_t) pjsua_vid_win_set_fullscreen(
+					pjsua_vid_win_id wid,
+					pjmedia_vid_dev_fullscreen_flag mode)
+{
+    UNIMPLEMENTED(pjsua_vid_win_set_fullscreen)
+    return PJ_ENOTSUP;
+}
+
+/* Set output window. */
+PJ_DEF(pj_status_t) pjsua_vid_win_set_win( pjsua_vid_win_id wid,
+                                           const pjmedia_vid_dev_hwnd *win)
+{
+    UNIMPLEMENTED(pjsua_vid_win_set_win)
+    return PJ_ENOTSUP;
+}
+
 /* Set video orientation. */
 PJ_DEF(pj_status_t) pjsua_vid_win_rotate( pjsua_vid_win_id wid,
                                           int angle)
@@ -596,6 +646,68 @@ PJ_DEF(pj_bool_t) pjsua_call_vid_stream_is_running( pjsua_call_id call_id,
 {
     UNIMPLEMENTED(pjsua_call_vid_stream_is_running)
     return PJ_FALSE;
+}
+
+/*
+ * Enumerate all video conference ports.
+ */
+PJ_DEF(pj_status_t) pjsua_vid_conf_enum_ports( pjsua_conf_port_id id[],
+					       unsigned *count)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_enum_ports)
+    return PJ_ENOTSUP;
+}
+
+/*
+ * Get information about the specified video conference port
+ */
+PJ_DEF(pj_status_t) pjsua_vid_conf_get_port_info(
+					    pjsua_conf_port_id port_id,
+					    pjsua_vid_conf_port_info *info)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_get_port_info)
+    return PJ_ENOTSUP;
+}
+
+/* Establish unidirectional video flow from souce to sink. */
+PJ_DEF(pj_status_t) pjsua_vid_conf_connect( pjsua_conf_port_id source,
+					    pjsua_conf_port_id sink,
+					    const void *param)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_connect)
+    return PJ_ENOTSUP;
+}
+
+/* Disconnect video flow from the source to destination port. */
+PJ_DEF(pj_status_t) pjsua_vid_conf_disconnect(pjsua_conf_port_id source,
+					      pjsua_conf_port_id sink)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_disconnect)
+    return PJ_ENOTSUP;
+}
+
+/* Add arbitrary video media port to PJSUA's video conference bridge. */
+PJ_DEF(pj_status_t) pjsua_vid_conf_add_port( pj_pool_t *pool,
+					     pjmedia_port *port,
+					     const void *param,
+					     pjsua_conf_port_id *p_id)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_add_port)
+    return PJ_ENOTSUP;
+}
+
+/* Remove arbitrary slot from the video conference bridge. */
+PJ_DEF(pj_status_t) pjsua_vid_conf_remove_port(pjsua_conf_port_id id)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_remove_port)
+    return PJ_ENOTSUP;
+}
+
+/* Update or refresh port states from video port info. */
+PJ_DEF(pj_status_t) pjsua_vid_conf_update_port(pjsua_conf_port_id id)
+{
+    UNIMPLEMENTED(pjsua_vid_conf_update_port)
+    return PJ_ENOTSUP;
 }
 
 #endif	/* PJSUA_HAS_VIDEO */

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
@@ -648,9 +648,7 @@ PJ_DEF(pj_bool_t) pjsua_call_vid_stream_is_running( pjsua_call_id call_id,
     return PJ_FALSE;
 }
 
-/*
- * Enumerate all video conference ports.
- */
+/* Enumerate all video conference ports. */
 PJ_DEF(pj_status_t) pjsua_vid_conf_enum_ports( pjsua_conf_port_id id[],
 					       unsigned *count)
 {
@@ -658,9 +656,7 @@ PJ_DEF(pj_status_t) pjsua_vid_conf_enum_ports( pjsua_conf_port_id id[],
     return PJ_ENOTSUP;
 }
 
-/*
- * Get information about the specified video conference port
- */
+/* Get information about the specified video conference port. */
 PJ_DEF(pj_status_t) pjsua_vid_conf_get_port_info(
 					    pjsua_conf_port_id port_id,
 					    pjsua_vid_conf_port_info *info)


### PR DESCRIPTION
There has been a lot of additional new pjsua APIs ever since the sample was last created/updated, so we need to add these otherwise the sample will fail to build with the undefined references errors.

