### PR TITLE
Fixed encoding video issue with odd resolution

### DIFF
--- a/pjmedia/include/pjmedia/vid_codec.h
+++ b/pjmedia/include/pjmedia/vid_codec.h
@@ -611,11 +611,11 @@ pjmedia_vid_codec_mgr_get_default_param(pjmedia_vid_codec_mgr *mgr,
  *                  manager instance will be used.
  * @param info      The codec info, which default parameter's is being
  *                  updated.
- * @param param     The new default codec parameter. Note that video
+ * @param param     The new default codec parameter. Note that encoding video
  *                  codec resolution must be even numbers. Set to NULL to
  *                  reset codec parameter to library default settings.
  *
- * @return          PJ_SUCCESS on success.
+ * @return          PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_DECL(pj_status_t) 
 pjmedia_vid_codec_mgr_set_default_param(pjmedia_vid_codec_mgr *mgr,
@@ -680,13 +680,20 @@ PJ_INLINE(pj_status_t) pjmedia_vid_codec_init( pjmedia_vid_codec *codec,
  * preferences via SDP fmtp).
  *
  * @param codec     The codec instance.
- * @param param     Codec initialization parameter.
+ * @param param     Codec initialization parameter. Note that encoding video
+ *                  codec resolution must be even numbers.
  *
- * @return          PJ_SUCCESS on success.
+ * @return          PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_INLINE(pj_status_t) pjmedia_vid_codec_open(pjmedia_vid_codec *codec,
                                               pjmedia_vid_codec_param *param)
 {
+    if (param && ((param->enc_fmt.det.vid.size.w % 2 == 1) ||
+        (param->enc_fmt.det.vid.size.h % 2 == 1)))
+    {
+        return PJ_EINVAL;
+    }
+
     return (*codec->op->open)(codec, param);
 }
 
@@ -711,15 +718,22 @@ PJ_INLINE(pj_status_t) pjmedia_vid_codec_close( pjmedia_vid_codec *codec )
  * When the parameter cannot be changed, this function will return 
  * non-PJ_SUCCESS, and the original parameters will not be changed.
  *
- * @param codec The codec instance.
- * @param param The new codec parameter.
+ * @param codec         The codec instance.
+ * @param param         The new codec parameter. Note that encoding video
+ *                      codec resolution must be even numbers.
  *
- * @return              PJ_SUCCESS on success.
+ * @return              PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_INLINE(pj_status_t)
 pjmedia_vid_codec_modify(pjmedia_vid_codec *codec,
                          const pjmedia_vid_codec_param *param)
 {
+    if (param && ((param->enc_fmt.det.vid.size.w % 2 == 1) ||
+        (param->enc_fmt.det.vid.size.h % 2 == 1)))
+    {
+        return PJ_EINVAL;
+    }
+
     return (*codec->op->modify)(codec, param);
 }
 

--- a/pjmedia/include/pjmedia/vid_codec.h
+++ b/pjmedia/include/pjmedia/vid_codec.h
@@ -611,8 +611,9 @@ pjmedia_vid_codec_mgr_get_default_param(pjmedia_vid_codec_mgr *mgr,
  *                  manager instance will be used.
  * @param info      The codec info, which default parameter's is being
  *                  updated.
- * @param param     The new default codec parameter. Set to NULL to reset
- *                  codec parameter to library default settings.
+ * @param param     The new default codec parameter. Note that video
+ *                  codec resolution must be even numbers. Set to NULL to
+ *                  reset codec parameter to library default settings.
  *
  * @return          PJ_SUCCESS on success.
  */

--- a/pjmedia/src/pjmedia/format.c
+++ b/pjmedia/src/pjmedia/format.c
@@ -170,18 +170,20 @@ static pj_status_t apply_planar_420(const pjmedia_video_format_info *fi,
                                      pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t Y_bytes;
+    pj_size_t rounded_wxh, Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize */
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
-    aparam->framebytes = Y_bytes + (Y_bytes>>1);
+    /* Calculate memsize, round up resolution to the nearest even number. */
+    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
+                              (aparam->size.h + (aparam->size.h % 2)));
+    aparam->framebytes = rounded_wxh + (rounded_wxh>>1);
 
     /* Planar formats use 3 plane */
     aparam->strides[0] = aparam->size.w;
     aparam->strides[1] = aparam->strides[2] = (aparam->size.w>>1);
 
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
     aparam->planes[2] = aparam->planes[1] + (Y_bytes>>2);
@@ -203,18 +205,20 @@ static pj_status_t apply_planar_422(const pjmedia_video_format_info *fi,
                                      pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t Y_bytes;
+    pj_size_t rounded_wxh, Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize */
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
-    aparam->framebytes = (Y_bytes << 1);
+    /* Calculate memsize, round up resolution to the nearest even number. */
+    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
+                              (aparam->size.h + (aparam->size.h % 2)));
+    aparam->framebytes = (rounded_wxh << 1);
 
     /* Planar formats use 3 plane */
     aparam->strides[0] = aparam->size.w;
     aparam->strides[1] = aparam->strides[2] = (aparam->size.w>>1);
 
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
     aparam->planes[2] = aparam->planes[1] + (Y_bytes>>1);
@@ -236,18 +240,21 @@ static pj_status_t apply_planar_444(const pjmedia_video_format_info *fi,
                                     pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t Y_bytes;
+    pj_size_t rounded_wxh, Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize */
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
-    aparam->framebytes = (Y_bytes * 3);
+    /* Calculate memsize, round up resolution to the nearest even number. */
+    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
+                              (aparam->size.h + (aparam->size.h % 2)));
+    aparam->framebytes = (rounded_wxh * 3);
 
     /* Planar formats use 3 plane */
     aparam->strides[0] = aparam->strides[1] = 
                          aparam->strides[2] = aparam->size.w;
 
+
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
     aparam->planes[2] = aparam->planes[1] + Y_bytes;
@@ -269,18 +276,20 @@ static pj_status_t apply_biplanar_420(const pjmedia_video_format_info *fi,
                                       pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t Y_bytes;
+    pj_size_t rounded_wxh, Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize */
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
-    aparam->framebytes = Y_bytes + (Y_bytes>>1);
+    /* Calculate memsize, round up resolution to the nearest even number. */
+    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
+                              (aparam->size.h + (aparam->size.h % 2)));
+    aparam->framebytes = rounded_wxh + (rounded_wxh>>1);
 
     /* Planar formats use 2 plane */
     aparam->strides[0] = aparam->size.w;
     aparam->strides[1] = aparam->size.w;
 
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
 

--- a/pjmedia/src/pjmedia/format.c
+++ b/pjmedia/src/pjmedia/format.c
@@ -170,20 +170,18 @@ static pj_status_t apply_planar_420(const pjmedia_video_format_info *fi,
                                      pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t rounded_wxh, Y_bytes;
+    pj_size_t Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize, round up resolution to the nearest even number. */
-    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
-                              (aparam->size.h + (aparam->size.h % 2)));
-    aparam->framebytes = rounded_wxh + (rounded_wxh>>1);
+    /* Calculate memsize */
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
+    aparam->framebytes = Y_bytes + (Y_bytes>>1);
 
     /* Planar formats use 3 plane */
     aparam->strides[0] = aparam->size.w;
     aparam->strides[1] = aparam->strides[2] = (aparam->size.w>>1);
 
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
     aparam->planes[2] = aparam->planes[1] + (Y_bytes>>2);
@@ -205,20 +203,18 @@ static pj_status_t apply_planar_422(const pjmedia_video_format_info *fi,
                                      pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t rounded_wxh, Y_bytes;
+    pj_size_t Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize, round up resolution to the nearest even number. */
-    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
-                              (aparam->size.h + (aparam->size.h % 2)));
-    aparam->framebytes = (rounded_wxh << 1);
+    /* Calculate memsize */
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
+    aparam->framebytes = (Y_bytes << 1);
 
     /* Planar formats use 3 plane */
     aparam->strides[0] = aparam->size.w;
     aparam->strides[1] = aparam->strides[2] = (aparam->size.w>>1);
 
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
     aparam->planes[2] = aparam->planes[1] + (Y_bytes>>1);
@@ -240,21 +236,18 @@ static pj_status_t apply_planar_444(const pjmedia_video_format_info *fi,
                                     pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t rounded_wxh, Y_bytes;
+    pj_size_t Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize, round up resolution to the nearest even number. */
-    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
-                              (aparam->size.h + (aparam->size.h % 2)));
-    aparam->framebytes = (rounded_wxh * 3);
+    /* Calculate memsize */
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
+    aparam->framebytes = (Y_bytes * 3);
 
     /* Planar formats use 3 plane */
     aparam->strides[0] = aparam->strides[1] = 
                          aparam->strides[2] = aparam->size.w;
 
-
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
     aparam->planes[2] = aparam->planes[1] + Y_bytes;
@@ -276,20 +269,18 @@ static pj_status_t apply_biplanar_420(const pjmedia_video_format_info *fi,
                                       pjmedia_video_apply_fmt_param *aparam)
 {
     unsigned i;
-    pj_size_t rounded_wxh, Y_bytes;
+    pj_size_t Y_bytes;
 
     PJ_UNUSED_ARG(fi);
 
-    /* Calculate memsize, round up resolution to the nearest even number. */
-    rounded_wxh = (pj_size_t)((aparam->size.w + (aparam->size.w % 2)) *
-                              (aparam->size.h + (aparam->size.h % 2)));
-    aparam->framebytes = rounded_wxh + (rounded_wxh>>1);
+    /* Calculate memsize */
+    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
+    aparam->framebytes = Y_bytes + (Y_bytes>>1);
 
     /* Planar formats use 2 plane */
     aparam->strides[0] = aparam->size.w;
     aparam->strides[1] = aparam->size.w;
 
-    Y_bytes = (pj_size_t)(aparam->size.w * aparam->size.h);
     aparam->planes[0] = aparam->buffer;
     aparam->planes[1] = aparam->planes[0] + Y_bytes;
 

--- a/pjmedia/src/pjmedia/vid_codec.c
+++ b/pjmedia/src/pjmedia/vid_codec.c
@@ -680,7 +680,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_set_default_param(
         (param->enc_fmt.det.vid.size.h % 2 == 1)))
     {
         PJ_LOG(3, (THIS_FILE, "Video resolution must be even"));
-        return PJ_EINVALIDOP;
+        return PJ_EINVAL;
     }
 
     pj_mutex_lock(mgr->mutex);

--- a/pjmedia/src/pjmedia/vid_codec.c
+++ b/pjmedia/src/pjmedia/vid_codec.c
@@ -677,7 +677,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_set_default_param(
         return PJ_EINVAL;
 
     if (param && ((param->enc_fmt.det.vid.size.w % 2 == 1) ||
-        (param->enc_fmt.det.vid.size.w % 2 == 1)))
+        (param->enc_fmt.det.vid.size.h % 2 == 1)))
     {
         PJ_LOG(3, (THIS_FILE, "Video resolution must be even"));
         return PJ_EINVALIDOP;

--- a/pjmedia/src/pjmedia/vid_codec.c
+++ b/pjmedia/src/pjmedia/vid_codec.c
@@ -186,6 +186,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_register_factory(
                                     pjmedia_vid_codec_factory *factory)
 {
     pjmedia_vid_codec_info info[PJMEDIA_CODEC_MGR_MAX_CODECS];
+    pjmedia_vid_codec_param param;
     unsigned i, count;
     pj_status_t status;
 
@@ -199,6 +200,18 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_register_factory(
     status = factory->op->enum_info(factory, &count, info);
     if (status != PJ_SUCCESS)
         return status;
+
+    if ((factory->op->test_alloc)(factory, info) == PJ_SUCCESS) {
+        status = (factory->op->default_attr)(factory, info, &param);
+        if (status == PJ_SUCCESS) {
+            if ((param.enc_fmt.det.vid.size.w % 2 == 1) ||
+                (param.enc_fmt.det.vid.size.h % 2 == 1))
+            {
+                PJ_LOG(3, (THIS_FILE, "Video resolution must be even"));
+                return PJ_EINVAL;
+            }
+        }
+    }
 
     pj_mutex_lock(mgr->mutex);
 

--- a/pjmedia/src/pjmedia/vid_codec.c
+++ b/pjmedia/src/pjmedia/vid_codec.c
@@ -676,6 +676,13 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_set_default_param(
     if (!pjmedia_vid_codec_info_to_id(info, (char*)&codec_id, sizeof(codec_id)))
         return PJ_EINVAL;
 
+    if (param && ((param->enc_fmt.det.vid.size.w % 2 == 1) ||
+        (param->enc_fmt.det.vid.size.w % 2 == 1)))
+    {
+        PJ_LOG(3, (THIS_FILE, "Video resolution must be even"));
+        return PJ_EINVALIDOP;
+    }
+
     pj_mutex_lock(mgr->mutex);
 
     /* Lookup codec desc */

--- a/pjmedia/src/pjmedia/vid_codec.c
+++ b/pjmedia/src/pjmedia/vid_codec.c
@@ -186,7 +186,6 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_register_factory(
                                     pjmedia_vid_codec_factory *factory)
 {
     pjmedia_vid_codec_info info[PJMEDIA_CODEC_MGR_MAX_CODECS];
-    pjmedia_vid_codec_param param;
     unsigned i, count;
     pj_status_t status;
 
@@ -200,18 +199,6 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_register_factory(
     status = factory->op->enum_info(factory, &count, info);
     if (status != PJ_SUCCESS)
         return status;
-
-    if ((factory->op->test_alloc)(factory, info) == PJ_SUCCESS) {
-        status = (factory->op->default_attr)(factory, info, &param);
-        if (status == PJ_SUCCESS) {
-            if ((param.enc_fmt.det.vid.size.w % 2 == 1) ||
-                (param.enc_fmt.det.vid.size.h % 2 == 1))
-            {
-                PJ_LOG(3, (THIS_FILE, "Video resolution must be even"));
-                return PJ_EINVAL;
-            }
-        }
-    }
 
     pj_mutex_lock(mgr->mutex);
 

--- a/pjmedia/src/pjmedia/vid_codec.c
+++ b/pjmedia/src/pjmedia/vid_codec.c
@@ -593,7 +593,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_get_default_param(
                                         pjmedia_vid_codec_param *param )
 {
     pjmedia_vid_codec_factory *factory;
-    pj_status_t status;
+    pj_status_t status = PJMEDIA_CODEC_EUNSUP;
     pjmedia_codec_id codec_id;
     pjmedia_vid_codec_desc *codec_desc = NULL;
     unsigned i;
@@ -622,8 +622,8 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_get_default_param(
         pj_memcpy(param, codec_desc->def_param->param, 
                   sizeof(pjmedia_vid_codec_param));
 
-        pj_mutex_unlock(mgr->mutex);
-        return PJ_SUCCESS;
+        status = PJ_SUCCESS;
+        goto on_return;
     }
 
     /* Otherwise query the default param from codec factory */
@@ -638,8 +638,8 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_get_default_param(
                 //if (param->info.max_bps < param->info.avg_bps)
                 //    param->info.max_bps = param->info.avg_bps;
 
-                pj_mutex_unlock(mgr->mutex);
-                return PJ_SUCCESS;
+                status = PJ_SUCCESS;
+                goto on_return;
             }
 
         }
@@ -647,10 +647,21 @@ PJ_DEF(pj_status_t) pjmedia_vid_codec_mgr_get_default_param(
         factory = factory->next;
     }
 
+on_return:
     pj_mutex_unlock(mgr->mutex);
 
+    if (status == PJ_SUCCESS) {
+        if ((param->enc_fmt.det.vid.size.w % 2 == 1) ||
+            (param->enc_fmt.det.vid.size.h % 2 == 1))
+        {
+            PJ_LOG(4, (THIS_FILE, "Rounding up video resolution to "
+                                  "nearest even numbers"));
+            param->enc_fmt.det.vid.size.w += param->enc_fmt.det.vid.size.w % 2;
+            param->enc_fmt.det.vid.size.h += param->enc_fmt.det.vid.size.h % 2;
+        }
+    }
 
-    return PJMEDIA_CODEC_EUNSUP;
+    return status;
 }
 
 


### PR DESCRIPTION
It is reported that running pjsip that sends video with a non-even resolution will cause a crash when hanging up the call.

```
    frame #0: `op_disconnect_ports(vid_conf=0x0000000104d1eda8, prm=0x00000001707d22c0) at vid_conf.c:913:16
    frame #1: `op_remove_port(vid_conf=0x0000000104d1eda8, prm=0x0000000104d1ebec) at vid_conf.c:619:9
    frame #2: `handle_op_queue(conf=0x0000000104d1eda8) at vid_conf.c:206:17
    frame #3: `on_clock_tick(now=0x0000000104d1eb58, user_data=0x0000000104d1eda8) at vid_conf.c:1009:9
```

Running the app under address sanitizer will reveal that there's a heap buffer overflow during the conversion:
```
SUMMARY: AddressSanitizer: heap-buffer-overflow scale_common.cc:497 in ScaleFilterCols_C
    #0 0x1006bed20 in ScaleFilterCols_C scale_common.cc:497
    #1 0x1006b1838 in ScalePlane scale.cc:1667
    #2 0x1002ea884 in pjmedia_converter_convert converter.c:185
    #3 0x1003d91a0 in convert_frame vid_port.c:1108
    #4 0x1003d5394 in vid_pasv_port_get_frame vid_port.c:1433
    #5 0x100325138 in pjmedia_port_get_frame port.c:99
    #6 0x1003f1394 in on_clock_tick vid_conf.c:1087
```
The memory buffer is allocated here:
```
0x00010ddbdee2 is located 46 bytes to the right of 120500-byte region [0x00010dda0800,0x00010ddbdeb4)
allocated by thread T9 here:
    #6 0x1003f03cc in pj_pool_zalloc pool.h:490
    #7 0x1003f3f10 in pjmedia_vid_conf_add_port vid_conf.c:492
```

~~The solution is to round up the resolution to the nearest even number during calculation~~ 
We need to reject these odd resolutions since throughout video processing, many components/operations (such as codec, buffer size allocation, or video conversion) assume these numbers to be even and divide the resolution by 2, hence causing the rounding down.

Note that it only affects planar video type, and decoding is unaffected since the decoding buffer is allocated based on the max possible resolution.
