### PR TITLE
Fix compile error due to variable not in beginning of block (C89 compatibility)

### DIFF
--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -490,20 +490,22 @@ static void set_thread_display_name(const char *name)
 	return;
     }
 
-    const DWORD MS_VC_EXCEPTION = 0x406D1388;
-    THREADNAME_INFO info;
-    info.dwType = 0x1000;
-    info.szName = name;
-    info.dwThreadID = (DWORD)-1;
-    info.dwFlags = 0;
+    {
+	const DWORD MS_VC_EXCEPTION = 0x406D1388;
+	THREADNAME_INFO info;
+	info.dwType = 0x1000;
+	info.szName = name;
+	info.dwThreadID = (DWORD)-1;
+	info.dwFlags = 0;
 #pragma warning(push)
 #pragma warning(disable : 6320 6322)
-    __try {
-	RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR),
-		       (ULONG_PTR *)&info);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-    }
+	__try {
+	    RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR),
+			   (ULONG_PTR *)&info);
+	} __except (EXCEPTION_EXECUTE_HANDLER) {
+	}
 #pragma warning(pop)
+    }
 #endif
 }
 


### PR DESCRIPTION
Occurred on older compilers such as MSVC2005.