### PR TITLE
Fixed TURN allocation parameter

### DIFF
--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -273,6 +273,7 @@ PJ_DEF(pj_status_t) pj_turn_session_create( const pj_stun_config *cfg,
     sess->ka_interval = PJ_TURN_KEEP_ALIVE_SEC;
     sess->user_data = user_data;
     sess->next_ch = PJ_TURN_CHANNEL_MIN;
+    pj_turn_alloc_param_default(&sess->alloc_param);
 
     /* Copy STUN session */
     pj_memcpy(&sess->stun_cfg, cfg, sizeof(pj_stun_config));
@@ -777,8 +778,8 @@ PJ_DEF(pj_status_t) pj_turn_session_alloc(pj_turn_session *sess,
 
     /* MUST include REQUESTED-TRANSPORT attribute */
     pj_stun_msg_add_uint_attr(tdata->pool, tdata->msg,
-                              PJ_STUN_ATTR_REQ_TRANSPORT, 
-                              PJ_STUN_SET_RT_PROTO(param->peer_conn_type));
+        PJ_STUN_ATTR_REQ_TRANSPORT,
+        PJ_STUN_SET_RT_PROTO(sess->alloc_param.peer_conn_type));
 
     /* Include BANDWIDTH if requested */
     if (sess->alloc_param.bandwidth > 0) {


### PR DESCRIPTION
The TURN allocation parameter in `pj_turn_session_alloc(pj_turn_session *sess, const pj_turn_alloc_param *param)` is specified as optional:
```
 * @param param         Optional TURN allocation parameter.
```

However, there is an instance when we access it directly, potentially causing a crash.
The fix is to use `sess->alloc_param` instead. But this creates another problem, since `sess->alloc_param` can be uninitialised, so we have to initialise it in `pj_turn_session_create()`.

Note: This fix is for branch `coverity01`.