### PR TITLE
Fixed use-after-free in sip_100rel

### DIFF
--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -381,8 +381,9 @@ static void clear_all_responses(dlg_data *dd)
 
     tl = dd->uas_state->tx_data_list.next;
     while (tl != &dd->uas_state->tx_data_list) {
+        tx_data_list_t *tl_next = tl->next;
         pjsip_tx_data_dec_ref(tl->tdata);
-        tl = tl->next;
+        tl = tl_next;
     }
     pj_list_init(&dd->uas_state->tx_data_list);
 }


### PR DESCRIPTION
To fix #2660.

As it has been explained in detail by @lauriva in the above issue, the list node is allocated from  tdata->pool:
```
            tx_data_list_t *tl;            
            tl = PJ_POOL_ZALLOC_T(tdata->pool, tx_data_list_t);
            pj_list_push_back(&dd->uas_state->tx_data_list, tl);
```

So if `pjsip_tx_data_dec_ref(tl->tdata)` destroys `tdata`, `tl->next` is no longer valid.
```
    while (tl != &dd->uas_state->tx_data_list) {
        pjsip_tx_data_dec_ref(tl->tdata);
        tl = tl->next;
    }
```

Thanks to @lauriva for the report and analysis.
