### PR TITLE
Fix undefined "IN6_IS_ADDR_LINKLOCAL" on Visual Studio

### DIFF
--- a/pjlib/include/pj/compat/os_win32.h
+++ b/pjlib/include/pj/compat/os_win32.h
@@ -27,7 +27,7 @@
 #define PJ_OS_NAME                  "win32"
 
 #define WIN32_LEAN_AND_MEAN
-#define PJ_WIN32_WINNT              0x0400
+#define PJ_WIN32_WINNT              0x0501
 #ifndef _WIN32_WINNT
 #  define _WIN32_WINNT              PJ_WIN32_WINNT
 #endif


### PR DESCRIPTION
The changes in #3442 uses `IN6_IS_ADDR_LINKLOCAL` to check if the interface address is link local address.
Using Visual Studio 2022, the build failed with : 
```
LNK2019	unresolved external symbol _IN6_IS_ADDR_LINKLOCAL1
```

After checking, the `IN6_IS_ADDR_LINKLOCAL` is define within the block check
```
#if (NTDDI_VERSION >= NTDDI_WIN2KSP1)
```
The `NTDDI_WIN2KSP1` is defined as `0x05000100`.
The `NTDDI_VERSION` is defined based on `_WIN32_WINNT` which is set to `0x0400` (Windows NT 4.0).
After testing, the build process will succeed, minimal by using `0x0501` (Windows XP). 

Ref:
- https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
