### PR TITLE
[Fix #3385 Assertion error] return status for proper status checking afterwards

### DIFF
--- a/pjsip-apps/src/samples/simpleua.c
+++ b/pjsip-apps/src/samples/simpleua.c
@@ -896,7 +896,7 @@ static void call_on_media_update( pjsip_inv_session *inv,
     }
 
     /* Start the UDP media transport */
-    pjmedia_transport_media_start(g_med_transport[0], 0, 0, 0, 0);
+    status = pjmedia_transport_media_start(g_med_transport[0], 0, 0, 0, 0);
 
     /* Get the media port interface of the audio stream. 
      * Media port interface is basicly a struct containing get_frame() and
@@ -904,10 +904,10 @@ static void call_on_media_update( pjsip_inv_session *inv,
      * the port interface to conference bridge, or directly to a sound
      * player/recorder device.
      */
-    pjmedia_stream_get_port(g_med_stream, &media_port);
+    status = pjmedia_stream_get_port(g_med_stream, &media_port);
 
     /* Create sound port */
-    pjmedia_snd_port_create(inv->pool,
+    status = pjmedia_snd_port_create(inv->pool,
                             PJMEDIA_AUD_DEFAULT_CAPTURE_DEV,
                             PJMEDIA_AUD_DEFAULT_PLAYBACK_DEV,
                             PJMEDIA_PIA_SRATE(&media_port->info),/* clock rate      */
@@ -1078,5 +1078,4 @@ static void call_on_media_update( pjsip_inv_session *inv,
 
     /* Done with media. */
 }
-
 

--- a/pjsip-apps/src/samples/simpleua.c
+++ b/pjsip-apps/src/samples/simpleua.c
@@ -897,6 +897,10 @@ static void call_on_media_update( pjsip_inv_session *inv,
 
     /* Start the UDP media transport */
     status = pjmedia_transport_media_start(g_med_transport[0], 0, 0, 0, 0);
+    if (status != PJ_SUCCESS) {
+        app_perror( THIS_FILE, "Unable to start UDP media transport", status);
+        return;
+    }
 
     /* Get the media port interface of the audio stream. 
      * Media port interface is basicly a struct containing get_frame() and
@@ -905,6 +909,10 @@ static void call_on_media_update( pjsip_inv_session *inv,
      * player/recorder device.
      */
     status = pjmedia_stream_get_port(g_med_stream, &media_port);
+    if (status != PJ_SUCCESS) {
+        app_perror( THIS_FILE, "Unable to create media port interface of the audio stream", status);
+        return;
+    }
 
     /* Create sound port */
     status = pjmedia_snd_port_create(inv->pool,


### PR DESCRIPTION
This is my proposed fix for #3385 `Assertion 'snd_port && port' failed`. Since it is a straightforward change in `simpleua.c`, I am creating a PR directly. Please review my PR if you have time. Thanks!