### PR TITLE
Update media state when SDP contain "a=inactive" attribute

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -199,28 +199,6 @@ static const char* get_dtmf_method_name(int type)
     return "(Unknown)";
 }
 
-static pj_bool_t call_is_hold(const pjsua_call_setting *call_opt) 
-{
-    if (call_opt->flag & PJSUA_CALL_SET_MEDIA_DIR) 
-    {	
-	unsigned med_cnt = 
-	    PJ_MIN(PJMEDIA_MAX_SDP_MEDIA, \
-		   (call_opt->vid_cnt + call_opt->aud_cnt));
-
-	if (med_cnt) {
-	    unsigned i=0;
-	    for (;i<med_cnt;++i) {
-                if ((call_opt->media_dir[i] == PJMEDIA_DIR_ENCODING) ||
-		    (call_opt->media_dir[i] == PJMEDIA_DIR_NONE))
-		{
-		    return PJ_TRUE;
-		}
-	    }
-	}
-    }
-    return PJ_FALSE;
-}
-
 /*
  * Init call subsystem.
  */
@@ -589,10 +567,6 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
     /* Must increment call counter now */
     ++pjsua_var.call_cnt;
 
-    if (call_is_hold(&call->opt)) {
-        call->hold_msg = tdata;
-        call->local_hold = PJ_TRUE;
-    }
     /* Send initial INVITE: */
 
     status = pjsip_inv_send_msg(inv, tdata);
@@ -603,10 +577,6 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
 	 * session would have been cleared.
 	 */
 	call->inv = inv = NULL;
-        if (call_is_hold(&call->opt)) {
-            call->hold_msg = NULL;
-            call->local_hold = PJ_FALSE;
-        }
 	goto on_error;
     }
 
@@ -2799,11 +2769,6 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
     if (reason && reason->slen == 0)
 	reason = NULL;
 
-    if (call_is_hold(&call->opt)) {
-        call->hold_msg = tdata;
-        call->local_hold = PJ_TRUE;
-    }
-
     /* Create response message */
     status = pjsip_inv_answer(call->inv, code, reason, NULL, &tdata);
     if (status != PJ_SUCCESS) {
@@ -2823,14 +2788,9 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
 
     /* Send the message */
     status = pjsip_inv_send_msg(call->inv, tdata);
-    if (status != PJ_SUCCESS) {
-	if (call_is_hold(&call->opt)) {
-	    call->hold_msg = NULL;
-	    call->local_hold = PJ_FALSE;
-	}
+    if (status != PJ_SUCCESS)
 	pjsua_perror(THIS_FILE, "Error sending response",
 		     status);
-    }
 
 on_return:
     if (dlg) pjsip_dlg_dec_lock(dlg);
@@ -3353,10 +3313,6 @@ PJ_DEF(pj_status_t) pjsua_call_reinvite2(pjsua_call_id call_id,
     /* Add additional headers etc */
     pjsua_process_msg_data( tdata, msg_data);
 
-    if (call_is_hold(&call->opt)) {
-        call->hold_msg = tdata;
-        call->local_hold = PJ_TRUE;
-    }
     /* Send the request */
     call->med_update_success = PJ_FALSE;
     status = pjsip_inv_send_msg( call->inv, tdata);
@@ -3366,10 +3322,6 @@ PJ_DEF(pj_status_t) pjsua_call_reinvite2(pjsua_call_id call_id,
     {
     	call->local_hold = PJ_FALSE;
     } else if (status != PJ_SUCCESS) {
-        if (call_is_hold(&call->opt)) {
-            call->hold_msg = NULL;
-            call->local_hold = PJ_FALSE;
-        }
 	pjsua_perror(THIS_FILE, "Unable to send re-INVITE", status);
 	goto on_return;
     }
@@ -3502,9 +3454,6 @@ PJ_DEF(pj_status_t) pjsua_call_update2(pjsua_call_id call_id,
     {
     	call->local_hold = PJ_FALSE;
     } else if (status != PJ_SUCCESS) {
-        if (call_is_hold(&call->opt)) {
-            call->local_hold = PJ_TRUE;
-        }
 	pjsua_perror(THIS_FILE, "Unable to send UPDATE request", status);
 	goto on_return;
     }

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -199,9 +199,10 @@ static const char* get_dtmf_method_name(int type)
     return "(Unknown)";
 }
 
-static pj_bool_t call_is_hold(const pjsua_call_setting *call_opt) 
+static pj_bool_t call_local_hold(const pjsua_call_setting *call_opt) 
 {
-    if (call_opt->flag & PJSUA_CALL_SET_MEDIA_DIR) 
+    if ((call_opt->flag & PJSUA_CALL_SET_MEDIA_DIR) &&
+	(call_opt->flag & PJSUA_CALL_NO_SDP_OFFER) == 0)
     {	
 	unsigned med_cnt = 
 	    PJ_MIN(PJMEDIA_MAX_SDP_MEDIA, \
@@ -216,6 +217,35 @@ static pj_bool_t call_is_hold(const pjsua_call_setting *call_opt)
 		    return PJ_TRUE;
 		}
 	    }
+	}
+    }
+    return PJ_FALSE;
+}
+
+static pj_bool_t call_release_hold(const pjsua_call_setting *call_opt) 
+{
+    if ((call_opt->flag & PJSUA_CALL_UNHOLD) &&
+        (call_opt->flag & PJSUA_CALL_NO_SDP_OFFER) == 0)
+    {
+        return PJ_TRUE;
+    }
+
+    if ((call_opt->flag & PJSUA_CALL_SET_MEDIA_DIR) &&
+	(call_opt->flag & PJSUA_CALL_NO_SDP_OFFER) == 0)
+    {	
+	unsigned med_cnt = 
+	    PJ_MIN(PJMEDIA_MAX_SDP_MEDIA, \
+		   (call_opt->vid_cnt + call_opt->aud_cnt));
+
+	if (med_cnt) {
+	    unsigned i=0;
+	    for (;i<med_cnt;++i) {
+                if (call_opt->media_dir[i] != PJMEDIA_DIR_ENCODING_DECODING)
+		{
+		    return PJ_FALSE;
+		}
+	    }
+	    return PJ_TRUE;
 	}
     }
     return PJ_FALSE;
@@ -589,7 +619,7 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
     /* Must increment call counter now */
     ++pjsua_var.call_cnt;
 
-    if (call_is_hold(&call->opt)) {
+    if (call_local_hold(&call->opt)) {
         call->hold_msg = tdata;
         call->local_hold = PJ_TRUE;
     }
@@ -603,7 +633,7 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
 	 * session would have been cleared.
 	 */
 	call->inv = inv = NULL;
-        if (call_is_hold(&call->opt)) {
+        if (call_local_hold(&call->opt)) {
             call->hold_msg = NULL;
             call->local_hold = PJ_FALSE;
         }
@@ -2799,7 +2829,7 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
     if (reason && reason->slen == 0)
 	reason = NULL;
 
-    if (call_is_hold(&call->opt)) {
+    if (call_local_hold(&call->opt)) {
         call->hold_msg = tdata;
         call->local_hold = PJ_TRUE;
     }
@@ -2824,7 +2854,7 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
     /* Send the message */
     status = pjsip_inv_send_msg(call->inv, tdata);
     if (status != PJ_SUCCESS) {
-	if (call_is_hold(&call->opt)) {
+	if (call_local_hold(&call->opt)) {
 	    call->hold_msg = NULL;
 	    call->local_hold = PJ_FALSE;
 	}
@@ -3308,7 +3338,7 @@ PJ_DEF(pj_status_t) pjsua_call_reinvite2(pjsua_call_id call_id,
     }
 
     /* Create SDP */
-    if (call->local_hold && (call->opt.flag & PJSUA_CALL_UNHOLD)==0) {
+    if (call->local_hold && !call_release_hold(&call->opt)) {
 	status = create_sdp_of_call_hold(call, &sdp);
     } else if ((call->opt.flag & PJSUA_CALL_NO_SDP_OFFER) == 0) {
 	status = pjsua_media_channel_create_sdp(call->index,
@@ -3353,20 +3383,17 @@ PJ_DEF(pj_status_t) pjsua_call_reinvite2(pjsua_call_id call_id,
     /* Add additional headers etc */
     pjsua_process_msg_data( tdata, msg_data);
 
-    if (call_is_hold(&call->opt)) {
+    if (call_local_hold(&call->opt)) {
         call->hold_msg = tdata;
         call->local_hold = PJ_TRUE;
     }
     /* Send the request */
     call->med_update_success = PJ_FALSE;
     status = pjsip_inv_send_msg( call->inv, tdata);
-    if (status == PJ_SUCCESS &&
-        ((call->opt.flag & PJSUA_CALL_UNHOLD) &&
-         (call->opt.flag & PJSUA_CALL_NO_SDP_OFFER) == 0))
-    {
+    if ((status == PJ_SUCCESS) && call_release_hold(&call->opt)) {
     	call->local_hold = PJ_FALSE;
     } else if (status != PJ_SUCCESS) {
-        if (call_is_hold(&call->opt)) {
+        if (call_local_hold(&call->opt)) {
             call->hold_msg = NULL;
             call->local_hold = PJ_FALSE;
         }
@@ -3447,7 +3474,7 @@ PJ_DEF(pj_status_t) pjsua_call_update2(pjsua_call_id call_id,
     }
 
     /* Create SDP */
-    if (call->local_hold && (call->opt.flag & PJSUA_CALL_UNHOLD)==0) {
+    if (call->local_hold && !call_release_hold(&call->opt)) {
 	status = create_sdp_of_call_hold(call, &sdp);
     } else if ((call->opt.flag & PJSUA_CALL_NO_SDP_OFFER) == 0) {
 	status = pjsua_media_channel_create_sdp(call->index,
@@ -3496,13 +3523,10 @@ PJ_DEF(pj_status_t) pjsua_call_update2(pjsua_call_id call_id,
     /* Send the request */
     call->med_update_success = PJ_FALSE;
     status = pjsip_inv_send_msg( call->inv, tdata);
-    if (status == PJ_SUCCESS &&
-        ((call->opt.flag & PJSUA_CALL_UNHOLD) &&
-         (call->opt.flag & PJSUA_CALL_NO_SDP_OFFER) == 0))
-    {
+    if ((status == PJ_SUCCESS) && (call_release_hold(&call->opt))) {
     	call->local_hold = PJ_FALSE;
     } else if (status != PJ_SUCCESS) {
-        if (call_is_hold(&call->opt)) {
+        if (call_local_hold(&call->opt)) {
             call->local_hold = PJ_TRUE;
         }
 	pjsua_perror(THIS_FILE, "Unable to send UPDATE request", status);

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3983,8 +3983,7 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 	    }
 
 	    /* Check if no media is active */
-	    if ((local_sdp->media[mi]->desc.port == 0) || 
-	        (si->dir == PJMEDIA_DIR_NONE))	    
+            if (local_sdp->media[mi]->desc.port == 0)
 	    {
 
 		/* Update call media state and direction */
@@ -3999,12 +3998,27 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		call_med->dir = si->dir;
 
 		/* Call media state */
-		if (call->local_hold)
+                if (call->local_hold) {
 		    call_med->state = PJSUA_CALL_MEDIA_LOCAL_HOLD;
-		else if (call_med->dir == PJMEDIA_DIR_DECODING)
+		} else if (call_med->dir == PJMEDIA_DIR_DECODING) {
 		    call_med->state = PJSUA_CALL_MEDIA_REMOTE_HOLD;
-		else
+		} else if (call_med->dir == PJMEDIA_DIR_NONE) {
+		    pj_bool_t remote_hold = PJ_FALSE;
+
+		    if (pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
+						     "inactive", NULL) ||
+			pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
+						     "sendonly", NULL)) 
+                    {
+                        remote_hold = PJ_TRUE;
+                    }
+		    
+		    call_med->state = remote_hold? 
+						PJSUA_CALL_MEDIA_REMOTE_HOLD:
+					        PJSUA_CALL_MEDIA_NONE;
+                } else {
 		    call_med->state = PJSUA_CALL_MEDIA_ACTIVE;
+		}
 
 		if (call->inv->following_fork) {
 		    unsigned options = (call_med->enable_rtcp_mux?
@@ -4231,12 +4245,27 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		call_med->dir = si->dir;
 
 		/* Call media state */
-		if (call->local_hold)
+                if (call->local_hold) {
 		    call_med->state = PJSUA_CALL_MEDIA_LOCAL_HOLD;
-		else if (call_med->dir == PJMEDIA_DIR_DECODING)
+		} else if (call_med->dir == PJMEDIA_DIR_DECODING) {
 		    call_med->state = PJSUA_CALL_MEDIA_REMOTE_HOLD;
-		else
+		} else if (call_med->dir == PJMEDIA_DIR_NONE) {
+		    pj_bool_t remote_hold = PJ_FALSE;
+
+		    if (pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
+						     "inactive", NULL) ||
+			pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
+						     "sendonly", NULL)) 
+                    {
+                        remote_hold = PJ_TRUE;
+                    }
+		    
+		    call_med->state = remote_hold? 
+						PJSUA_CALL_MEDIA_REMOTE_HOLD:
+					        PJSUA_CALL_MEDIA_NONE;
+                } else {
 		    call_med->state = PJSUA_CALL_MEDIA_ACTIVE;
+		}
 
 		/* Start/restart media transport */
 		status = pjmedia_transport_media_start(call_med->tp,

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4229,7 +4229,7 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 	    }
 
 	    /* Check if no media is active */
-	    if (si->dir == PJMEDIA_DIR_NONE) {
+	    if (local_sdp->media[mi]->desc.port == 0) {
 
 		/* Update call media state and direction */
 		call_med->state = PJSUA_CALL_MEDIA_NONE;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3983,7 +3983,8 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 	    }
 
 	    /* Check if no media is active */
-            if (local_sdp->media[mi]->desc.port == 0)
+	    if ((local_sdp->media[mi]->desc.port == 0) || 
+	        (si->dir == PJMEDIA_DIR_NONE))	    
 	    {
 
 		/* Update call media state and direction */
@@ -3998,27 +3999,12 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		call_med->dir = si->dir;
 
 		/* Call media state */
-                if (call->local_hold) {
+		if (call->local_hold)
 		    call_med->state = PJSUA_CALL_MEDIA_LOCAL_HOLD;
-		} else if (call_med->dir == PJMEDIA_DIR_DECODING) {
+		else if (call_med->dir == PJMEDIA_DIR_DECODING)
 		    call_med->state = PJSUA_CALL_MEDIA_REMOTE_HOLD;
-		} else if (call_med->dir == PJMEDIA_DIR_NONE) {
-		    pj_bool_t remote_hold = PJ_FALSE;
-
-		    if (pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
-						     "inactive", NULL) ||
-			pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
-						     "sendonly", NULL)) 
-                    {
-                        remote_hold = PJ_TRUE;
-                    }
-		    
-		    call_med->state = remote_hold? 
-						PJSUA_CALL_MEDIA_REMOTE_HOLD:
-					        PJSUA_CALL_MEDIA_NONE;
-                } else {
+		else
 		    call_med->state = PJSUA_CALL_MEDIA_ACTIVE;
-		}
 
 		if (call->inv->following_fork) {
 		    unsigned options = (call_med->enable_rtcp_mux?
@@ -4245,27 +4231,12 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		call_med->dir = si->dir;
 
 		/* Call media state */
-                if (call->local_hold) {
+		if (call->local_hold)
 		    call_med->state = PJSUA_CALL_MEDIA_LOCAL_HOLD;
-		} else if (call_med->dir == PJMEDIA_DIR_DECODING) {
+		else if (call_med->dir == PJMEDIA_DIR_DECODING)
 		    call_med->state = PJSUA_CALL_MEDIA_REMOTE_HOLD;
-		} else if (call_med->dir == PJMEDIA_DIR_NONE) {
-		    pj_bool_t remote_hold = PJ_FALSE;
-
-		    if (pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
-						     "inactive", NULL) ||
-			pjmedia_sdp_media_find_attr2(remote_sdp->media[mi], 
-						     "sendonly", NULL)) 
-                    {
-                        remote_hold = PJ_TRUE;
-                    }
-		    
-		    call_med->state = remote_hold? 
-						PJSUA_CALL_MEDIA_REMOTE_HOLD:
-					        PJSUA_CALL_MEDIA_NONE;
-                } else {
+		else
 		    call_med->state = PJSUA_CALL_MEDIA_ACTIVE;
-		}
 
 		/* Start/restart media transport */
 		status = pjmedia_transport_media_start(call_med->tp,

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3983,9 +3983,7 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 	    }
 
 	    /* Check if no media is active */
-	    if ((local_sdp->media[mi]->desc.port == 0) || 
-	        (si->dir == PJMEDIA_DIR_NONE))	    
-	    {
+	    if (local_sdp->media[mi]->desc.port == 0) {
 
 		/* Update call media state and direction */
 		call_med->state = PJSUA_CALL_MEDIA_NONE;
@@ -3999,12 +3997,26 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		call_med->dir = si->dir;
 
 		/* Call media state */
-		if (call->local_hold)
+		if (call->local_hold ||
+		    ((call_med->dir & PJMEDIA_DIR_DECODING) == 0 &&
+		     (call_med->def_dir & PJMEDIA_DIR_DECODING) == 0))
+		{
+		    /* Local hold: Either the user holds the call, or sets
+		     * the media direction that requests the remote party to
+		     * stop sending media (i.e. sendonly or inactive).
+		     */
 		    call_med->state = PJSUA_CALL_MEDIA_LOCAL_HOLD;
-		else if (call_med->dir == PJMEDIA_DIR_DECODING)
+		} else if ((call_med->dir & PJMEDIA_DIR_ENCODING) == 0 &&
+		           (call_med->def_dir & PJMEDIA_DIR_DECODING) != 0)
+		{
+		    /* Remote hold: Remote doesn't want us to send media
+		     * (recvonly or inactive) and we don't set media dir that
+		     * locally holds the media.
+		     */
 		    call_med->state = PJSUA_CALL_MEDIA_REMOTE_HOLD;
-		else
+		} else {
 		    call_med->state = PJSUA_CALL_MEDIA_ACTIVE;
+		}
 
 		if (call->inv->following_fork) {
 		    unsigned options = (call_med->enable_rtcp_mux?
@@ -4231,12 +4243,26 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 		call_med->dir = si->dir;
 
 		/* Call media state */
-		if (call->local_hold)
+		if (call->local_hold ||
+		    ((call_med->dir & PJMEDIA_DIR_DECODING) == 0 &&
+		     (call_med->def_dir & PJMEDIA_DIR_DECODING) == 0))
+		{
+		    /* Local hold: Either the user holds the call, or sets
+		     * the media direction that requests the remote party to
+		     * stop sending media (i.e. sendonly or inactive).
+		     */
 		    call_med->state = PJSUA_CALL_MEDIA_LOCAL_HOLD;
-		else if (call_med->dir == PJMEDIA_DIR_DECODING)
+		} else if ((call_med->dir & PJMEDIA_DIR_ENCODING) == 0 &&
+		           (call_med->def_dir & PJMEDIA_DIR_DECODING) != 0)
+		{
+		    /* Remote hold: Remote doesn't want us to send media 
+		     * (recvonly or inactive) and we don't set media dir that
+		     * locally holds the media.
+		     */
 		    call_med->state = PJSUA_CALL_MEDIA_REMOTE_HOLD;
-		else
+		} else {
 		    call_med->state = PJSUA_CALL_MEDIA_ACTIVE;
+		}
 
 		/* Start/restart media transport */
 		status = pjmedia_transport_media_start(call_med->tp,

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3983,7 +3983,9 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
 	    }
 
 	    /* Check if no media is active */
-	    if (local_sdp->media[mi]->desc.port == 0) {
+	    if ((local_sdp->media[mi]->desc.port == 0) || 
+	        (si->dir == PJMEDIA_DIR_NONE))	    
+	    {
 
 		/* Update call media state and direction */
 		call_med->state = PJSUA_CALL_MEDIA_NONE;

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1073,7 +1073,8 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
 				     const pjmedia_sdp_session *remote_sdp)
 {
     pjsua_call *call = call_med->call;
-    pjsua_acc  *acc  = &pjsua_var.acc[call->acc_id];
+    unsigned strm_idx = call_med->idx;
+    pjsua_acc  *acc  = &pjsua_var.acc[call->acc_id];    
     pjmedia_port *media_port;
     pj_status_t status;
  
@@ -1087,7 +1088,7 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
     si->rtcp_sdes_bye_disabled = pjsua_var.media_cfg.no_rtcp_sdes_bye;;
 
     /* Check if no media is active */
-    if (si->dir != PJMEDIA_DIR_NONE) {
+    if (local_sdp->media[strm_idx]->desc.port != 0) {
 	/* Optionally, application may modify other stream settings here
 	 * (such as jitter buffer parameters, codec ptime, etc.)
 	 */
@@ -1155,7 +1156,7 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
 
         if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_stream_precreate) {
             pjsua_on_stream_precreate_param prm;
-            prm.stream_idx = call_med->idx;
+            prm.stream_idx = strm_idx;
             prm.stream_info.type = PJMEDIA_TYPE_VIDEO;
             prm.stream_info.info.vid = *si;
             (*pjsua_var.ua_cfg.cb.on_stream_precreate)(call->index, &prm);


### PR DESCRIPTION
SDP may specify `a=inactive` with media port set to non zero.

```
v=0
o=- 3872230549 3872230550 IN IP4 192.168.1.121
s=pjmedia
b=AS:84
t=0 0
a=X-nat:0
m=audio 4002 RTP/AVP 0 120
c=IN IP4 192.168.1.121
b=TIAS:64000
a=rtcp:4003 IN IP4 192.168.1.121
a=rtpmap:0 PCMU/8000
a=rtpmap:120 telephone-event/8000
a=fmtp:120 0-16
a=ssrc:2705443 cname:39b32d12074d4dc8
a=inactive
```
Consider the scenario:
1. Receive initial INVITE with a=inactive.
1. User does local Hold, sends a=sendonly and receives a=inactive.
1. a=inactive is received from remote side for Hold.

For the side which receives the 'a=inactive':
On 1 & 3, the media state to `PJSUA_CALL_MEDIA_ACTIVE`.
On 2, the media state to `PJSUA_CALL_MEDIA_LOCAL_HOLD`.

This patch will update the media state when a=inactive is received, also when it is sent (e.g: by specifying media dir using `PJSUA_CALL_SET_MEDIA_DIR`).

The update media state:
- `PJSUA_CALL_MEDIA_LOCAL_HOLD` 
   Either the user holds the call, or sets the media direction that requests the remote party to stop sending media (i.e. sendonly or inactive).
- `PJSUA_CALL_MEDIA_REMOTE_HOLD`
   Remote doesn't want us to send media (recvonly or inactive) and we don't set media dir that locally holds the media.

