### PR TITLE
Use better initial values for pool initialization

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -47,14 +47,14 @@
  * Initial memory block for media endpoint.
  */
 #ifndef PJMEDIA_POOL_LEN_ENDPT
-#   define PJMEDIA_POOL_LEN_ENDPT               4096
+#   define PJMEDIA_POOL_LEN_ENDPT               8192
 #endif
 
 /**
  * Memory increment for media endpoint.
  */
 #ifndef PJMEDIA_POOL_INC_ENDPT
-#   define PJMEDIA_POOL_INC_ENDPT               8192
+#   define PJMEDIA_POOL_INC_ENDPT               4096
 #endif
 
 /**

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -47,14 +47,14 @@
  * Initial memory block for media endpoint.
  */
 #ifndef PJMEDIA_POOL_LEN_ENDPT
-#   define PJMEDIA_POOL_LEN_ENDPT               512
+#   define PJMEDIA_POOL_LEN_ENDPT               4096
 #endif
 
 /**
  * Memory increment for media endpoint.
  */
 #ifndef PJMEDIA_POOL_INC_ENDPT
-#   define PJMEDIA_POOL_INC_ENDPT               512
+#   define PJMEDIA_POOL_INC_ENDPT               8192
 #endif
 
 /**

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -47,14 +47,14 @@
  * Initial memory block for media endpoint.
  */
 #ifndef PJMEDIA_POOL_LEN_ENDPT
-#   define PJMEDIA_POOL_LEN_ENDPT               8192
+#   define PJMEDIA_POOL_LEN_ENDPT               8000
 #endif
 
 /**
  * Memory increment for media endpoint.
  */
 #ifndef PJMEDIA_POOL_INC_ENDPT
-#   define PJMEDIA_POOL_INC_ENDPT               4096
+#   define PJMEDIA_POOL_INC_ENDPT               4000
 #endif
 
 /**

--- a/pjmedia/src/pjmedia-codec/gsm.c
+++ b/pjmedia/src/pjmedia-codec/gsm.c
@@ -163,7 +163,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_gsm_init( pjmedia_endpt *endpt )
     gsm_codec_factory.base.factory_data = NULL;
     gsm_codec_factory.endpt = endpt;
 
-    gsm_codec_factory.pool = pjmedia_endpt_create_pool(endpt, "gsm", 4000, 
+    gsm_codec_factory.pool = pjmedia_endpt_create_pool(endpt, "gsm", 1024,
                                                        4000);
     if (!gsm_codec_factory.pool)
         return PJ_ENOMEM;

--- a/pjmedia/src/pjmedia-codec/gsm.c
+++ b/pjmedia/src/pjmedia-codec/gsm.c
@@ -163,7 +163,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_gsm_init( pjmedia_endpt *endpt )
     gsm_codec_factory.base.factory_data = NULL;
     gsm_codec_factory.endpt = endpt;
 
-    gsm_codec_factory.pool = pjmedia_endpt_create_pool(endpt, "gsm", 1024,
+    gsm_codec_factory.pool = pjmedia_endpt_create_pool(endpt, "gsm", 1000,
                                                        4000);
     if (!gsm_codec_factory.pool)
         return PJ_ENOMEM;

--- a/pjmedia/src/pjmedia-codec/l16.c
+++ b/pjmedia/src/pjmedia-codec/l16.c
@@ -164,7 +164,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_l16_init(pjmedia_endpt *endpt,
     l16_factory.endpt = endpt;
 
     /* Create pool */
-    l16_factory.pool = pjmedia_endpt_create_pool(endpt, "l16", 1024, 4000);
+    l16_factory.pool = pjmedia_endpt_create_pool(endpt, "l16", 1000, 4000);
     if (!l16_factory.pool)
         return PJ_ENOMEM;
 

--- a/pjmedia/src/pjmedia-codec/l16.c
+++ b/pjmedia/src/pjmedia-codec/l16.c
@@ -164,7 +164,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_l16_init(pjmedia_endpt *endpt,
     l16_factory.endpt = endpt;
 
     /* Create pool */
-    l16_factory.pool = pjmedia_endpt_create_pool(endpt, "l16", 4000, 4000);
+    l16_factory.pool = pjmedia_endpt_create_pool(endpt, "l16", 1024, 4000);
     if (!l16_factory.pool)
         return PJ_ENOMEM;
 

--- a/pjmedia/src/pjmedia-codec/speex_codec.c
+++ b/pjmedia/src/pjmedia-codec/speex_codec.c
@@ -228,7 +228,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_speex_init( pjmedia_endpt *endpt,
     spx_factory.endpt = endpt;
 
     spx_factory.pool = pjmedia_endpt_create_pool(endpt, "speex", 
-                                                       1024, 4000);
+                                                       1000, 4000);
     if (!spx_factory.pool)
         return PJ_ENOMEM;
 

--- a/pjmedia/src/pjmedia-codec/speex_codec.c
+++ b/pjmedia/src/pjmedia-codec/speex_codec.c
@@ -228,7 +228,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_speex_init( pjmedia_endpt *endpt,
     spx_factory.endpt = endpt;
 
     spx_factory.pool = pjmedia_endpt_create_pool(endpt, "speex", 
-                                                       4000, 4000);
+                                                       1024, 4000);
     if (!spx_factory.pool)
         return PJ_ENOMEM;
 

--- a/pjmedia/src/pjmedia-videodev/colorbar_dev.c
+++ b/pjmedia/src/pjmedia-videodev/colorbar_dev.c
@@ -175,7 +175,7 @@ pjmedia_vid_dev_factory* pjmedia_cbar_factory(pj_pool_factory *pf)
     struct cbar_factory *f;
     pj_pool_t *pool;
 
-    pool = pj_pool_create(pf, "cbar video", 512, 512, NULL);
+    pool = pj_pool_create(pf, "cbar video", 4096, 4096, NULL);
     f = PJ_POOL_ZALLOC_T(pool, struct cbar_factory);
     f->pf = pf;
     f->pool = pool;

--- a/pjmedia/src/pjmedia-videodev/colorbar_dev.c
+++ b/pjmedia/src/pjmedia-videodev/colorbar_dev.c
@@ -175,7 +175,7 @@ pjmedia_vid_dev_factory* pjmedia_cbar_factory(pj_pool_factory *pf)
     struct cbar_factory *f;
     pj_pool_t *pool;
 
-    pool = pj_pool_create(pf, "cbar video", 4096, 4096, NULL);
+    pool = pj_pool_create(pf, "cbar video", 4000, 4000, NULL);
     f = PJ_POOL_ZALLOC_T(pool, struct cbar_factory);
     f->pf = pf;
     f->pool = pool;

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -256,7 +256,7 @@ pjmedia_vid_dev_factory* pjmedia_darwin_factory(pj_pool_factory *pf)
     struct darwin_factory *f;
     pj_pool_t *pool;
 
-    pool = pj_pool_create(pf, "darwin video", 512, 512, NULL);
+    pool = pj_pool_create(pf, "darwin video", 8192, 4096, NULL);
     f = PJ_POOL_ZALLOC_T(pool, struct darwin_factory);
     f->pf = pf;
     f->pool = pool;

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -256,7 +256,7 @@ pjmedia_vid_dev_factory* pjmedia_darwin_factory(pj_pool_factory *pf)
     struct darwin_factory *f;
     pj_pool_t *pool;
 
-    pool = pj_pool_create(pf, "darwin video", 8192, 4096, NULL);
+    pool = pj_pool_create(pf, "darwin video", 8000, 4000, NULL);
     f = PJ_POOL_ZALLOC_T(pool, struct darwin_factory);
     f->pf = pf;
     f->pool = pool;

--- a/pjmedia/src/pjmedia-videodev/sdl_dev.c
+++ b/pjmedia/src/pjmedia-videodev/sdl_dev.c
@@ -281,7 +281,7 @@ pjmedia_vid_dev_factory* pjmedia_sdl_factory(pj_pool_factory *pf)
     struct sdl_factory *f;
     pj_pool_t *pool;
 
-    pool = pj_pool_create(pf, "sdl video", 4096, 4096, NULL);
+    pool = pj_pool_create(pf, "sdl video", 4000, 4000, NULL);
     f = PJ_POOL_ZALLOC_T(pool, struct sdl_factory);
     f->pf = pf;
     f->pool = pool;

--- a/pjmedia/src/pjmedia-videodev/sdl_dev.c
+++ b/pjmedia/src/pjmedia-videodev/sdl_dev.c
@@ -281,7 +281,7 @@ pjmedia_vid_dev_factory* pjmedia_sdl_factory(pj_pool_factory *pf)
     struct sdl_factory *f;
     pj_pool_t *pool;
 
-    pool = pj_pool_create(pf, "sdl video", 1000, 1000, NULL);
+    pool = pj_pool_create(pf, "sdl video", 4096, 4096, NULL);
     f = PJ_POOL_ZALLOC_T(pool, struct sdl_factory);
     f->pf = pf;
     f->pool = pool;

--- a/pjmedia/src/pjmedia/g711.c
+++ b/pjmedia/src/pjmedia/g711.c
@@ -156,7 +156,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_g711_init(pjmedia_endpt *endpt)
     pj_list_init(&g711_factory.codec_list);
 
     /* Create pool */
-    g711_factory.pool = pjmedia_endpt_create_pool(endpt, "g711", 1024, 4000);
+    g711_factory.pool = pjmedia_endpt_create_pool(endpt, "g711", 1000, 4000);
     if (!g711_factory.pool)
         return PJ_ENOMEM;
 

--- a/pjmedia/src/pjmedia/g711.c
+++ b/pjmedia/src/pjmedia/g711.c
@@ -156,7 +156,7 @@ PJ_DEF(pj_status_t) pjmedia_codec_g711_init(pjmedia_endpt *endpt)
     pj_list_init(&g711_factory.codec_list);
 
     /* Create pool */
-    g711_factory.pool = pjmedia_endpt_create_pool(endpt, "g711", 4000, 4000);
+    g711_factory.pool = pjmedia_endpt_create_pool(endpt, "g711", 1024, 4000);
     if (!g711_factory.pool)
         return PJ_ENOMEM;
 

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -924,14 +924,14 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  * Initial memory block for the endpoint.
  */
 #ifndef PJSIP_POOL_LEN_ENDPT
-#   define PJSIP_POOL_LEN_ENDPT         (4000)
+#   define PJSIP_POOL_LEN_ENDPT         (8192)
 #endif
 
 /**
  * Memory increment for endpoint.
  */
 #ifndef PJSIP_POOL_INC_ENDPT
-#   define PJSIP_POOL_INC_ENDPT         (4000)
+#   define PJSIP_POOL_INC_ENDPT         (16384)
 #endif
 
 

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -924,14 +924,14 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  * Initial memory block for the endpoint.
  */
 #ifndef PJSIP_POOL_LEN_ENDPT
-#   define PJSIP_POOL_LEN_ENDPT         (8192)
+#   define PJSIP_POOL_LEN_ENDPT         (16384)
 #endif
 
 /**
  * Memory increment for endpoint.
  */
 #ifndef PJSIP_POOL_INC_ENDPT
-#   define PJSIP_POOL_INC_ENDPT         (16384)
+#   define PJSIP_POOL_INC_ENDPT         (4096)
 #endif
 
 

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -924,14 +924,14 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  * Initial memory block for the endpoint.
  */
 #ifndef PJSIP_POOL_LEN_ENDPT
-#   define PJSIP_POOL_LEN_ENDPT         (16384)
+#   define PJSIP_POOL_LEN_ENDPT         (16000)
 #endif
 
 /**
  * Memory increment for endpoint.
  */
 #ifndef PJSIP_POOL_INC_ENDPT
-#   define PJSIP_POOL_INC_ENDPT         (4096)
+#   define PJSIP_POOL_INC_ENDPT         (4000)
 #endif
 
 


### PR DESCRIPTION
This is similar to the issue reported in #3077 , where suboptimal pool allocation can cause delay that can stretch up to several seconds due to the expensive reallocation processes.

Here's the typical result of memory dump with default config:
```
    pept0x13600c400:   322776 of   328096 (98%) used
            med-ept:    43064 of    50176 (85%) used
       darwin video:    19712 of    20480 (96%) used
          sdl video:     7564 of     9024 (83%) used
         cbar video:     5096 of     5632 (90%) used
```

Here we also fix memory that are allocated too large (for codec we are apparently okay with allocating 4KB, which we don't need, but for other components, such as media and video!, we start too conservatively with only 0.5kb):
```
              speex:      312 of     4096 (7%) used
                gsm:      312 of     4096 (7%) used
               g711:      312 of     4096 (7%) used
               g722:      312 of     1024 (30%) used
                l16:      312 of     4096 (7%) used
```
