### PR TITLE
Check if interface address returned by pj_getipinterface() is link-local address

### DIFF
--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -1069,11 +1069,16 @@ PJ_DEF(pj_status_t) pj_getipinterface(int af,
     }
 
 #if defined(PJ_HAS_IPV6) && PJ_HAS_IPV6
-    /* Check that the address is not a link-local address */
+    /* Check if the local address is link-local but the destination
+     * is not link-local.
+     */
     if (af == pj_AF_INET6() &&
-        IN6_IS_ADDR_LINKLOCAL(&itf_addr->ipv6.sin6_addr))
+        IN6_IS_ADDR_LINKLOCAL(&itf_addr->ipv6.sin6_addr) &&
+        (!IN6_IS_ADDR_LINKLOCAL(&dst_addr.ipv6.sin6_addr)))
     {
-        TRACE_((THIS_FILE, "Interface address is a link-local address"));
+        TRACE_((THIS_FILE, "Local interface address is link-local and "
+                           "the destination host is external"));
+
         return PJ_ENOTFOUND;
     }
 #endif

--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -1068,6 +1068,16 @@ PJ_DEF(pj_status_t) pj_getipinterface(int af,
         return PJ_ENOTFOUND;
     }
 
+#if defined(PJ_HAS_IPV6) && PJ_HAS_IPV6
+    /* Check that the address is not a link-local address */
+    if (af == pj_AF_INET6() &&
+        IN6_IS_ADDR_LINKLOCAL(&itf_addr->ipv6.sin6_addr))
+    {
+        TRACE_((THIS_FILE, "Interface address is a link-local address"));
+        return PJ_ENOTFOUND;
+    }
+#endif
+
     if (p_dst_addr)
         *p_dst_addr = dst_addr;
 


### PR DESCRIPTION
It's been reported that for IPv6, `pj_getipinterface()` can return success and give link-local address even though the device has no routable IPv6 address. This will cause the address returned not to be of much use since it can't be used to send/receive data to the external host.

`pj_getipinterface()` relies on `connect()` and `getsockname()` to get the interface address, i.e.:
```
    status = pj_sock_socket(af, pj_SOCK_DGRAM(), 0, &fd);
    status = pj_sock_connect(fd, &dst_addr, pj_sockaddr_get_len(&dst_addr));
    status = pj_sock_getsockname(fd, itf_addr, &len);
```
 
As it turns out, since the socket created is a connection-less socket, yes, it is possible `connect()` to return 0/success for an IPv6 datagram socket even if there is no routable IPv6 address available on any of the local network interfaces. The failure will happen later when you attempt to send or receive data using the socket.

When you use `connect()` on an IPv6 datagram socket, the operating system selects a source IP address to use for the connection, based on the routing table and the local network interfaces. If there is no routable IPv6 address available on any of the local network interfaces, the operating system may still be able to select a source IP address for the connection, such as a link-local address or a site-local address.

However, if the selected source address is not routable to the destination, any subsequent attempt to send or receive data using the socket will fail. This is because the IPv6 routing infrastructure will not be able to deliver the packets to the destination.

Therefore, while it's technically possible for connect() to return 0 for an IPv6 datagram socket even if there is no routable IPv6 address available, it's generally not useful or practical to establish a connection in this case.
