### PR TITLE
SRTP not able to restart after receiving old packets, SRTP being bypassed when it should not

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -892,7 +892,10 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
 
     /* If all options points to 'NULL' method, just bypass SRTP */
     if (cr_tx_idx == 0 && cr_rx_idx == 0 && au_tx_idx == 0 && au_rx_idx == 0) {
-        srtp->bypass_srtp = PJ_TRUE;
+        srtp->bypass_srtp = srtp->setting.use != PJMEDIA_SRTP_MANDATORY ? PJ_FALSE : PJ_TRUE;
+
+        PJ_LOG(4, (THIS_FILE, "SRTP bypass flag has been %s",
+            srtp->bypass_srtp == PJ_TRUE ? "enabled" : "disabled"));
         goto on_return;
     }
 

--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -1530,8 +1530,8 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
         pjmedia_srtp_crypto tx, rx;
         pj_status_t status;
 
-        tx = srtp->tx_policy;
-        rx = srtp->rx_policy;
+        tx = srtp->tx_policy_neg;
+        rx = srtp->rx_policy_neg;
 
         /* Stop SRTP first, otherwise srtp_start() will maintain current
          * roll-over counter.


### PR DESCRIPTION
This PR addresses two issues:

- When the configuration PJMEDIA_SRTP_CHECK_RTP_SEQ_ON_RESTART is enabled, old RTP packets arriving can cause the SRTP transport to stop and start again. However, during this process, the stop method empties the currently used TX/RX policies, causing the transport to not start correctly and leaving it in an invalid state.
- If the policies become invalid (issue above), the bypass_srtp flag is set to PJ_TRUE. This poses a security risk if the SRTP use is set to MANDATORY.

To resolve the first issue, the PR uses the temporary variables (rx_policy_neg and tx_policy_neg) which are still valid at this point. Personally speaking, the reason for the restart feature is unknown. Is it really needed?

The second issue is resolved by setting the bypass_srtp flag to PJ_FALSE if the use is MANDATORY and to PJ_TRUE otherwise.
