### PR TITLE
Prevent data race in stream when sending RTCP

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1083,6 +1083,12 @@ static pj_status_t send_rtcp(pjmedia_stream *stream,
     int len, max_len;
     pj_status_t status;
 
+    /* We need to prevent data race since there is only a single instance
+     * of rtcp packet buffer. Let's just use the JB mutex for this instead
+     * of creating a separate lock.
+     */
+    pj_mutex_lock(stream->jb_mutex);
+
     /* Build RTCP RR/SR packet */
     pjmedia_rtcp_build_rtcp(&stream->rtcp, &sr_rr_pkt, &len);
 
@@ -1201,6 +1207,8 @@ static pj_status_t send_rtcp(pjmedia_stream *stream,
             stream->rtcp_tx_err_cnt = 0;
         }
     }
+
+    pj_mutex_unlock(stream->jb_mutex);
 
     return status;
 }

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -584,6 +584,8 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
     int len, max_len;
     pj_status_t status;
 
+    pj_grp_lock_acquire( stream->grp_lock );
+
     /* Build RTCP RR/SR packet */
     pjmedia_rtcp_build_rtcp(&stream->rtcp, &sr_rr_pkt, &len);
 
@@ -664,6 +666,9 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
             stream->rtcp_tx_err_cnt = 0;
         }
     }
+
+    pj_grp_lock_release( stream->grp_lock );
+
     return status;
 }
 


### PR DESCRIPTION
To fix #1973, copy pasted here for convenience:
"
Reported that race condition scenarios potentially occur in `pjmedia_stream` specifically in call hangup where UI/SIP thread invokes `pjmedia_stream_destroy()` and media/audio thread that may still doing some streaming processing, both may access the same `pjmedia_stream` states without mutex protection. For example, `pjmedia_rtcp_build_rtcp_sdes()` may be called at the same time:

UI/SIP thread:
```
    #0 pjmedia_rtcp_build_rtcp_sdes pjproject/pjmedia/build/../src/pjmedia/rtcp.c:1014:10
    #1 send_rtcp pjproject/pjmedia/build/../src/pjmedia/stream.c:991:11
    #2 pjmedia_stream_send_rtcp_bye pjproject/pjmedia/build/../src/pjmedia/stream.c:2943:9
    #3 pjsua_aud_stop_stream pjproject/pjsip/build/../src/pjsua-lib/pjsua_aud.c:505:2
    #4 stop_media_stream pjproject/pjsip/build/../src/pjsua-lib/pjsua_media.c:2462:2
    #5 stop_media_session pjproject/pjsip/build/../src/pjsua-lib/pjsua_media.c:2514:2
    #6 pjsua_media_channel_deinit pjproject/pjsip/build/../src/pjsua-lib/pjsua_media.c:2538:5
    ...
```
Media endpoint thread:
```
    #0 pjmedia_rtcp_build_rtcp_sdes pjproject/pjmedia/build/../src/pjmedia/rtcp.c:1014:10
    #1 send_rtcp pjproject/pjmedia/build/../src/pjmedia/stream.c:991:11
    #2 on_rx_rtp pjproject/pjmedia/build/../src/pjmedia/stream.c:1905:11
    ...
```
"
