### PR TITLE
Add Android audio driver names

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/android_jni_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/android_jni_dev.c
@@ -405,6 +405,7 @@ static pj_status_t android_get_dev_info(pjmedia_aud_dev_factory *f,
     pj_bzero(info, sizeof(*info));
     
     pj_ansi_strcpy(info->name, "Android JNI");
+    pj_ansi_strcpy(info->driver, DRIVER_NAME);
     info->default_samples_per_sec = 8000;
     info->caps = PJMEDIA_AUD_DEV_CAP_OUTPUT_VOLUME_SETTING |
                  PJMEDIA_AUD_DEV_CAP_INPUT_SOURCE;

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -413,9 +413,13 @@ static pj_status_t oboe_refresh(pjmedia_aud_dev_factory *ff)
         base_adi->caps = 0;
 
         /* Get name info */
-        jstring jstrtmp = (jstring)jni_env->GetObjectField(jdev_info, jobjs.dev_info.f_name);
+        jstring jstrtmp = (jstring)
+                          jni_env->GetObjectField(jdev_info,
+                                                  jobjs.dev_info.f_name);
         const char *strtmp = jni_env->GetStringUTFChars(jstrtmp, NULL);
         pj_ansi_strncpy(base_adi->name, strtmp, sizeof(base_adi->name));
+        pj_ansi_strncpy(base_adi->driver, DRIVER_NAME,
+                        sizeof(base_adi->driver));
 
         f->dev_count++;
 

--- a/pjmedia/src/pjmedia-audiodev/opensl_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/opensl_dev.c
@@ -403,6 +403,7 @@ static pj_status_t opensl_get_dev_info(pjmedia_aud_dev_factory *f,
     pj_bzero(info, sizeof(*info));
     
     pj_ansi_strcpy(info->name, "OpenSL ES Audio");
+    pj_ansi_strcpy(info->driver, DRIVER_NAME);
     info->default_samples_per_sec = 8000;
     info->caps = PJMEDIA_AUD_DEV_CAP_OUTPUT_VOLUME_SETTING;
     info->input_count = 1;


### PR DESCRIPTION
Currently, Android driver names are left blank. This causes the function `AudDevManager::lookupDev()` to fail, since `pjmedia_aud_dev_lookup()` will lookup and match the driver name first.
