### PR TITLE
Add SRTP ROC checking for video

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4211,9 +4211,18 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
                 }
             }
 
-            /* Check if this media is changed */
             stream_info.type = PJMEDIA_TYPE_VIDEO;
             stream_info.info.vid = the_si;
+
+#if PJSUA_MEDIA_HAS_PJMEDIA || PJSUA_THIRD_PARTY_STREAM_HAS_GET_INFO
+#if defined(PJMEDIA_HAS_SRTP) && (PJMEDIA_HAS_SRTP != 0)
+            /* Check if we need to reset or maintain SRTP ROC */
+            check_srtp_roc(call, mi, &stream_info,
+                           local_sdp->media[mi], remote_sdp->media[mi]);
+#endif
+#endif
+
+            /* Check if this media is changed */
             if (is_media_changed(call, mi, &stream_info)) {
                 media_changed = PJ_TRUE;
                 /* Stop the media */


### PR DESCRIPTION
The feature #2846 is only applied for audio media, so in this PR, we add the check for video media as well.
