### PR TITLE
Add function for printing SDP attributes

### DIFF
--- a/pjmedia/include/pjmedia/sdp.h
+++ b/pjmedia/include/pjmedia/sdp.h
@@ -491,7 +491,7 @@ typedef struct pjmedia_sdp_media pjmedia_sdp_media;
  * @param buf       The buffer.
  * @param size      The buffer length.
  *
- * @return          the length printed, or -1 if the buffer is too
+ * @return          The length printed, or -1 if the buffer is too
  *                  short.
  */
 PJ_DECL(int) pjmedia_sdp_media_print(const pjmedia_sdp_media *media, char *buf, pj_size_t size);
@@ -507,6 +507,18 @@ PJ_DECL(int) pjmedia_sdp_media_print(const pjmedia_sdp_media *media, char *buf, 
 PJ_DECL(pjmedia_sdp_media*) 
 pjmedia_sdp_media_clone( pj_pool_t *pool, 
                          const pjmedia_sdp_media *rhs);
+
+/**
+ * Print attribute to a buffer.
+ *
+ * @param attr      The attribute.
+ * @param buf       The buffer.
+ * @param size      The buffer length.
+ *
+ * @return          The length printed, or -1 if the buffer is too
+ *                  short.
+ */
+PJ_DECL(int) pjmedia_sdp_attr_print(const pjmedia_sdp_attr *attr, char *buf, pj_size_t size);
 
 /**
  * Find the first occurence of the specified attribute name in the media 

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -789,7 +789,13 @@ static int print_media_desc(const pjmedia_sdp_media *m, char *buf, pj_size_t len
 PJ_DEF(int) pjmedia_sdp_media_print(const pjmedia_sdp_media *media,
                                char *buf, pj_size_t size)
 {
-        return print_media_desc(media, buf, size);
+    return print_media_desc(media, buf, size);
+}
+
+PJ_DEF(int) pjmedia_sdp_attr_print(const pjmedia_sdp_attr *attr,
+                               char *buf, pj_size_t size)
+{
+    return print_attr(attr, buf, size);
 }
 
 PJ_DEF(pjmedia_sdp_media*) pjmedia_sdp_media_clone(


### PR DESCRIPTION
It adds a function `pjmedia_sdp_attr_print()` similar to `pjmedia_sdp_media_print()`.