### PR TITLE
Support different From URI in outgoing calls

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -2403,6 +2403,13 @@ struct pjsua_msg_data
     pj_str_t    target_uri;
 
     /**
+     * Optional local URI (i.e. From header). If NULL, the account ID
+     * \a pjsua_acc_config.id is used for the From header. This field is
+     * currently used only by pjsua_call_make_call() and pjsua_im_send().
+     */
+    pj_str_t    local_uri;
+
+    /**
      * Additional message headers as linked list. Application can add
      * headers to the list by creating the header, either from the heap/pool
      * or from temporary local variable, and add the header using

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -838,6 +838,13 @@ struct SipTxOption
     string                  targetUri;
 
     /**
+     * Optional local URI (i.e. From header). If empty (""), the
+     * \a AccountConfig::idUri is used for the From header. At the moment this
+     * field is only used when sending initial INVITE and MESSAGE requests.
+     */
+    string                  localUri;
+
+    /**
      * Additional message headers to be included in the outgoing message.
      */
     SipHeaderVector         headers;

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -948,7 +948,9 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
 
     /* Create outgoing dialog: */
     status = pjsip_dlg_create_uac( pjsip_ua_instance(),
-                                   &acc->cfg.id, &contact,
+                                   (msg_data && msg_data->local_uri.slen?
+                                    &msg_data->local_uri: &acc->cfg.id),
+                                   &contact,
                                    dest_uri,
                                    (msg_data && msg_data->target_uri.slen?
                                     &msg_data->target_uri: dest_uri),

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -167,6 +167,7 @@ PJ_DEF(pjsua_msg_data*) pjsua_msg_data_clone(pj_pool_t *pool,
     PJ_ASSERT_RETURN(msg_data != NULL, NULL);
 
     pj_strdup(pool, &msg_data->target_uri, &rhs->target_uri);
+    pj_strdup(pool, &msg_data->local_uri, &rhs->local_uri);
 
     pj_list_init(&msg_data->hdr_list);
     hdr = rhs->hdr_list.next;

--- a/pjsip/src/pjsua-lib/pjsua_im.c
+++ b/pjsip/src/pjsua-lib/pjsua_im.c
@@ -560,7 +560,8 @@ PJ_DEF(pj_status_t) pjsua_im_send( pjsua_acc_id acc_id,
                                         &pjsip_message_method,
                                         (msg_data && msg_data->target_uri.slen? 
                                          &msg_data->target_uri: to),
-                                        &acc->cfg.id,
+                                        (msg_data && msg_data->local_uri.slen?
+                                         &msg_data->local_uri: &acc->cfg.id),
                                         to, NULL, NULL, -1, NULL, &tdata);
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Unable to create request", status);

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -600,14 +600,16 @@ TsxStateEvent::TsxStateEvent()
 
 bool SipTxOption::isEmpty() const
 {
-    return (targetUri == "" && headers.size() == 0 && contentType == "" &&
-            msgBody == "" && multipartContentType.type == "" &&
+    return (targetUri == "" && localUri == "" &&  headers.size() == 0 &&
+            contentType == "" && msgBody == "" && multipartContentType.type == "" &&
             multipartContentType.subType == "" && multipartParts.size() == 0);
 }
 
 void SipTxOption::fromPj(const pjsua_msg_data &prm) PJSUA2_THROW(Error)
 {
     targetUri = pj2Str(prm.target_uri);
+
+    localUri = pj2Str(prm.local_uri);
 
     headers.clear();
     pjsip_hdr* pj_hdr = prm.hdr_list.next;
@@ -639,6 +641,8 @@ void SipTxOption::toPj(pjsua_msg_data &msg_data) const
     pjsua_msg_data_init(&msg_data);
 
     msg_data.target_uri = str2Pj(targetUri);
+
+    msg_data.local_uri = str2Pj(localUri);
 
     pj_list_init(&msg_data.hdr_list);
     for (i = 0; i < headers.size(); i++) {


### PR DESCRIPTION
In outgoing calls, PJSUA(2) uses the account's ID as URI for From headers. This commit enables to overwrite the URI in the From headers.

The solution is similar to PR #1688.