### PR TITLE
Add .git-blame-ignore-revs for #3292

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# expand tab to spaces and remove $Id$ (#3292)
+5ac9104514499d648f68991ef796368c51b4dfec


### PR DESCRIPTION
This ticket will add .git-blame-ignre-revs for #3292 .
- Check https://git-scm.com/docs/git-blame for more details
- Alternatively, use `git blame -w` to ignore whitespace changes