### PR TITLE
Change socket assertion check to allow socket handle value 0

### DIFF
--- a/pjlib/src/pj/activesock.c
+++ b/pjlib/src/pj/activesock.c
@@ -196,7 +196,7 @@ PJ_DEF(pj_status_t) pj_activesock_create( pj_pool_t *pool,
     pj_status_t status;
 
     PJ_ASSERT_RETURN(pool && ioqueue && cb && p_asock, PJ_EINVAL);
-    PJ_ASSERT_RETURN(sock!=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sock>=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
     PJ_ASSERT_RETURN(sock_type==pj_SOCK_STREAM() ||
                      sock_type==pj_SOCK_DGRAM(), PJ_EINVAL);
     PJ_ASSERT_RETURN(!opt || opt->async_cnt >= 1, PJ_EINVAL);

--- a/pjlib/src/pj/sock_qos_symbian.cpp
+++ b/pjlib/src/pj/sock_qos_symbian.cpp
@@ -21,7 +21,7 @@
 PJ_DEF(pj_status_t) pj_sock_set_qos_params(pj_sock_t sock,
                                            pj_qos_params *param)
 {
-    PJ_ASSERT_RETURN(sock>=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sock!=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
     
     CPjSocket *pjsock = (CPjSocket*)sock;
     RSocket & rsock = pjsock->Socket();
@@ -61,7 +61,7 @@ PJ_DEF(pj_status_t) pj_sock_set_qos_type(pj_sock_t sock,
 PJ_DEF(pj_status_t) pj_sock_get_qos_params(pj_sock_t sock,
                                            pj_qos_params *p_param)
 {
-    PJ_ASSERT_RETURN(sock>=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sock!=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
     
     CPjSocket *pjsock = (CPjSocket*)sock;
     RSocket & rsock = pjsock->Socket();

--- a/pjlib/src/pj/sock_qos_symbian.cpp
+++ b/pjlib/src/pj/sock_qos_symbian.cpp
@@ -21,7 +21,7 @@
 PJ_DEF(pj_status_t) pj_sock_set_qos_params(pj_sock_t sock,
                                            pj_qos_params *param)
 {
-    PJ_ASSERT_RETURN(sock!=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sock>=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
     
     CPjSocket *pjsock = (CPjSocket*)sock;
     RSocket & rsock = pjsock->Socket();
@@ -61,7 +61,7 @@ PJ_DEF(pj_status_t) pj_sock_set_qos_type(pj_sock_t sock,
 PJ_DEF(pj_status_t) pj_sock_get_qos_params(pj_sock_t sock,
                                            pj_qos_params *p_param)
 {
-    PJ_ASSERT_RETURN(sock!=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sock>=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
     
     CPjSocket *pjsock = (CPjSocket*)sock;
     RSocket & rsock = pjsock->Socket();

--- a/pjnath/src/pjnath/nat_detect.c
+++ b/pjnath/src/pjnath/nat_detect.c
@@ -367,7 +367,7 @@ static void sess_destroy(nat_detect_session *sess)
         pj_ioqueue_unregister(sess->key);
         sess->key = NULL;
         sess->sock = PJ_INVALID_SOCKET;
-    } else if (sess->sock && sess->sock != PJ_INVALID_SOCKET) {
+    } else if (sess->sock != PJ_INVALID_SOCKET) {
         pj_sock_close(sess->sock);
         sess->sock = PJ_INVALID_SOCKET;
     }

--- a/pjsip/src/pjsip/sip_transport_udp.c
+++ b/pjsip/src/pjsip/sip_transport_udp.c
@@ -470,7 +470,7 @@ static pj_status_t udp_destroy( pjsip_transport *transport )
         tp->key = NULL;
     } else {
         /* Close socket. */
-        if (tp->sock && tp->sock != PJ_INVALID_SOCKET) {
+        if (tp->sock != PJ_INVALID_SOCKET) {
             pj_sock_close(tp->sock);
             tp->sock = PJ_INVALID_SOCKET;
         }
@@ -1131,7 +1131,7 @@ PJ_DEF(pj_status_t) pjsip_udp_transport_pause(pjsip_transport *transport,
             tp->key = NULL;
         } else {
             /* Close socket. */
-            if (tp->sock && tp->sock != PJ_INVALID_SOCKET) {
+            if (tp->sock != PJ_INVALID_SOCKET) {
                 pj_sock_close(tp->sock);
                 tp->sock = PJ_INVALID_SOCKET;
             }
@@ -1201,7 +1201,7 @@ PJ_DEF(pj_status_t) pjsip_udp_transport_restart2(pjsip_transport *transport,
             tp->key = NULL;
         } else {
             /* Close socket. */
-            if (tp->sock && tp->sock != PJ_INVALID_SOCKET) {
+            if (tp->sock != PJ_INVALID_SOCKET) {
                 pj_sock_close(tp->sock);
                 tp->sock = PJ_INVALID_SOCKET;
             }


### PR DESCRIPTION
Currently there is an assertion to check socket handle validity:
```c
PJ_ASSERT_RETURN(sock!=0 && sock!=PJ_INVALID_SOCKET, PJ_EINVAL);
```
However socket handle itself might have 0 value: (-1 indicates error)
- https://man7.org/linux/man-pages/man2/socket.2.html