### PR TITLE
Fixed adding note to a tuple when adding RPID element

### DIFF
--- a/pjsip/include/pjsip-simple/rpid.h
+++ b/pjsip/include/pjsip-simple/rpid.h
@@ -106,8 +106,9 @@ PJ_DECL(void) pjrpid_element_dup(pj_pool_t *pool, pjrpid_element *dst,
  * Add RPID element information into existing PIDF document. This will also
  * add the appropriate XML namespace attributes into the presence's XML
  * node, if the attributes are not already present, and also a <note> element
- * to the first <tuple> element of the PIDF document, if a <note> element
- * is not present.
+ * if it is not present. The <note> element is added to the first <tuple>
+ * element of the PIDF document, or if there is no <tuple> element found,
+ * to the root <presence> element of the document.
  *
  * @param pres      The PIDF presence document.
  * @param pool      Pool.

--- a/pjsip/src/pjsip-simple/rpid.c
+++ b/pjsip/src/pjsip-simple/rpid.c
@@ -120,7 +120,7 @@ PJ_DEF(pj_status_t) pjrpid_add_element(pjpidf_pres *pres,
 
         nd_tuple = find_node(pres, "tuple");
         nd_note = nd_tuple? find_node(nd_tuple, "note"):NULL;
-        if (!nd_note) {
+        if (nd_tuple && !nd_note) {
             nd_note = pj_xml_node_new(pool, &NOTE);
             pj_strdup(pool, &nd_note->content, &elem->note);
             pj_xml_add_node(nd_tuple, nd_note);

--- a/pjsip/src/pjsip-simple/rpid.c
+++ b/pjsip/src/pjsip-simple/rpid.c
@@ -114,16 +114,19 @@ PJ_DEF(pj_status_t) pjrpid_add_element(pjpidf_pres *pres,
 
     PJ_UNUSED_ARG(options);
 
-    /* Add <note> to <tuple>, if none */
+    /* Add <note>, if none. We add it to the first <tuple>, if any,
+     * otherwise to the root <presence>.
+     */
     if (elem->note.slen != 0) {
         pj_xml_node *nd_tuple;
 
         nd_tuple = find_node(pres, "tuple");
-        nd_note = nd_tuple? find_node(nd_tuple, "note"):NULL;
-        if (nd_tuple && !nd_note) {
+        nd_note = nd_tuple? find_node(nd_tuple, "note"):
+                  find_node(pres, "note");
+        if (!nd_note) {
             nd_note = pj_xml_node_new(pool, &NOTE);
             pj_strdup(pool, &nd_note->content, &elem->note);
-            pj_xml_add_node(nd_tuple, nd_note);
+            pj_xml_add_node(nd_tuple? nd_tuple: pres, nd_note);
             nd_note = NULL;
         }
     }


### PR DESCRIPTION
The doc of `pjrpid_add_element()` says:
```
 * Add RPID element information into existing PIDF document. This will also
 * add the appropriate XML namespace attributes into the presence's XML
 * node, if the attributes are not already present, and also a <note> element
 * to the first <tuple> element of the PIDF document, if a <note> element
 * is not present.
```

The implementation:
```
    /* Add <note> to <tuple>, if none */
    if (elem->note.slen != 0) {
        pj_xml_node *nd_tuple;

        nd_tuple = find_node(pres, "tuple");
        nd_note = nd_tuple? find_node(nd_tuple, "note"):NULL;
        if (nd_tuple && !nd_note) {
            nd_note = pj_xml_node_new(pool, &NOTE);
            pj_strdup(pool, &nd_note->content, &elem->note);
            pj_xml_add_node(nd_tuple, nd_note);
            nd_note = NULL;
        }
    }
```

Note that RPID PIDF (Rich Presence Information Data format) is an XML-based format used to describe a user's presence status in real-time communication systems. The `<tuple>` element in PIDF contains the actual presence information for a user, including their status, contact information, and other related data.

If there is no `<tuple>` element present in a PIDF document, it means that no presence information is available for the user. In such cases, the PIDF document may still contain other elements, such as `<note>` or `<status>`, which provide additional information about the user's status, for example:
```
<presence xmlns="urn:ietf:params:xml:ns:pidf" entity="sip:johndoe@example.com">
  <note>John is currently on a call.</note>
</presence>
```

So there are two alternatives here:
1. If there is a `<tuple>` but no `<note>` within the tuple, we add the note inside `<tuple>`.
2. In addition to 1, if there is no`<tuple>` and no `<note>` in the root element `<presence>`, we add the note inside `<presence>`.

The proposed patch is for the first alternative.

For the second alternative, the fix should be like this:
```
        nd_tuple = find_node(pres, "tuple");
        nd_note = nd_tuple? find_node(nd_tuple, "note"):find_node(pres, "note");
        if (!nd_note) {
            nd_note = pj_xml_node_new(pool, &NOTE);
            pj_strdup(pool, &nd_note->content, &elem->note);
            pj_xml_add_node(nd_tuple? nd_tuple: pres, nd_note);
            nd_note = NULL;
        }
```

Let me know what you think.

Note: the fix is going to be merged into `coverity01` branch.
