### PR TITLE
IP change returns false error when there is no call

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -2695,10 +2695,16 @@ static pj_status_t cmd_quit_handler(pj_cli_cmd_val *cval)
 static pj_status_t cmd_ip_change_handler(pj_cli_cmd_val *cval)
 {
     pjsua_ip_change_param param;
+    pj_status_t status;
     PJ_UNUSED_ARG(cval);
 
     pjsua_ip_change_param_default(&param);
-    pjsua_handle_ip_change(&param);    
+    status = pjsua_handle_ip_change(&param);
+    if (status != PJ_SUCCESS) {
+	pjsua_perror(THIS_FILE, "IP change failed", status);
+    } else {
+	PJ_LOG(3,(THIS_FILE, "IP change succeeded"));
+    }
 
     return PJ_SUCCESS;
 }

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1763,8 +1763,15 @@ static void ui_call_redirect(char menuin[])
 static void ui_handle_ip_change()
 {
     pjsua_ip_change_param param;
+    pj_status_t status;
+
     pjsua_ip_change_param_default(&param);
-    pjsua_handle_ip_change(&param);
+    status = pjsua_handle_ip_change(&param);
+    if (status != PJ_SUCCESS) {
+	pjsua_perror(THIS_FILE, "IP change failed", status);
+    } else {
+	PJ_LOG(3,(THIS_FILE, "IP change succeeded"));
+    }
 }
 
 /*

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4216,9 +4216,9 @@ pj_status_t pjsua_acc_handle_call_on_ip_change(pjsua_acc *acc)
 	for (i = 0; i < (int)pjsua_var.ua_cfg.max_calls; ++i) {
 	    pjsua_call_info call_info;
 
-	    status = pjsua_call_get_info(i, &call_info);
-	    if (status != PJ_SUCCESS ||
-		pjsua_var.calls[i].acc_id != acc->index)
+	    if (!pjsua_call_is_active(i) ||
+		pjsua_var.calls[i].acc_id != acc->index ||
+		pjsua_call_get_info(i, &call_info) != PJ_SUCCESS)
 	    {
 		continue;
 	    }


### PR DESCRIPTION
After investigation, there seems to be a bug in `pjsua_acc_handle_call_on_ip_change()`, the function returns the last status, and when there is no call, the last status will be error (currently it is `PJSIP_ESESSIONTERMINATED`), which is returned by `pjsua_call_get_info()` because the passed call ID is actually invalid.

Thanks to Marcus Froeschl for the report.