### PR TITLE
zero initialize the message buffer

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/errno.c
+++ b/pjmedia/src/pjmedia-audiodev/errno.c
@@ -81,11 +81,11 @@ PJ_DEF(pj_str_t) pjmedia_audiodev_strerror(pj_status_t statcode,
         statcode <= PJMEDIA_AUDIODEV_COREAUDIO_ERRNO_END)
     {
         int ca_err = PJMEDIA_AUDIODEV_COREAUDIO_ERRNO_START - statcode;
+        pj_str_t msg = pj_str("Core audio error");
 
         PJ_UNUSED_ARG(ca_err);
         // TODO: create more helpful error messages
         errstr.ptr = buf;
-        pj_str_t msg = pj_str("Core audio error");
         pj_strncpy_with_null(&errstr, &msg, bufsize);
         return errstr;
     } else

--- a/pjmedia/src/pjmedia-audiodev/errno.c
+++ b/pjmedia/src/pjmedia-audiodev/errno.c
@@ -85,7 +85,8 @@ PJ_DEF(pj_str_t) pjmedia_audiodev_strerror(pj_status_t statcode,
         PJ_UNUSED_ARG(ca_err);
         // TODO: create more helpful error messages
         errstr.ptr = buf;
-        pj_strcpy2(&errstr, "Core audio error");
+        pj_str_t msg = pj_str("Core audio error");
+        pj_strncpy_with_null(&errstr, &msg, bufsize);
         return errstr;
     } else
 #endif

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -44,6 +44,7 @@ PJ_DEF(void) pjsua_perror( const char *sender, const char *title,
                            pj_status_t status)
 {
     char errmsg[PJ_ERR_MSG_SIZE];
+    pj_bzero(errmsg, sizeof(errmsg));
 
     pj_strerror(status, errmsg, sizeof(errmsg));
     PJ_LOG(1,(sender, "%s: %s [status=%d]", title, errmsg, status));

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -44,7 +44,6 @@ PJ_DEF(void) pjsua_perror( const char *sender, const char *title,
                            pj_status_t status)
 {
     char errmsg[PJ_ERR_MSG_SIZE];
-    pj_bzero(errmsg, sizeof(errmsg));
 
     pj_strerror(status, errmsg, sizeof(errmsg));
     PJ_LOG(1,(sender, "%s: %s [status=%d]", title, errmsg, status));


### PR DESCRIPTION
While using pjmedia I encounter a few error messages like this:

`10:45:55.540            pjsua_aud.c  .Unable to open sound device: Core audio errorP�` [status=450851]`

where there is some garbage behind the error message. I'm not 100% sure if this is the way to do it. Normally I'd use memset.