### PR TITLE
OpenSSL sock: Delete context and reset pointer when setting cipher list fails

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1221,8 +1221,11 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
 
     /* Set cipher list */
     status = set_cipher_list(ssock);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+	SSL_CTX_free(ctx);
+	ossock->ossl_ctx = NULL;
         return status;
+    }
 
     /* Apply credentials */
     if (cert) {


### PR DESCRIPTION
This is a followup of #3069. When initializing a new ossl context and setting the cipher list fails, init_ossl_ctx() will exit early without cleaning up the context and without resetting ossock->ossl_ctx.