### PR TITLE
Optimize memory usage for SRTP ROC checking functionality

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -80,10 +80,8 @@ struct pjsua_call_media
                                          bit 1     : timestamp flag         */
 
     pjmedia_type         prev_type;            /**< Previous media type     */
-    pj_sockaddr          prev_aud_local_addr;  /**< Prev aud local address  */
-    pj_sockaddr          prev_aud_rem_addr;    /**< Prev aud remote address */
-    pj_sockaddr          prev_vid_local_addr;  /**< Prev vid local address  */
-    pj_sockaddr          prev_vid_rem_addr;    /**< Prev vid remote address */
+    pj_sockaddr          prev_local_addr;      /**< Prev media local address*/
+    pj_sockaddr          prev_rem_addr;        /**< Prev media remote addr  */
     pj_bool_t            prev_srtp_use;        /**< Prev SRTP use           */
     pjmedia_srtp_info    prev_srtp_info;       /**< Prev SRTP transport info*/
     pj_bool_t            prev_ice_use;         /**< Prev ICE use            */

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -79,12 +79,14 @@ struct pjsua_call_media
                                          bit 0/LSB : sequence flag
                                          bit 1     : timestamp flag         */
 
-    pjmedia_type                prev_type;     /**< Previous media type     */
-    pjmedia_stream_info         prev_aud_si;   /**< Prev audio stream info  */
-    pjmedia_vid_stream_info     prev_vid_si;   /**< Prev video stream info  */
-    pj_bool_t                   prev_srtp_use; /**< Prev SRTP use           */
-    pjmedia_srtp_info           prev_srtp_info;/**< Prev SRTP transport info*/
-    pj_bool_t                   prev_ice_use;  /**< Prev ICE use            */
+    pjmedia_type         prev_type;            /**< Previous media type     */
+    pj_sockaddr          prev_aud_local_addr;  /**< Prev aud local address  */
+    pj_sockaddr          prev_aud_rem_addr;    /**< Prev aud remote address */
+    pj_sockaddr          prev_vid_local_addr;  /**< Prev vid local address  */
+    pj_sockaddr          prev_vid_rem_addr;    /**< Prev vid remote address */
+    pj_bool_t            prev_srtp_use;        /**< Prev SRTP use           */
+    pjmedia_srtp_info    prev_srtp_info;       /**< Prev SRTP transport info*/
+    pj_bool_t            prev_ice_use;         /**< Prev ICE use            */
     pjmedia_ice_transport_info  prev_ice_info; /**< Prev ICE transport info */
 
     pjmedia_transport   *tp;        /**< Current media transport (can be 0) */

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -546,7 +546,11 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
     pjmedia_rtcp_stat stat;
 
     if (strm) {
-        pjmedia_stream_get_info(strm, &call_med->prev_aud_si);
+        pjmedia_stream_info prev_aud_si;
+
+        pjmedia_stream_get_info(strm, &prev_aud_si);
+        call_med->prev_aud_local_addr = prev_aud_si.local_addr;
+        call_med->prev_aud_rem_addr = prev_aud_si.rem_addr;
 
         /* Unsubscribe from stream events */
         pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med, strm);

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -549,8 +549,8 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
         pjmedia_stream_info prev_aud_si;
 
         pjmedia_stream_get_info(strm, &prev_aud_si);
-        call_med->prev_aud_local_addr = prev_aud_si.local_addr;
-        call_med->prev_aud_rem_addr = prev_aud_si.rem_addr;
+        call_med->prev_local_addr = prev_aud_si.local_addr;
+        call_med->prev_rem_addr = prev_aud_si.rem_addr;
 
         /* Unsubscribe from stream events */
         pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med, strm);

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3140,10 +3140,12 @@ static void stop_media_stream(pjsua_call *call, unsigned med_idx)
         prov_med->rtp_tx_seq        = call_med->rtp_tx_seq;
         prov_med->rtp_tx_ts         = call_med->rtp_tx_ts;
 
-        /* Saved media type and stream info */
+        /* Saved media type and addresses */
         prov_med->prev_type = call_med->prev_type;
-        prov_med->prev_aud_si = call_med->prev_aud_si;
-        prov_med->prev_vid_si = call_med->prev_vid_si;
+        prov_med->prev_aud_local_addr = call_med->prev_aud_local_addr;
+        prov_med->prev_aud_rem_addr   = call_med->prev_aud_rem_addr;
+        prov_med->prev_vid_local_addr = call_med->prev_vid_local_addr;
+        prov_med->prev_vid_rem_addr   = call_med->prev_vid_rem_addr;
 
         /* Stream */
         if (call_med->type == PJMEDIA_TYPE_AUDIO) {
@@ -3378,10 +3380,12 @@ static void check_srtp_roc(pjsua_call *call,
     pjmedia_srtp_info *srtp_info;
     pjmedia_transport *srtp;
     pjmedia_ice_transport_info *ice_info;
-    const pjmedia_stream_info *prev_aud_si = NULL;
+    const pj_sockaddr *prev_aud_local_addr = NULL;
+    const pj_sockaddr *prev_aud_rem_addr = NULL;
     pjmedia_stream_info aud_si;
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
-    const pjmedia_vid_stream_info *prev_vid_si = NULL;
+    const pj_sockaddr *prev_vid_local_addr = NULL;
+    const pj_sockaddr *prev_vid_rem_addr = NULL;
     pjmedia_vid_stream_info vid_si;
 #endif
     pj_bool_t local_change = PJ_FALSE, rem_change = PJ_FALSE;
@@ -3423,11 +3427,15 @@ static void check_srtp_roc(pjsua_call *call,
         /* The stream has been deinitialized by now, so we need to retrieve
          * the previous stream info from the stored data.
          */
-        if (call_med->prev_type == PJMEDIA_TYPE_AUDIO)
-            prev_aud_si = &call_med->prev_aud_si;
+        if (call_med->prev_type == PJMEDIA_TYPE_AUDIO) {
+            prev_aud_local_addr = &call_med->prev_aud_local_addr;
+            prev_aud_rem_addr = &call_med->prev_aud_rem_addr;
+        }
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
-        else if (call_med->prev_type == PJMEDIA_TYPE_VIDEO)
-            prev_vid_si = &call_med->prev_vid_si;
+        else if (call_med->prev_type == PJMEDIA_TYPE_VIDEO) {
+            prev_vid_local_addr = &call_med->prev_vid_local_addr;
+            prev_vid_rem_addr = &call_med->prev_vid_rem_addr;
+        }
 #endif
     } else {
         call_med->prev_srtp_use = PJ_TRUE;
@@ -3441,7 +3449,8 @@ static void check_srtp_roc(pjsua_call *call,
             /* Get current active audio stream info */
             if (call_med->strm.a.stream) {
                 pjmedia_stream_get_info(call_med->strm.a.stream, &aud_si);
-                prev_aud_si = &aud_si;
+                prev_aud_local_addr = &aud_si.local_addr;
+                prev_aud_rem_addr = &aud_si.rem_addr;
             }
         } 
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
@@ -3449,7 +3458,8 @@ static void check_srtp_roc(pjsua_call *call,
             /* Get current active video stream info */
             if (call_med->strm.v.stream) {
                 pjmedia_vid_stream_get_info(call_med->strm.v.stream, &vid_si);
-                prev_vid_si = &vid_si;
+                prev_vid_local_addr = &vid_si.local_addr;
+                prev_vid_rem_addr = &vid_si.rem_addr;
             }
         }
 #endif
@@ -3464,25 +3474,25 @@ static void check_srtp_roc(pjsua_call *call,
                           call_med->prev_srtp_info.rx_roc.roc));
 #endif
     
-    if (prev_aud_si) {
+    if (prev_aud_local_addr) {
         const pjmedia_stream_info *new_si = &new_si_->info.aud;
 
         /* Local IP address changes */
-        if (pj_sockaddr_cmp(&prev_aud_si->local_addr, &new_si->local_addr))
+        if (pj_sockaddr_cmp(&prev_aud_local_addr, &new_si->local_addr))
             local_change = PJ_TRUE;
         /* Remote IP address changes */
-        if (pj_sockaddr_cmp(&prev_aud_si->rem_addr, &new_si->rem_addr))
+        if (pj_sockaddr_cmp(&prev_aud_rem_addr, &new_si->rem_addr))
             rem_change = PJ_TRUE;
     }
 #if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
-    if (prev_vid_si) {
+    if (prev_vid_local_addr) {
         const pjmedia_vid_stream_info *new_si = &new_si_->info.vid;
         
         /* Local IP address changes */
-        if (pj_sockaddr_cmp(&prev_vid_si->local_addr, &new_si->local_addr))
+        if (pj_sockaddr_cmp(&prev_vid_local_addr, &new_si->local_addr))
             local_change = PJ_TRUE;
         /* Remote IP address changes */
-        if (pj_sockaddr_cmp(&prev_vid_si->rem_addr, &new_si->rem_addr))
+        if (pj_sockaddr_cmp(&prev_vid_rem_addr, &new_si->rem_addr))
             rem_change = PJ_TRUE;
     }
 #endif

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1337,8 +1337,8 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
     pj_log_push_indent();
     
     pjmedia_vid_stream_get_info(strm, &prev_vid_si);
-    call_med->prev_vid_local_addr = prev_vid_si.local_addr;
-    call_med->prev_vid_rem_addr = prev_vid_si.rem_addr;
+    call_med->prev_local_addr = prev_vid_si.local_addr;
+    call_med->prev_rem_addr = prev_vid_si.rem_addr;
 
     pjmedia_vid_stream_send_rtcp_bye(strm);
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1325,6 +1325,7 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
 {
     pjmedia_vid_stream *strm = call_med->strm.v.stream;
     pjmedia_rtcp_stat stat;
+    pjmedia_vid_stream_info prev_vid_si;
     unsigned num_locks = 0;
 
     pj_assert(call_med->type == PJMEDIA_TYPE_VIDEO);
@@ -1335,7 +1336,9 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
     PJ_LOG(4,(THIS_FILE, "Stopping video stream.."));
     pj_log_push_indent();
     
-    pjmedia_vid_stream_get_info(strm, &call_med->prev_vid_si);
+    pjmedia_vid_stream_get_info(strm, &prev_vid_si);
+    call_med->prev_vid_local_addr = prev_vid_si.local_addr;
+    call_med->prev_vid_rem_addr = prev_vid_si.rem_addr;
 
     pjmedia_vid_stream_send_rtcp_bye(strm);
 


### PR DESCRIPTION
To fix https://github.com/pjsip/pjproject/issues/3278.

To implement #2846 (maintenance of SRTP ROC), we add two fields `pjmedia_stream_info` and `pjmedia_stream_info` into `pjsua_call_media`. 

The size of each structure itself is "only" 2k, but for large number of max calls, this can significantly increase memory usage.
For example, if max calls is 4K:
4K * 16 (PJSUA_MAX_CALL_MEDIA) * 2 (media+prov_media) * 2 (audio&video stream info) * 2K (sizeof(struct)) = 512 MB.

Since not all the stream info fields are needed, we only keep the necessary ones.
