### PR TITLE
when create audio  stream port can't custom setup OPUS codec param

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -724,7 +724,8 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
                             attr->info.channel_cnt,
                             OPUS_APPLICATION_VOIP);
     if (err != OPUS_OK) {
-        PJ_LOG(2, (THIS_FILE, "Unable to create encoder"));
+        PJ_LOG(2, (THIS_FILE, "Unable to create encoder: %s %d",
+                   opus_strerror(err), err));
         pj_mutex_unlock (opus_data->mutex);
         return PJMEDIA_CODEC_EFAILED;
     }
@@ -754,10 +755,11 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     opus_encoder_ctl(opus_data->enc,
                      OPUS_SET_VBR(opus_data->cfg.cbr ? 0 : 1));
 
-    PJ_LOG(4, (THIS_FILE, "Initialize Opus encoder, sample rate: %d, "
+    PJ_LOG(4, (THIS_FILE, "Initialize Opus encoder, sample rate: %d, ch: %d, "
                           "avg bitrate: %d%s, vad: %d, plc: %d, pkt loss: %d, "
                           "complexity: %d, constant bit rate: %d",
                           opus_data->cfg.sample_rate,
+                          opus_data->cfg.channel_cnt,
                           (auto_bit_rate? 0: attr->info.avg_bps),
                           (auto_bit_rate? "(auto)": ""),
                           attr->setting.vad?1:0,
@@ -771,7 +773,8 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
                              opus_data->cfg.sample_rate,
                              attr->info.channel_cnt);
     if (err != OPUS_OK) {
-        PJ_LOG(2, (THIS_FILE, "Unable to initialize decoder"));
+        PJ_LOG(2, (THIS_FILE, "Unable to initialize decoder: %s %d",
+                   opus_strerror(err), err));
         pj_mutex_unlock (opus_data->mutex);
         return PJMEDIA_CODEC_EFAILED;
     }
@@ -843,10 +846,11 @@ static pj_status_t  codec_modify( pjmedia_codec *codec,
     opus_encoder_ctl(opus_data->enc,
                      OPUS_SET_VBR(attr->setting.cbr ? 0 : 1));
 
-    PJ_LOG(4, (THIS_FILE, "Modifying Opus encoder, sample rate: %d, "
+    PJ_LOG(4, (THIS_FILE, "Modifying Opus encoder, sample rate: %d, ch: %d, "
                           "avg bitrate: %d%s, vad: %d, plc: %d, pkt loss: %d, "
                           "complexity: %d, constant bit rate: %d",
                           attr->info.clock_rate,
+                          attr->info.channel_cnt,
                           (attr->info.avg_bps? attr->info.avg_bps: 0),
                           (attr->info.avg_bps? "": "(auto)"),
                           attr->setting.vad?1:0,


### PR DESCRIPTION
Use the sample: streamutil to streaming opus by play a wav file.
which  only work with  sampleRate: 48000, channel: 2  wav file.

I found the reason is:  in pjmedia_stream_create( ),  it force use  codec_info's  clockrate and channel to open opus codec.

changes:
-  streamutil
   support opus custom settings (payload type,  clockrate, channel )
- opus  codec
   more detail logging


