### PR TITLE
Fix memory leak in PJSUA2 timer

### DIFF
--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -763,7 +763,11 @@ void Endpoint::on_timer(pj_timer_heap_t *timer_heap,
     if (ut->signature != TIMER_SIGNATURE)
         return;
 
+    /* Best effort to handle race condition with utilTimerCancel() */
+    ut->signature = 0xFFFFFFFE;
+
     ep.onTimer(ut->prm);
+    delete ut;
 }
 
 void Endpoint::on_nat_detect(const pj_stun_nat_detect_result *res)


### PR DESCRIPTION
PJSUA2 `Endpoint::utilTimerSchedule()` allocates memory for timer data 

https://github.com/pjsip/pjproject/blob/72b46f74dd17b31815d4a0a19898bd2b425b45b3/pjsip/src/pjsua2/endpoint.cpp#L2131

It is released when the timer is cancelled 

https://github.com/pjsip/pjproject/blob/72b46f74dd17b31815d4a0a19898bd2b425b45b3/pjsip/src/pjsua2/endpoint.cpp#L2164

and should also be released after it is fired, but it does not seem so, see the `Endpoint::on_timer()` code [here](https://github.com/pjsip/pjproject/blob/72b46f74dd17b31815d4a0a19898bd2b425b45b3/pjsip/src/pjsua2/endpoint.cpp#L755-L767).

