### PR TITLE
fix sdp miss check '=' when parse connection and bandwith info

### DIFF
--- a/pjmedia/include/pjmedia/sdp.h
+++ b/pjmedia/include/pjmedia/sdp.h
@@ -495,7 +495,8 @@ typedef struct pjmedia_sdp_media pjmedia_sdp_media;
  * @return	    the length printed, or -1 if the buffer is too
  *		    short.
  */
-PJ_DECL(int) pjmedia_sdp_media_print(const pjmedia_sdp_media *media, char *buf, pj_size_t size);
+PJ_DECL(int) pjmedia_sdp_media_print(const pjmedia_sdp_media *media,
+				     char *buf, pj_size_t size);
 
 /** 
  * Clone SDP media description. 

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -781,7 +781,7 @@ static int print_media_desc(const pjmedia_sdp_media *m, char *buf,
 }
 
 PJ_DEF(int) pjmedia_sdp_media_print(const pjmedia_sdp_media *media,
-			       char *buf, pj_size_t size)
+				    char *buf, pj_size_t size)
 {
 	return print_media_desc(media, buf, size);
 }


### PR DESCRIPTION
- Fix sdp miss check '=' when parse connection and bandwith info
- Enhance sdp error log print
   use pjmedia_strerror() to get error string message
- Fix format error