### PR TITLE
Fixed race condition between session timer and call disconnection

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -3922,6 +3922,9 @@ static void inv_respond_incoming_bye( pjsip_inv_session *inv,
     status = pjsip_dlg_send_response(inv->dlg, bye_tsx, tdata);
     if (status != PJ_SUCCESS) return;
 
+    /* End Session Timer */
+    pjsip_timer_end_session(inv);
+
     /* Terminate session: */
 
     if (inv->state != PJSIP_INV_STATE_DISCONNECTED) {


### PR DESCRIPTION
To fix #2732.

I can reproduce it on my machine with the reported scenario:
* A calls B, session timer enabled
* B answers the call
* B hangs up at the same time of session refresh timer

When trying to perform session refresh, A will assert in `pjsip_inv_update()`: `inv->state < PJSIP_INV_STATE_DISCONNECTED`.

Note that the issue doesn't happen when A is the one hanging up the call since the session timer will be ended upon calling `pjsip_inv_end_session()` here:
https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip-ua/sip_inv.c#L2925

So the proposed patch is to end the session timer upon receipt of incoming BYE.

Additionally, we can also consider to remove the assertion in `pjsip_inv_update()` if state is `DISCONNECTED` and return normal error instead.
