### PR TITLE
Add Reason/Warning header in disconnecting call

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -133,6 +133,13 @@ static pj_bool_t inv_check_secure_dlg(pjsip_inv_session *inv,
 
 static int print_sdp(pjsip_msg_body *body, char *buf, pj_size_t len);
 
+/* Add Reason header to request (rfc3326) or Warning header to error response
+ * (rfc3261 20.43).
+ */
+static pj_status_t add_reason_warning_hdr(pjsip_tx_data *tdata,
+                                          unsigned code,
+                                          const char *str);
+
 static void (*inv_state_handler[])( pjsip_inv_session *inv, pjsip_event *e) = 
 {
     &inv_on_state_null,
@@ -180,6 +187,69 @@ struct tsx_inv_data
     pj_bool_t            done_early_rel;/* Early med was realiable?         */
     pj_bool_t            has_sdp;   /* Message with SDP?                    */
 };
+
+
+/* Add Reason header to request (rfc3326) or Warning header to error response
+ * (rfc3261 20.43).
+ */
+static pj_status_t add_reason_warning_hdr(pjsip_tx_data *tdata,
+                                          unsigned code,
+                                          const char *str)
+{
+    pj_str_t reason;
+    pj_cstr(&reason, str);
+    if (tdata->msg->type == PJSIP_REQUEST_MSG) {
+
+        /* Add Reason header in request messages */
+        pjsip_hdr *hdr;
+        const pj_str_t hname = { "Reason", 6 };
+        pj_str_t hvalue;
+
+        PJ_ASSERT_RETURN(code < 1000, PJ_EINVAL);
+
+        hvalue.ptr = (char*)pj_pool_alloc(tdata->pool,
+                                          3 +              /* "SIP" */
+                                          11 +             /* " ;cause=code */
+                                          reason.slen+10); /* " ;text=".." */
+
+        if (!hvalue.ptr)
+            return PJ_ENOMEM;
+
+        hvalue.slen = pj_ansi_sprintf(hvalue.ptr,
+                                      "SIP ;cause=%u ;text=\"%.*s\"",
+                                      code, (int)reason.slen, reason.ptr);
+        hdr = (pjsip_hdr*)
+               pjsip_generic_string_hdr_create(tdata->pool, &hname, &hvalue);
+        if (hdr)
+            pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)hdr);
+        else
+            return PJ_ENOMEM;
+
+    } else {
+
+        /* Add Warning header in response messages */
+        pjsip_warning_hdr *hdr;
+        pjsip_dialog *dlg = pjsip_tdata_get_dlg(tdata);
+
+        PJ_ASSERT_RETURN(dlg, PJ_EINVAL);
+
+        // Let's always use code 390 for now.
+        //PJ_ASSERT_RETURN(code >= 300 && code < 400, PJ_EINVAL);
+        code = 390;
+
+        hdr = pjsip_warning_hdr_create(tdata->pool,
+                                       code? code : 390,
+                                       pjsip_endpt_name(dlg->endpt),
+                                       &reason);
+        if (hdr)
+            pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)hdr);
+        else
+            return PJ_ENOMEM;
+    }
+
+    return PJ_SUCCESS;
+}
+
 
 /*
  * Module load()
@@ -305,18 +375,23 @@ static void inv_set_state(pjsip_inv_session *inv, pjsip_inv_state state,
                                                 PJMEDIA_SDP_NEG_STATE_DONE))
         {
             pjsip_tx_data *bye;
+            pj_str_t reason = pj_str("SDP offer/answer incomplete");
 
             PJ_LOG(4,(inv->obj_name, "SDP offer/answer incomplete, ending the "
                       "session"));
 
             status = pjsip_inv_end_session(inv, PJSIP_SC_NOT_ACCEPTABLE, 
-                                           NULL, &bye);
+                                           &reason, &bye);
             if (status == PJ_SUCCESS && bye)
                 status = pjsip_inv_send_msg(inv, bye);
 
             return;
         }
     }
+
+    PJ_LOG(5, (inv->obj_name, "State changed from %s to %s, event=%s",
+               inv_state_names[inv->state], inv_state_names[state],
+               pjsip_event_str(e->type)));
 
     /* Set state. */
     inv->state = state;
@@ -671,8 +746,9 @@ static pj_status_t handle_timer_response(pjsip_inv_session *inv,
     if (status != PJ_SUCCESS && end_sess_on_failure) {
         pjsip_tx_data *tdata;
         pj_status_t status2;
+        pj_str_t reason = pj_str("Failed processing session timer response");
 
-        status2 = pjsip_inv_end_session(inv, st_code, NULL, &tdata);
+        status2 = pjsip_inv_end_session(inv, st_code, &reason, &tdata);
         if (tdata && status2 == PJ_SUCCESS)
             pjsip_inv_send_msg(inv, tdata);
     }
@@ -2380,7 +2456,7 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
                           "because on_rx_reinvite() is implemented"));
                 return PJ_SUCCESS;
             }
-            return PJ_EINVALIDOP;
+            return PJMEDIA_SDPNEG_EINSTATE;
         }
 
     } else if (pjmedia_sdp_neg_get_state(inv->neg) == 
@@ -2818,6 +2894,9 @@ PJ_DEF(pj_status_t) pjsip_inv_end_session(  pjsip_inv_session *inv,
                 return status;
             }
 
+            if (st_text && st_text->slen)
+                add_reason_warning_hdr(tdata, st_code, st_text->ptr);
+
             /* Set timeout for the INVITE transaction, in case UAS is not
              * able to respond the INVITE with 487 final response. The 
              * timeout value is 64*T1.
@@ -2847,6 +2926,8 @@ PJ_DEF(pj_status_t) pjsip_inv_end_session(  pjsip_inv_session *inv,
         /* For established dialog, send BYE */
         status = pjsip_dlg_create_request(inv->dlg, pjsip_get_bye_method(), 
                                           -1, &tdata);
+        if (st_text && st_text->slen)
+            add_reason_warning_hdr(tdata, st_code, st_text->ptr);
         break;
 
     case PJSIP_INV_STATE_DISCONNECTED:
@@ -3038,7 +3119,6 @@ void pjsip_inv_process_hparam(pjsip_inv_session *sess,
                               const pj_str_t *hvalue, 
                               pjsip_tx_data *tdata)
 {
-    PJ_UNUSED_ARG(sess);
     const pjsip_hdr_e ignored_hdrs[] = {
         /* According to RFC 3261 section 19.1.5, we should not honor
          * the following headers as they can potentially be malicious
@@ -3092,6 +3172,7 @@ void pjsip_inv_process_hparam(pjsip_inv_session *sess,
     unsigned i;
     pjsip_hdr *hdr;
 
+    PJ_UNUSED_ARG(sess);
     PJ_UNUSED_ARG(verify_hdrs);
 
     /* Check if we should reject/ignore the header. */
@@ -4368,7 +4449,7 @@ static pj_bool_t inv_check_secure_dlg(pjsip_inv_session *inv,
                           "Secure dialog requires SIPS scheme in Contact and "
                           "Record-Route headers, ending the session"));
 
-                status = pjsip_inv_end_session(inv, 480, NULL, &bye);
+                status = pjsip_inv_end_session(inv, 480, &warn_text, &bye);
                 if (status == PJ_SUCCESS && bye) {
                     pjsip_warning_hdr *w;
                     w = pjsip_warning_hdr_create(bye->pool, 381,
@@ -5519,7 +5600,7 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
                     (pjmedia_sdp_neg_get_state(inv->neg) !=
                         PJMEDIA_SDP_NEG_STATE_WAIT_NEGO))
                 {
-                    status = PJ_EINVALIDOP;
+                    status = PJMEDIA_SDPNEG_EINSTATE;
                 }
             }
 
@@ -5540,6 +5621,7 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
                 if (reject_message) {
                     /* Not Acceptable */
                     const pjsip_hdr *accept;
+                    const char *reason = "SDP negotiation failed";
 
                     /* The incoming SDP is unacceptable. If the SDP negotiator
                      * state has just been changed, i.e: DONE -> REMOTE_OFFER,
@@ -5558,6 +5640,13 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
                     if (status != PJ_SUCCESS)
                         return;
 
+                    /* Add Warning header */
+                    if (status == PJMEDIA_SDP_EINSDP)
+                        reason = "Bad SDP";
+                    else if (status == PJMEDIA_SDPNEG_EINSTATE)
+                        reason = "No SDP answer";
+
+                    add_reason_warning_hdr(tdata, 0, reason);
 
                     accept = pjsip_endpt_get_capability(dlg->endpt, 
                                                         PJSIP_H_ACCEPT,

--- a/pjsip/src/pjsip-ua/sip_timer.c
+++ b/pjsip/src/pjsip-ua/sip_timer.c
@@ -429,6 +429,7 @@ static void timer_cb(pj_timer_heap_t *timer_heap, struct pj_timer_entry *entry)
     } else {
         
         pj_time_val now;
+        pj_str_t reason = pj_str("No session refresh received.");
 
         if (as_refresher)
             inv->timer->expire_timer.id = 0;
@@ -437,7 +438,7 @@ static void timer_cb(pj_timer_heap_t *timer_heap, struct pj_timer_entry *entry)
 
         /* Terminate the session */
         status = pjsip_inv_end_session(inv, PJSIP_SC_REQUEST_TIMEOUT, 
-                                       NULL, &tdata);
+                                       &reason, &tdata);
 
         pj_gettimeofday(&now);
         PJ_LOG(3, (obj_name,


### PR DESCRIPTION
This PR will add Reason header to BYE/CANCEL requests (rfc3326) or Warning header to error responses (rfc3261 20.43). SIP response message already has a status/reason text, but sometimes additional info can be useful for debugging/troubleshooting.

Thanks Taisto Qvist for the suggestions.