### PR TITLE
Ignore closing transport when acquiring SIP UDP transport

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2399,8 +2399,12 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
 		key_len = sizeof(key.type) + addr_len;
 		tp_entry = (transport *) pj_hash_get(mgr->table, &key,
 						     key_len, NULL);
-		if (tp_entry) {
+
+		while (tp_entry) {
 		    tp_ref = tp_entry->tp;
+                    if (!tp_ref->is_shutdown && !tp_ref->is_destroying)
+                        break;
+                    tp_entry = tp_entry->next;
 		}
 	    }
 	}


### PR DESCRIPTION
Currently when trying to acquire SIP UDP transport, we do not check if the transport is in the process of shutting down or being destroyed (the check already exists for TCP&TLS).

This causes issue for example during SIP UDP restart scenario that calls `pjsua_transport_close()` followed by `pjsua_transport_create()`. Since immediate close is now deprecated (i.e. `pjsua_transport_close()` with `force==PJ_TRUE`), the old transport likely still exists and the newly added transport will be added to the end of the list instead:
```
sip_transport.c  Remote address already registered, appended the transport to the list
sip_transport.c  Transport udp0x119e0a8a0 registered: type=UDP, remote=:0
```
(the above log was obtained by enabling tracing in `sip_transport.c`).

With no checking, the old transport will still be acquired, causing failure to send the message with error such as:
`Failed to send Request msg REGISTER/cseq=6103 (tdta0x11a86cea8)! err=171060 (Unsupported transport (PJSIP_EUNSUPTRANSPORT))`
