### PR TITLE
Fixed memory leak in AudDevManager

### DIFF
--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -680,7 +680,13 @@ AudDevManager::~AudDevManager()
 {
     // At this point, devMedia should have been cleaned up by Endpoint,
     // as AudDevManager destructor is called after Endpoint destructor.
-    //delete devMedia;
+#if DEPRECATED_FOR_TICKET_2232
+    // Starting from ticket #2232, Endpoint no longer cleans up media.
+    if (devMedia) {
+        delete devMedia;
+        devMedia = NULL;
+    }
+#endif
     
     clearAudioDevList();
 }


### PR DESCRIPTION
To fix #2511

Starting from ticket #2232, Endpoint will no longer clean up media, so it should be AudDevManager's own responsibility to delete its media objects.
