### PR TITLE
Fixed memory leak in OpenSSL when getting certificate chain

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1355,6 +1355,7 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
 	    X509_STORE *cts = SSL_CTX_get_cert_store(ctx);
 
 	    if (cbio && cts) {
+	    printf("pem x509 read bio\n");
 		STACK_OF(X509_INFO) *inf = PEM_X509_INFO_read_bio(cbio, NULL, 
 								  NULL, NULL);
 
@@ -2225,6 +2226,13 @@ static void update_certs_info(pj_ssl_sock_t* ssock,
 	ssl_update_remote_cert_chain_info(ssock->info_pool,
        					  remote_cert_info,
        					  chain, PJ_TRUE);
+	/* Only free the chain returned by X509_STORE_CTX_get1_chain().
+	 * The reference count of each cert returned by
+	 * SSL_get_peer_cert_chain() is not incremented.
+	 */
+	if (is_verify) {
+	    sk_X509_pop_free(chain, X509_free);
+	}
     } else {
 	remote_cert_info->raw_chain.cnt = 0;
     }

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1355,7 +1355,6 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
 	    X509_STORE *cts = SSL_CTX_get_cert_store(ctx);
 
 	    if (cbio && cts) {
-	    printf("pem x509 read bio\n");
 		STACK_OF(X509_INFO) *inf = PEM_X509_INFO_read_bio(cbio, NULL, 
 								  NULL, NULL);
 


### PR DESCRIPTION
According to the doc:
https://www.openssl.org/docs/man1.1.1/man3/X509_STORE_CTX_get1_chain.html
`
The returned chain persists after the ctx structure is freed, when it is no longer needed it should be free up using:
 sk_X509_pop_free(chain, X509_free);
`
But for https://www.openssl.org/docs/man1.1.1/man3/SSL_get_peer_cert_chain.html
`
The reference count of each certificate in the returned STACK_OF(X509) object is not incremented and the returned stack may be invalidated by renegotiation. If applications wish to use any certificates in the returned chain indefinitely they must increase the reference counts using X509_up_ref() or obtain a copy of the whole chain with X509_chain_up_ref().
`

Thanks to Peter Koletzki for the report and the suggested fix.
