### PR TITLE
Check tp_ref validity before referencing it in pjsip_tpmgr_acquire_transport2()

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2410,7 +2410,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
 
         /* If transport is found and listener is specified, verify listener */
         else if (sel && sel->type == PJSIP_TPSELECTOR_LISTENER &&
-                 sel->u.listener && tp_ref->factory != sel->u.listener)
+                 sel->u.listener && tp_ref && tp_ref->factory != sel->u.listener)
         {
             tp_ref = NULL;
             /* This will cause a new transport to be created which will be a


### PR DESCRIPTION
To fix #2794

To prevent the crash in `pjsip_tpmgr_acquire_transport2()`, check to `tp_ref` is required.