### PR TITLE
Fixed crash if jb max size equals frame ptime

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2695,7 +2695,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
         jb_max_pre = info->jb_max_pre / stream->codec_param.info.frm_ptime;
     else
         //jb_max_pre = 240 / stream->codec_param.info.frm_ptime;
-        jb_max_pre = jb_max * 4 / 5;
+        jb_max_pre = PJ_MAX(1, jb_max * 4 / 5);
 
     if (info->jb_init >= stream->codec_param.info.frm_ptime)
         jb_init = info->jb_init / stream->codec_param.info.frm_ptime;

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -1953,7 +1953,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
     if (info->jb_max_pre >= frm_ptime)
         jb_max_pre  = info->jb_max_pre * chunks_per_frm / frm_ptime;
     else
-        jb_max_pre  = jb_max * 4 / 5;
+        jb_max_pre  = PJ_MAX(1, jb_max * 4 / 5);
 
     /* JB init prefetch, default 0 */
     if (info->jb_init >= frm_ptime)

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -166,7 +166,7 @@ static void usage(void)
     puts  ("                      Specify N=-1 to disable this feature.");
     puts  ("                      Specify N=0 for instant close when unused.");
     puts  ("  --no-tones          Disable audible tones");
-    puts  ("  --jb-max-size       Specify jitter buffer maximum size, in frames (default=-1)");
+    puts  ("  --jb-max-size       Specify jitter buffer maximum size, in msec (default=-1)");
     puts  ("  --extra-audio       Add one more audio stream");
 
 #if PJSUA_HAS_VIDEO


### PR DESCRIPTION
To fix #3271, and to continue the work in #3277.
