### PR TITLE
Incorrect pjlib-test on GitHub CI

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         python-version: 2.7
     - name: unit tests
-      run: make pjlib-test pjlib-util-test pjmedia-test pjsua-test
+      run: make pjlib-test-ci pjlib-util-test pjmedia-test pjsua-test
 
   ubuntu-default-full-bundle-2:
   # full bundle 2: running pjnath test
@@ -122,7 +122,7 @@ jobs:
       with:
         python-version: 2.7
     - name: unit tests
-      run: make pjlib-test pjlib-util-test pjmedia-test pjsua-test
+      run: make pjlib-test-ci pjlib-util-test pjmedia-test pjsua-test
 
   ubuntu-video-openh264-2:
   # video 2: running pjnath test

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         python-version: 2.7
     - name: unit tests
-      run: make pjlib-test pjmedia-test pjlib-util-test pjsua-test
+      run: make pjlib-test-ci pjmedia-test pjlib-util-test pjsua-test
 
   mac-default-full-bundle-2:
   # full bundle 2: running pjnath test
@@ -126,7 +126,7 @@ jobs:
       with:
         python-version: 2.7
     - name: unit tests
-      run: make pjlib-test pjmedia-test pjlib-util-test pjsua-test
+      run: make pjlib-test-ci pjmedia-test pjlib-util-test pjsua-test
 
   mac-video-openh264-2:
   # video 2: running pjnath test

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
         $env:PATH+=";$env:OPENSSL_DIR\bin"
-        cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe
+        cd pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe --ci-mode
         cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Release.exe
         cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Release.exe
       shell: powershell
@@ -267,7 +267,7 @@ jobs:
         $env:SDL_DIR = Get-Content .\sdl_dir.txt
         $env:PATH+=";$env:OPENSSL_DIR\bin;$env:SDL_DIR\lib\x86;"
         cd tests/pjsua; python runall.py
-        cd ../../pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe
+        cd ../../pjlib/bin; ./pjlib-test-i386-Win32-vc14-Release.exe --ci-mode
         cd ../../pjlib-util/bin; ./pjlib-util-test-i386-Win32-vc14-Release.exe
         cd ../../pjmedia/bin/; ./pjmedia-test-i386-Win32-vc14-Release.exe
       shell: powershell

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ selftest: pjlib-test pjlib-util-test pjnath-test pjmedia-test pjsip-test pjsua-t
 pjlib-test: pjlib/bin/pjlib-test-$(TARGET_NAME)
 	cd pjlib/build && ../bin/pjlib-test-$(TARGET_NAME)
 
+pjlib-test-ci: pjlib/bin/pjlib-test-$(TARGET_NAME)
+	cd pjlib/build && ../bin/pjlib-test-$(TARGET_NAME) --ci-mode
+
 pjlib-util-test: pjlib-util/bin/pjlib-util-test-$(TARGET_NAME)
 	cd pjlib-util/build && ../bin/pjlib-util-test-$(TARGET_NAME)
 

--- a/pjlib/src/pjlib-test/main.c
+++ b/pjlib/src/pjlib-test/main.c
@@ -26,6 +26,7 @@
 extern int param_echo_sock_type;
 extern const char *param_echo_server;
 extern int param_echo_port;
+extern pj_bool_t param_ci_mode;
 
 
 //#if defined(PJ_WIN32) && PJ_WIN32!=0
@@ -83,14 +84,14 @@ static void init_signals(void)
 
 int main(int argc, char *argv[])
 {
-    int rc;
+    int iarg=1, rc;
     int interractive = 0;
     int no_trap = 0;
 
     boost();
 
-    while (argc > 1) {
-        char *arg = argv[--argc];
+    while (iarg < argc) {
+        char *arg = argv[iarg++];
 
         if (*arg=='-' && *(arg+1)=='i') {
             interractive = 1;
@@ -98,24 +99,30 @@ int main(int argc, char *argv[])
         } else if (*arg=='-' && *(arg+1)=='n') {
             no_trap = 1;
         } else if (*arg=='-' && *(arg+1)=='p') {
-            pj_str_t port = pj_str(argv[--argc]);
+            pj_str_t port = pj_str(argv[iarg++]);
 
             param_echo_port = pj_strtoul(&port);
 
         } else if (*arg=='-' && *(arg+1)=='s') {
-            param_echo_server = argv[--argc];
+            param_echo_server = argv[iarg++];
 
         } else if (*arg=='-' && *(arg+1)=='t') {
-            pj_str_t type = pj_str(argv[--argc]);
+            pj_str_t type = pj_str(argv[iarg++]);
             
             if (pj_stricmp2(&type, "tcp")==0)
                 param_echo_sock_type = pj_SOCK_STREAM();
             else if (pj_stricmp2(&type, "udp")==0)
                 param_echo_sock_type = pj_SOCK_DGRAM();
             else {
-                PJ_LOG(3,("", "error: unknown socket type %s", type.ptr));
+                printf("Error: unknown socket type %s\n", type.ptr);
                 return 1;
             }
+        } else if (strcmp(arg, "--ci-mode")==0) {
+            param_ci_mode = PJ_TRUE;
+
+        } else {
+            printf("Error in argument \"%s\"\n", arg);
+            return 1;
         }
     }
 

--- a/pjlib/src/pjlib-test/sleep.c
+++ b/pjlib/src/pjlib-test/sleep.c
@@ -52,6 +52,8 @@
 
 #define THIS_FILE   "sleep_test"
 
+extern pj_bool_t param_ci_mode;
+
 static int simple_sleep_test(void)
 {
     enum { COUNT = 10 };
@@ -90,7 +92,7 @@ static int simple_sleep_test(void)
 
 static int sleep_duration_test(void)
 {
-    enum { MIS = 20};
+    const int MIS = param_ci_mode? 30 : 10;
     unsigned duration[] = { 2000, 1000, 500, 200, 100 };
     unsigned i;
     pj_status_t rc;

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -49,6 +49,7 @@ const char *param_echo_server = ECHO_SERVER_ADDRESS;
 int param_echo_port = ECHO_SERVER_START_PORT;
 int param_log_decor = PJ_LOG_HAS_NEWLINE | PJ_LOG_HAS_TIME |
                       PJ_LOG_HAS_MICRO_SEC | PJ_LOG_HAS_INDENT;
+pj_bool_t param_ci_mode = PJ_FALSE;  /* GH CI mode: more lenient tests */
 
 int null_func()
 {
@@ -75,6 +76,9 @@ int test_inner(void)
 
     //pj_dump_config();
     pj_caching_pool_init( &caching_pool, NULL, 0 );
+
+    if (param_ci_mode)
+        PJ_LOG(3,("test", "Using ci-mode"));
 
 #if INCLUDE_ERRNO_TEST
     DO_TEST( errno_test() );

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -221,7 +221,7 @@ on_return:
 
     pj_shutdown();
 
-    return 0;
+    return rc;
 }
 
 #include <pj/sock.h>


### PR DESCRIPTION
- fix pjlib-test always returns success even on error
- fix failing tests when pjlib-test is run on GitHub CI:
  - add `--ci-mode` argument to pjlib-test. Some tests become more lenient under this mode.
  - add `pjlib-test-ci` Makefile target,
  - modify CI to use `make pjlib-test-ci` rather than `make pjlib-test`