### PR TITLE
Make sure that epoll sleep is done only if the delay is positive

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -1065,7 +1065,8 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
          */
 	int delay = msec - pj_elapsed_usec(&t1, &t2)/1000;
         if (delay > 10) delay = 10;
-	pj_thread_sleep(delay);
+	if (delay > 0)
+	    pj_thread_sleep(delay);
     }
 
     TRACE_((THIS_FILE, "     poll: count=%d events=%d processed=%d",


### PR DESCRIPTION
In epoll, we add sleep to avoid busy polling, and the sleep delay/duration is calculated as follows:
```int delay = msec - pj_elapsed_usec(&t1, &t2)/1000;```

Note that `pj_elapsed_usec()` is used to measure the time that has elapsed when doing `os_epoll_wait()`. In ideal circumstances, this should not exceed the timeout specified:  `msec`. But in practice, there can be inaccuracies of 1 or 2 ms that can cause the calculation to be negative.
