### PR TITLE
Respond with ACK first before hanging up call for dialog fork

### DIFF
--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -615,6 +615,23 @@ PJ_DECL(pj_grp_lock_t *) pjsip_dlg_get_lock( pjsip_dialog *dlg );
 
 
 /**
+ * Set the dialog instance in the incoming rdata.
+ *
+ * Note that if an incoming message matches an existing dialog, the user
+ * agent will put the matching dialog instance in the rdata, so typically
+ * application does not need to call this function directly.
+ * In other words, this function is only useful if application needs to
+ * associate the incoming rdata with the dialog instance before the user
+ * agent sets it (such as in the context of module that runs in priority
+ * number lower than PJSIP_MOD_PRIORITY_UA_PROXY_LAYER).
+ *
+ * @param rdata             Incoming message buffer.
+ * @param dlg               The dialog.
+ */
+PJ_DECL(void) pjsip_rdata_set_dlg( pjsip_rx_data *rdata, pjsip_dialog *dlg);
+
+
+/**
  * Get the dialog instance in the incoming rdata. If an incoming message 
  * matches an existing dialog, the user agent must have put the matching 
  * dialog instance in the rdata, or otherwise this function will return 

--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -615,23 +615,6 @@ PJ_DECL(pj_grp_lock_t *) pjsip_dlg_get_lock( pjsip_dialog *dlg );
 
 
 /**
- * Set the dialog instance in the incoming rdata.
- *
- * Note that if an incoming message matches an existing dialog, the user
- * agent will put the matching dialog instance in the rdata, so typically
- * application does not need to call this function directly.
- * In other words, this function is only useful if application needs to
- * associate the incoming rdata with the dialog instance before the user
- * agent sets it (such as in the context of module that runs in priority
- * number lower than PJSIP_MOD_PRIORITY_UA_PROXY_LAYER).
- *
- * @param rdata             Incoming message buffer.
- * @param dlg               The dialog.
- */
-PJ_DECL(void) pjsip_rdata_set_dlg( pjsip_rx_data *rdata, pjsip_dialog *dlg);
-
-
-/**
  * Get the dialog instance in the incoming rdata. If an incoming message 
  * matches an existing dialog, the user agent must have put the matching 
  * dialog instance in the rdata, or otherwise this function will return 

--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -160,6 +160,7 @@ struct pjsip_dialog
     pj_bool_t           uac_has_2xx;/**< UAC has received 2xx response?     */
     pj_bool_t           secure;     /**< Use secure transport?              */
     pj_bool_t           add_allow;  /**< Add Allow header in requests?      */
+    pj_bool_t           ack_sent;   /**< ACK has been sent?                 */
     pjsip_cid_hdr      *call_id;    /**< Call-ID header.                    */
     pjsip_route_hdr     route_set;  /**< Route set.                         */
     pj_bool_t           route_set_frozen; /**< Route set has been set.      */

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1920,7 +1920,7 @@ void pjsip_dlg_on_rx_response( pjsip_dialog *dlg, pjsip_rx_data *rdata )
     pjsip_dlg_inc_lock(dlg);
 
     /* Check that rdata already has dialog in mod_data. */
-    pj_assert(pjsip_rdata_get_dlg(rdata) == dlg);
+    //pj_assert(pjsip_rdata_get_dlg(rdata) == dlg);
 
     /* Keep the response's status code */
     res_code = rdata->msg_info.msg->line.status.code;

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1363,6 +1363,8 @@ PJ_DEF(pj_status_t) pjsip_dlg_send_request( pjsip_dialog *dlg,
         }
 
     } else {
+        dlg->ack_sent = PJ_TRUE;
+
         /* Set transport selector */
         pjsip_tx_data_set_transport(tdata, &dlg->tp_sel);
 
@@ -2079,7 +2081,8 @@ void pjsip_dlg_on_rx_response( pjsip_dialog *dlg, pjsip_rx_data *rdata )
         pj_status_t status;
 
         if (rdata->msg_info.cseq->method.id==PJSIP_INVITE_METHOD &&
-            rdata->msg_info.msg->line.status.code/100 == 2)
+            rdata->msg_info.msg->line.status.code/100 == 2 &&
+            !dlg->ack_sent)
         {
             pjsip_tx_data *ack;
 

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1920,7 +1920,7 @@ void pjsip_dlg_on_rx_response( pjsip_dialog *dlg, pjsip_rx_data *rdata )
     pjsip_dlg_inc_lock(dlg);
 
     /* Check that rdata already has dialog in mod_data. */
-    //pj_assert(pjsip_rdata_get_dlg(rdata) == dlg);
+    pj_assert(pjsip_rdata_get_dlg(rdata) == dlg);
 
     /* Keep the response's status code */
     res_code = rdata->msg_info.msg->line.status.code;

--- a/pjsip/src/pjsip/sip_ua_layer.c
+++ b/pjsip/src/pjsip/sip_ua_layer.c
@@ -448,11 +448,6 @@ PJ_DEF(pj_status_t) pjsip_ua_unregister_dlg( pjsip_user_agent *ua,
 }
 
 
-PJ_DEF(void) pjsip_rdata_set_dlg( pjsip_rx_data *rdata, pjsip_dialog *dlg)
-{
-    rdata->endpt_info.mod_data[mod_ua.mod.id] = dlg;
-}
-
 PJ_DEF(pjsip_dialog*) pjsip_rdata_get_dlg( pjsip_rx_data *rdata )
 {
     return (pjsip_dialog*) rdata->endpt_info.mod_data[mod_ua.mod.id];
@@ -900,7 +895,7 @@ retry_on_deadlock:
             if (mod_ua.param.on_dlg_forked) {
                 dlg = (*mod_ua.param.on_dlg_forked)(dlg_set->dlg_list.next, 
                                                     rdata);
-                if (dlg == NULL || dlg != dlg_set->dlg_list.next) {
+                if (dlg == NULL) {
                     pj_mutex_unlock(mod_ua.mutex);
                     return PJ_TRUE;
                 }

--- a/pjsip/src/pjsip/sip_ua_layer.c
+++ b/pjsip/src/pjsip/sip_ua_layer.c
@@ -448,6 +448,11 @@ PJ_DEF(pj_status_t) pjsip_ua_unregister_dlg( pjsip_user_agent *ua,
 }
 
 
+PJ_DEF(void) pjsip_rdata_set_dlg( pjsip_rx_data *rdata, pjsip_dialog *dlg)
+{
+    rdata->endpt_info.mod_data[mod_ua.mod.id] = dlg;
+}
+
 PJ_DEF(pjsip_dialog*) pjsip_rdata_get_dlg( pjsip_rx_data *rdata )
 {
     return (pjsip_dialog*) rdata->endpt_info.mod_data[mod_ua.mod.id];

--- a/pjsip/src/pjsip/sip_ua_layer.c
+++ b/pjsip/src/pjsip/sip_ua_layer.c
@@ -895,7 +895,7 @@ retry_on_deadlock:
             if (mod_ua.param.on_dlg_forked) {
                 dlg = (*mod_ua.param.on_dlg_forked)(dlg_set->dlg_list.next, 
                                                     rdata);
-                if (dlg == NULL) {
+                if (dlg == NULL || dlg != dlg_set->dlg_list.next) {
                     pj_mutex_unlock(mod_ua.mutex);
                     return PJ_TRUE;
                 }

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5116,6 +5116,9 @@ pjsip_dialog* on_dlg_forked(pjsip_dialog *dlg, pjsip_rx_data *res)
 
         pjsip_dlg_inc_lock(forked_dlg);
 
+        /* Respond with ACK first */
+        pjsip_dlg_on_rx_response(forked_dlg, res);
+
         /* Disconnect the call */
         status = pjsip_dlg_create_request(forked_dlg, pjsip_get_bye_method(),
                                           -1, &bye);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5106,7 +5106,7 @@ pjsip_dialog* on_dlg_forked(pjsip_dialog *dlg, pjsip_rx_data *res)
         res->msg_info.msg->line.status.code/100 == 2)
     {
         pjsip_dialog *forked_dlg;
-        pjsip_tx_data *bye;
+        pjsip_tx_data *bye, *ack;
         pj_status_t status;
 
         /* Create forked dialog */
@@ -5117,8 +5117,10 @@ pjsip_dialog* on_dlg_forked(pjsip_dialog *dlg, pjsip_rx_data *res)
         pjsip_dlg_inc_lock(forked_dlg);
 
         /* Respond with ACK first */
-        pjsip_rdata_set_dlg(res, forked_dlg);
-        pjsip_dlg_on_rx_response(forked_dlg, res);
+        status = pjsip_dlg_create_request(forked_dlg, &pjsip_ack_method,
+                                          res->msg_info.cseq->cseq, &ack);
+        if (status == PJ_SUCCESS)
+            pjsip_dlg_send_request(forked_dlg, ack, -1, NULL);
 
         /* Disconnect the call */
         status = pjsip_dlg_create_request(forked_dlg, pjsip_get_bye_method(),

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5117,6 +5117,7 @@ pjsip_dialog* on_dlg_forked(pjsip_dialog *dlg, pjsip_rx_data *res)
         pjsip_dlg_inc_lock(forked_dlg);
 
         /* Respond with ACK first */
+        pjsip_rdata_set_dlg(res, forked_dlg);
         pjsip_dlg_on_rx_response(forked_dlg, res);
 
         /* Disconnect the call */

--- a/tests/pjsua/scripts-sipp/uas-forked-200.xml
+++ b/tests/pjsua/scripts-sipp/uas-forked-200.xml
@@ -97,6 +97,9 @@
     ]]>
   </send>
 
+  <!-- Receive ACK -->
+  <recv request="ACK" optional="false">
+  </recv>
 
   <!-- Receive BYE (for leg 2) -->
   <recv request="BYE" optional="false">
@@ -113,11 +116,6 @@
       [last_CSeq:]
     ]]>
   </send>
-
-
-  <!-- Receive ACK -->
-  <recv request="ACK" optional="false">
-  </recv>
 
 
   <!-- definition of the response time repartition table (unit is ms)   -->


### PR DESCRIPTION
Attempt to fix #3234 

Currently for dialog fork, the flow is like this:
`sip_ua_layer` -> `on_dlg_forked()` -> pjsua_call: send BYE -> back to `sip_ua_layer`: respond with ACK.

Ideally, we want the ACK to be sent first and the patch will do this. Unfortunately, it will cause a behaviour change: now it's app's responsibility to send the ACK.

As a consequence of the behaviour change, the sipp script `uas-forked-200.xml` to test the scenario needs to be modified.

So do you think we should change the current behaviour?
