### PR TITLE
Build Python Wheels via Makefile

### DIFF
--- a/pjsip-apps/src/swig/python/Makefile
+++ b/pjsip-apps/src/swig/python/Makefile
@@ -33,6 +33,9 @@ SWIG_FLAGS += -w312 $(USE_THREADS)
 
 all: $(PYTHON_SO)
 
+wheel: pjsua2_wrap.cpp setup.py $(GCC_EXE)
+	$(PYTHON_EXE) setup.py bdist_wheel $(PYTHON_SETUP_FLAGS)
+
 $(PYTHON_SO): pjsua2_wrap.cpp setup.py $(GCC_EXE)
 	$(PYTHON_EXE) setup.py build $(PYTHON_SETUP_FLAGS)
 
@@ -53,4 +56,3 @@ install:
 uninstall:
 	rm -f $(PYTHON_PKG_DIR)/pjsua2*
 	rm -f $(PYTHON_PKG_DIR)/_pjsua2*
-

--- a/pjsip-apps/src/swig/python/setup.py
+++ b/pjsip-apps/src/swig/python/setup.py
@@ -30,7 +30,12 @@ pj_version_minor=""
 pj_version_rev=""
 pj_version_suffix=""
 write=sys.stdout.write
-f = open('../../../../version.mak', 'r')
+
+# This is needed for building wheels, because pip moves files to a temporary folder
+path_version_relative = '../../../../version.mak'
+path_version_by_env = os.path.join(os.environ.get("PJDIR", ""), "version.mak")
+path_version = path_version_relative if os.path.exists(path_version_relative) else path_version_by_env
+f = open(path_version, 'r')
 for line in f:
     tokens=""
     if line.find("export PJ_VERSION_MAJOR") != -1:
@@ -110,5 +115,3 @@ setup(name="pjsua2",
                     ],
       py_modules=["pjsua2"]
      )
-
-


### PR DESCRIPTION
Currently via make it's only possible to install python bindings.
This PR adds the possibility to build a python [wheel](https://pythonwheels.com/) instead.

Prerequisite: `wheel` (run `pip install wheel` to install).

Command:
```bash
cd pjsip-apps/src/swig/python
make wheel
```

To install PJSIP's wheel dist package, from the above directory, run:
`pip install dist/*.whl` 
