### PR TITLE
Fixed video unhold failure when using SRTP

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -2005,6 +2005,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
 
 	pjmedia_rtcp_init2(&stream->rtcp, &rtcp_setting);
 
+	if (info->rtp_seq_ts_set) {
+	    stream->rtcp.stat.rtp_tx_last_seq = info->rtp_seq;
+	    stream->rtcp.stat.rtp_tx_last_ts = info->rtp_ts;
+	}
+
 	/* Subscribe to RTCP events */
 	pjmedia_event_subscribe(NULL, &stream_event_cb, stream,
 				&stream->rtcp);


### PR DESCRIPTION
When using SRTP, video will fail to resume after holding and unholding it with error:
`vstenc0x12581cd28  Error sending RTP: replay check failed (index too old)`
(audio is okay though).

The issue happens because when creating a new video stream after unholding, the previous RTP seq and ts is not set.

Note: the issue occurs after the change in #2640 that tries to maintain the timestamp.
