### PR TITLE
Fixed bug when converting from n to 1 in stereo port

### DIFF
--- a/pjmedia/src/pjmedia/stereo_port.c
+++ b/pjmedia/src/pjmedia/stereo_port.c
@@ -195,7 +195,7 @@ static pj_status_t stereo_get_frame(pjmedia_port *this_port,
         pjmedia_convert_channel_nto1((pj_int16_t*)frame->buf, 
                                      (const pj_int16_t*)tmp_frame.buf,
                                      dn_afd->channel_count,
-                                     PJMEDIA_AFD_SPF(s_afd),
+                                     PJMEDIA_AFD_SPF(dn_afd),
                                      (sport->options & PJMEDIA_STEREO_MIX), 0);
     } else {
         pjmedia_convert_channel_1ton((pj_int16_t*)frame->buf, 


### PR DESCRIPTION
There is a bug in stereo port that causes distorted audio in the result.

In `stereo_get_frame()`, the samples per frame is calculated from the stereo port's audio format detail, which is incorrect. It should be calculated from the frame source's audio format detail, i.e. from the downstream port's.

Thanks to Pirmin Walthert for the report and the issue investigation.
