### PR TITLE
Open/Create files on Windows with FILE_SHARE_DELETE flag

### DIFF
--- a/pjlib/src/pj/file_io_win32.c
+++ b/pjlib/src/pj/file_io_win32.c
@@ -119,7 +119,7 @@ PJ_DEF(pj_status_t) pj_file_open( pj_pool_t *pool,
         return PJ_EINVAL;
     }
 
-    dwShareMode = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    dwShareMode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
     
     dwFlagsAndAttributes = FILE_ATTRIBUTE_NORMAL;
 


### PR DESCRIPTION
This PR adds the FILE_SHARE_DELETE flag to the CreateFile() call when opening/creating files on Windows.
Setting this flag allows i.e. for using temporary files with the WAV player/recorder.

My concrete use case looks like this:
- User wants to play a WAV file
- WAV file has to be downloaded via HTTP
- HTTP download will create a temporary file (with the flags FILE_SHARE_DELETE and FILE_FLAG_DELETE_ON_CLOSE)
 (This ensures the file will be removed when the last handle to the file is closed).
- When download is finished, the file handle is kept open
- Create WAV player, set EOF callback, play WAV file
- When EOF hits: Destroy WAV player and close file handle -> file is removed

Of course there could be other use cases like text-to-speech, where the file is not downloaded but generated locally.
One must make sure, that temporary/generated files are always cleaned up.
Using it like I described above makes this easy.

I don't think there is any harm in adding this flag in general, is there?
The behaviour is now closer to what it's like on Linux where the directory entry
of a file can be moved around or deleted altogether while it's still in use.
