### PR TITLE
Increment origin version when there's a change in local SDP answer

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -817,9 +817,18 @@
  * compatibility and performance this is set to 0.
  *
  * Default is 0 (No)
+ * 
+ * This macro has been deprecated in version 2.14.
+ * See https://github.com/pjsip/pjproject/pull/3322 for more info.
  */
-#ifndef PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
-#   define PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION   0
+#ifdef PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
+#   ifdef _MSC_VER
+#       pragma message("Warning: PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION macro is"\
+                       " deprecated and has no effect")
+#   else
+#       warning "PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION macro is deprecated"\
+                " and has no effect"
+#   endif
 #endif
 
 

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -126,6 +126,11 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_create_w_local_offer( pj_pool_t *pool,
     neg->neg_local_sdp = pjmedia_sdp_session_clone(pool, local);
     neg->last_sent = neg->initial_sdp;
 
+    /* Init last_sent's pool to app's pool, will be updated to active
+     * SDPs pool after a successful SDP nego.
+     */
+    neg->pool_active = pool;
+
     *p_neg = neg;
     return PJ_SUCCESS;
 }
@@ -173,6 +178,11 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_create_w_remote_offer(pj_pool_t *pool,
         neg->state = PJMEDIA_SDP_NEG_STATE_REMOTE_OFFER;
 
     }
+
+    /* Init last_sent's pool to app's pool, will be updated to active
+     * SDPs pool after a successful SDP nego.
+     */
+    neg->pool_active = pool;
 
     *p_neg = neg;
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1603,16 +1603,10 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_negotiate( pj_pool_t *pool,
                                neg->neg_local_sdp, neg->neg_remote_sdp,
                                &answer);
         if (status == PJ_SUCCESS) {
-            pj_uint32_t active_ver;
+            if (neg->last_sent)
+                answer->origin.version = neg->last_sent->origin.version;
 
-            if (neg->active_local_sdp)
-                active_ver = neg->active_local_sdp->origin.version;
-            else
-                active_ver = neg->initial_sdp->origin.version;
-
-            answer->origin.version = active_ver;
-
-            if (neg->last_sent &&
+            if (!neg->last_sent ||
                 pjmedia_sdp_session_cmp(neg->last_sent, answer, 0) !=
                 PJ_SUCCESS)
             {

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -457,16 +457,6 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_send_local_offer( pj_pool_t *pool,
         neg->neg_local_sdp = pjmedia_sdp_session_clone(pool, 
                                                        neg->active_local_sdp);
 
-#if PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
-        if (pjmedia_sdp_session_cmp(neg->neg_local_sdp, 
-                                    neg->initial_sdp, 0) != PJ_SUCCESS)
-        {
-            neg->neg_local_sdp->origin.version++;
-        }    
-#else
-        neg->neg_local_sdp->origin.version++;
-#endif
-
         *offer = neg->neg_local_sdp;
 
     } else {
@@ -1586,6 +1576,17 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_negotiate( pj_pool_t *pool,
             /* Only update active SDPs when negotiation is successfull */
             neg->active_local_sdp = active;
             neg->active_remote_sdp = neg->neg_remote_sdp;
+
+#if PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
+            if (pjmedia_sdp_session_cmp(neg->neg_local_sdp, 
+                                        neg->active_local_sdp, 0) != PJ_SUCCESS)
+            {
+                ++neg->active_local_sdp->origin.version;
+            }
+#else
+            ++neg->active_local_sdp->origin.version;
+#endif
+
         }
     } else {
         pjmedia_sdp_session *answer = NULL;

--- a/pjmedia/src/test/sdp_neg_test.c
+++ b/pjmedia/src/test/sdp_neg_test.c
@@ -660,11 +660,7 @@ static struct test
             NULL,
             /* This is how Bob's answer should look like: */
             "v=0\r\n"
-#if PJMEDIA_SDP_NEG_COMPARE_BEFORE_INC_VERSION
             "o=bob 2808844564 2808844564 IN IP4 host.biloxi.example.com\r\n"
-#else
-            "o=bob 2808844564 2808844565 IN IP4 host.biloxi.example.com\r\n"
-#endif
             "s=bob\r\n"
             "c=IN IP4 host.biloxi.example.com\r\n"
             "t=0 0\r\n"


### PR DESCRIPTION
Related to #2646.

Consider the scenario:
1. TX INITIAL INVITE. (multiple codecs offer)
2. RX 200 OK for INVITE (single codec answer) 
3. TX INVITE (Session Refresh) 
4. TX INVITE (Session Refresh)

When sending re-INVITE for SIP session refresh, the origin version will always be incremented although there's no SDP change (INVITE [4] and onwards). 

This ticket will move the SDP check to `pjmedia_sdp_neg_negotiate()` and change the origin version there. 

