### PR TITLE
Fix false error PJMEDIA_RTP_EINLEN when decoding empty RTP

### DIFF
--- a/pjmedia/src/pjmedia/rtp.c
+++ b/pjmedia/src/pjmedia/rtp.c
@@ -188,11 +188,6 @@ PJ_DEF(pj_status_t) pjmedia_rtp_decode_rtp2(
     /* Payload is located right after header plus CSRC */
     offset = sizeof(pjmedia_rtp_hdr) + ((*hdr)->cc * sizeof(pj_uint32_t));
 
-    /* Check that offset is less than packet size */
-    if (offset >= pkt_len) {
-        return PJMEDIA_RTP_EINLEN;
-    }
-
     /* Decode RTP extension. */
     if ((*hdr)->x) {
         if (offset + sizeof (pjmedia_rtp_ext_hdr) > (unsigned)pkt_len)
@@ -207,12 +202,13 @@ PJ_DEF(pj_status_t) pjmedia_rtp_decode_rtp2(
 	dec_hdr->ext_len = 0;
     }
 
-    /* Check again that offset is still less than packet size */
-    if (offset >= pkt_len)
-	return PJMEDIA_RTP_EINLEN;
+    /* Check that offset is not greater than packet size */
+    if (offset > pkt_len) {
+        return PJMEDIA_RTP_EINLEN;
+    }
 
     /* Find and set payload. */
-    *payload = ((pj_uint8_t*)pkt) + offset;
+    *payload = offset==pkt_len? NULL : ((pj_uint8_t*)pkt) + offset;
     *payloadlen = pkt_len - offset;
  
     /* Remove payload padding if any */


### PR DESCRIPTION
The error log line looks like this:
```
RTP decode error: Invalid RTP packet length (PJMEDIA_RTP_EINLEN)
```
which seems to be introduced by this [patch](https://github.com/pjsip/pjproject/commit/c4d34984ec92b3d5252a7d5cddd85a1d3a8001ae#diff-e2d83771d62cf4a8c6a5c28cf52d1ca58146b691bd54008d70f9e313fcf6d108).

This PR tries to revisit the patch, specifically the modifications in `pjmedia/src/pjmedia/rtp.c`:
- RTP extension has its own RTP length verification, so the check before it should not be needed.
- The change of `if (offset > pkt_len)` to `if (offset >= pkt_len)` before setting `payload` & `payloadlen` will cause false error on empty RTP (i.e: `payloadlen==0`). But without it, `payload` will be set to an invalid pointer address when RTP is empty. So to avoid the bad pointer issue, the `payload` should be set to `NULL` if RTP is empty.