### PR TITLE
Prevent CI actions from running twice on PR commits

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,5 +1,10 @@
 name: CI Linux
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build-ubuntu-default:
   # checking pure lib source distribution with plain configure & make

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -1,5 +1,10 @@
 name: CI Mac
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build-mac-default:
   # checking pure lib source distribution with plain configure & make

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -1,5 +1,10 @@
 name: CI Windows
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build-windows-default:
     runs-on: windows-latest


### PR DESCRIPTION
In summary, here are the expected changes:

- on commit/changes to PR by Teluu team:
   - before: CI Windows, Linux, and Mac are run twice, which is inefficient since those runs can take hours combined
   - after: will be run only once
- on commit/changes to PR by contributor:
   - before/after: CI actions are run once (no change)
- on push to master
   - before/after: CI actions are run once (no change)

Note:

`types: [opened, synchronize, reopened]` are the default for `pull_request` (see [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request))