### PR TITLE
Fix ASAN error (heap-use-after-free) when app_init() failed

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1941,6 +1941,12 @@ static pj_status_t app_init(void)
     return PJ_SUCCESS;
 
 on_error:
+
+#if defined(PJSIP_HAS_TLS_TRANSPORT) && PJSIP_HAS_TLS_TRANSPORT!=0
+    /* Wipe out TLS key settings in transport configs */
+    pjsip_tls_setting_wipe_keys(&app_config.udp_cfg.tls_setting);
+#endif
+
     pj_pool_release(tmp_pool);
     app_destroy();
     return status;
@@ -2097,6 +2103,11 @@ static pj_status_t app_destroy(void)
 	}
     }
 
+#if defined(PJSIP_HAS_TLS_TRANSPORT) && PJSIP_HAS_TLS_TRANSPORT!=0
+    /* Wipe out TLS key settings in transport configs */
+    pjsip_tls_setting_wipe_keys(&app_config.udp_cfg.tls_setting);
+#endif
+
     pj_pool_safe_release(&app_config.pool);
 
     status = pjsua_destroy();
@@ -2106,11 +2117,6 @@ static pj_status_t app_destroy(void)
 	cli_fe = app_config.cli_cfg.cli_fe;
 	cli_telnet_port = app_config.cli_cfg.telnet_cfg.port;	
     }
-
-#if defined(PJSIP_HAS_TLS_TRANSPORT) && PJSIP_HAS_TLS_TRANSPORT!=0
-    /* Wipe out TLS key settings in transport configs */
-    pjsip_tls_setting_wipe_keys(&app_config.udp_cfg.tls_setting);
-#endif
 
     /* Reset config */
     pj_bzero(&app_config, sizeof(app_config));


### PR DESCRIPTION
On pjsua sample app, when `app_init()` failed ASAN error might be raised.
```
ERROR: AddressSanitizer: heap-use-after-free on address 0x05d1d430 at pc 0x00d82fa7 bp 0x003bb984 sp 0x003bb978
WRITE of size 1 at 0x05d1d430 thread T0
    #0 0xd82fa6 in wipe_buf pjsip\src\pjsip\sip_transport_tls.c:2118
    #1 0xd7e3fb in pjsip_tls_setting_wipe_keys pjsip\src\pjsip\sip_transport_tls.c:2127
    #2 0xc3feda in app_destroy pjsip-apps\src\pjsua\pjsua_app.c:2112
    #3 0xc3fa1f in app_init pjsip-apps\src\pjsua\pjsua_app.c:1945
    #4 0xc3cf2b in pjsua_app_init pjsip-apps\src\pjsua\pjsua_app.c:1954
    #5 0xc3ca5b in main_func pjsip-apps\src\pjsua\main.c:139
    #6 0xcc853d in pj_run_app

0x05d1d430 is located 688 bytes inside of 1024-byte region [0x05d1d180,0x05d1d580)
freed by thread T0 here:
    #0 0xc94af3 in free 1\s\src\vctools\crt\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:115
    #1 0xd0a906 in default_block_free pjlib\src\pj\pool_policy_malloc.c:78
    #2 0xcd7ccf in pj_pool_destroy_int pjlib\src\pj\pool.c:296
    #3 0xcf1aab in cpool_release_pool pjlib\src\pj\pool_caching.c:238
    #4 0xcd6d01 in pj_pool_release pjlib\include\pj\pool_i.h:103
    #5 0xcd6da9 in pj_pool_safe_release pjlib\include\pj\pool_i.h:112
    #6 0xc3fea0 in app_destroy pjsip-apps\src\pjsua\pjsua_app.c:2100 
```
This happen because the `app_config.pool` was released prior to calling `pjsip_tls_setting_wipe_keys()`.
