### PR TITLE
char* argument for pj_str should be const.

### DIFF
--- a/pjlib/include/pj/string.h
+++ b/pjlib/include/pj/string.h
@@ -88,7 +88,7 @@ PJ_BEGIN_DECL
  *
  * @return	pj_str_t.
  */
-PJ_IDECL(pj_str_t) pj_str(char *str);
+PJ_IDECL(pj_str_t) pj_str(const char *str);
 
 /**
  * Create constant string from normal C string.

--- a/pjlib/include/pj/string_i.h
+++ b/pjlib/include/pj/string_i.h
@@ -21,7 +21,7 @@
 #include <pj/assert.h>
 #include <pj/pool.h>
 
-PJ_IDEF(pj_str_t) pj_str(char *str)
+PJ_IDEF(pj_str_t) pj_str(const char *str)
 {
     pj_str_t dst;
     dst.ptr = str;


### PR DESCRIPTION
Signed-off-by: Jaco Kroon <jaco@uls.co.za>