### PR TITLE
Allow transport other than TLS to be used for SIPS scheme

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -111,9 +111,9 @@ typedef struct pjsip_cfg_t
         pj_bool_t disable_tcp_switch;
 
         /**
-         * Disable automatic switching to TLS if target-URI does not use
-         * "sips" scheme nor TLS transport, even when request-URI uses
-         * "sips" scheme.
+         * Disable automatic switching to secure transport (such as TLS)
+         * if target-URI does not use "sips" scheme nor secure transport,
+         * even when request-URI uses "sips" scheme.
          *
          * Default is PJSIP_DONT_SWITCH_TO_TLS.
          */
@@ -397,9 +397,13 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  * As specified RFC 3261 section 8.1.2, when request-URI uses "sips" scheme,
  * TLS must always be used regardless of the target-URI scheme or transport
  * type.
+ * Update: Newer RFCs, such as RFC 5630 and 7118, expands this by allowing
+ * the use of other transports as long as the SIP resource designated by
+ * the target SIPS URI is contacted securely.
  *
- * This option will specify whether the behavior of automatic switching to TLS
- * should be disabled, i.e: regard the target-URI scheme or transport type.
+ * This option will specify whether the behavior of automatic switching to secure
+ * transport (such as TLS) should be disabled, i.e: regard the target-URI scheme
+ * or transport type.
  *
  * This option can also be controlled at run-time by the \a disable_tls_switch
  * setting in pjsip_cfg_t.

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -124,7 +124,7 @@ PJ_DECL(pjsip_transport_type_e)
 pjsip_transport_get_type_from_name(const pj_str_t *name);
 
 /**
- * Get the transport type for the specified flags.
+ * Get the first transport type that has the specified flags.
  *
  * @param flag      The transport flag.
  *

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -372,7 +372,7 @@ PJ_DEF(pjsip_transport_type_e) pjsip_transport_get_type_from_flag(unsigned flag)
 
     /* Get the transport type for the specified flags. */
     for (i=0; i<PJ_ARRAY_SIZE(transport_names); ++i) {
-        if (transport_names[i].flag == flag) {
+        if ((transport_names[i].flag & flag) == flag) {
             return transport_names[i].type;
         }
     }

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -810,7 +810,8 @@ PJ_DEF(pj_status_t) pjsip_get_dest_info(const pjsip_uri *target_uri,
      */
     pj_bzero(dest_info, sizeof(*dest_info));
 
-    /* When request URI uses sips scheme, TLS must always be used regardless
+    /* When request URI uses sips scheme, secure transport
+     * (the default is TLS) must always be used regardless
      * of the target scheme or transport type (see ticket #1740).
      */
     if (PJSIP_URI_SCHEME_IS_SIPS(target_uri) || 
@@ -822,7 +823,7 @@ PJ_DEF(pj_status_t) pjsip_get_dest_info(const pjsip_uri *target_uri,
         unsigned flag;
 
         if (!PJSIP_URI_SCHEME_IS_SIPS(target_uri)) {
-            PJ_LOG(4,(THIS_FILE, "Automatic switch to TLS transport as "
+            PJ_LOG(4,(THIS_FILE, "Automatic switch to secure transport as "
                                  "request-URI uses ""sips"" scheme."));
         }
 

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -827,7 +827,11 @@ PJ_DEF(pj_status_t) pjsip_get_dest_info(const pjsip_uri *target_uri,
                                  "request-URI uses ""sips"" scheme."));
         }
 
-        dest_info->flag |= (PJSIP_TRANSPORT_SECURE | PJSIP_TRANSPORT_RELIABLE);
+        dest_info->flag |= PJSIP_TRANSPORT_SECURE;
+        /* There doesn't seem to be any requirement for SIPS to use
+         * reliable transport though, so we disable this.
+         */
+        // dest_info->flag |= PJSIP_TRANSPORT_RELIABLE;
         if (url->maddr_param.slen)
             pj_strdup(pool, &dest_info->addr.host, &url->maddr_param);
         else

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -820,18 +820,13 @@ PJ_DEF(pj_status_t) pjsip_get_dest_info(const pjsip_uri *target_uri,
     {
         pjsip_uri *uri = (pjsip_uri*) target_uri;
         const pjsip_sip_uri *url=(const pjsip_sip_uri*)pjsip_uri_get_uri(uri);
-        unsigned flag;
+        unsigned flag, tp_flag;
 
         if (!PJSIP_URI_SCHEME_IS_SIPS(target_uri)) {
             PJ_LOG(4,(THIS_FILE, "Automatic switch to secure transport as "
                                  "request-URI uses ""sips"" scheme."));
         }
 
-        dest_info->flag |= PJSIP_TRANSPORT_SECURE;
-        /* There doesn't seem to be any requirement for SIPS to use
-         * reliable transport though, so we disable this.
-         */
-        // dest_info->flag |= PJSIP_TRANSPORT_RELIABLE;
         if (url->maddr_param.slen)
             pj_strdup(pool, &dest_info->addr.host, &url->maddr_param);
         else
@@ -839,18 +834,27 @@ PJ_DEF(pj_status_t) pjsip_get_dest_info(const pjsip_uri *target_uri,
         dest_info->addr.port = url->port;
         dest_info->type = 
             pjsip_transport_get_type_from_name(&url->transport_param);
+
         /* Double-check that the transport parameter match.
          * Sample case:     sips:host;transport=tcp
          * See https://github.com/pjsip/pjproject/issues/1319
          */
         flag = pjsip_transport_get_flag_from_type(dest_info->type);
-        if ((flag & dest_info->flag) != dest_info->flag) {
+        tp_flag = PJSIP_TRANSPORT_SECURE;
+        /* There doesn't seem to be any requirement for SIPS to use
+         * reliable transport, so we disable this.
+         */
+        // tp_flag |= PJSIP_TRANSPORT_RELIABLE;
+        if ((flag & tp_flag) != tp_flag) {
             pjsip_transport_type_e t;
 
-            t = pjsip_transport_get_type_from_flag(dest_info->flag);
+            t = pjsip_transport_get_type_from_flag(tp_flag);
             if (t != PJSIP_TRANSPORT_UNSPECIFIED)
                 dest_info->type = t;
         }
+
+        dest_info->flag =
+            pjsip_transport_get_flag_from_type(dest_info->type);
 
     } else if (PJSIP_URI_SCHEME_IS_SIP(target_uri)) {
         pjsip_uri *uri = (pjsip_uri*) target_uri;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3434,7 +3434,7 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
     if (PJSIP_URI_SCHEME_IS_SIPS(sip_uri)) {
         unsigned flag, tp_flag;
 
-        tp_flag = (PJSIP_TRANSPORT_SECURE | PJSIP_TRANSPORT_RELIABLE);
+        tp_flag = PJSIP_TRANSPORT_SECURE;
         flag  = pjsip_transport_get_flag_from_type(tp_type);
         if ((flag & tp_flag) != tp_flag) {
             tp_type = pjsip_transport_get_type_from_flag(tp_flag);
@@ -3817,7 +3817,7 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uas_contact( pj_pool_t *pool,
     if (PJSIP_URI_SCHEME_IS_SIPS(sip_uri)) {
         unsigned flag, tp_flag;
 
-        tp_flag = (PJSIP_TRANSPORT_SECURE | PJSIP_TRANSPORT_RELIABLE);
+        tp_flag = PJSIP_TRANSPORT_SECURE;
         flag  = pjsip_transport_get_flag_from_type(tp_type);
         if ((flag & tp_flag) != tp_flag) {
             tp_type = pjsip_transport_get_type_from_flag(tp_flag);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3425,12 +3425,21 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
     }
 
     /* Get transport type of the URI */
-    if (PJSIP_URI_SCHEME_IS_SIPS(sip_uri))
-        tp_type = PJSIP_TRANSPORT_TLS;
-    else if (sip_uri->transport_param.slen == 0) {
+    if (sip_uri->transport_param.slen == 0) {
         tp_type = PJSIP_TRANSPORT_UDP;
     } else
         tp_type = pjsip_transport_get_type_from_name(&sip_uri->transport_param);
+
+    /* If the URI uses sips scheme, make sure we use secure transport. */
+    if (PJSIP_URI_SCHEME_IS_SIPS(sip_uri)) {
+        unsigned flag, tp_flag;
+
+        tp_flag = (PJSIP_TRANSPORT_SECURE | PJSIP_TRANSPORT_RELIABLE);
+        flag  = pjsip_transport_get_flag_from_type(tp_type);
+        if ((flag & tp_flag) != tp_flag) {
+            tp_type = pjsip_transport_get_type_from_flag(tp_flag);
+        }
+    }
 
     if (tp_type == PJSIP_TRANSPORT_UNSPECIFIED)
         return PJSIP_EUNSUPTRANSPORT;
@@ -3799,12 +3808,21 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uas_contact( pj_pool_t *pool,
     }
 
     /* Get transport type of the URI */
-    if (PJSIP_URI_SCHEME_IS_SIPS(sip_uri))
-        tp_type = PJSIP_TRANSPORT_TLS;
-    else if (sip_uri->transport_param.slen == 0) {
+    if (sip_uri->transport_param.slen == 0) {
         tp_type = PJSIP_TRANSPORT_UDP;
     } else
         tp_type = pjsip_transport_get_type_from_name(&sip_uri->transport_param);
+
+    /* If the URI uses sips scheme, make sure we use secure transport. */
+    if (PJSIP_URI_SCHEME_IS_SIPS(sip_uri)) {
+        unsigned flag, tp_flag;
+
+        tp_flag = (PJSIP_TRANSPORT_SECURE | PJSIP_TRANSPORT_RELIABLE);
+        flag  = pjsip_transport_get_flag_from_type(tp_type);
+        if ((flag & tp_flag) != tp_flag) {
+            tp_type = pjsip_transport_get_type_from_flag(tp_flag);
+        }
+    }
 
     if (tp_type == PJSIP_TRANSPORT_UNSPECIFIED)
         return PJSIP_EUNSUPTRANSPORT;


### PR DESCRIPTION
As reported in #3306 (SIPS URIs are being forwarded to TLS transport regardless of 'transport=' parameter).

In #1735 and #1740, we use TLS for SIPS URI based on the RFCs such as RFC 3261 and 5630:
```
Local policy MAY specify an alternate set of destinations to attempt.
   If the Request-URI contains a SIPS URI, any alternate destinations
   MUST be contacted with TLS.
```
and
```
This document specifies that SIPS means that the SIP resource
   designated by the target SIPS URI is to be contacted securely, using
   TLS on each hop between the UAC and the remote UAS (as opposed to
   only to the proxy responsible for the target domain of the Request-
   URI).  It is outside of the scope of this document to specify what
   happens when a SIPS URI identifies a UAS resource that "maps" outside
   the SIP network, for example, to other networks such as the Public
   Switched Telephone Network (PSTN).
```

However, note that the RFC makes a specific note that this applies only in a SIP network, so TLS is actually not mandatory, such as described in RFC 7118:
```
The "sips" scheme in a SIP URI dictates that the entire request path
   to the target be secure.  If such a path includes a WebSocket
   connection, it MUST be a secure WebSocket connection.
```

Thus this PR is to make the following modifications:
- The implementation in `sip_util.c` `pjsip_get_dest_info()` is actually already correct. We only require the transport to be secure for SIPS scheme, however the documentation and log message can be misleading as it seems to suggest that the secure transport has to be only TLS. So we fix the doc and log here. The setting and macro names `disable_tls_switch` and `PJSIP_DONT_SWITCH_TO_TLS` however, will remain unchanged for backward compatibility.
- Fixing the contact generation in pjsua acc that is hardcoded to TLS.
- Remove requirement for the transport to be reliable as there doesn't seem to be any RFC recommendation that mandates it.

Note: this PR also modifies the behaviour of API `pjsip_transport_get_type_from_flag()` to return the first transport type that contains the specified flags, instead of the one that matches the exact flag.
