### PR TITLE
Fix multiple definition of pj_time_local_to_gmt() and pj_time_gmt_to_local()

### DIFF
--- a/pjlib/src/pj/os_time_common.c
+++ b/pjlib/src/pj/os_time_common.c
@@ -71,9 +71,6 @@ PJ_DEF(pj_status_t) pj_time_encode(const pj_parsed_time *pt, pj_time_val *tv)
     return PJ_SUCCESS;
 }
 
-#endif /* !PJ_WIN32 */
-
-
 static int get_tz_offset_secs()
 {
     time_t epoch_plus_11h = 60 * 60 * 11;
@@ -110,4 +107,4 @@ PJ_DEF(pj_status_t) pj_time_gmt_to_local(pj_time_val *tv)
     return PJ_SUCCESS;
 }
 
-
+#endif /* !PJ_WIN32 */


### PR DESCRIPTION
To fix #3404.

The error caused by multiple definition of `pj_time_local_to_gmt()` and `pj_time_gmt_to_local()` when building using MingW