### PR TITLE
Fix scan-build (Clang Static Analyzer) build fail

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -4858,7 +4858,7 @@ if test "$LIBEXT" = ""; then LIBEXT='a'; fi
 
 if test "$LIBEXT2" = ""; then LIBEXT2=""; fi
 
-if test "$CC_OUT" = ""; then CC_OUT="-o "; fi
+if test "$CC_OUT" = ""; then CC_OUT="-c -o "; fi
 
 if test "$CC_INC" = ""; then CC_INC="-I"; fi
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -56,7 +56,7 @@ if test "$LIBEXT" = ""; then LIBEXT='a'; fi
 AC_SUBST(LIBEXT)
 if test "$LIBEXT2" = ""; then LIBEXT2=""; fi
 AC_SUBST(LIBEXT2)
-if test "$CC_OUT" = ""; then CC_OUT="-o "; fi
+if test "$CC_OUT" = ""; then CC_OUT="-c -o "; fi
 AC_SUBST(CC_OUT)
 if test "$CC_INC" = ""; then CC_INC="-I"; fi
 AC_SUBST(CC_INC)

--- a/build/cc-auto.mak.in
+++ b/build/cc-auto.mak.in
@@ -1,5 +1,5 @@
-export CC = @CC@ -c
-export CXX = @CXX@ -c
+export CC = @CC@
+export CXX = @CXX@
 export AR = @AR@
 export AR_FLAGS = @AR_FLAGS@
 export LD = @LD@


### PR DESCRIPTION
I want to use scan-build to build & analysis source

```bash
export CC=clang
export CXX=clang++

./configure ....
make dep

# only build pjlib for test
scan-build make -C pjlib/build
```

which will be fail.


I found that the fail reason is that:
      scan-build auto use the clang tool ccc-analyzer replace cc/cxx to generate *.o  without "-c" option

Two methods to solve it:
1.  export CC_OUT="-c -o "
2.  this commit

I think the 2nd is better


PS:
scan-build find out some problems/bugs, need find time to fix them





