### PR TITLE
Make sure that NOTIFY tdata is set before sending it

### DIFF
--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -2223,9 +2223,12 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
         /* Send the pending NOTIFY sent by app from inside
          * on_rx_refresh() callback.
          */
-        pj_assert(sub->pending_notify);
-        status = pjsip_evsub_send_request(sub, sub->pending_notify);
-        sub->pending_notify = NULL;
+        //pj_assert(sub->pending_notify);
+        /* Make sure that pending_notify is set. */
+        if (sub->pending_notify) {
+            status = pjsip_evsub_send_request(sub, sub->pending_notify);
+            sub->pending_notify = NULL;
+        }
 
     } else if (pjsip_method_cmp(&tsx->method, &pjsip_notify_method)==0) {
 


### PR DESCRIPTION
PR #3126 will delay sending NOTIFY after the SUBSCRIBE response.
This is done by saving the NOTIFY tdata (`pending_notify`) from `pjsip_evsub_send_request()` called from `on_rx_refresh()` callback and send it later.
However, `pjsip_evsub_send_request()` might not get called and `pending_notify` not set, which will raise the assertion and crash.
This will remove the assertion and check the `pending_notify` before sending it.