### PR TITLE
Fixed failed CI pjsua tests

### DIFF
--- a/tests/pjsua/scripts-sipp/uac-183-wrong-codec.xml
+++ b/tests/pjsua/scripts-sipp/uac-183-wrong-codec.xml
@@ -40,7 +40,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 109 105
+      m=audio [media_port] RTP/AVP 109 105
       a=rtpmap:109 EVS/16000
       a=fmtp:109 br=5.9-24.4; bw=nb-wb; max-red=220
       a=rtpmap:105 telephone-event/16000

--- a/tests/pjsua/scripts-sipp/uac-prack-sdp-decline.xml
+++ b/tests/pjsua/scripts-sipp/uac-prack-sdp-decline.xml
@@ -41,7 +41,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 8 101
+      m=audio [media_port] RTP/AVP 8 101
       a=rtpmap:8 PCMA/8000
       a=rtpmap:101 telephone-event/8000
       a=inactive
@@ -87,7 +87,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 109 105
+      m=audio [media_port] RTP/AVP 109 105
       a=rtpmap:109 EVS/16000
       a=fmtp:109 br=5.9-24.4; bw=nb-wb; max-red=220
       a=rtpmap:105 telephone-event/16000

--- a/tests/pjsua/scripts-sipp/uac-prack-sdp-offer.xml
+++ b/tests/pjsua/scripts-sipp/uac-prack-sdp-offer.xml
@@ -41,7 +41,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 8 101
+      m=audio [media_port] RTP/AVP 8 101
       a=rtpmap:8 PCMA/8000
       a=rtpmap:101 telephone-event/8000
       a=inactive
@@ -87,7 +87,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 8 101
+      m=audio [media_port] RTP/AVP 8 101
       a=rtpmap:8 PCMA/8000
       a=rtpmap:101 telephone-event/8000
       a=sendrecv

--- a/tests/pjsua/scripts-sipp/uac-upd-sdp-decline.xml
+++ b/tests/pjsua/scripts-sipp/uac-upd-sdp-decline.xml
@@ -41,7 +41,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 8 101
+      m=audio [media_port] RTP/AVP 8 101
       a=rtpmap:8 PCMA/8000
       a=rtpmap:101 telephone-event/8000
       a=sendrecv
@@ -109,7 +109,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 109 105
+      m=audio [media_port] RTP/AVP 109 105
       a=rtpmap:109 EVS/16000
       a=fmtp:109 br=5.9-24.4; bw=nb-wb; max-red=220
       a=rtpmap:105 telephone-event/16000

--- a/tests/pjsua/scripts-sipp/uac-upd-sdp-offer.xml
+++ b/tests/pjsua/scripts-sipp/uac-upd-sdp-offer.xml
@@ -41,7 +41,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 8 101
+      m=audio [media_port] RTP/AVP 8 101
       a=rtpmap:8 PCMA/8000
       a=rtpmap:101 telephone-event/8000
       a=inactive
@@ -109,7 +109,7 @@
       s=-
       c=IN IP[local_ip_type] [local_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 8 101
+      m=audio [media_port] RTP/AVP 8 101
       a=rtpmap:8 PCMA/8000
       a=rtpmap:101 telephone-event/8000
       a=sendrecv

--- a/tests/pjsua/scripts-sipp/uas-answer-183-wrong-codec.xml
+++ b/tests/pjsua/scripts-sipp/uas-answer-183-wrong-codec.xml
@@ -73,7 +73,7 @@
       s=-
       c=IN IP[media_ip_type] [media_ip]
       t=0 0
-      m=audio [auto_media_port] RTP/AVP 109 105
+      m=audio [media_port] RTP/AVP 109 105
       a=rtpmap:109 EVS/16000
       a=fmtp:109 br=5.9-24.4; bw=nb-wb; max-red=220
       a=rtpmap:105 telephone-event/16000


### PR DESCRIPTION
Recently, CI pjsua tests suddenly failed:
```
Running 150/205 (#1): python run.py  mod_sipp.py scripts-sipp/uac-prack-sdp-offer.xml... failed!! [19s]
Running 153/205 (#1): python run.py  mod_sipp.py scripts-sipp/uac-upd-sdp-decline.xml... failed!! [19s]
...
205 tests completed, 6 test(s) failed
```

The cause is because as of Sipp 3.7, the keyword `[auto_media_port]` is removed:
https://github.com/SIPp/sipp/blob/master/CHANGES.md
`Removed -mp in favor of -min_rtp_port and -max_rtp_port. Also removed [auto_media_port]. There are way too many (conflicting) options to specify ports here.`
