### PR TITLE
Add socket option params to transport config in PJSUA2

### DIFF
--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -308,6 +308,72 @@ public:
 
 
 /**
+ * Socket option parameters, to be specified in TransportConfig.
+ */
+struct SockOptParams : public PersistentObject
+{
+    /**
+     * Socket option type.
+     */
+    struct SockOpt {
+        /**
+         * The level at which the option is defined.
+         */
+        int                 level;
+
+        /**
+         * Option name.
+         */
+        int                 optName;
+
+        /**
+         * Pointer to the buffer in which the option is specified.
+         */
+        void               *optVal;
+
+        /**
+         * Buffer size of the buffer pointed by optVal.
+         */
+        int                 optLen;
+
+        /**
+         * Internal buffer for optval.
+         */
+        string optValBuf_;
+    };
+
+    /**
+     * Array of socket options.
+     */
+    std::vector<SockOpt>    sockOpts;
+
+public:
+    /** Default constructor initialises with default values */
+    SockOptParams();
+
+    /** Convert to pjsip */
+    pj_sockopt_params toPj() const;
+
+    /** Convert from pjsip */
+    void fromPj(const pj_sockopt_params &prm);
+
+    /**
+     * Read this object from a container node.
+     *
+     * @param node              Container to read values from.
+     */
+    virtual void readObject(const ContainerNode &node) PJSUA2_THROW(Error);
+
+    /**
+     * Write this object to a container node.
+     *
+     * @param node              Container to write values to.
+     */
+    virtual void writeObject(ContainerNode &node) const PJSUA2_THROW(Error);
+};
+
+
+/**
  * Parameters to create a transport instance.
  */
 struct TransportConfig : public PersistentObject
@@ -392,6 +458,13 @@ struct TransportConfig : public PersistentObject
      * Default is QoS not set.
      */
     pj_qos_params       qosParams;
+
+    /**
+     * Set the low level socket options to the transport.
+     *
+     * Default is no socket option set.
+     */
+    SockOptParams       sockOptParams;
 
 public:
     /** Default constructor initialises with default values */

--- a/pjsip/src/pjsua2/json.cpp
+++ b/pjsip/src/pjsua2/json.cpp
@@ -471,7 +471,9 @@ static void jsonNode_writeString(ContainerNode *node,
     pj_json_elem *el = jdat->doc->allocElement();
     pj_str_t nm = alloc_name(jdat->doc, name);
     pj_str_t new_val;
-    pj_strdup2(jdat->doc->getPool(), &new_val, value.c_str());
+    pj_str_t str_val;
+    pj_strset(&str_val, (char*)value.data(), value.size());
+    pj_strdup(jdat->doc->getPool(), &new_val, &str_val);
     pj_json_elem_string(el, &nm, &new_val);
 
     pj_json_elem_add(jdat->jnode, el);
@@ -489,8 +491,10 @@ static void jsonNode_writeStringVector(ContainerNode *node,
     pj_json_elem_array(el, &nm);
     for (unsigned i=0; i<value.size(); ++i) {
         pj_str_t new_val;
+        pj_str_t str_val;
 
-        pj_strdup2(jdat->doc->getPool(), &new_val, value[i].c_str());
+        pj_strset(&str_val, (char*)value[i].data(), value[i].size());
+        pj_strdup(jdat->doc->getPool(), &new_val, &str_val);
         pj_json_elem *child = jdat->doc->allocElement();
         pj_json_elem_string(child, NULL, &new_val);
         pj_json_elem_add(el, child);


### PR DESCRIPTION
- Add type `SockOptParams` to PJSUA2 which wraps `pj_sockopt_params`.
- Add field `sockOptParams` to PJSUA2 `TransportConfig`.
- Update PJSUA2 JSON `WriteString()` to write as long as C++ string length, otherwise it may not write full string if there is any null character in the middle.