### PR TITLE
Invoke callback upon transaction timer timeout for pjsip_endpt_send_request()

### DIFF
--- a/pjsip/include/pjsip/sip_util.h
+++ b/pjsip/include/pjsip/sip_util.h
@@ -773,11 +773,12 @@ typedef void (*pjsip_endpt_send_callback)(void *token, pjsip_event *e);
  *
  * @param endpt     The endpoint instance.
  * @param tdata     The transmit data to be sent.
- * @param timeout   Optional timeout for final response to be received, or -1 
- *                  if the transaction should not have a timeout restriction.
- *                  The value is in miliseconds. Note that this is not 
- *                  implemented yet, so application needs to use its own timer 
- *                  to handle timeout.
+ * @param timeout   Optional timeout for final response to be received.
+ *                  Note that this is not implemented yet, so application needs
+ *                  to use its own timer to handle timeout.
+ *                  Specify 0 if you want the callback to be called upon
+ *                  transaction timer timeout, or -1 if the transaction should
+ *                  not have a timeout restriction.
  * @param token     Optional token to be associated with the transaction, and 
  *                  to be passed to the callback.
  * @param cb        Optional callback to be called when the transaction has


### PR DESCRIPTION
Currently the timeout is not implemented, but since we already have the underlying transaction timeout, we may as well use it.

Potential backward compatibility:
For existing apps that call `pjsip_endpt_send_request()` with timeout parameter set exactly to 0. It will now receive `EVENT_TIMER` whereas previously it won't.
PJSIP library itself won't be affected since we always call with timeout set to -1, except in `sip_reg` here:
https://github.com/pjsip/pjproject/blame/master/pjsip/src/pjsip-ua/sip_reg.c#L1496

If we want to minimise the chance of backward compatibility, we can introduce a setting such as `PJSIP_ENDPT_SEND_REQUEST_TIMEOUT_USE_TSX_TIMEOUT` set to any negative value other than -1. So user will have to specifically call `pjsip_endpt_send_request(.., ..., PJSIP_ENDPT_SEND_REQUEST_TIMEOUT_USE_TSX_TIMEOUT, ...)` to trigger the new behavior.