### PR TITLE
Do not run cron workflow( Coverity Scan) in forks

### DIFF
--- a/.github/workflows/coverity-scan-daily.yml
+++ b/.github/workflows/coverity-scan-daily.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   ubuntu-full-bundle:
+    if: github.repository == 'pjsip/pjproject'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
as title  #3515 

[doc, Example: Only run job for specific repository](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository)