### PR TITLE
Fixed repeated identical OpenSSL error

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -333,9 +333,14 @@ static void SSLLogErrors(char * action, int ret, int ssl_err, int len,
 	int level = 0;
 
 	while (err2) {
+	    unsigned long next_err;
+
 	    ERROR_LOG("SSL_ERROR_SSL", err2, ssock);
 	    level++;
-	    err2 = ERR_get_error();
+
+	    next_err = ERR_get_error();
+	    if (next_err == err2) break;
+	    err2 = next_err;
 	}
 	break;
     }

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -338,8 +338,9 @@ static void SSLLogErrors(char * action, int ret, int ssl_err, int len,
 	    ERROR_LOG("SSL_ERROR_SSL", err2, ssock);
 	    level++;
 
-	    next_err = ERR_get_error();
-	    if (next_err == err2) break;
+	    do {
+	    	next_err = ERR_get_error();
+	    } while (next_err == err2);
 	    err2 = next_err;
 	}
 	break;


### PR DESCRIPTION
According to the [OpenSSL doc](https://www.openssl.org/docs/man3.0/man3/ERR_get_error.html):
`ERR_get_error() returns the earliest error code from the thread's error queue and removes the entry. This function can be called repeatedly until there are no more error codes to return.`

But it seems that in some cases, either the entry is not removed or the error queue is filled with identical errors, causing cascading error logs like this:
```
12:45:39.444                    SSL  .SSL_ERROR_SSL (Read): Level: 0 err: <478150766> <error:1C80006E:Provider routines::invalid tag> len: 4000 peer: 139.162.62.29:5061
12:45:39.444                    SSL  .SSL_ERROR_SSL (Read): Level: 1 err: <478150766> <error:1C80006E:Provider routines::invalid tag> len: 4000 peer: 139.162.62.29:5061
...
12:45:39.444                    SSL  .SSL_ERROR_SSL (Read): Level: 14 err: <478150766> <error:1C80006E:Provider routines::invalid tag> len: 4000 peer: 139.162.62.29:5061
```

The workaround is to avoid printing error message that has the same error code as the previous one.
