### PR TITLE
Fixed coverity warnings

### DIFF
--- a/pjlib/include/pj/types.h
+++ b/pjlib/include/pj/types.h
@@ -293,7 +293,7 @@ typedef int pj_exception_id_t;
 #if defined(__GNUC__) || defined(__clang__)
 #  define PJ_PRINT_FUNC_DECOR(idx) __attribute__((format (printf, idx, idx+1)))
 #else
-#  define PJ_PRINT_FUNC_DECOR()
+#  define PJ_PRINT_FUNC_DECOR(idx)
 #endif
 
 /* ************************************************************************* */

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -5625,6 +5625,11 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
                     const pjsip_hdr *accept;
                     const char *reason = "SDP negotiation failed";
 
+                    if (status == PJMEDIA_SDP_EINSDP)
+                        reason = "Bad SDP";
+                    else if (status == PJMEDIA_SDPNEG_EINSTATE)
+                        reason = "No SDP answer";
+
                     /* The incoming SDP is unacceptable. If the SDP negotiator
                      * state has just been changed, i.e: DONE -> REMOTE_OFFER,
                      * revert it back.
@@ -5643,11 +5648,6 @@ static void inv_on_state_confirmed( pjsip_inv_session *inv, pjsip_event *e)
                         return;
 
                     /* Add Warning header */
-                    if (status == PJMEDIA_SDP_EINSDP)
-                        reason = "Bad SDP";
-                    else if (status == PJMEDIA_SDPNEG_EINSTATE)
-                        reason = "No SDP answer";
-
                     add_reason_warning_hdr(tdata, 0, reason);
 
                     accept = pjsip_endpt_get_capability(dlg->endpt, 


### PR DESCRIPTION
* Fixed `warning C4002: too many actual parameters for macro 'PJ_PRINT_FUNC_DECOR'` for non-GNU and non-clang compilers, such as MSVC.
* Fixed reason setting in `sip_inv` (#3475), since variable status has been overwritten.
