### PR TITLE
Modify default value of PJ_MAX_HOSTNAME

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -668,10 +668,10 @@
  * Libraries sometimes needs to make copy of an address to stack buffer;
  * the value here affects the stack usage.
  *
- * Default: 128
+ * Default: 253
  */
 #ifndef PJ_MAX_HOSTNAME
-#  define PJ_MAX_HOSTNAME           (128)
+#  define PJ_MAX_HOSTNAME           (253)
 #endif
 
 /**


### PR DESCRIPTION
To close #3421.

RFC 1035, which is the current standard for the Domain Name System (DNS), section 2.3.1 of the RFC, states that "the total length of a domain name (i.e., label octets and label length octets) is restricted to 255 octets or less."

The 255-character limit includes the length of the individual labels (the parts of the hostname separated by dots), as well as the dots themselves. However, since the maximum length of a label is 63 characters, the maximum length of a hostname is typically limited to 253 characters, to allow for a period between labels.
