### PR TITLE
Fix failure in PJLIB UDP socket replace for iOS due to uninitialized status

### DIFF
--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -754,7 +754,7 @@ static pj_status_t replace_udp_sock(pj_ioqueue_key_t *h)
     unsigned i, fds_cnt, flags=0;
     pj_qos_params qos_params;
     unsigned msec;
-    pj_status_t status;
+    pj_status_t status = PJ_EUNKNOWN;
 
     pj_lock_acquire(h->ioqueue->lock);
 


### PR DESCRIPTION
PJLIB provides a iOS specific feature to automatically replace invalid UDP socket (usually UDP socket will be invalid somehow when app goes background). It is reported that UDP socket auto-replace in PJLIB ioqueue sometimes failed. It turns out that the replace procedure may not be performed because of bug in the `replace_udp_sock()`, i.e: the stack var `status` is not initialized (so it will be initialized randomly?):

https://github.com/pjsip/pjproject/blob/85cb6660fa56cb86007ef681e6e29e3c7e4ca549/pjlib/src/pj/ioqueue_select.c#L757

and when it is initialized to `0/PJ_SUCCESS`, the `for` loop will be skipped and no replace procedure is performed:

https://github.com/pjsip/pjproject/blob/85cb6660fa56cb86007ef681e6e29e3c7e4ca549/pjlib/src/pj/ioqueue_select.c#L775-L776

Thanks to Marcus Froeschl & Atsushi Yamauchi for the report and the analysis.
