### PR TITLE
Fixed possible integer overflow in pj_strtol

### DIFF
--- a/pjlib/src/pj/string.c
+++ b/pjlib/src/pj/string.c
@@ -301,7 +301,7 @@ PJ_DEF(pj_status_t) pj_strtol2(const pj_str_t *str, long *value)
         return PJ_ETOOSMALL;
     }
 
-    *value = is_negative ? -(long)retval : retval;
+    *value = is_negative ? (long)-retval : retval;
 
     return PJ_SUCCESS;
 }


### PR DESCRIPTION
In `pj_strtol()` implementation:
```
    if (retval > (PJ_MAXLONG + 1UL) && is_negative) {
        *value = PJ_MINLONG;
        return PJ_ETOOSMALL;
    }

    *value = is_negative ? -(long)retval : retval;
```

The statement `-(long)retval` will overflow if `retval == PJ_MAXLONG+1` since it will be cast to long first. We should reverse the order of the negation and the cast.

An alternative fix is to change the above if check to `if retval > PJ_MAXLONG`.
