### PR TITLE
Add sleep in ioq kqueue and fixed failed ioq stress test

### DIFF
--- a/pjlib/src/pj/ioqueue_kqueue.c
+++ b/pjlib/src/pj/ioqueue_kqueue.c
@@ -588,6 +588,7 @@ PJ_DEF(int) pj_ioqueue_poll(pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
     };
     struct kevent events[MAX_EVENTS];
     struct queue queue[MAX_EVENTS];
+    pj_timestamp t1, t2;
 
     PJ_CHECK_STACK();
 
@@ -598,8 +599,11 @@ PJ_DEF(int) pj_ioqueue_poll(pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 
     TRACE_((THIS_FILE, "start kqueue wait, msec=%d",
             xtimeout.tv_sec * 1000 + xtimeout.tv_nsec / 1000000));
+
+    pj_get_timestamp(&t1);
     count =
         os_kqueue_wait(ioqueue->kfd, NULL, 0, events, MAX_EVENTS, &xtimeout);
+    pj_get_timestamp(&t2);
     if (count == 0) {
 #if PJ_IOQUEUE_HAS_SAFE_UNREG
         /* Check the closing keys only when there's no activity and when there
@@ -697,6 +701,19 @@ PJ_DEF(int) pj_ioqueue_poll(pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 
         if (queue[i].key->grp_lock)
             pj_grp_lock_dec_ref_dbg(queue[i].key->grp_lock, "ioqueue", 0);
+    }
+
+    if (!event_cnt) {
+        /* We need to sleep in order to avoid busy polling.
+         * Limit the duration of the sleep, as doing pj_thread_sleep() for
+         * a long time is very inefficient. The main objective here is just
+         * to avoid busy loop.
+         */
+        long msec = xtimeout.tv_sec * 1000 + xtimeout.tv_nsec / 1000000;
+        long delay = msec - pj_elapsed_usec(&t1, &t2)/1000;
+        if (delay > 10) delay = 10;
+        if (delay > 0)
+            pj_thread_sleep(delay);
     }
 
     TRACE_((THIS_FILE, "     poll: count=%d events=%d processed=%d", count,

--- a/pjlib/src/pjlib-test/ioq_stress_test.c
+++ b/pjlib/src/pjlib-test/ioq_stress_test.c
@@ -459,7 +459,10 @@ static int worker_thread(void *p)
         }
     }
 
-    /* Flush events. Check if polling is blocked (it should). */
+    /* Flush events. Check if polling is blocked (for ioq select, it should,
+     * but for epoll and kqueue backends, the blocking duration is just minimal
+     * to avoid busy loop).
+     */
     if (test->state.retcode==test->cfg.expected_ret_code) {
         pj_timestamp t0, t1;
         unsigned i, msec, duration;

--- a/pjlib/src/pjlib-test/ioq_stress_test.c
+++ b/pjlib/src/pjlib-test/ioq_stress_test.c
@@ -462,7 +462,7 @@ static int worker_thread(void *p)
     /* Flush events. Check if polling is blocked (it should). */
     if (test->state.retcode==test->cfg.expected_ret_code) {
         pj_timestamp t0, t1;
-        unsigned i, msec;
+        unsigned i, msec, duration;
 
         pj_get_timestamp(&t0);
         for (i=0; i<10; ++i) {
@@ -472,9 +472,12 @@ static int worker_thread(void *p)
         }
         pj_get_timestamp(&t1);
         msec = pj_elapsed_msec(&t0, &t1);
-        if (msec <= 500) {
+        duration = (!pj_ansi_strcmp(pj_ioqueue_name(), "select"))? 500: 200;
+        if (msec <= duration) {
             test->state.retcode = 5000;
-            PJ_LOG(1,(THIS_FILE, "Error: pj_ioqueue_poll is not blocking"));
+            PJ_LOG(1,(THIS_FILE, "Error: pj_ioqueue_poll is not blocking, "
+                                 "time elapsed: %d, no events: %d",
+                                 msec, n_events));
         }
     }
 


### PR DESCRIPTION
To fix #3497.

Unlike `select`, both `epoll` and `kqueue` polling can return before the timeout, especially when there are multiple threads polling the same event.

So here we need to fix a couple of things:
- Add sleep in `kqueue` backend to avoid busy pollling, similar to `epoll`
- Fix failure in `ioq_stress_test` which expects ioq backends to block for the entire timeout duration.
