### PR TITLE
Fixed SDP fmtp parsing

### DIFF
--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -108,9 +108,9 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_parse_fmtp( pj_pool_t *pool,
             }
 
             /* Check if it contains '=' */
-            while (p2 < p_end && *p2 != '=') ++p2;
+            while (p2 < end && *p2 != '=') ++p2;
 
-            if (p2 < p_end) {
+            if (p2 < end) {
                 char *p3;
 
                 pj_assert (*p2 == '=');


### PR DESCRIPTION
To fix #3025.

[RFC 4566](https://www.rfc-editor.org/rfc/rfc4566) doesn't really specify the format specific parameters.
```
a=fmtp:<format> <format specific parameters>
Format-specific parameters may be any
         set of parameters required to be conveyed by SDP and given
         unchanged to the media tool that will use this format.
```

But the newer [RFC 8866](https://datatracker.ietf.org/doc/html/rfc8866#name-fmtp-format-parameters) specifies it as semicolon separated.
```
fmtp-value = fmt SP format-specific-params
      format-specific-params = byte-string
        ; Notes:
        ; - The format parameters are media type parameters and
        ;   need to reflect their syntax.
Example:
      a=fmtp:96 profile-level-id=42e016;max-mbps=108000;max-fs=3600

Format-specific parameters, semicolon separated, may be any set of parameter
required to be conveyed by SDP and given unchanged to the media tool
that will use this format.
```

Currently our fmtp parsing tries to tokenise based on `=` and `;`, which causes issues when there is more than one `=`. So in the proposed patch, we tokenise based on `;` only, as per the RFC. Then within the token itself, we find the first `=` (if any) and separate the name and value.
