### PR TITLE
Fixed buffer overflow in h264 unpacketizer

### DIFF
--- a/pjmedia/src/pjmedia-codec/h264_packetizer.c
+++ b/pjmedia/src/pjmedia-codec/h264_packetizer.c
@@ -437,6 +437,9 @@ PJ_DEF(pj_status_t) pjmedia_h264_unpacketize(pjmedia_h264_packetizer *pktz,
         while (q < q_end && p < p_end) {
             pj_uint16_t tmp_nal_size;
 
+            if (p + pktz->cfg.unpack_nal_start > p_end)
+                return PJ_EINVAL;
+
             /* Write NAL unit start code */
             pj_memcpy(p, nal_start_code, pktz->cfg.unpack_nal_start);
             p += pktz->cfg.unpack_nal_start;
@@ -444,7 +447,7 @@ PJ_DEF(pj_status_t) pjmedia_h264_unpacketize(pjmedia_h264_packetizer *pktz,
             /* Get NAL unit size */
             tmp_nal_size = (*q << 8) | *(q+1);
             q += 2;
-            if (q + tmp_nal_size > q_end) {
+            if (p + tmp_nal_size > p_end || q + tmp_nal_size > q_end) {
                 /* Invalid bitstream, discard the rest of the payload */
                 return PJ_EINVAL;
             }


### PR DESCRIPTION
A couple of reports found from #3422:
```
==91355==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x000108f0239f at pc 0x000105f2148c bp 0x00016b04a200 sp 0x00016b0499c0
WRITE of size 4 at 0x000108f0239f thread T0
    #0 0x105f21488 in __asan_memcpy+0x22c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x3d488) (BuildId: ee0fd54f5b5b37fab0dff0277a63fa1d32000000200000000100000000000b00)
    #1 0x104db909c in pj_memcpy string.h:797
    #2 0x104dbc6c0 in pjmedia_h264_unpacketize h264_packetizer.c:441
    #3 0x104db868c in h264_unpacketizer+0xb0 (fuzz-h264:arm64+0x10000468c) (BuildId: a06ddb6329fd32ef8f32febfe73af5a832000000200000000100000000000d00)
```

```
==91224==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x0001050002f5 at pc 0x000101eb948c bp 0x00016f0b2200 sp 0x00016f0b19c0
WRITE of size 30 at 0x0001050002f5 thread T0
    #0 0x101eb9488 in __asan_memcpy+0x22c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x3d488) (BuildId: ee0fd54f5b5b37fab0dff0277a63fa1d32000000200000000100000000000b00)
    #1 0x100d5109c in pj_memcpy string.h:797
    #2 0x100d54884 in pjmedia_h264_unpacketize h264_packetizer.c:453
```
