### PR TITLE
Loop transport: add new setting item (max_attach_cnt) to set the max number of attachments

### DIFF
--- a/pjmedia/include/pjmedia/transport_loop.h
+++ b/pjmedia/include/pjmedia/transport_loop.h
@@ -87,6 +87,11 @@ typedef struct pjmedia_loop_tp_setting
      */
     pj_bool_t   disable_rx;
 
+    /*
+     * Max number of attachments
+     */
+    unsigned max_attach_cnt;
+
 } pjmedia_loop_tp_setting;
 
 


### PR DESCRIPTION
Currently the max number of attachments is 4 ,
which  limit to some testing cases that need more than 4 attachments to a loop transport.