### PR TITLE
Fix ipjsystest build error

### DIFF
--- a/pjsip-apps/src/ipjsystest/Classes/ipjsystestAppDelegate.m
+++ b/pjsip-apps/src/ipjsystest/Classes/ipjsystestAppDelegate.m
@@ -30,7 +30,7 @@
 - (void)applicationDidFinishLaunching:(UIApplication *)application {    
     
     // Override point for customization after app launch
-    [window addSubview:[navigationController view]];
+    [window setRootViewController:navigationController];
     [window makeKeyAndVisible];
 }
 

--- a/pjsip-apps/src/ipjsystest/ipjsystest-Info.plist
+++ b/pjsip-apps/src/ipjsystest/ipjsystest-Info.plist
@@ -28,8 +28,6 @@
 	<string>MainWindow</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>Camera permission required</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Mic permission required</string>
 	<key>UIBackgroundModes</key>

--- a/pjsip-apps/src/ipjsystest/ipjsystest-Info.plist
+++ b/pjsip-apps/src/ipjsystest/ipjsystest-Info.plist
@@ -26,9 +26,16 @@
 	<true/>
 	<key>NSMainNibFile</key>
 	<string>MainWindow</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera permission required</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Mic permission required</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>voip</string>
 	</array>
 </dict>
 </plist>

--- a/pjsip-apps/src/ipjsystest/ipjsystest.xcodeproj/project.pbxproj
+++ b/pjsip-apps/src/ipjsystest/ipjsystest.xcodeproj/project.pbxproj
@@ -17,29 +17,43 @@
 		28F335F11007B36200424DE2 /* RootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* RootViewController.xib */; };
 		3A3478AA1154BF8E00D51880 /* TestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A3478A91154BF8E00D51880 /* TestViewController.xib */; };
 		3A3478AF1154BFD700D51880 /* TestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A3478AE1154BFD700D51880 /* TestViewController.m */; };
-		3A3479221154DB0800D51880 /* systest.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A3479211154DB0800D51880 /* systest.c */; };
-		3A34794B1154E39900D51880 /* libpjmedia-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34794A1154E39900D51880 /* libpjmedia-arm-apple-darwin9.a */; };
-		3A34794D1154E39900D51880 /* libpjmedia-audiodev-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34794C1154E39900D51880 /* libpjmedia-audiodev-arm-apple-darwin9.a */; };
-		3A34794F1154E3F000D51880 /* libpjsip-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34794E1154E3F000D51880 /* libpjsip-arm-apple-darwin9.a */; };
-		3A3479511154E42400D51880 /* libpjsip-simple-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3479501154E42400D51880 /* libpjsip-simple-arm-apple-darwin9.a */; };
-		3A3479531154E42400D51880 /* libpjsip-ua-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3479521154E42400D51880 /* libpjsip-ua-arm-apple-darwin9.a */; };
-		3A3479551154E42400D51880 /* libpjsua-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3479541154E42400D51880 /* libpjsua-arm-apple-darwin9.a */; };
-		3A34795B1154E45A00D51880 /* libpj-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34795A1154E45A00D51880 /* libpj-arm-apple-darwin9.a */; };
-		3A34795D1154E48700D51880 /* libpjlib-util-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34795C1154E48700D51880 /* libpjlib-util-arm-apple-darwin9.a */; };
-		3A3479791154EBDE00D51880 /* libpjmedia-codec-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3479781154EBDE00D51880 /* libpjmedia-codec-arm-apple-darwin9.a */; };
-		3A34797B1154EBDE00D51880 /* libpjnath-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34797A1154EBDE00D51880 /* libpjnath-arm-apple-darwin9.a */; };
 		3A3479871154EC4E00D51880 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3479861154EC4E00D51880 /* AudioToolbox.framework */; };
-		3A34799A1154ECA300D51880 /* libgsmcodec-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A3479991154ECA300D51880 /* libgsmcodec-arm-apple-darwin9.a */; };
-		3A34799C1154ECB100D51880 /* libresample-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A34799B1154ECB100D51880 /* libresample-arm-apple-darwin9.a */; };
 		3ABE0507147CA00B00A57A62 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3ABE0506147CA00B00A57A62 /* CFNetwork.framework */; };
 		3AC6435E1162192900B7A751 /* tock8.wav in Resources */ = {isa = PBXBuildFile; fileRef = 3AC6435D1162192900B7A751 /* tock8.wav */; };
 		3ADA4AB911572300008D95FE /* input.8.wav in Resources */ = {isa = PBXBuildFile; fileRef = 3ADA4AB811572300008D95FE /* input.8.wav */; };
-		3AE90E9B115F7A4F00FAEAA5 /* libg7221codec-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE90E95115F7A4E00FAEAA5 /* libg7221codec-arm-apple-darwin9.a */; };
-		3AE90E9C115F7A4F00FAEAA5 /* libilbccodec-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE90E96115F7A4F00FAEAA5 /* libilbccodec-arm-apple-darwin9.a */; };
-		3AE90E9D115F7A4F00FAEAA5 /* libmilenage-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE90E97115F7A4F00FAEAA5 /* libmilenage-arm-apple-darwin9.a */; };
-		3AE90E9E115F7A4F00FAEAA5 /* libpjsdp-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE90E98115F7A4F00FAEAA5 /* libpjsdp-arm-apple-darwin9.a */; };
-		3AE90E9F115F7A4F00FAEAA5 /* libspeex-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE90E99115F7A4F00FAEAA5 /* libspeex-arm-apple-darwin9.a */; };
-		3AE90EA0115F7A4F00FAEAA5 /* libsrtp-arm-apple-darwin9.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AE90E9A115F7A4F00FAEAA5 /* libsrtp-arm-apple-darwin9.a */; };
+		5218C4AF29CDA73600E7A53A /* libpjsua-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C49B29CDA73300E7A53A /* libpjsua-arm64-apple-darwin_ios.a */; };
+		5218C4B029CDA73600E7A53A /* libspeex-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C49C29CDA73400E7A53A /* libspeex-arm64-apple-darwin_ios.a */; };
+		5218C4B129CDA73600E7A53A /* libpjnath-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C49D29CDA73400E7A53A /* libpjnath-arm64-apple-darwin_ios.a */; };
+		5218C4B229CDA73700E7A53A /* libwebrtc-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C49E29CDA73400E7A53A /* libwebrtc-arm64-apple-darwin_ios.a */; };
+		5218C4B329CDA73700E7A53A /* libpjsip-ua-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C49F29CDA73400E7A53A /* libpjsip-ua-arm64-apple-darwin_ios.a */; };
+		5218C4B429CDA73700E7A53A /* libpj-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A029CDA73400E7A53A /* libpj-arm64-apple-darwin_ios.a */; };
+		5218C4B529CDA73700E7A53A /* libpjsua2-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A129CDA73500E7A53A /* libpjsua2-arm64-apple-darwin_ios.a */; };
+		5218C4B629CDA73700E7A53A /* libsrtp-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A229CDA73500E7A53A /* libsrtp-arm64-apple-darwin_ios.a */; };
+		5218C4B729CDA73800E7A53A /* libyuv-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A329CDA73500E7A53A /* libyuv-arm64-apple-darwin_ios.a */; };
+		5218C4B829CDA73800E7A53A /* libresample-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A429CDA73500E7A53A /* libresample-arm64-apple-darwin_ios.a */; };
+		5218C4B929CDA73800E7A53A /* libpjsip-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A529CDA73500E7A53A /* libpjsip-arm64-apple-darwin_ios.a */; };
+		5218C4BA29CDA73900E7A53A /* libpjmedia-codec-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A629CDA73500E7A53A /* libpjmedia-codec-arm64-apple-darwin_ios.a */; };
+		5218C4BB29CDA73900E7A53A /* libpjmedia-audiodev-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A729CDA73600E7A53A /* libpjmedia-audiodev-arm64-apple-darwin_ios.a */; };
+		5218C4BC29CDA73900E7A53A /* libpjmedia-videodev-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A829CDA73600E7A53A /* libpjmedia-videodev-arm64-apple-darwin_ios.a */; };
+		5218C4BD29CDA73A00E7A53A /* libpjlib-util-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4A929CDA73600E7A53A /* libpjlib-util-arm64-apple-darwin_ios.a */; };
+		5218C4BE29CDA73A00E7A53A /* libpjmedia-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4AA29CDA73600E7A53A /* libpjmedia-arm64-apple-darwin_ios.a */; };
+		5218C4BF29CDA73A00E7A53A /* libpjsip-simple-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4AB29CDA73600E7A53A /* libpjsip-simple-arm64-apple-darwin_ios.a */; };
+		5218C4C029CDA73B00E7A53A /* libg7221codec-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4AC29CDA73600E7A53A /* libg7221codec-arm64-apple-darwin_ios.a */; };
+		5218C4C129CDA73B00E7A53A /* libgsmcodec-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4AD29CDA73600E7A53A /* libgsmcodec-arm64-apple-darwin_ios.a */; };
+		5218C4C229CDA73C00E7A53A /* libilbccodec-arm64-apple-darwin_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4AE29CDA73600E7A53A /* libilbccodec-arm64-apple-darwin_ios.a */; };
+		5218C4C629CDAAA300E7A53A /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4C529CDAAA300E7A53A /* VideoToolbox.framework */; };
+		5218C4C829CDAADF00E7A53A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4C729CDAADE00E7A53A /* Security.framework */; };
+		5218C4CA29CDAAED00E7A53A /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4C929CDAAEC00E7A53A /* SystemConfiguration.framework */; };
+		5218C4CC29CDAAFD00E7A53A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4CB29CDAAFC00E7A53A /* AVFoundation.framework */; };
+		5218C4CE29CDAB2300E7A53A /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4CD29CDAB2300E7A53A /* CoreAudio.framework */; };
+		5218C4D029CDAB2B00E7A53A /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4CF29CDAB2B00E7A53A /* CoreFoundation.framework */; };
+		5218C4D229CDAB3A00E7A53A /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4D129CDAB3A00E7A53A /* CoreVideo.framework */; };
+		5218C4D429CDAB4F00E7A53A /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4D329CDAB4F00E7A53A /* OpenGLES.framework */; };
+		5218C4D529CDABBA00E7A53A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4CB29CDAAFC00E7A53A /* AVFoundation.framework */; };
+		5218C4D729CDAC6000E7A53A /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4D629CDAC5F00E7A53A /* CoreImage.framework */; };
+		5218C4D929CDAC7200E7A53A /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4D829CDAC7200E7A53A /* CoreMedia.framework */; };
+		5218C4DB29CDACC000E7A53A /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5218C4DA29CDACC000E7A53A /* QuartzCore.framework */; };
+		5218C4E629CDE39B00E7A53A /* systest.c in Sources */ = {isa = PBXBuildFile; fileRef = 5218C4DE29CDE39B00E7A53A /* systest.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,31 +72,44 @@
 		3A3478A91154BF8E00D51880 /* TestViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TestViewController.xib; sourceTree = "<group>"; };
 		3A3478AD1154BFD700D51880 /* TestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestViewController.h; sourceTree = "<group>"; };
 		3A3478AE1154BFD700D51880 /* TestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestViewController.m; sourceTree = "<group>"; };
-		3A3479211154DB0800D51880 /* systest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = systest.c; path = ../pjsystest/systest.c; sourceTree = SOURCE_ROOT; };
-		3A34794A1154E39900D51880 /* libpjmedia-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-arm-apple-darwin9.a"; path = "../../../pjmedia/lib/libpjmedia-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A34794C1154E39900D51880 /* libpjmedia-audiodev-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-audiodev-arm-apple-darwin9.a"; path = "../../../pjmedia/lib/libpjmedia-audiodev-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A34794E1154E3F000D51880 /* libpjsip-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsip-arm-apple-darwin9.a"; path = "../../../pjsip/lib/libpjsip-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A3479501154E42400D51880 /* libpjsip-simple-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsip-simple-arm-apple-darwin9.a"; path = "../../../pjsip/lib/libpjsip-simple-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A3479521154E42400D51880 /* libpjsip-ua-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsip-ua-arm-apple-darwin9.a"; path = "../../../pjsip/lib/libpjsip-ua-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A3479541154E42400D51880 /* libpjsua-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsua-arm-apple-darwin9.a"; path = "../../../pjsip/lib/libpjsua-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A34795A1154E45A00D51880 /* libpj-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpj-arm-apple-darwin9.a"; path = "../../../pjlib/lib/libpj-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A34795C1154E48700D51880 /* libpjlib-util-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjlib-util-arm-apple-darwin9.a"; path = "../../../pjlib-util/lib/libpjlib-util-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A3479721154EB5B00D51880 /* gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gui.h; path = ../pjsystest/gui.h; sourceTree = SOURCE_ROOT; };
-		3A3479731154EB6B00D51880 /* systest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = systest.h; path = ../pjsystest/systest.h; sourceTree = SOURCE_ROOT; };
-		3A3479781154EBDE00D51880 /* libpjmedia-codec-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-codec-arm-apple-darwin9.a"; path = "../../../pjmedia/lib/libpjmedia-codec-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A34797A1154EBDE00D51880 /* libpjnath-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjnath-arm-apple-darwin9.a"; path = "../../../pjnath/lib/libpjnath-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
 		3A3479861154EC4E00D51880 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		3A3479991154ECA300D51880 /* libgsmcodec-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libgsmcodec-arm-apple-darwin9.a"; path = "../../../third_party/lib/libgsmcodec-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3A34799B1154ECB100D51880 /* libresample-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libresample-arm-apple-darwin9.a"; path = "../../../third_party/lib/libresample-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
 		3ABE0506147CA00B00A57A62 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		3AC6435D1162192900B7A751 /* tock8.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = tock8.wav; path = ../../../tests/pjsua/wavs/tock8.wav; sourceTree = SOURCE_ROOT; };
-		3ADA4AB811572300008D95FE /* input.8.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = input.8.wav; path = "../../../../../../../../teluu/pjproject-new-iphone/tests/pjsua/wavs/input.8.wav"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3AE90E95115F7A4E00FAEAA5 /* libg7221codec-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libg7221codec-arm-apple-darwin9.a"; path = "../../../third_party/lib/libg7221codec-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3AE90E96115F7A4F00FAEAA5 /* libilbccodec-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libilbccodec-arm-apple-darwin9.a"; path = "../../../third_party/lib/libilbccodec-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3AE90E97115F7A4F00FAEAA5 /* libmilenage-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmilenage-arm-apple-darwin9.a"; path = "../../../third_party/lib/libmilenage-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3AE90E98115F7A4F00FAEAA5 /* libpjsdp-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsdp-arm-apple-darwin9.a"; path = "../../../pjmedia/lib/libpjsdp-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3AE90E99115F7A4F00FAEAA5 /* libspeex-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libspeex-arm-apple-darwin9.a"; path = "../../../third_party/lib/libspeex-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
-		3AE90E9A115F7A4F00FAEAA5 /* libsrtp-arm-apple-darwin9.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libsrtp-arm-apple-darwin9.a"; path = "../../../third_party/lib/libsrtp-arm-apple-darwin9.a"; sourceTree = SOURCE_ROOT; };
+		3ADA4AB811572300008D95FE /* input.8.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = input.8.wav; path = ../../../tests/pjsua/wavs/input.8.wav; sourceTree = SOURCE_ROOT; };
+		5218C49B29CDA73300E7A53A /* libpjsua-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsua-arm64-apple-darwin_ios.a"; path = "../../../pjsip/lib/libpjsua-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C49C29CDA73400E7A53A /* libspeex-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libspeex-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libspeex-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C49D29CDA73400E7A53A /* libpjnath-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjnath-arm64-apple-darwin_ios.a"; path = "../../../pjnath/lib/libpjnath-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C49E29CDA73400E7A53A /* libwebrtc-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libwebrtc-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libwebrtc-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C49F29CDA73400E7A53A /* libpjsip-ua-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsip-ua-arm64-apple-darwin_ios.a"; path = "../../../pjsip/lib/libpjsip-ua-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A029CDA73400E7A53A /* libpj-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpj-arm64-apple-darwin_ios.a"; path = "../../../pjlib/lib/libpj-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A129CDA73500E7A53A /* libpjsua2-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsua2-arm64-apple-darwin_ios.a"; path = "../../../pjsip/lib/libpjsua2-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A229CDA73500E7A53A /* libsrtp-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libsrtp-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libsrtp-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A329CDA73500E7A53A /* libyuv-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libyuv-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libyuv-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A429CDA73500E7A53A /* libresample-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libresample-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libresample-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A529CDA73500E7A53A /* libpjsip-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsip-arm64-apple-darwin_ios.a"; path = "../../../pjsip/lib/libpjsip-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A629CDA73500E7A53A /* libpjmedia-codec-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-codec-arm64-apple-darwin_ios.a"; path = "../../../pjmedia/lib/libpjmedia-codec-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A729CDA73600E7A53A /* libpjmedia-audiodev-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-audiodev-arm64-apple-darwin_ios.a"; path = "../../../pjmedia/lib/libpjmedia-audiodev-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A829CDA73600E7A53A /* libpjmedia-videodev-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-videodev-arm64-apple-darwin_ios.a"; path = "../../../pjmedia/lib/libpjmedia-videodev-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4A929CDA73600E7A53A /* libpjlib-util-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjlib-util-arm64-apple-darwin_ios.a"; path = "../../../pjlib-util/lib/libpjlib-util-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4AA29CDA73600E7A53A /* libpjmedia-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjmedia-arm64-apple-darwin_ios.a"; path = "../../../pjmedia/lib/libpjmedia-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4AB29CDA73600E7A53A /* libpjsip-simple-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libpjsip-simple-arm64-apple-darwin_ios.a"; path = "../../../pjsip/lib/libpjsip-simple-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4AC29CDA73600E7A53A /* libg7221codec-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libg7221codec-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libg7221codec-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4AD29CDA73600E7A53A /* libgsmcodec-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libgsmcodec-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libgsmcodec-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4AE29CDA73600E7A53A /* libilbccodec-arm64-apple-darwin_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libilbccodec-arm64-apple-darwin_ios.a"; path = "../../../third_party/lib/libilbccodec-arm64-apple-darwin_ios.a"; sourceTree = "<group>"; };
+		5218C4C529CDAAA300E7A53A /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
+		5218C4C729CDAADE00E7A53A /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		5218C4C929CDAAEC00E7A53A /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		5218C4CB29CDAAFC00E7A53A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		5218C4CD29CDAB2300E7A53A /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		5218C4CF29CDAB2B00E7A53A /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		5218C4D129CDAB3A00E7A53A /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		5218C4D329CDAB4F00E7A53A /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		5218C4D629CDAC5F00E7A53A /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
+		5218C4D829CDAC7200E7A53A /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		5218C4DA29CDACC000E7A53A /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		5218C4DE29CDE39B00E7A53A /* systest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = systest.c; sourceTree = "<group>"; };
+		5218C4E029CDE39B00E7A53A /* gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gui.h; sourceTree = "<group>"; };
+		5218C4E329CDE39B00E7A53A /* systest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = systest.h; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* ipjsystest-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ipjsystest-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -91,29 +118,43 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5218C4BC29CDA73900E7A53A /* libpjmedia-videodev-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4BF29CDA73A00E7A53A /* libpjsip-simple-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4D729CDAC6000E7A53A /* CoreImage.framework in Frameworks */,
+				5218C4BB29CDA73900E7A53A /* libpjmedia-audiodev-arm64-apple-darwin_ios.a in Frameworks */,
 				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
+				5218C4CC29CDAAFD00E7A53A /* AVFoundation.framework in Frameworks */,
 				1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */,
+				5218C4B429CDA73700E7A53A /* libpj-arm64-apple-darwin_ios.a in Frameworks */,
 				2892E4100DC94CBA00A64D0F /* CoreGraphics.framework in Frameworks */,
-				3A34794B1154E39900D51880 /* libpjmedia-arm-apple-darwin9.a in Frameworks */,
-				3A34794D1154E39900D51880 /* libpjmedia-audiodev-arm-apple-darwin9.a in Frameworks */,
-				3A34794F1154E3F000D51880 /* libpjsip-arm-apple-darwin9.a in Frameworks */,
-				3A3479511154E42400D51880 /* libpjsip-simple-arm-apple-darwin9.a in Frameworks */,
-				3A3479531154E42400D51880 /* libpjsip-ua-arm-apple-darwin9.a in Frameworks */,
-				3A3479551154E42400D51880 /* libpjsua-arm-apple-darwin9.a in Frameworks */,
-				3A34795B1154E45A00D51880 /* libpj-arm-apple-darwin9.a in Frameworks */,
-				3A34795D1154E48700D51880 /* libpjlib-util-arm-apple-darwin9.a in Frameworks */,
-				3A3479791154EBDE00D51880 /* libpjmedia-codec-arm-apple-darwin9.a in Frameworks */,
-				3A34797B1154EBDE00D51880 /* libpjnath-arm-apple-darwin9.a in Frameworks */,
+				5218C4B129CDA73600E7A53A /* libpjnath-arm64-apple-darwin_ios.a in Frameworks */,
 				3A3479871154EC4E00D51880 /* AudioToolbox.framework in Frameworks */,
-				3A34799A1154ECA300D51880 /* libgsmcodec-arm-apple-darwin9.a in Frameworks */,
-				3A34799C1154ECB100D51880 /* libresample-arm-apple-darwin9.a in Frameworks */,
-				3AE90E9B115F7A4F00FAEAA5 /* libg7221codec-arm-apple-darwin9.a in Frameworks */,
-				3AE90E9C115F7A4F00FAEAA5 /* libilbccodec-arm-apple-darwin9.a in Frameworks */,
-				3AE90E9D115F7A4F00FAEAA5 /* libmilenage-arm-apple-darwin9.a in Frameworks */,
-				3AE90E9E115F7A4F00FAEAA5 /* libpjsdp-arm-apple-darwin9.a in Frameworks */,
-				3AE90E9F115F7A4F00FAEAA5 /* libspeex-arm-apple-darwin9.a in Frameworks */,
-				3AE90EA0115F7A4F00FAEAA5 /* libsrtp-arm-apple-darwin9.a in Frameworks */,
+				5218C4C129CDA73B00E7A53A /* libgsmcodec-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4D929CDAC7200E7A53A /* CoreMedia.framework in Frameworks */,
+				5218C4B029CDA73600E7A53A /* libspeex-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4B529CDA73700E7A53A /* libpjsua2-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4BE29CDA73A00E7A53A /* libpjmedia-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4AF29CDA73600E7A53A /* libpjsua-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4D229CDAB3A00E7A53A /* CoreVideo.framework in Frameworks */,
+				5218C4C629CDAAA300E7A53A /* VideoToolbox.framework in Frameworks */,
+				5218C4C229CDA73C00E7A53A /* libilbccodec-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4C829CDAADF00E7A53A /* Security.framework in Frameworks */,
+				5218C4CE29CDAB2300E7A53A /* CoreAudio.framework in Frameworks */,
+				5218C4B629CDA73700E7A53A /* libsrtp-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4DB29CDACC000E7A53A /* QuartzCore.framework in Frameworks */,
 				3ABE0507147CA00B00A57A62 /* CFNetwork.framework in Frameworks */,
+				5218C4B829CDA73800E7A53A /* libresample-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4C029CDA73B00E7A53A /* libg7221codec-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4BD29CDA73A00E7A53A /* libpjlib-util-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4CA29CDAAED00E7A53A /* SystemConfiguration.framework in Frameworks */,
+				5218C4D429CDAB4F00E7A53A /* OpenGLES.framework in Frameworks */,
+				5218C4B729CDA73800E7A53A /* libyuv-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4D529CDABBA00E7A53A /* AVFoundation.framework in Frameworks */,
+				5218C4B929CDA73800E7A53A /* libpjsip-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4B229CDA73700E7A53A /* libwebrtc-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4D029CDAB2B00E7A53A /* CoreFoundation.framework in Frameworks */,
+				5218C4B329CDA73700E7A53A /* libpjsip-ua-arm64-apple-darwin_ios.a in Frameworks */,
+				5218C4BA29CDA73900E7A53A /* libpjmedia-codec-arm64-apple-darwin_ios.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,7 +198,7 @@
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
-				3A3479201154DAE600D51880 /* pjsystest */,
+				5218C4DC29CDE39B00E7A53A /* pjsystest */,
 				28A0AAE50D9B0CCF005BE974 /* ipjsystest_Prefix.pch */,
 				29B97316FDCFA39411CA2CEA /* main.m */,
 			);
@@ -180,6 +221,17 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5218C4DA29CDACC000E7A53A /* QuartzCore.framework */,
+				5218C4D829CDAC7200E7A53A /* CoreMedia.framework */,
+				5218C4D629CDAC5F00E7A53A /* CoreImage.framework */,
+				5218C4D329CDAB4F00E7A53A /* OpenGLES.framework */,
+				5218C4D129CDAB3A00E7A53A /* CoreVideo.framework */,
+				5218C4CF29CDAB2B00E7A53A /* CoreFoundation.framework */,
+				5218C4CD29CDAB2300E7A53A /* CoreAudio.framework */,
+				5218C4CB29CDAAFC00E7A53A /* AVFoundation.framework */,
+				5218C4C929CDAAEC00E7A53A /* SystemConfiguration.framework */,
+				5218C4C729CDAADE00E7A53A /* Security.framework */,
+				5218C4C529CDAAA300E7A53A /* VideoToolbox.framework */,
 				3ABE0506147CA00B00A57A62 /* CFNetwork.framework */,
 				3A3479861154EC4E00D51880 /* AudioToolbox.framework */,
 				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
@@ -189,39 +241,42 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		3A3479201154DAE600D51880 /* pjsystest */ = {
-			isa = PBXGroup;
-			children = (
-				3A3479731154EB6B00D51880 /* systest.h */,
-				3A3479721154EB5B00D51880 /* gui.h */,
-				3A3479211154DB0800D51880 /* systest.c */,
-			);
-			name = pjsystest;
-			sourceTree = "<group>";
-		};
 		3A3479941154EC6B00D51880 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				3AE90E95115F7A4E00FAEAA5 /* libg7221codec-arm-apple-darwin9.a */,
-				3AE90E96115F7A4F00FAEAA5 /* libilbccodec-arm-apple-darwin9.a */,
-				3AE90E97115F7A4F00FAEAA5 /* libmilenage-arm-apple-darwin9.a */,
-				3AE90E98115F7A4F00FAEAA5 /* libpjsdp-arm-apple-darwin9.a */,
-				3AE90E99115F7A4F00FAEAA5 /* libspeex-arm-apple-darwin9.a */,
-				3AE90E9A115F7A4F00FAEAA5 /* libsrtp-arm-apple-darwin9.a */,
-				3A3479991154ECA300D51880 /* libgsmcodec-arm-apple-darwin9.a */,
-				3A34799B1154ECB100D51880 /* libresample-arm-apple-darwin9.a */,
-				3A34794A1154E39900D51880 /* libpjmedia-arm-apple-darwin9.a */,
-				3A34794C1154E39900D51880 /* libpjmedia-audiodev-arm-apple-darwin9.a */,
-				3A34794E1154E3F000D51880 /* libpjsip-arm-apple-darwin9.a */,
-				3A3479501154E42400D51880 /* libpjsip-simple-arm-apple-darwin9.a */,
-				3A3479521154E42400D51880 /* libpjsip-ua-arm-apple-darwin9.a */,
-				3A3479541154E42400D51880 /* libpjsua-arm-apple-darwin9.a */,
-				3A34795A1154E45A00D51880 /* libpj-arm-apple-darwin9.a */,
-				3A34795C1154E48700D51880 /* libpjlib-util-arm-apple-darwin9.a */,
-				3A3479781154EBDE00D51880 /* libpjmedia-codec-arm-apple-darwin9.a */,
-				3A34797A1154EBDE00D51880 /* libpjnath-arm-apple-darwin9.a */,
+				5218C4AC29CDA73600E7A53A /* libg7221codec-arm64-apple-darwin_ios.a */,
+				5218C4AD29CDA73600E7A53A /* libgsmcodec-arm64-apple-darwin_ios.a */,
+				5218C4AE29CDA73600E7A53A /* libilbccodec-arm64-apple-darwin_ios.a */,
+				5218C4A029CDA73400E7A53A /* libpj-arm64-apple-darwin_ios.a */,
+				5218C4A929CDA73600E7A53A /* libpjlib-util-arm64-apple-darwin_ios.a */,
+				5218C4AA29CDA73600E7A53A /* libpjmedia-arm64-apple-darwin_ios.a */,
+				5218C4A729CDA73600E7A53A /* libpjmedia-audiodev-arm64-apple-darwin_ios.a */,
+				5218C4A629CDA73500E7A53A /* libpjmedia-codec-arm64-apple-darwin_ios.a */,
+				5218C4A829CDA73600E7A53A /* libpjmedia-videodev-arm64-apple-darwin_ios.a */,
+				5218C49D29CDA73400E7A53A /* libpjnath-arm64-apple-darwin_ios.a */,
+				5218C4A529CDA73500E7A53A /* libpjsip-arm64-apple-darwin_ios.a */,
+				5218C4AB29CDA73600E7A53A /* libpjsip-simple-arm64-apple-darwin_ios.a */,
+				5218C49F29CDA73400E7A53A /* libpjsip-ua-arm64-apple-darwin_ios.a */,
+				5218C49B29CDA73300E7A53A /* libpjsua-arm64-apple-darwin_ios.a */,
+				5218C4A129CDA73500E7A53A /* libpjsua2-arm64-apple-darwin_ios.a */,
+				5218C4A429CDA73500E7A53A /* libresample-arm64-apple-darwin_ios.a */,
+				5218C49C29CDA73400E7A53A /* libspeex-arm64-apple-darwin_ios.a */,
+				5218C4A229CDA73500E7A53A /* libsrtp-arm64-apple-darwin_ios.a */,
+				5218C49E29CDA73400E7A53A /* libwebrtc-arm64-apple-darwin_ios.a */,
+				5218C4A329CDA73500E7A53A /* libyuv-arm64-apple-darwin_ios.a */,
 			);
 			name = Libraries;
+			sourceTree = "<group>";
+		};
+		5218C4DC29CDE39B00E7A53A /* pjsystest */ = {
+			isa = PBXGroup;
+			children = (
+				5218C4DE29CDE39B00E7A53A /* systest.c */,
+				5218C4E029CDE39B00E7A53A /* gui.h */,
+				5218C4E329CDE39B00E7A53A /* systest.h */,
+			);
+			name = pjsystest;
+			path = ../pjsystest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -296,7 +351,7 @@
 				1D3623260D0F684500981E51 /* ipjsystestAppDelegate.m in Sources */,
 				28C286E10D94DF7D0034E888 /* RootViewController.m in Sources */,
 				3A3478AF1154BFD700D51880 /* TestViewController.m in Sources */,
-				3A3479221154DB0800D51880 /* systest.c in Sources */,
+				5218C4E629CDE39B00E7A53A /* systest.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,12 +362,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ipjsystest_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = "PJ_AUTOCONF=1";
+				HEADER_SEARCH_PATHS = (
+					../../../pjsip/include,
+					../../../pjlib/include,
+					"../../../pjlib-util/include",
+					../../../pjnath/include,
+					../../../pjmedia/include,
+					../../src/pjsystest,
+				);
 				INFOPLIST_FILE = "ipjsystest-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -332,10 +396,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ipjsystest_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = "PJ_AUTOCONF=1";
+				HEADER_SEARCH_PATHS = (
+					../../../pjsip/include,
+					../../../pjlib/include,
+					"../../../pjlib-util/include",
+					../../../pjnath/include,
+					../../../pjmedia/include,
+					../../src/pjsystest,
+				);
 				INFOPLIST_FILE = "ipjsystest-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/pjsip-apps/src/ipjsystest/main.m
+++ b/pjsip-apps/src/ipjsystest/main.m
@@ -17,10 +17,11 @@
  */
 #import <UIKit/UIKit.h>
 
+#import "ipjsystestAppDelegate.h"
+
 int main(int argc, char *argv[]) {
     
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    int retVal = UIApplicationMain(argc, argv, nil, nil);
-    [pool release];
-    return retVal;
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([ipjsystestAppDelegate class]));
+    }
 }


### PR DESCRIPTION
This PR will fix the build error for `ipjsystest` on current xCode (14.2)
Changes:
- Fix path to input.8.wav 
- Update library/arch used 
- Update the app permission
- Error : `Application windows are expected to have a root view controller at the end of application launch`