### PR TITLE
Fixed assertion when adding too many SDP attributes

### DIFF
--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -183,7 +183,15 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_add(unsigned *count,
                                          pjmedia_sdp_attr *attr)
 {
     PJ_ASSERT_RETURN(count && attr_array && attr, PJ_EINVAL);
-    PJ_ASSERT_RETURN(*count < PJMEDIA_MAX_SDP_ATTR, PJ_ETOOMANY);
+
+    if (*count >= PJMEDIA_MAX_SDP_ATTR) {
+        PJ_PERROR(2, (THIS_FILE, PJ_ETOOMANY, 
+                  "Error adding SDP attribute %.*s, "
+                  "attr is ignored",
+                  (int)attr->name.slen, attr->name.ptr));
+
+        return PJ_ETOOMANY;
+    }
 
     attr_array[*count] = attr;
     (*count)++;


### PR DESCRIPTION
This issue was reported by [oss-fuzz](https://github.com/google/oss-fuzz).

It occurred when the incoming SDP message has too many attributes, which triggered an assertion. However, note that this only affects debug version with assertion enabled. For release version or if assertion is disabled, it should correctly return error.
