### PR TITLE
conditional compilation removed from macro expansion to satisfy MSVC

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2361,11 +2361,7 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
 	    PJ_LOG(5, (THIS_FILE, "Session info: reused=%d, resumable=%d, "
 		       "timeout=%d",
 		       SSL_session_reused(ossock->ossl_ssl),
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
 		       SSL_SESSION_is_resumable(sess),
-#else
-		       -1,
-#endif
 		       SSL_SESSION_get_timeout(sess)));
 #else
 	    PJ_LOG(5, (THIS_FILE, "Session info: reused=%d, resumable=%d, "

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2357,6 +2357,7 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
 	    
 	    sess = SSL_get_session(ossock->ossl_ssl);
 
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
 	    PJ_LOG(5, (THIS_FILE, "Session info: reused=%d, resumable=%d, "
 		       "timeout=%d",
 		       SSL_session_reused(ossock->ossl_ssl),
@@ -2366,6 +2367,13 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
 		       -1,
 #endif
 		       SSL_SESSION_get_timeout(sess)));
+#else
+	    PJ_LOG(5, (THIS_FILE, "Session info: reused=%d, resumable=%d, "
+		       "timeout=%d",
+		       SSL_session_reused(ossock->ossl_ssl),
+		       -1,
+		       SSL_SESSION_get_timeout(sess)));
+#endif
 
 	    sid = SSL_SESSION_get_id(sess, &len);
 	    len *= 2;


### PR DESCRIPTION
I was not able to compile the latest master branch with 
Microsoft (R) C/C++ Optimizing Compiler Version 19.32.31332 for x86 which comes with Visual Studio 2022.
The error is 
Error	C2121	'#': invalid character: possibly the result of a macro expansion	\pjsip\pjlib\src\pj\ssl_sock_ossl.c	2368
It looks like the compiler does not allow conditional compilation in a macro expansion. 
 