### PR TITLE
Allow dialog establishment when remote does not provide To tag

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1944,8 +1944,7 @@ void pjsip_dlg_on_rx_response( pjsip_dialog *dlg, pjsip_rx_data *rdata )
      */
     if ((dlg->state == PJSIP_DIALOG_STATE_NULL &&
          pjsip_method_creates_dialog(&rdata->msg_info.cseq->method) &&
-         (res_code > 100 && res_code < 300) &&
-         rdata->msg_info.to->tag.slen)
+         (res_code > 100 && res_code < 300))
          ||
         (dlg->role==PJSIP_ROLE_UAC &&
          !dlg->uac_has_2xx &&

--- a/tests/pjsua/scripts-sipp/uas-answer-200-without-to-tag.py
+++ b/tests/pjsua/scripts-sipp/uas-answer-200-without-to-tag.py
@@ -1,0 +1,6 @@
+#
+import inc_const as const
+
+PJSUA = ["--null-audio --max-calls=1 --no-tcp $SIPP_URI"]
+
+PJSUA_EXPECTS = [[0, const.STATE_CONFIRMED, "U"]]

--- a/tests/pjsua/scripts-sipp/uas-answer-200-without-to-tag.xml
+++ b/tests/pjsua/scripts-sipp/uas-answer-200-without-to-tag.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+<!--                                                                    -->
+<!-- You should have received a copy of the GNU General Public License  -->
+<!-- along with this program; if not, write to the                      -->
+<!-- Free Software Foundation, Inc.,                                    -->
+<!-- 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA             -->
+<!--                                                                    -->
+
+<scenario name="UAS sending 200 without To tag (#1096)">
+
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=- 3441953879 3441953879 IN IP4 192.168.0.15
+      s=pjmedia
+      c=IN IP4 192.168.0.15
+      t=0 0
+      m=audio 4004 RTP/AVP 0
+
+    ]]>
+  </send>
+
+  <recv request="ACK" crlf="true">
+  </recv>
+
+
+  <recv request="UPDATE" crlf="true">
+  </recv>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=- 3441953879 3441953879 IN IP4 192.168.0.15
+      s=pjmedia
+      c=IN IP4 192.168.0.15
+      t=0 0
+      m=audio 4004 RTP/AVP 0
+
+    ]]>
+  </send>
+
+  
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+


### PR DESCRIPTION
To fix #1096.

The assertion occurs in the following line because the dialog is not established:
https://github.com/pjsip/pjproject/blob/66c101f3d361761993a2a8a59082cb5a30d28e0d/pjsip/src/pjsip-ua/sip_inv.c#L3453-L3455

The standard (rfc3261 [12.1.2 UAC Behavior](https://www.rfc-editor.org/rfc/rfc3261#section-12.1.2)) specifies that it should be tolerated:
```
   A UAC MUST be prepared to receive a response without a tag in the To
   field, in which case the tag is considered to have a value of null.

      This is to maintain backwards compatibility with [RFC 2543](https://www.rfc-editor.org/rfc/rfc2543), which
      did not mandate To tags.
```
