### PR TITLE
Linking errors in building PJSIP as shared library with WebRTC AEC3

### DIFF
--- a/third_party/build/webrtc_aec3/Makefile
+++ b/third_party/build/webrtc_aec3/Makefile
@@ -38,7 +38,6 @@ export WEBRTC_AEC3_OBJS = \
 	api/audio/channel_layout.o \
 	api/audio/echo_canceller3_config.o \
 	api/audio/echo_canceller3_factory.o \
-	api/audio/echo_detector_creator.o \
 	modules/audio_processing/audio_buffer.o \
 	modules/audio_processing/gain_controller2.o \
 	modules/audio_processing/high_pass_filter.o \
@@ -103,7 +102,6 @@ export WEBRTC_AEC3_OBJS = \
 	modules/audio_processing/agc2/adaptive_digital_gain_applier.o \
 	modules/audio_processing/agc2/adaptive_mode_level_estimator.o \
 	modules/audio_processing/agc2/biquad_filter.o \
-	modules/audio_processing/agc2/compute_interpolated_gain_curve.o \
 	modules/audio_processing/agc2/cpu_features.o \
 	modules/audio_processing/agc2/down_sampler.o \
 	modules/audio_processing/agc2/fixed_digital_level_estimator.o \


### PR DESCRIPTION
Reported that linking error occurs in building PJSIP as shared library when `--enable-libwebrtc-aec3` is passed to the configure script, e.g:
```
./configure --enable-shared --enable-libwebrtc-aec3
```
Then `make` will show some errors like:
```
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::ResidualEchoDetector::GetMetrics() const'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `typeinfo for webrtc::ResidualEchoDetector'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::ResidualEchoDetector::AnalyzeCaptureAudio(rtc::ArrayView<float const, -4711l>)'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::ResidualEchoDetector::ResidualEchoDetector()'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::ResidualEchoDetector::Initialize(int, int, int, int)'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::ResidualEchoDetector::AnalyzeRenderAudio(rtc::ArrayView<float const, -4711l>)'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::ResidualEchoDetector::~ResidualEchoDetector()'
/usr/bin/ld: /usr/local/src/pjsip/third_party/lib/libwebrtc-aec3.so: undefined reference to `webrtc::test::LinSpace(double, double, int)'
```

It looks like some unused files are included in the `Makefile` which eventually cause dependency error as shown above.

Thanks to Liviu Andron for the report.