### PR TITLE
Formulate headers in new request upon receiving 3xx

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -19,6 +19,7 @@
 #include <pjsip-ua/sip_inv.h>
 #include <pjsip-ua/sip_100rel.h>
 #include <pjsip-ua/sip_timer.h>
+#include <pjsip/print_util.h>
 #include <pjsip/sip_module.h>
 #include <pjsip/sip_endpoint.h>
 #include <pjsip/sip_event.h>
@@ -3077,45 +3078,37 @@ PJ_DEF(pj_status_t) pjsip_inv_process_redirect( pjsip_inv_session *inv,
                 uri = (pjsip_sip_uri *)pjsip_uri_get_uri(req_uri);
                 param = uri->header_param.next;
                 while (param != &uri->header_param) {
-                    const pj_str_t hdr_names[] =
+                    const pjsip_hdr_e hdr_types[] =
                     {
                     /* We should reject the following headers as
                      * they can potentially be malicious or misleading.
                      */
-                    {"Accept",              6}, // PJSIP_H_ACCEPT,
-                    {"Accept-Encoding",    15}, // PJSIP_H_ACCEPT_ENCODING,
-                    {"Accept-Language",    15}, // PJSIP_H_ACCEPT_LANGUAGE,
-                    {"Allow",               5}, // PJSIP_H_ALLOW,
-                    {"Call-ID",             7}, // PJSIP_H_CALL_ID,
-                    {"Contact",             7}, // PJSIP_H_CONTACT,
-                    {"CSeq",                4}, // PJSIP_H_CSEQ,
-                    {"From",                4}, // PJSIP_H_FROM,
-                    {"Organization",       12}, // PJSIP_H_ORGANIZATION,
-                    {"Record-Route",       12}, // PJSIP_H_RECORD_ROUTE,
-                    {"Route",               5}, // PJSIP_H_ROUTE,
-                    {"Supported",           9}, // PJSIP_H_SUPPORTED,
-                    {"To",                  2}, // PJSIP_H_TO,
-                    {"User-Agent",         10}, // PJSIP_H_USER_AGENT,
-                    {"Via",                 3}, // PJSIP_H_VIA,
+                    PJSIP_H_ACCEPT, PJSIP_H_ACCEPT_ENCODING_UNIMP,
+                    PJSIP_H_ACCEPT_LANGUAGE_UNIMP, PJSIP_H_ALLOW,
+                    PJSIP_H_CALL_ID, PJSIP_H_CONTACT, PJSIP_H_CSEQ,
+                    PJSIP_H_FROM, PJSIP_H_ORGANIZATION_UNIMP,
+                    PJSIP_H_RECORD_ROUTE, PJSIP_H_ROUTE,
+                    PJSIP_H_SUPPORTED, PJSIP_H_TO,
+                    PJSIP_H_USER_AGENT_UNIMP, PJSIP_H_VIA,
                     /* We opt to ignore the following headers as
                      * they may contain inaccurate information.
                      */
-                    {"Content-Disposition",19}, // PJSIP_H_CONTENT_DISPOSITION,
-                    {"Content-Encoding",   16}, // PJSIP_H_CONTENT_ENCODING,
-                    {"Content-Language",   16}, // PJSIP_H_CONTENT_LANGUAGE,
-                    {"Content-Length",     14}, // PJSIP_H_CONTENT_LENGTH,
-                    {"Content-Type",       12}, // PJSIP_H_CONTENT_TYPE,
-                    {"Date",                4}, // PJSIP_H_DATE,
-                    {"MIME-Version",       12}, // PJSIP_H_MIME_VERSION,
-                    {"Timestamp",           9}, // PJSIP_H_TIMESTAMP,
+                    PJSIP_H_CONTENT_DISPOSITION_UNIMP,
+                    PJSIP_H_CONTENT_ENCODING_UNIMP,
+                    PJSIP_H_CONTENT_LANGUAGE_UNIMP, PJSIP_H_CONTENT_LENGTH,
+                    PJSIP_H_CONTENT_TYPE, PJSIP_H_DATE_UNIMP,
+                    PJSIP_H_MIME_VERSION_UNIMP, PJSIP_H_TIMESTAMP_UNIMP,
                     };
                     pjsip_generic_string_hdr *hdr;
                     unsigned i;
                     pj_bool_t found = PJ_FALSE;
 
                     /* Check if we should reject/ignore the header. */
-                    for (i = 0; i < sizeof(hdr_names)/sizeof(pj_str_t); i++) {
-                        if (!pj_stricmp(&param->name, &hdr_names[i])) {
+                    for (i = 0; i < sizeof(hdr_types)/sizeof(pjsip_hdr_e); i++)
+                    {
+                        if (!pj_stricmp2(&param->name,
+                                         pjsip_hdr_names[hdr_types[i]].name))
+                        {
                             found = PJ_TRUE;
                             break;
                         }

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -3063,7 +3063,7 @@ void pjsip_inv_process_hparam(pjsip_inv_session *sess,
     /* According to RFC 3261 section 19.1.5, we should verify
      * the accuracy of the header fields.
      * Application will need to do its own verification by
-     * overriding the function.
+     * overriding the handler function.
      */
     const pjsip_hdr_e verify_hdrs[] = {
         PJSIP_H_CONTENT_DISPOSITION_UNIMP,
@@ -3094,10 +3094,9 @@ void pjsip_inv_process_hparam(pjsip_inv_session *sess,
     PJ_UNUSED_ARG(verify_hdrs);
 
     /* Check if we should reject/ignore the header. */
-    for (i = 0; i < sizeof(ignored_hdrs)/sizeof(pjsip_hdr_e); i++) {
+    for (i = 0; i < PJ_ARRAY_SIZE(ignored_hdrs); i++) {
         if (!pj_stricmp2(hname, pjsip_hdr_names[ignored_hdrs[i]].name)) {
-            PJ_LOG(4, (THIS_FILE, "Redirection header %.*s "
-                                  "rejected/ignored",
+            PJ_LOG(4, (THIS_FILE, "Redirection header %.*s ignored",
                                   (int)hname->slen,
                                   hname->ptr));
             return;
@@ -3109,7 +3108,7 @@ void pjsip_inv_process_hparam(pjsip_inv_session *sess,
     /* Check if the header exists. */
     if (hdr) {
         /* Yes, now check if we can append the header. */
-        for (i = 0; i < sizeof(append_hdrs)/sizeof(pjsip_hdr_e); i++) {
+        for (i = 0; i < PJ_ARRAY_SIZE(append_hdrs); i++) {
             if (!pj_stricmp2(hname, pjsip_hdr_names[append_hdrs[i]].name)) {
                 pjsip_generic_string_hdr *shdr;
                 pj_str_t old_hval;
@@ -3136,6 +3135,7 @@ void pjsip_inv_process_hparam(pjsip_inv_session *sess,
         pjsip_msg_find_remove_hdr(tdata->msg, PJSIP_H_OTHER, hdr);
     }
 
+    /* Add the header */
     hdr = (pjsip_hdr *)pjsip_generic_string_hdr_create(tdata->pool, hname,
                                                        hvalue);
     pjsip_msg_add_hdr(tdata->msg, hdr);
@@ -3238,7 +3238,6 @@ PJ_DEF(pj_status_t) pjsip_inv_process_redirect( pjsip_inv_session *inv,
                 if (!pj_list_empty(&uri->header_param)) {
                     pj_list_init(&uri->header_param);
                 }
-
             }
 
             /* Remove branch param in Via header. */

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -3113,28 +3113,27 @@ int pjsip_inv_get_hparam_action(pjsip_inv_session *sess, const pj_str_t *hname,
     int ret = REPLACE;
 
     /* Check if we should reject/ignore the header. */
-    for (i = 0; i < sizeof(ignored_hdrs)/sizeof(pjsip_hdr_e); i++)
-    {
+    for (i = 0; i < sizeof(ignored_hdrs)/sizeof(pjsip_hdr_e); i++) {
         if (!pj_stricmp2(hname, pjsip_hdr_names[ignored_hdrs[i]].name))
             return IGNORE;
     }
 
     /* Check if we need to verify the header. */
-    for (i = 0; i < sizeof(verify_hdrs)/sizeof(pjsip_hdr_e); i++)
-    {
+    for (i = 0; i < sizeof(verify_hdrs)/sizeof(pjsip_hdr_e); i++) {
         if (!pj_stricmp2(hname, pjsip_hdr_names[verify_hdrs[i]].name))
             return VERIFY;
     }
 
     /* Check if we can append the header. */
-    for (i = 0; i < sizeof(append_hdrs)/sizeof(pjsip_hdr_e); i++)
-    {
+    for (i = 0; i < sizeof(append_hdrs)/sizeof(pjsip_hdr_e); i++) {
         if (!pj_stricmp2(hname, pjsip_hdr_names[append_hdrs[i]].name)) {
-            ret = APPEND;
-            break;
+            return APPEND;
         }
     }
 
+    /* The following code is just an example for appending values
+     * and will not be executed.
+     */
     if (ret == APPEND && hdr) {
         /* The header exists and we can append it. */
         pjsip_generic_string_hdr *shdr;

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -3090,14 +3090,19 @@ PJ_DEF(pj_status_t) pjsip_inv_process_redirect( pjsip_inv_session *inv,
                     PJSIP_H_RECORD_ROUTE, PJSIP_H_ROUTE,
                     PJSIP_H_SUPPORTED, PJSIP_H_TO,
                     PJSIP_H_USER_AGENT_UNIMP, PJSIP_H_VIA,
-                    /* We opt to ignore the following headers as
-                     * they may contain inaccurate information.
+                    /* For future use, we should verify the content
+                     * of the following headers, but these headers
+                     * are currently unimplemented in PJSIP.
                      */
-                    PJSIP_H_CONTENT_DISPOSITION_UNIMP,
-                    PJSIP_H_CONTENT_ENCODING_UNIMP,
-                    PJSIP_H_CONTENT_LANGUAGE_UNIMP, PJSIP_H_CONTENT_LENGTH,
-                    PJSIP_H_CONTENT_TYPE, PJSIP_H_DATE_UNIMP,
-                    PJSIP_H_MIME_VERSION_UNIMP, PJSIP_H_TIMESTAMP_UNIMP,
+                    // PJSIP_H_CONTENT_DISPOSITION_UNIMP,
+                    // PJSIP_H_CONTENT_ENCODING_UNIMP,
+                    // PJSIP_H_CONTENT_LANGUAGE_UNIMP,
+                    // PJSIP_H_DATE_UNIMP, PJSIP_H_MIME_VERSION_UNIMP,
+                    // PJSIP_H_TIMESTAMP_UNIMP,
+                    /* We opt to ignore the following headers as
+                     * they will be automatically populated by PJSIP.
+                     */
+                    PJSIP_H_CONTENT_LENGTH, PJSIP_H_CONTENT_TYPE
                     };
                     pjsip_generic_string_hdr *hdr;
                     unsigned i;


### PR DESCRIPTION
When receiving 3xx response, we need to formulate headers in the new request according to [RFC 3261 section 8.1.3.4](https://www.rfc-editor.org/rfc/rfc3261#section-8.1.3.4) and [19.1.5](https://www.rfc-editor.org/rfc/rfc3261#section-19.1.5):

If you wish to implement your own custom function to handle the headers, you can do the following:
```
/* Optional: Declare this if you want to call the default handler */
void pjsip_inv_process_hparam(pjsip_inv_session *sess, 
                              const pj_str_t *hname, 
                              const pj_str_t *hvalue, 
                              pjsip_tx_data *tdata);

/* Declare this to get access to the external function handler pointer */
extern void (*pjsip_inv_process_hparam_ptr)(pjsip_inv_session *sess, 
                                     const pj_str_t *hname, 
                                     const pj_str_t *hvalue, 
                                     pjsip_tx_data *tdata);

/* Your custom processing function */
void custom_process_hparam(pjsip_inv_session *sess, 
                              const pj_str_t *hname, 
                              const pj_str_t *hvalue, 
                              pjsip_tx_data *tdata)
{
    /* Perform the custom handling here */
    /* .... */

    /* Call the default handler */
    pjsip_inv_process_hparam(sess, hname, hvalue, tdata);
}

int main() {
    /* Assign the function pointer to your own handler */
    pjsip_inv_process_hparam_ptr = &custom_process_hparam;
}
```

Notes (any default behaviour mentioned below can be overwritten by implementing the custom function above):
* In section 8.1.3.4, it is specified:
```
   It uses the "header" parameters to create header field values for the
   new request, overwriting header field values associated with the
   redirected request in accordance with the guidelines in Section 19.1.5.

Note that in some instances, header fields that have been
   communicated in the contact address may instead append to existing
   request header fields in the original redirected request.  As a
   general rule, if the header field can accept a comma-separated list
   of values, then the new header field value MAY be appended to any
   existing values in the original redirected request.  If the header
   field does not accept multiple values, the value in the original
   redirected request MAY be overwritten by the header field value
   communicated in the contact address.
```
By default, we only append `Call-Info` header as exemplified in 8.1.3.4. Other headers will be overwritten, if it already exists.
* In 19.1.5:
```
If the URI
   contains a method parameter, its value MUST be used as the method of
   the request.  The method parameter MUST NOT be placed in the
   Request-URI.
```
In the patch, we will terminate the session if the method is not INVITE.
* In 19.1.5:
```
   An implementation SHOULD NOT honor these obviously dangerous header
   fields: From, Call-ID, CSeq, Via, and Record-Route.

   An implementation SHOULD NOT honor any requested Route header field
   values in order to not be used as an unwitting agent in malicious
   attacks.

   An implementation SHOULD NOT honor requests to include header fields
   that may cause it to falsely advertise its location or capabilities.
   These include: Accept, Accept-Encoding, Accept-Language, Allow,
   Contact (in its dialog usage), Organization, Supported, and User-
   Agent.
```
By default, we will reject the headers.
* In 19.1.5:
```
   An implementation SHOULD verify the accuracy of any requested
   descriptive header fields, including: Content-Disposition, Content-
   Encoding, Content-Language, Content-Length, Content-Type, Date,
   Mime-Version, and Timestamp.
```
By default, we will include the above headers, except `Content-Type` or `Content-Length` since they will be automatically populated with the correct values by PJSIP. Application wishing to verify the headers need to implement the custom handler above.

To close #3084.
