### PR TITLE
Fix problem in detecting Android STL shared library on msys

### DIFF
--- a/configure-android
+++ b/configure-android
@@ -219,10 +219,16 @@ if test "$1" = "--use-ndk-cflags" || [ "${NDK_VER}" -ge "17" ]; then
         #echo "--- found RANLIB=${NDK_RANLIB}"
       #fi
     fi
+
     # Get STD C++ lib path
     if test "x${STD_CPP_LIB}" = "x"; then
-      if test "x`echo $i | grep '/libc++_shared.so'`" != "x"; then
-        STD_CPP_LIB=$i
+      if test "x`echo $i | grep 'libc++_shared.so'`" != "x"; then
+        MY_CONF_TMP=`echo ${i} | sed -e 's/\\\/\\//g' | sed -e 's/\\"//g'`
+        if test -e $MY_CONF_TMP; then
+          STD_CPP_LIB=$MY_CONF_TMP
+        else
+          echo "--- not good path for libc++_shared.so: ${MY_CONF_TMP}"
+        fi
       fi
     fi
   done

--- a/configure-android
+++ b/configure-android
@@ -349,6 +349,10 @@ else
   STDCPP_LDFLAGS="-L${STDCPP_TC_VER}/libs/${TARGET_ABI}/"
 fi
 
+if test "x$AR_FLAGS" = "x"; then
+  AR_FLAGS="rvc"
+fi
+
 # stlport
 #STDCPP_CFLAGS="-I${ANDROID_NDK_ROOT}/sources/cxx-stl/stlport/stlport"
 #STDCPP_LIBS="-lstlport_static -ldl"
@@ -360,6 +364,7 @@ export LDFLAGS="${LDFLAGS} ${STDCPP_LDFLAGS}"
 export CPPFLAGS="${CPPFLAGS}"
 export CXXFLAGS="${CXXFLAGS} ${STDCPP_CFLAGS}"
 export STD_CPP_LIB="${STD_CPP_LIB}"
+export AR_FLAGS="${AR_FLAGS}"
 
 # Print settings
 if test "1" = "1"; then
@@ -373,6 +378,7 @@ if test "1" = "1"; then
   echo " LDFLAGS = ${LDFLAGS}"
   echo " LIBS = ${LIBS}"
   echo " AR = ${AR}"
+  echo " AR_FLAGS = ${AR_FLAGS}"
   echo " RANLIB = ${RANLIB}"
   echo " TARGET_HOST = ${TARGET_HOST}"
   echo " TARGET_ABI = ${TARGET_ABI}"

--- a/configure-android
+++ b/configure-android
@@ -226,8 +226,8 @@ if test "$1" = "--use-ndk-cflags" || [ "${NDK_VER}" -ge "17" ]; then
         MY_CONF_TMP=`echo ${i} | sed -e 's/\\\/\\//g' | sed -e 's/\\"//g'`
         if test -e $MY_CONF_TMP; then
           STD_CPP_LIB=$MY_CONF_TMP
-        else
-          echo "--- not good path for libc++_shared.so: ${MY_CONF_TMP}"
+        #else
+          #echo "--- not good path for libc++_shared.so: ${MY_CONF_TMP}"
         fi
       fi
     fi


### PR DESCRIPTION
This is related to PR #3200 (about fixing build/configure error when using Android NDK 25b), the fix does not seem to work on msys.

Also added fix to suppress this warning
```
llvm-ar: warning: creating ../lib/libpj-aarch64-unknown-linux-android.a
```