### PR TITLE
Fixed max hostname default value and usage

### DIFF
--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -803,7 +803,7 @@ static void init_res_key(struct res_key *key, int type, const pj_str_t *name)
     key->qtype = (pj_uint16_t)type;
 
     len = name->slen;
-    if (len > PJ_MAX_HOSTNAME) len = PJ_MAX_HOSTNAME;
+    if (len >= PJ_MAX_HOSTNAME) len = PJ_MAX_HOSTNAME - 1;
 
     /* Copy key, in lowercase */
     for (i=0; i<len; ++i) {

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -233,7 +233,7 @@ static void build_server_entries(pj_dns_srv_async_query *query_job,
             continue;
         }
 
-        if (rr->rdata.srv.target.slen > PJ_MAX_HOSTNAME) {
+        if (rr->rdata.srv.target.slen >= PJ_MAX_HOSTNAME) {
             PJ_LOG(4,(query_job->objname, "Hostname is too long!"));
             continue;
         }

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -668,10 +668,13 @@
  * Libraries sometimes needs to make copy of an address to stack buffer;
  * the value here affects the stack usage.
  *
- * Default: 253
+ * Note that the length here should include the NULL character. In other
+ * words, a hostname is invalid if length of hostname >=  PJ_MAX_HOSTNAME.
+ *
+ * Default: 254
  */
 #ifndef PJ_MAX_HOSTNAME
-#  define PJ_MAX_HOSTNAME           (253)
+#  define PJ_MAX_HOSTNAME           (254)
 #endif
 
 /**

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -668,8 +668,9 @@
  * Libraries sometimes needs to make copy of an address to stack buffer;
  * the value here affects the stack usage.
  *
- * Note that the length here should include the NULL character. In other
- * words, a hostname is invalid if length of hostname >=  PJ_MAX_HOSTNAME.
+ * Note that the length here should include the NULL termination. In other
+ * words, the maximum hostname length is PJ_MAX_HOSTNAME with the NULL
+ * termination and PJ_MAX_HOSTNAME-1 without the NULL termination.
  *
  * Default: 254
  */


### PR DESCRIPTION
To fix #3450.
Continuation of #3438.

It's not obvious whether a valid hostname length is strictly < `PJ_MAX_HOSTNAME` or <= `PJ_MAX_HOSTNAME`.

In some parts, such as https://github.com/pjsip/pjproject/blob/5ac9104514499d648f68991ef796368c51b4dfec/pjlib/src/pj/addr_resolv_sock.c#L38
we seem to assume the first one to be true, however, in other parts, we seem to assume the latter:
https://github.com/pjsip/pjproject/blob/5ac9104514499d648f68991ef796368c51b4dfec/pjlib-util/src/pjlib-util/resolver.c#L806

So here we clarify the specification in the doc and make the usage consistent.
