### PR TITLE
Fix string DISCONNCTD

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -68,7 +68,7 @@ static const char *inv_state_names[] =
     "EARLY",
     "CONNECTING",
     "CONFIRMED",
-    "DISCONNCTD",
+    "DISCONNECTED",
     "TERMINATED",
 };
 


### PR DESCRIPTION
It is the only string which was abbreviated and had not be cleaned up in Commit 4be63b5a58e4af810db790a8cb34b4da4adb0969.