### PR TITLE
iOS 16 issue: application gets killed when using VoIP socket

### DIFF
--- a/pjlib/include/pj/compat/os_auto.h.in
+++ b/pjlib/include/pj/compat/os_auto.h.in
@@ -200,8 +200,11 @@
 #    	ifdef __IPHONE_4_0
  	    /* Is multitasking support available?  (see ticket #1107) */
 #	    define PJ_IPHONE_OS_HAS_MULTITASKING_SUPPORT 	1
-	    /* Enable activesock TCP background mode support */
-#	    define PJ_ACTIVESOCK_TCP_IPHONE_OS_BG		1
+	    /* Activesock TCP background mode support (VoIP socket).
+	     * Disabled by default, VoIP socket deprecated since iOS 9 and
+	     * on iOS16 using VoIP socket causes app getting killed.
+	     */
+#	    define PJ_ACTIVESOCK_TCP_IPHONE_OS_BG		0
 #	endif
 #    endif
 #endif


### PR DESCRIPTION
VoIP socket is deprecated since iOS 9, in iOS 16 it causes app gets killed, so it is now disabled by default (configurable via `PJ_ACTIVESOCK_TCP_IPHONE_OS_BG`).