### PR TITLE
Suppress use-of-uninitialized-value warning when comparing SIP parser handler

### DIFF
--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -594,12 +594,10 @@ PJ_INLINE(int) compare_handler( const handler_rec *r1,
         return 1;
 
     /* Compare length. */
-    /*
     if (r1->hname_len < name_len)
         return -1;
     if (r1->hname_len > name_len)
         return 1;
-     */
 
     /* Equal length and equal hash. compare the strings. */
     return pj_memcmp(r1->hname, name, name_len);


### PR DESCRIPTION
In `compare_handler()` of SIP parser:
```
    /* Compare length. */
    /*
    if (r1->hname_len < name_len)
        return -1;
    if (r1->hname_len > name_len)
        return 1;
    */

    /* Equal length and equal hash. compare the strings. */
    return pj_memcmp(r1->hname, name, name_len);
```

For optimization, we commented the length checking long time ago in https://github.com/pjsip/pjproject/commit/cec5f4ae2ca9daffcd229f71e693c9910f308050.

But because of this, we can potentially proceed with the memory comparison even when r1's length is smaller (`r1->hname_len < name_len`) in the rare case of a hash value collision (`r1->hname_hash == hash`).

Theoretically, this should be safe though since `r1->hname` has actually been initialised for up to `r1->hname_len`, but since the rest of the buffer is uninitialized/gibberish, this will trigger the warning.
