### PR TITLE
Improve POSIX shell portability

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -8136,7 +8136,7 @@ printf %s "checking ffmpeg packages... " >&6; }
 				av_pkg="$av_pkg libavutil"
 			fi
 
-			if test "x$av_pkg" == "x"; then
+			if test "x$av_pkg" = "x"; then
 			   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none detected (check the prefix)! **" >&5
 printf "%s\n" "none detected (check the prefix)! **" >&6; }
 			else

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -1379,7 +1379,7 @@ AC_ARG_ENABLE(ffmpeg,
 				av_pkg="$av_pkg libavutil"
 			fi
 			
-			if test "x$av_pkg" == "x"; then
+			if test "x$av_pkg" = "x"; then
 			   AC_MSG_RESULT([none detected (check the prefix)! **])
 			else
 			   AC_MSG_RESULT([$av_pkg])


### PR DESCRIPTION
The conditional, `test XXX == YYY` is bash-specific.
Like the other conditionals in aconfigure.ac and aconfigure, use `test XXX = YYY` instead.