### PR TITLE
Forcing lock codec to always use INVITE method

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4944,6 +4944,24 @@ PJ_DECL(pj_status_t) pjsua_acc_set_transport(pjsua_acc_id acc_id,
 #   define PJSUA_MAX_VID_WINS	    16
 #endif
 
+
+/**
+ * Specifies if lock codec feature should always use INVITE method.
+ * This will also affect ICE completion update in updating default address
+ * in SDP.
+ *
+ * This can be useful when communicating with endpoints that do not
+ * respond to UPDATE properly while indicating UPDATE support (by
+ * specifying UPDATE in its SIP Allow header).
+ *
+ * Note that UPDATE can be sent when dialog is still in early state,
+ * while re-INVITE needs to wait until the dialog is confirmed.
+ */
+#ifndef PJSUA_LOCK_CODEC_DONT_USE_UPDATE
+#   define PJSUA_LOCK_CODEC_DONT_USE_UPDATE	    0
+#endif
+
+
 /**
  * Video window ID.
  */

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -4166,7 +4166,8 @@ static pj_status_t process_pending_reinvite(pjsua_call *call)
     if (inv->state == PJSIP_INV_STATE_EARLY) {
     	if (pjsip_dlg_remote_has_cap(inv->dlg, PJSIP_H_ALLOW, NULL,
     	        &ST_UPDATE) == PJSIP_DIALOG_CAP_SUPPORTED &&
-    	    inv->sdp_done_early_rel)
+	    inv->sdp_done_early_rel &&
+	    !PJSUA_LOCK_CODEC_DONT_USE_UPDATE)
     	{
     	    /* Yes, remote supports UPDATE and SDP negotiation was done
     	     * using reliable provisional responses. We can proceed.
@@ -4193,7 +4194,8 @@ static pj_status_t process_pending_reinvite(pjsua_call *call)
     /* Okay! So we need to send re-INVITE/UPDATE */
 
     /* Check if remote support UPDATE */
-    rem_can_update = pjsip_dlg_remote_has_cap(inv->dlg, PJSIP_H_ALLOW, NULL,
+    rem_can_update = !PJSUA_LOCK_CODEC_DONT_USE_UPDATE &&
+		     pjsip_dlg_remote_has_cap(inv->dlg, PJSIP_H_ALLOW, NULL,
 					      &ST_UPDATE) ==
 						PJSIP_DIALOG_CAP_SUPPORTED;
 


### PR DESCRIPTION
Reported that some endpoints may not respond to UPDATE properly while indicating UPDATE support (by specifying UPDATE in its SIP Allow header). So when UPDATE is sent for locking codec, it is responded with 491 and call is disconnected.

This PR introduce compile-time `PJSUA_LOCK_CODEC_DONT_USE_UPDATE` to force lock codec feature to always use INVITE method. This will also affect ICE completion update in updating default address in SDP.