### PR TITLE
[Issue 3367 fix] Sipecho updates pj status properly when responding to invalid incoming message with status 400

### DIFF
--- a/pjsip-apps/src/samples/sipecho.c
+++ b/pjsip-apps/src/samples/sipecho.c
@@ -469,6 +469,7 @@ static pj_bool_t on_rx_request( pjsip_rx_data *rdata )
         pjsip_endpt_respond_stateless( app.sip_endpt, rdata,
                                        400, &reason,
                                        NULL, NULL);
+        return PJ_TRUE;
     }
 
     for (i=0; i<MAX_CALLS; ++i) {


### PR DESCRIPTION
Proposed fix for Issue #3367 