### PR TITLE
Increase log level for dropped packet in sip_transport

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2091,7 +2091,7 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
              * which were sent to keep NAT bindings.
              */
             if (tmp.slen) {
-                PJ_LOG(1, (THIS_FILE, 
+                PJ_LOG(4, (THIS_FILE, 
                       "Error processing %ld bytes packet from %s %s:%d %.*s:\n"
                       "%.*s\n"
                       "-- end of packet.",

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2092,7 +2092,7 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
              */
             if (tmp.slen) {
                 PJ_LOG(4, (THIS_FILE, 
-                      "Error processing %ld bytes packet from %s %s:%d %.*s:\n"
+                      "Dropping %ld bytes packet from %s %s:%d %.*s:\n"
                       "%.*s\n"
                       "-- end of packet.",
                       msg_fragment_size,


### PR DESCRIPTION
To fix #3476.

Currently, in `sip_transport`, when we receive a malformed packet, we will output the following log:
```
PJ_LOG(1, (THIS_FILE, 
               "Error processing %ld bytes packet from %s %s:%d %.*s:\n"
               "%.*s\n"
```
Even though the log message contains the word "error", it's actually not a fatal error since the we will just drop/ignore the packet anyway.

This causes problems if there are some entities who keep sending rogue packets since the log will keep being printed and since the level is the highest, it can't be disabled and may even trigger unwanted actions.

Just for comparisons, other components have correctly used the appropriate log level:
https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip/sip_endpoint.c#L1083

https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip/sip_dialog.c#L1800

So in this PR, we will increase the log level and change the message to better reflect the circumstances.

Special thanks to [@cristalink](https://github.com/cristalink) for the discussion and proposed fix.
