### PR TITLE
Hangup not yet confirmed outgoing calls in IP change

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4281,6 +4281,31 @@ pj_status_t pjsua_acc_handle_call_on_ip_change(pjsua_acc *acc)
                                                              status,
                                                              &info);
                 }
+            }
+            else if (call_info.role==PJSIP_ROLE_UAC &&
+                     call_info.state < PJSIP_INV_STATE_CONFIRMED)
+            {
+                /* Hangup not yet confirmed outgoing calls */
+                acc->ip_change_op = PJSUA_IP_CHANGE_OP_ACC_HANGUP_CALLS;
+                PJ_LOG(3, (THIS_FILE, "Unconfirmed outgoing call to %.*s: "
+                           "hangup triggered by IP change",
+                           (int)call_info.remote_info.slen,
+                           call_info.remote_info.ptr));
+
+                status = pjsua_call_hangup(i, PJSIP_SC_GONE, NULL, NULL);
+
+                if (pjsua_var.ua_cfg.cb.on_ip_change_progress) {
+                    pjsua_ip_change_op_info info;
+
+                    pj_bzero(&info, sizeof(info));
+                    info.acc_hangup_calls.acc_id = acc->index;
+                    info.acc_hangup_calls.call_id = call_info.id;
+
+                    pjsua_var.ua_cfg.cb.on_ip_change_progress(
+                                                             acc->ip_change_op,
+                                                             status,
+                                                             &info);
+                }
             } else if ((acc->cfg.ip_change_cfg.reinvite_flags) &&
                 (call_info.state == PJSIP_INV_STATE_CONFIRMED))
             {


### PR DESCRIPTION
There was PR #2737 for avoiding call disconnection on IP change, but its scope is limited to a confirmed call. Also this PR #2683 for maintaining INVITE transactions in the UAS/callee side. While for UAC/caller in the connecting state, it is actually a bit more complex, an attempt to handle it has been done in PR #3288 (still unsolved).

Some of the challenges are:
- as the INVITE transaction is not completed yet, by standard we cannot send another INVITE to update remote about our new address, we can only use UPDATE and not all endpoints support UPDATE,
- if the initial INVITE contains SDP offer, and the SDP negotiation is not completed yet, also by standard, the UPDATE cannot contain another SDP offer, we need to renegotiate the SDP to update the media addresses,
- updating routing info for the INVITE transaction so remote/server can send its response to the correct latest address, but is not a simple task as remote/server may already send the response before our UPDATE is sent.

So for now, let's just hang up not confirmed outgoing call in IP change scenario. Note that the remote may see a dangling call as there may be race condition, e.g: remote has sent some response but not received by local/caller.