### PR TITLE
Only include upnpdebug.h if logging is enabled

### DIFF
--- a/pjnath/src/pjnath/upnp.c
+++ b/pjnath/src/pjnath/upnp.c
@@ -28,7 +28,6 @@
 #if defined(PJNATH_HAS_UPNP) && (PJNATH_HAS_UPNP != 0)
 
 #include <upnp/upnp.h>
-#include <upnp/upnpdebug.h>
 #include <upnp/upnptools.h>
 
 #define THIS_FILE	"upnp.c"
@@ -40,6 +39,10 @@
 
 /* Maximum number of devices. */
 #define MAX_DEVS 16
+
+#if ENABLE_LOG
+#   include <upnp/upnpdebug.h>
+#endif
 
 
 /* UPnP device descriptions. */


### PR DESCRIPTION
As reported in #3203, `upnpdebug.h` may not be available in the installation location if `libupnp` is not build with `--enable-debug`, so we shouldn't include it by default.
