### PR TITLE
TLS uses remote IP address instead of hostname when sending BYE

### DIFF
--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -165,7 +165,7 @@ struct pjsip_dialog
     pj_bool_t           route_set_frozen; /**< Route set has been set.      */
     pjsip_auth_clt_sess auth_sess;  /**< Client authentication session.     */
     pj_str_t            initial_dest;/**< Initial destination host (used for
-				          verifying remote TLS cert).	    */
+                                          verifying remote TLS cert).       */
 
     /** Session counter. */
     int                 sess_count; /**< Number of sessions.                */

--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -164,7 +164,8 @@ struct pjsip_dialog
     pjsip_route_hdr     route_set;  /**< Route set.                         */
     pj_bool_t           route_set_frozen; /**< Route set has been set.      */
     pjsip_auth_clt_sess auth_sess;  /**< Client authentication session.     */
-    pj_str_t            initial_dest;/**< Initial destination host.         */
+    pj_str_t            initial_dest;/**< Initial destination host (used for
+				          verifying remote TLS cert).	    */
 
     /** Session counter. */
     int                 sess_count; /**< Number of sessions.                */

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -469,8 +469,8 @@ pj_status_t create_uas_dialog( pjsip_user_agent *ua,
     
     /* Save initial destination host from transport's info */
     if (rdata->tp_info.transport->dir == PJSIP_TP_DIR_OUTGOING) {
-	pj_strdup(dlg->pool, &dlg->initial_dest,
-		  &rdata->tp_info.transport->remote_name.host);
+        pj_strdup(dlg->pool, &dlg->initial_dest,
+                  &rdata->tp_info.transport->remote_name.host);
     }
 
     /* Init remote's contact from Contact header.

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -468,9 +468,10 @@ pj_status_t create_uas_dialog( pjsip_user_agent *ua,
     pj_strdup(dlg->pool, &dlg->remote.info_str, &tmp);
     
     /* Save initial destination host from transport's info */
-    pj_strdup(dlg->pool, &dlg->initial_dest,
-              &rdata->tp_info.transport->remote_name.host);
-
+    if (rdata->tp_info.transport->dir == PJSIP_TP_DIR_OUTGOING) {
+	pj_strdup(dlg->pool, &dlg->initial_dest,
+		  &rdata->tp_info.transport->remote_name.host);
+    }
 
     /* Init remote's contact from Contact header.
      * Iterate the Contact URI until we find sip: or sips: scheme.
@@ -1831,8 +1832,9 @@ static void dlg_update_routeset(pjsip_dialog *dlg, const pjsip_rx_data *rdata)
      * transaction as the initial transaction that establishes dialog.
      */
     if (dlg->role == PJSIP_ROLE_UAC) {
-        /* Save initial destination host from transport's info. */
-        if (!dlg->initial_dest.slen) {
+        /* Update initial destination host from transport's info. */
+        if (rdata->tp_info.transport->dir == PJSIP_TP_DIR_OUTGOING)
+	{
             pj_strdup(dlg->pool, &dlg->initial_dest,
                       &rdata->tp_info.transport->remote_name.host);
         }

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1834,7 +1834,7 @@ static void dlg_update_routeset(pjsip_dialog *dlg, const pjsip_rx_data *rdata)
     if (dlg->role == PJSIP_ROLE_UAC) {
         /* Update initial destination host from transport's info. */
         if (rdata->tp_info.transport->dir == PJSIP_TP_DIR_OUTGOING)
-	{
+        {
             pj_strdup(dlg->pool, &dlg->initial_dest,
                       &rdata->tp_info.transport->remote_name.host);
         }


### PR DESCRIPTION
This is an attempt to fix issue #2706.

The issue seems to occur only when the transport used in dialog creation is a server socket, where remote address is an IP address not a hostname, so the `dlg->initial_dest` will be an IP address. Note that the `dlg->initial_dest` is currently used only for initializing `tdata->dest_info.name` which eventually used for verifying remote TLS certificate.

The idea here is to only set the `dlg->initial_dest` from transport info when the transport is a client socket, which TLS verification is usually performed. When it is a server socket, the `tdata->dest_info.name` will be initialized from request URI or route header (later by `pjsip_endpt_send_request_stateless()` or `pjsip_endpt_send_response()`.