### PR TITLE
Add logs for RTP/RTCP socket binding error in PJSUA

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -342,6 +342,9 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
 	if (status != PJ_SUCCESS) {
 	    pj_sock_close(sock[0]);
 	    sock[0] = PJ_INVALID_SOCKET;
+	    PJ_PERROR(1,(THIS_FILE, status, "RTP socket bind() at %s error",
+		      pj_sockaddr_print(&bound_addr, addr_buf,
+					sizeof(addr_buf), 3)));
 	    continue;
 	}
 	
@@ -386,6 +389,10 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
 
 	    pj_sock_close(sock[1]);
 	    sock[1] = PJ_INVALID_SOCKET;
+
+	    PJ_PERROR(1,(THIS_FILE, status, "RTCP socket bind() at %s error",
+		      pj_sockaddr_print(&bound_addr, addr_buf,
+					sizeof(addr_buf), 3)));
 	    continue;
 	}
 


### PR DESCRIPTION
Printing the bound IP address and port may help investigating binding error cases.