### PR TITLE
Limit the number of searched blocks searched for pool allocation

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -549,6 +549,8 @@
  * number of blocks specified before deciding that the pool is full and
  * a new memory block needs to be created.
  *
+ * Set it to 0 to disable the limitation (i.e. it will search all blocks).
+ *
  * Default: 5
  */
 #ifndef PJ_POOL_MAX_SEARCH_BLOCK_COUNT

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -545,6 +545,18 @@
 
 
 /**
+ * If enabled, when allocating memory, pool will only search for a maximum
+ * number of blocks specified before deciding that the pool is full and
+ * a new memory block needs to be created.
+ *
+ * Default: 5
+ */
+#ifndef PJ_POOL_MAX_SEARCH_BLOCK_COUNT
+#   define PJ_POOL_MAX_SEARCH_BLOCK_COUNT 5
+#endif
+
+
+/**
  * Enable timer debugging facility. When this is enabled, application
  * can call pj_timer_heap_dump() to show the contents of the timer
  * along with the source location where the timer entries were scheduled.

--- a/pjlib/src/pj/pool.c
+++ b/pjlib/src/pj/pool.c
@@ -84,14 +84,17 @@ static pj_pool_block *pj_pool_create_block( pj_pool_t *pool, pj_size_t size)
 /*
  * Allocate memory chunk for user from available blocks.
  * This will iterate through block list to find space to allocate the chunk.
- * If no space is available in all the blocks, a new block might be created
- * (depending on whether the pool is allowed to resize).
+ * If no space is available in all the blocks (or
+ * PJ_POOL_MAX_SEARCH_BLOCK_COUNT blocks if the config is > 0),
+ * a new block might be created (depending on whether the pool is allowed
+ * to resize).
  */
 PJ_DEF(void*) pj_pool_allocate_find(pj_pool_t *pool, pj_size_t size)
 {
     pj_pool_block *block = pool->block_list.next;
     void *p;
     pj_size_t block_size;
+    unsigned i = 0;
 
     PJ_CHECK_STACK();
 
@@ -99,6 +102,14 @@ PJ_DEF(void*) pj_pool_allocate_find(pj_pool_t *pool, pj_size_t size)
         p = pj_pool_alloc_from_block(block, size);
         if (p != NULL)
             return p;
+
+#if PJ_POOL_MAX_SEARCH_BLOCK_COUNT > 0
+        if (i >= PJ_POOL_MAX_SEARCH_BLOCK_COUNT) {
+            break;
+        }
+#endif
+
+        i++;
         block = block->next;
     }
     /* No available space in all blocks. */

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -568,7 +568,7 @@ static pj_status_t factory_alloc_codec( pjmedia_codec_factory *factory,
     PJ_UNUSED_ARG(ci);
     TRACE_((THIS_FILE, "%s:%d: - TRACE", __FUNCTION__, __LINE__));
 
-    pool = pjmedia_endpt_create_pool(f->endpt, "opus", 512, 512);
+    pool = pjmedia_endpt_create_pool(f->endpt, "opus", 4000, 4000);
     if (!pool) return PJ_ENOMEM;
     
     opus_data = PJ_POOL_ZALLOC_T(pool, struct opus_data);

--- a/pjmedia/src/pjmedia-codec/vid_toolbox.m
+++ b/pjmedia/src/pjmedia-codec/vid_toolbox.m
@@ -358,7 +358,7 @@ static pj_status_t vtool_alloc_codec(pjmedia_vid_codec_factory *factory,
 
     *p_codec = NULL;
 
-    pool = pj_pool_create(vtool_factory.pf, "vtool%p", 512, 512, NULL);
+    pool = pj_pool_create(vtool_factory.pf, "vtool%p", 16000, 4000, NULL);
     if (!pool)
         return PJ_ENOMEM;
 

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -64,11 +64,11 @@
 #endif
 
 #ifndef PJMEDIA_STREAM_SIZE
-#   define PJMEDIA_STREAM_SIZE  1000
+#   define PJMEDIA_STREAM_SIZE  4000
 #endif
 
 #ifndef PJMEDIA_STREAM_INC
-#   define PJMEDIA_STREAM_INC   1000
+#   define PJMEDIA_STREAM_INC   4000
 #endif
 
 /* Number of DTMF E bit transmissions */

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -60,11 +60,11 @@
 #endif
 
 #ifndef PJMEDIA_VSTREAM_SIZE
-#   define PJMEDIA_VSTREAM_SIZE 1000
+#   define PJMEDIA_VSTREAM_SIZE 16000
 #endif
 
 #ifndef PJMEDIA_VSTREAM_INC
-#   define PJMEDIA_VSTREAM_INC  1000
+#   define PJMEDIA_VSTREAM_INC  4000
 #endif
 
 /* Due to network MTU limitation, a picture bitstream may be splitted into

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1098,9 +1098,9 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #define PJSIP_MAX_HNAME_LEN             64
 
 /** Dialog's pool setting. */
-#define PJSIP_POOL_LEN_DIALOG           1200
+#define PJSIP_POOL_LEN_DIALOG           4000
 /** Dialog's pool setting. */
-#define PJSIP_POOL_INC_DIALOG           512
+#define PJSIP_POOL_INC_DIALOG           4000
 
 /** Maximum header types. */
 #define PJSIP_MAX_HEADER_TYPES          72

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -80,8 +80,8 @@ static const pjsip_method pjsip_update_method =
     { "UPDATE", 6 }
 };
 
-#define POOL_INIT_SIZE  256
-#define POOL_INC_SIZE   256
+#define POOL_INIT_SIZE  1000
+#define POOL_INC_SIZE   1000
 
 /* Process header parameter in redirection target. */
 void pjsip_inv_process_hparam(pjsip_inv_session *sess, 

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -73,12 +73,12 @@ static const char* print_tpsel_info(const pjsip_tpselector *sel)
 
 /* Specify the initial size of the transport manager's pool. */
 #ifndef  TPMGR_POOL_INIT_SIZE
-#   define TPMGR_POOL_INIT_SIZE 64
+#   define TPMGR_POOL_INIT_SIZE 1000
 #endif
 
 /* Specify the increment size of the transport manager's pool. */
 #ifndef TPMGR_POOL_INC_SIZE
-    #define TPMGR_POOL_INC_SIZE 64
+    #define TPMGR_POOL_INC_SIZE 1000
 #endif
 
 /* Specify transport entry allocation count. When registering a new transport,


### PR DESCRIPTION
In this PR, we add a new compile-time setting `PJ_POOL_MAX_SEARCH_BLOCK_COUNT` to limit the number of blocks searched before deciding that the pool is full and a new memory block needs to be created. Setting it to 0 will disable this (i.e. it will search all the blocks) and return to the old behaviour.

During testing, it is interesting to note that setting the macro to 5 or 10 doesn't yield in any increment of the number of memory blocks allocated in all the pools as compared when setting it to 0 (i.e. disabling it).

This shows that limiting the number of blocks to search should not result in any negative effect in most cases. It can be explained because the block searching is performed from the newest to the oldest blocks, so it becomes increasingly unlikely as the search proceeds that the older blocks still have enough space for the new allocation.
