### PR TITLE
Prevent integer underflow of sip regc's next registration time

### DIFF
--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -232,8 +232,12 @@ PJ_DEF(pj_status_t) pjsip_regc_get_info( pjsip_regc *regc,
 
 	next_reg = regc->next_reg;
 	pj_gettimeofday(&now);
-	PJ_TIME_VAL_SUB(next_reg, now);
-	info->next_reg = next_reg.sec;
+	if (PJ_TIME_VAL_GT(next_reg, now)) {
+	    PJ_TIME_VAL_SUB(next_reg, now);
+	    info->next_reg = next_reg.sec;
+	} else {
+	    info->next_reg = 0;
+	}
     }
 
     pj_lock_release(regc->lock);


### PR DESCRIPTION
Sip regs's next registration time, `pjsip_regc_info.next_reg`, is declared as `unsigned`, and calculated as follows:
```
	pj_gettimeofday(&now);
	PJ_TIME_VAL_SUB(regc->next_reg, now);
	info->next_reg = next_reg.sec;
```
`regc->next_reg` keeps track of the time of when the next registration will happen, which theoretically should happen in the future. But it's possible that `now` is later than `regc->next_reg`, in conditions such as:
- late timer, for example when app is suspended and waken up late.
- registration is in progress and `next_reg` is not yet updated.

So here we set it to 0 in such cases to prevent integer wraparound.
