### PR TITLE
pjsua2: Endpoint: Make transportGetInfo and transportEnum methods const

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1474,7 +1474,7 @@ public:
      *
      * @return			Array of transport IDs.
      */
-    IntVector transportEnum() PJSUA2_THROW(Error);
+    IntVector transportEnum() const PJSUA2_THROW(Error);
 
     /**
      * Get information about transport.
@@ -1483,7 +1483,7 @@ public:
      *
      * @return			Transport info.
      */
-    TransportInfo transportGetInfo(TransportId id) PJSUA2_THROW(Error);
+    TransportInfo transportGetInfo(TransportId id) const PJSUA2_THROW(Error);
 
     /**
      * Disable a transport or re-enable it. By default transport is always

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -2247,7 +2247,7 @@ TransportId Endpoint::transportCreate(pjsip_transport_type_e type,
     return tid;
 }
 
-IntVector Endpoint::transportEnum() PJSUA2_THROW(Error)
+IntVector Endpoint::transportEnum() const PJSUA2_THROW(Error)
 {
     pjsua_transport_id tids[32];
     unsigned count = PJ_ARRAY_SIZE(tids);
@@ -2257,7 +2257,7 @@ IntVector Endpoint::transportEnum() PJSUA2_THROW(Error)
     return IntVector(tids, tids+count);
 }
 
-TransportInfo Endpoint::transportGetInfo(TransportId id) PJSUA2_THROW(Error)
+TransportInfo Endpoint::transportGetInfo(TransportId id) const PJSUA2_THROW(Error)
 {
     pjsua_transport_info pj_tinfo;
     TransportInfo tinfo;


### PR DESCRIPTION
These methods do not change Endpoint's status, so could be const. At least I was not able to call them from a const method of a class derived from `pj::Endpoint`.