### PR TITLE
Avoid cancellation of retransmit timer after receiving provisional response of non-INVITE

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2665,11 +2665,6 @@ static pj_status_t tsx_on_state_calling( pjsip_transaction *tsx,
             }
 
         } else {
-            /* Cancel retransmit timer (for non-INVITE transaction, the
-             * retransmit timer will be rescheduled at T2.
-             */
-            tsx_cancel_timer(tsx, &tsx->retransmit_timer);
-
             /* For provisional response, only cancel retransmit when this
              * is an INVITE transaction. For non-INVITE, section 17.1.2.1
              * of RFC 3261 says that:
@@ -2678,6 +2673,8 @@ static pj_status_t tsx_on_state_calling( pjsip_transaction *tsx,
              */
             if (tsx->method.id == PJSIP_INVITE_METHOD) {
 
+                tsx_cancel_timer(tsx, &tsx->retransmit_timer);
+
                 /* Cancel timeout timer */
                 lock_timer(tsx);
                 tsx_cancel_timer(tsx, &tsx->timeout_timer);
@@ -2685,6 +2682,7 @@ static pj_status_t tsx_on_state_calling( pjsip_transaction *tsx,
 
             } else {
                 if (!tsx->is_reliable) {
+                    tsx_cancel_timer(tsx, &tsx->retransmit_timer);
                     tsx_schedule_timer(tsx, &tsx->retransmit_timer,
                                        &t2_timer_val, RETRANSMIT_TIMER);
                 }


### PR DESCRIPTION
Currently, retransmit timer is cancelled for provisional response of non-INVITE request when using reliable transport. The RFC does not state that the timer should be reset.

RFC 3261 section [17.1.2.1](https://www.rfc-editor.org/rfc/rfc3261#section-17.1.2.1):
```
Non-INVITE transactions do not make use of ACK.  They are simple
   request-response interactions.  For unreliable transports, requests
   are retransmitted at an interval which starts at T1 and doubles until
   it hits T2.  If a provisional response is received, retransmissions
   continue for unreliable transports, but at an interval of T2.  The
   server transaction retransmits the last response it sent, which can
   be a provisional or final response, only when a retransmission of the
   request is received.  This is why request retransmissions need to
   continue even after a provisional response; they are to ensure
   reliable delivery of the final response.

   Unlike an INVITE transaction, a non-INVITE transaction has no special
   handling for the 2xx response.  The result is that only a single 2xx
   response to a non-INVITE is ever delivered to a UAC.
```
