### PR TITLE
Fix port_range/portRange documentation

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3021,8 +3021,9 @@ typedef struct pjsua_transport_config
      * Specify the port range for socket binding, relative to the start
      * port number specified in \a port. Note that this setting is only
      * applicable to media transport when the start port number is non zero.
-     * Refer to pjsua_acc_config.rtp_cfg documentation for the sample
-     * implementation.
+     * Media transport is configurable via account setting, 
+     * i.e: pjsua_acc_config.rtp_cfg, please check the media transport 
+     * config docs for more info.
      *
      * Available ports are in the range of [\a port, \a port + \a port_range]. 
      * 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3020,11 +3020,10 @@ typedef struct pjsua_transport_config
     /**
      * Specify the port range for socket binding, relative to the start
      * port number specified in \a port. Note that this setting is only
-     * applicable when the start port number is non zero.
+     * applicable to media transport when the start port number is non zero.
+     * Refer to pjsua_acc_config.rtp_cfg documentation for the sample
+     * implementation.
      *
-     * Example: \a port=5000, \a port_range=4
-     * - Available ports: 5000, 5001, 5002, 5003, 5004 (SIP transport)
-     * 
      * Available ports are in the range of [\a port, \a port + \a port_range]. 
      * 
      * Default value is zero.

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -325,8 +325,9 @@ struct TransportConfig : public PersistentObject
      * Specify the port range for socket binding, relative to the start
      * port number specified in \a port. Note that this setting is only
      * applicable for media transport when the start port number is non zero.
-     * Refer to AccountMediaConfig::transportConfig documentation for the
-     * sample implementation.
+     * Media transport is configurable via account setting, 
+     * i.e: AccountMediaConfig::transportConfig, please check the media
+     * transport config docs for more info.
      * 
      * Available ports are in the range of [\a port, \a port + \a portRange].
      *

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -324,12 +324,11 @@ struct TransportConfig : public PersistentObject
     /**
      * Specify the port range for socket binding, relative to the start
      * port number specified in \a port. Note that this setting is only
-     * applicable when the start port number is non zero.
+     * applicable for media transport when the start port number is non zero.
+     * Refer to AccountMediaConfig::transportConfig documentation for the
+     * sample implementation.
      * 
-     * Example: \a port=5000, \a portRange=4
-     * - Available ports: 5000, 5001, 5002, 5003, 5004 (SIP transport)
-     * 
-     * Available ports are in the range of [\a port, \a port + \a portRange]. 
+     * Available ports are in the range of [\a port, \a port + \a portRange].
      *
      * Default value is zero.
      */


### PR DESCRIPTION
The `pjsua_transport_config::port_range` or `TransportConfig::portRange` settings are only applicable for media transport.
The documentation doesn't mention this and may lead to misinformation by providing sample implementation for **"SIP transport"**.