### PR TITLE
Fix PJSUA2 documentation

### DIFF
--- a/pjmedia/include/pjmedia/sdp_neg.h
+++ b/pjmedia/include/pjmedia/sdp_neg.h
@@ -493,7 +493,7 @@ pjmedia_sdp_neg_was_answer_remote(pjmedia_sdp_neg *neg);
  * Get the current remote SDP offer or answer. Application can only 
  * call this function in state PJMEDIA_SDP_NEG_STATE_REMOTE_OFFER or
  * PJMEDIA_SDP_NEG_STATE_WAIT_NEGO, or otherwise there won't be remote 
- * SDP offer/answer. Calling this  function will not change the state 
+ * SDP offer/answer. Calling this function will not change the state 
  * of the negotiator.
  *
  * @param neg           The SDP negotiator instance.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -1881,7 +1881,7 @@ public:
 
     /**
      * Notify application when an audio media session is about to be created
-     * (as opposed to onCallSdpCreated(), which is called *after* the session
+     * (as opposed to onStreamCreated(), which is called *after* the session
      * has been created). The application may change
      * some stream info parameter values, i.e: jbInit, jbMinPre, jbMaxPre,
      * jbMax, useKa, rtcpSdesByeDisabled, jbDiscardAlgo (audio),

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -788,11 +788,11 @@ struct OnStreamCreatedParam
     
     /**
      * Specify if PJSUA2 should take ownership of the port returned in
-     * the pPort parameter below. If set to PJ_TRUE,
+     * the pPort parameter below. If set to true,
      * pjmedia_port_destroy() will be called on the port when it is
      * no longer needed.
      *
-     * Default: PJ_FALSE
+     * Default: false
      */
     bool        destroyPort;
 
@@ -967,7 +967,7 @@ struct OnCallReplaceRequestParam
     
     /**
      * Status code to be set by application. Application should only
-     * return a final status (200-699)
+     * return a final status (>= PJSIP_SC_OK (200))
      */
     pjsip_status_code   statusCode;
     
@@ -1016,8 +1016,8 @@ struct OnCallRxOfferParam
     
     /**
      * Status code to be returned for answering the offer. On input,
-     * it contains status code 200. Currently, valid values are only
-     * 200 and 488.
+     * it contains status code PJSIP_SC_OK (200). Currently, valid values are only
+     * PJSIP_SC_OK (200) and PJSIP_SC_NOT_ACCEPTABLE_HERE (488).
      */
     pjsip_status_code   statusCode;
     
@@ -1051,8 +1051,8 @@ struct OnCallRxReinviteParam
     
     /**
      * Status code to be returned for answering the offer. On input,
-     * it contains status code 200. Currently, valid values are only
-     * 200 and 488.
+     * it contains status code PJSIP_SC_OK (200). Currently, valid values are only
+     * PJSIP_SC_OK (200) and PJSIP_SC_NOT_ACCEPTABLE_HERE (488).
      */
     pjsip_status_code   statusCode;
     
@@ -1090,9 +1090,8 @@ struct OnCallRedirectedParam
      * The event that caused this callback to be called.
      * This could be the receipt of 3xx response, or 4xx/5xx response
      * received for the INVITE sent to subsequent targets, or empty
-     * (e.type == PJSIP_EVENT_UNKNOWN)
-     * if this callback is called from within Call::processRedirect()
-     * context.
+     * (e.type == PJSIP_EVENT_UNKNOWN) if this callback is called from 
+     * within Call::processRedirect() context.
      */
     SipEvent        e;
 };
@@ -1512,8 +1511,8 @@ public:
      * which means for incoming call, this function can be called as soon as
      * call is received as long as incoming call contains SDP, and for outgoing
      * call, this function can be called only after SDP is received (normally in
-     * 200/OK response to INVITE). As a general case, application should call
-     * this function after or in \a onCallMediaState() callback.
+     * PJSIP_SC_OK (200) response to INVITE). As a general case, application
+     * should call this function after or in \a onCallMediaState() callback.
      *
      * @return              The NAT type.
      *
@@ -1547,7 +1546,7 @@ public:
      *    check CallSetting for its default values.
      *
      * @param prm.opt       Optional call setting.
-     * @param prm.statusCode   Status code, (100-699).
+     * @param prm.statusCode   Status code, (>= PJSIP_SC_TRYING (100)).
      * @param prm.reason    Optional reason phrase. If empty, default text
      *                      will be used.
      * @param prm.txOption  Optional list of headers etc to be added to outgoing
@@ -1882,8 +1881,8 @@ public:
 
     /**
      * Notify application when an audio media session is about to be created
-     * (as opposed to on_stream_created() and on_stream_created2() which are
-     * called *after* the session has been created). The application may change
+     * (as opposed to onCallSdpCreated(), which is called *after* the session
+     * has been created). The application may change
      * some stream info parameter values, i.e: jbInit, jbMinPre, jbMaxPre,
      * jbMax, useKa, rtcpSdesByeDisabled, jbDiscardAlgo (audio),
      * vidCodecParam.encFmt (video).
@@ -2021,8 +2020,8 @@ public:
      * Notify application when call has received new offer from remote
      * (i.e. re-INVITE/UPDATE with SDP is received). Application can
      * decide to accept/reject the offer by setting the code (default
-     * is 200). If the offer is accepted, application can update the
-     * call setting to be applied in the answer. When this callback is
+     * is PJSIP_SC_OK (200)). If the offer is accepted, application can update
+     * the call setting to be applied in the answer. When this callback is
      * not implemented, the default behavior is to accept the offer using
      * current call setting.
      *
@@ -2034,7 +2033,7 @@ public:
     /**
      * Notify application when call has received a re-INVITE offer from
      * the peer. It allows more fine-grained control over the response to
-     * a re-INVITE. If application sets async to PJ_TRUE, it can send
+     * a re-INVITE. If application sets prm.isAsync to true, it can send
      * the reply manually using the function #pj::Call::answer() and setting
      * the SDP answer. Otherwise, by default the re-INVITE will be
      * answered automatically after the callback returns.
@@ -2045,11 +2044,14 @@ public:
      *
      * Remarks: If manually answering at a later timing, application may
      * need to monitor onCallTsxState() callback to check whether
-     * the re-INVITE is already answered automatically with 487 due to
-     * being cancelled.
+     * the re-INVITE is already answered automatically with
+     * PJSIP_SC_REQUEST_TERMINATED (487) due to being cancelled.
      *
      * Note: onCallRxOffer() will still be called after this callback,
-     * but only if prm.async is false and prm.code is 200. 
+     * but only if prm.isAsync is false and prm.statusCode is PJSIP_SC_OK
+     * (200).
+     *
+     * @param prm       Callback parameter.
      */
     virtual void onCallRxReinvite(OnCallRxReinviteParam &prm)
     { PJ_UNUSED_ARG(prm); }


### PR DESCRIPTION
This commit fixes copy&past errors from PJSUA, uses enums instead of magic numbers, and some minors.