### PR TITLE
do not assert when there is no body or the body is not multipart

### DIFF
--- a/pjsip/include/pjsip/sip_multipart.h
+++ b/pjsip/include/pjsip/sip_multipart.h
@@ -117,7 +117,8 @@ PJ_DECL(pj_status_t) pjsip_multipart_add_part(pj_pool_t *pool,
  * @param mp            The multipart bodies.
  *
  * @return              The first part, or NULL if the multipart
- *                      bodies currently doesn't hold any elements.
+ *                      bodies currently doesn't hold any elements
+ *                      or mp doesn't point to multipart bodies.
  */
 PJ_DECL(pjsip_multipart_part*)
 pjsip_multipart_get_first_part(const pjsip_msg_body *mp);

--- a/pjsip/src/pjsip/sip_multipart.c
+++ b/pjsip/src/pjsip/sip_multipart.c
@@ -341,10 +341,12 @@ pjsip_multipart_get_first_part(const pjsip_msg_body *mp)
     struct multipart_data *m_data;
 
     /* Must specify mandatory params */
-    PJ_ASSERT_RETURN(mp, NULL);
+    if (!mp)
+        return NULL;
 
     /* mp must really point to an actual multipart msg body */
-    PJ_ASSERT_RETURN(mp->print_body==&multipart_print_body, NULL);
+    if (mp->print_body!=&multipart_print_body)
+        return NULL;
 
     m_data = (struct multipart_data*)mp->data;
     if (pj_list_empty(&m_data->part_head))


### PR DESCRIPTION
This PR removes the asserts in pjsip_multipart_get_first_part() and adds regular checks.

What's the use case?
In my code I inspect incoming messages and their bodies in a generic way.
If there is a body (or bodies in case of multipart) they're extracted
and put into a "nice" data structure for easy consumption later on.

The code for extracting payload looks something like this:
```
void extractAdditionalPayload( std::vector< SipBody >& additional_payload,
                               pjsip_rx_data* rdata ) const
{
  if( ! rdata ) { return; }

  pjsip_multipart_part* mp = pjsip_multipart_get_first_part( rdata->msg_info.msg->body );

  if( mp )	/* okay, we do have a multipart body... */
  {
    while( mp )
    {
      /* ignore SDP */
      if( (0 != pj_stricmp2( &mp->body->content_type.type, "application" ))
       || (0 != pj_stricmp2( &mp->body->content_type.subtype, "sdp" )) )
      {
        /* put multipart body into vector */
        additional_payload.emplace_back( MULTIPART-BODY );
      }

      mp = pjsip_multipart_get_next_part( rdata->msg_info.msg->body, mp );
    }
  }
  else if( rdata->msg_info.msg->body )    /* in case we don't have multipart... */
  {
    /* ignore SDP */
    if( (0 != pj_stricmp2( &rdata->msg_info.msg->body->content_type.type, "application" ))
     || (0 != pj_stricmp2( &rdata->msg_info.msg->body->content_type.subtype, "sdp" )) )
    {
      /* put body into vector */
      additional_payload.emplace_back( SINGLE-BODY );
    }
  }
}
```

The code above is working fine except in Debug build on Windows.
When I ported the code to Windows and did a quick test, it would assert, because pjsip_multipart_get_first_part() asserts \
when either the function parameter is NULL or when there is a body that is not multipart. \
\
As you can see I use the return value of pjsip_multipart_get_first_part() as an indicator \
for the existence of a multipart body and act accordingly. \
\
In order to avoid the assert (only in Debug builds mind you) I would have to insert an explicit check like so:
```
/* This seems pointless to me because PJ should already know whether this is multipart or not:
 * explicitly figure out whether this is a multipart message to avoid an assertion when building in Debug mode on Windows
 */
if( rdata->msg_info.ctype )
{
  if( 0 == pj_stricmp2( &rdata->msg_info.ctype->media.type, "multipart" ) )
  {
    mp = pjsip_multipart_get_first_part( rdata->msg_info.msg->body );
  }
}
```

As I stated in the comment, this additional check that each user would have to do in order to avoid the assert \
seems kind of pointless to me because the check happened already inside PJ, see here:
https://github.com/pjsip/pjproject/blob/74b0df1b047a4a8d55454f4f940f14ea7d978380/pjsip/src/pjsip/sip_parser.c#L1139

Also, the documentation of pjsip_multipart_get_first_part() doesn't explicitly prohibit this kind of usage.
With this change, we avoid having to do the same check twice.
Not asserting when __mp__ is NULL covers the case for messages with no body at all.