### PR TITLE
conference bridge: wirte_port() the if condition has mistake which make PJMEDIA_PORT_MUTE case never run

### DIFF
--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1718,7 +1718,7 @@ static pj_status_t write_port(pjmedia_conf *conf, struct conf_port *cport,
     *frm_type = PJMEDIA_FRAME_TYPE_AUDIO;
 
     /* Skip port if it is disabled */
-    if (cport->tx_setting != PJMEDIA_PORT_ENABLE) {
+    if (cport->tx_setting == PJMEDIA_PORT_DISABLE) {
         cport->tx_level = 0;
         *frm_type = PJMEDIA_FRAME_TYPE_NONE;
         return PJ_SUCCESS;


### PR DESCRIPTION
as title

```c
if (cport->tx_setting != PJMEDIA_PORT_ENABLE) {
          /*
            This case include PJMEDIA_PORT_DISABLE and PJMEDIA_PORT_MUTE, 
            which make the "else if  tx_setting == PJMEDIA_PORT_MUTE" case never run.
            
            should change to:  "if (cport->tx_setting == PJMEDIA_PORT_DISABLE)"
            
          */
    }
    else if ((cport->tx_setting == PJMEDIA_PORT_MUTE) ||
             (cport->transmitter_cnt == 0)) {
  }
```

This problem is imported by this  pr #2583 
