### PR TITLE
Terminate dialog after receiving 481/408 response for UPDATE in early dialog

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1555,7 +1555,8 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_cancel_offer(pjmedia_sdp_neg *neg)
                      neg->state == PJMEDIA_SDP_NEG_STATE_REMOTE_OFFER,
                      PJMEDIA_SDPNEG_EINSTATE);
 
-    if (neg->state == PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER &&
+    // No longer needed after #3322.
+    if (0 && neg->state == PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER &&
         neg->active_local_sdp) 
     {
         /* Increment next version number. This happens if for example

--- a/tests/pjsua/scripts-sipp/uac-early-recv-update-481.py
+++ b/tests/pjsua/scripts-sipp/uac-early-recv-update-481.py
@@ -1,0 +1,7 @@
+#
+import inc_const as const
+
+PJSUA = ["--null-audio --max-calls=1 --auto-answer=183"]
+
+PJSUA_EXPECTS = [[0, const.STATE_EARLY, "U"],
+                 [0, const.STATE_DISCONNECTED, ""]]

--- a/tests/pjsua/scripts-sipp/uac-early-recv-update-481.xml
+++ b/tests/pjsua/scripts-sipp/uac-early-recv-update-481.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+
+<scenario name="uac">
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bK-14480-1-0
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=FreeSWITCH 1575204365 1575204366 IN IP4 1.2.3.4
+      s=FreeSWITCH
+      c=IN IP4 1.2.3.4
+      t=0 0
+      m=audio 27538 RTP/AVP 0 8
+    
+    ]]>
+  </send>
+
+  <recv response="100" optional="true">
+  </recv>
+
+  <recv response="183">
+  </recv>
+
+  <recv request="UPDATE" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 481 tsx does not exist
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+    ]]>
+  </send>
+
+  <recv response="481">
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bK-14480-1-0
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      Cseq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+  
+  
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+


### PR DESCRIPTION
To fix #1167.

As per [RFC 3311 Section 5.3](https://www.rfc-editor.org/rfc/rfc3311#section-5.3):
```
If a UA receives a non-2xx final response to a UPDATE, the session
   parameters MUST remain unchanged, as if no UPDATE had been issued.
   Note that, as stated in Section 12.2.1 of RFC 3261, if the non-
   2xx final response is a 481 (Call/Transaction Does Not Exist), or a
   408 (Request Timeout), or no response at all is received for the
   UPDATE (that is, a timeout is returned by the UPDATE client
   transaction), the UAC will terminate the dialog.
```

Note: the changes in SDP negotiator is needed, because without it, there is a crash due to accessing freed memory.