### PR TITLE
Add API to shutdown TURN session with the appropriate error status

### DIFF
--- a/pjnath/include/pjnath/turn_session.h
+++ b/pjnath/include/pjnath/turn_session.h
@@ -583,6 +583,26 @@ PJ_DECL(pj_status_t) pj_turn_session_shutdown(pj_turn_session *sess);
 
 
 /**
+ * Shutdown TURN client session. This will gracefully deallocate and
+ * destroy the client session.
+ *
+ * @param sess      The TURN client session.
+ * @param last_err  Optional error code to be set to the session,
+ *                  which would be returned back in the \a info
+ *                  parameter of #pj_turn_session_get_info(). If
+ *                  this argument value is PJ_SUCCESS, the error
+ *                  code will not be set. If the session already
+ *                  has an error code set, this function will not
+ *                  overwrite that error code either.
+ *
+ * @return          PJ_SUCCESS if the operation has been successful,
+ *                  or the appropriate error code on failure.
+ */
+PJ_DECL(pj_status_t) pj_turn_session_shutdown2(pj_turn_session *sess,
+                                               pj_status_t last_err);
+
+
+/**
  * Forcefully destroy the TURN session. This will destroy the session
  * immediately. If there is an active allocation, the server will not
  * be notified about the client destruction.

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -460,7 +460,7 @@ PJ_DEF(pj_status_t) pj_turn_session_shutdown2(pj_turn_session *sess,
     pj_grp_lock_acquire(sess->grp_lock);
 
     if (last_err != PJ_SUCCESS && sess->last_status == PJ_SUCCESS)
-	sess->last_status = last_err;
+        sess->last_status = last_err;
 
     sess_shutdown(sess, PJ_SUCCESS);
 

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -449,9 +449,18 @@ static void sess_shutdown(pj_turn_session *sess,
  */
 PJ_DEF(pj_status_t) pj_turn_session_shutdown(pj_turn_session *sess)
 {
+    return pj_turn_session_shutdown2(sess, PJ_SUCCESS);
+}
+
+PJ_DEF(pj_status_t) pj_turn_session_shutdown2(pj_turn_session *sess,
+					      pj_status_t last_err)
+{
     PJ_ASSERT_RETURN(sess, PJ_EINVAL);
 
     pj_grp_lock_acquire(sess->grp_lock);
+
+    if (last_err != PJ_SUCCESS && sess->last_status == PJ_SUCCESS)
+	sess->last_status = last_err;
 
     sess_shutdown(sess, PJ_SUCCESS);
 


### PR DESCRIPTION
To close #3154.

We already have the API `pj_turn_session_destroy(pj_turn_session *sess, pj_status_t last_err);` but we lack a similar API for `pj_turn_session_shutdown()`, so TURN session shutdown will always be considered a success. Application querying `pj_turn_session_get_info()` will thus get the wrong info, since `info.last_status` will be PJ_SUCCESS.

Note that this is not known to affect internal PJSIP library, but applications or PJNATH users relying on `pj_turn_sock_get_info()` or `pj_turn_session_get_info()` may be affected.

This patch is a modification of the original patch provided by Olivier Dion from Savoir-faire Linux.
