### PR TITLE
Fix assertion when trying to set QOS type "signalling"

### DIFF
--- a/pjlib/src/pj/sock_qos_common.c
+++ b/pjlib/src/pj/sock_qos_common.c
@@ -43,7 +43,7 @@ static const pj_qos_params qos_map[] =
 PJ_DEF(pj_status_t) pj_qos_get_params(pj_qos_type type, 
 				      pj_qos_params *p_param)
 {
-    PJ_ASSERT_RETURN(type<=PJ_QOS_TYPE_CONTROL && p_param, PJ_EINVAL);
+    PJ_ASSERT_RETURN(type<=PJ_QOS_TYPE_SIGNALLING && p_param, PJ_EINVAL);
     pj_memcpy(p_param, &qos_map[type], sizeof(*p_param));
     return PJ_SUCCESS;
 }


### PR DESCRIPTION
Commit b1490d57d8c8004cc8427d591931c6a4691d7bf4 introduced a new enum member for _pj_qos_type_ called _PJ_QOS_TYPE_SIGNALLING_.
However, the assertion check in [pj_qos_get_params()](https://github.com/pjsip/pjproject/blob/4f280161f11f9d2d1a5dd0e223a462301c77f6d4/pjlib/src/pj/sock_qos_common.c#L46) was not updated to account for the new length of the QOS mapping array.
I noticed this, because I ported an app to Windows which would always abort() in Debug mode when starting up...