### PR TITLE
Fix indefinite wait when trying to stop pjmedia_clock

### DIFF
--- a/pjmedia/include/pjmedia/clock.h
+++ b/pjmedia/include/pjmedia/clock.h
@@ -272,11 +272,15 @@ PJ_DECL(pj_status_t) pjmedia_clock_start(pjmedia_clock *clock);
 
 
 /**
- * Stop the clock.
+ * Stop the clock. When the function returns PJ_SUCCESS, it is guaranteed
+ * that the clock thread (if any) has stopped and the callback has completed.
+ * But if the function is called from within the clock's callback itself,
+ * the callback will still be running until completion. In that case, 
+ * the function will only stop future callbacks and returns PJ_EBUSY.
  *
  * @param clock             The media clock.
  *
- * @return                  PJ_SUCCES on success.
+ * @return                  PJ_SUCCES on success, or PJ_EBUSY.
  */
 PJ_DECL(pj_status_t) pjmedia_clock_stop(pjmedia_clock *clock);
 


### PR DESCRIPTION
To fix #3298.

Based on the scenario in `transport_srtp_dtls`:
1. App calls `pjmedia_clock_stop()` and wait for the clock's thread.
2. At the same time, inside the callback called by the clock's thread, `pjmedia_clock_stop()` is also being invoked.

Because of #1394 (commit https://github.com/pjsip/pjproject/commit/f487ccfbacece44f095d6b2de41af53929d9fa4a), the later call to `pjmedia_clock_stop()` will revert the thread's `quitting` flag back to `PJ_FALSE` and causes the thread to run indefinitely.

The proposed fix here is to:
- avoid reverting the `quitting` flag to make sure that the thread stops (albeit not immediately).
- give a new return status `PJ_EBUSY` when `pjmedia_clock_stop()` is called from the clock's internal callback.
- remove the requirement to call `pjmedia_clock_stop()` again when it's called from the clock's callback. Instead, when (re)starting the clock, we check for any existing thread and destroy it first.
