### PR TITLE
Fix build warning and error for UWP

### DIFF
--- a/pjlib/include/pj/compat/os_winuwp.h
+++ b/pjlib/include/pj/compat/os_winuwp.h
@@ -58,6 +58,7 @@
 #define PJ_HAS_SYS_TYPES_H	    0	/* Doesn't have sys/types.h */
 #define PJ_HAS_TIME_H		    1
 #define PJ_HAS_UNISTD_H		    0
+#define PJ_HAS_LIMITS_H             1
 
 #define PJ_HAS_MSWSOCK_H	    1
 #define PJ_HAS_WINSOCK_H	    0

--- a/pjlib/include/pj/compat/socket.h
+++ b/pjlib/include/pj/compat/socket.h
@@ -37,6 +37,9 @@
 #   include <ws2tcpip.h>
 #endif
 
+#if (defined(PJ_WIN32_UWP) && PJ_WIN32_UWP!=0)
+#   include <in6addr.h>
+#endif
 
 /*
  * IPv6 for Visual Studio's

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -549,7 +549,7 @@ struct pj_sockaddr_in
  * recommended as it may cause build issues for anyone who uses
  * the macro. See #2311 for more details.
  */
-#if 0
+#if (defined(PJ_WIN32_UWP) && PJ_WIN32_UWP!=0)
 #undef s6_addr
 
 typedef union pj_in6_addr

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -549,7 +549,7 @@ struct pj_sockaddr_in
  * recommended as it may cause build issues for anyone who uses
  * the macro. See #2311 for more details.
  */
-#if (defined(PJ_WIN32_UWP) && PJ_WIN32_UWP!=0)
+#if 0
 #undef s6_addr
 
 typedef union pj_in6_addr

--- a/pjlib/src/pj/ip_helper_generic.c
+++ b/pjlib/src/pj/ip_helper_generic.c
@@ -586,6 +586,8 @@ PJ_DEF(pj_status_t) pj_enum_ip_interface2( const pj_enum_ip_option *opt,
 	pj_enum_ip_option_default(&opt_);
 
     if (opt_.af != pj_AF_INET() && opt_.omit_deprecated_ipv6) {
+
+#if defined(PJ_LINUX) && PJ_LINUX!=0
 	pj_sockaddr addrs[*p_cnt];
 	pj_sockaddr deprecatedAddrs[*p_cnt];
 	unsigned deprecatedCount = *p_cnt;
@@ -619,6 +621,9 @@ PJ_DEF(pj_status_t) pj_enum_ip_interface2( const pj_enum_ip_option *opt,
 
 	*p_cnt = cnt;
 	return *p_cnt ? PJ_SUCCESS : PJ_ENOTFOUND;
+#else
+        return PJ_ENOTSUP;
+#endif
     }
 
     return pj_enum_ip_interface(opt_.af, p_cnt, ifs);

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -469,6 +469,12 @@ typedef HRESULT(WINAPI *FnSetThreadDescription)(HANDLE hThread,
 
 static void set_thread_display_name(const char *name)
 {
+#if (defined(PJ_WIN32_UWP) && PJ_WIN32_UWP!=0) || \
+      (defined(PJ_WIN32_WINPHONE8) && PJ_WIN32_WINPHONE8!=0)
+
+    return;
+
+#else
     /* Set thread name by SetThreadDescription (if support) */
     FnSetThreadDescription fn = (FnSetThreadDescription)GetProcAddress(
 	GetModuleHandle(PJ_T("Kernel32.dll")), "SetThreadDescription");
@@ -506,6 +512,8 @@ static void set_thread_display_name(const char *name)
 	}
 #pragma warning(pop)
     }
+#  endif
+
 #endif
 }
 

--- a/pjsip-apps/src/pjsua/winrt/cli/comp/pjsua_cli_uwp_comp.vcxproj
+++ b/pjsip-apps/src/pjsua/winrt/cli/comp/pjsua_cli_uwp_comp.vcxproj
@@ -109,7 +109,7 @@
   </ImportGroup>
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <Import Project="pjsua_cli_shared_comp.vcxitems" Label="Shared" />  
+  <Import Project="pjsua_cli_shared_comp.vcxitems" Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -212,6 +212,7 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <IgnoreSpecificDefaultLibraries>libcmtd.lib;msvcrt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <OutputFile>..\lib\pjsua-cli-uwp-comp-$(TargetCPU)-$(Platform)-vc$(VSVer)-$(Configuration).dll</OutputFile>
+      <AdditionalDependencies>kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -268,10 +269,10 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>..\lib\pjsua-cli-uwp-comp-$(TargetCPU)-$(Platform)-vc$(VSVer)-$(Configuration).dll</OutputFile>
     </Link>
-  </ItemDefinitionGroup>  
+  </ItemDefinitionGroup>
   <!--Don't build this project unless it's for UWP-->
   <Import Condition="'$(API_Family)'=='UWP'" Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Import Condition="'$(API_Family)'!='UWP'" Project="..\..\..\..\..\..\build\vs\pjproject-vs14-build-targets.targets" />                                     
+  <Import Condition="'$(API_Family)'!='UWP'" Project="..\..\..\..\..\..\build\vs\pjproject-vs14-build-targets.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/pjsip-apps/src/pjsua/winrt/gui/uwp/VoipBackEnd/VoipBackEnd.vcxproj
+++ b/pjsip-apps/src/pjsua/winrt/gui/uwp/VoipBackEnd/VoipBackEnd.vcxproj
@@ -92,7 +92,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="..\..\..\..\..\..\..\build\vs\pjproject-vs14-win64-common-defaults.props" />
     <Import Project="..\..\..\..\..\..\..\build\vs\pjproject-vs14-debug-static-defaults.props" />
-  </ImportGroup>  
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="..\..\..\..\..\..\..\build\vs\pjproject-vs14-arm-common-defaults.props" />
     <Import Project="..\..\..\..\..\..\..\build\vs\pjproject-vs14-release-dynamic-defaults.props" />
@@ -104,7 +104,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="..\..\..\..\..\..\..\build\vs\pjproject-vs14-win64-common-defaults.props" />
     <Import Project="..\..\..\..\..\..\..\build\vs\pjproject-vs14-release-dynamic-defaults.props" />
-  </ImportGroup>  
+  </ImportGroup>
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -197,6 +197,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <AdditionalDependencies>kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">


### PR DESCRIPTION
This PR will fix some build warning and error for UWP.

Build warning/error:
1. `warning C4005: 'LONG_MIN': macro redefinition` 
    due to changes in https://github.com/pjsip/pjproject/issues/2056
    patch : `os_winuwp.h`
1.  `error C2079: 'sin6_addr' uses undefined struct 'in6_addr'`
    due to changes in https://github.com/pjsip/pjproject/pull/2423
    patch : `socket.h`
1. `error C2057: expected constant expression` 
   due to changes in https://github.com/pjsip/pjproject/issues/2217
   patch : `ip_helper_generic.h`
1. `error LNK2019: unresolved external symbol GetModuleHandle referenced in function set_thread_display_name` 
   due to changes in https://github.com/pjsip/pjproject/pull/3156
   patch : `os_core_win32.c`
1. `error LNK2019: unresolved external symbol LocalFileTimeToFileTime referenced in function pj_time_local_to_gmt`
   due to changes in https://github.com/pjsip/pjproject/pull/2638
   patch : `pjsua_cli_uwp_comp.vcxproj` `VoipBackEnd.vcxproj`
