### PR TITLE
Handle invalid SDP when call is in early state

### DIFF
--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -232,6 +232,7 @@ typedef struct pjsip_inv_callback
     /**
      * This callback is called after SDP offer/answer session has completed.
      * The status argument specifies the status of the offer/answer, 
+     * i.e. whether the SDP answer is valid or the negotiation result
      * as returned by pjmedia_sdp_neg_negotiate().
      * 
      * This callback is optional (from the point of view of the framework), 

--- a/tests/pjsua/scripts-sipp/uas-answer-183-wrong-attr.py
+++ b/tests/pjsua/scripts-sipp/uas-answer-183-wrong-attr.py
@@ -1,0 +1,15 @@
+# $Id$
+#
+import inc_const as const
+
+PJSUA = ["--null-audio --max-calls=1 --no-tcp $SIPP_URI"]
+
+PJSUA_EXPECTS = [[0, const.STATE_EARLY, ""],
+		 [0, "487/INVITE", ""],
+		 [0, const.STATE_DISCONNECTED, ""]
+		]
+
+PJSUA_CLI_EXPECTS = [[0, const.STATE_EARLY, ""],
+		     [0, "487/INVITE", ""],
+		     [0, const.STATE_DISCONNECTED, ""]
+		    ]

--- a/tests/pjsua/scripts-sipp/uas-answer-183-wrong-attr.xml
+++ b/tests/pjsua/scripts-sipp/uas-answer-183-wrong-attr.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+<!--                                                                    -->
+<!-- You should have received a copy of the GNU General Public License  -->
+<!-- along with this program; if not, write to the                      -->
+<!-- Free Software Foundation, Inc.,                                    -->
+<!-- 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA             -->
+<!--                                                                    -->
+<!--                 Sipp default 'uas' scenario.                       -->
+<!--                                                                    -->
+
+<scenario name="UAS sending 183 with wrong SDP version">
+  <!-- By adding rrs="true" (Record Route Sets), the route sets         -->
+  <!-- are saved and used for following messages sent. Useful to test   -->
+  <!-- against stateful SIP proxies/B2BUAs.                             -->
+
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 100 Trying
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 183 Session Progress
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      1=1
+      o=- 3441953879 3441953879 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio 4000 RTP/AVP 8 101
+      a=rtpmap:8 PCMA/8000
+      a=rtpmap:101 telephone-event/8000
+      a=fmtp:101 0-11,16
+      a=sendrecv
+
+    ]]>
+  </send>
+
+  <!-- Wait for CANCEL -->
+  <recv request="CANCEL" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 487 Request Terminated
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      CSeq: [cseq] INVITE
+      Contact: <sip:sipp@[local_ip]:[local_port]>
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <!-- Wait for CANCEL -->
+  <recv request="ACK" crlf="true">
+  </recv>
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+


### PR DESCRIPTION
To fix #3287.

Currently, when SDP negotiation fails when call is in early state, `sip_inv` will call `on_media_update()` callback and pjsua will terminate the call. (The flow is: `inv_check_sdp_in_incoming_msg()` -> `inv_negotiate_sdp()` -> `on_media_update()`).

However, if there's an error when checking the SDP before the negotiation even happens, such as SDP parsing error, the callback won't be called at all.
