### PR TITLE
Parse SDP connection info with multicast address

### DIFF
--- a/pjmedia/include/pjmedia/sdp.h
+++ b/pjmedia/include/pjmedia/sdp.h
@@ -383,6 +383,8 @@ struct pjmedia_sdp_conn
     pj_str_t    net_type;       /**< Network type ("IN").               */
     pj_str_t    addr_type;      /**< Address type ("IP4", "IP6").       */
     pj_str_t    addr;           /**< The address.                       */
+    pj_uint8_t  ttl;            /**< Multicast address TTL              */
+    pj_uint8_t  no_addr;        /**< Multicast number of addresses      */
 };
 
 

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -1151,7 +1151,28 @@ static void parse_connection_info(pj_scanner *scanner, pjmedia_sdp_conn *conn,
 
     /* address. */
     pj_scan_get_until_chr(scanner, "/ \t\r\n", &conn->addr);
-    PJ_TODO(PARSE_SDP_CONN_ADDRESS_SUBFIELDS);
+    /* Parse multicast details, if any. */
+    if (*scanner->curptr == '/') {
+        pj_str_t str;
+        unsigned long ul;
+
+        pj_scan_get_until_chr(scanner, "/ \t\r\n", &str);
+        if (*scanner->curptr == '/') {
+            if ((pj_strtoul3(&str, &ul, 10) != PJ_SUCCESS) || ul > 255) {
+                on_scanner_error(scanner);
+                return;
+            }
+
+            conn->ttl = (pj_uint8_t)ul;
+        }        
+
+        if ((pj_strtoul3(&str, &ul, 10) != PJ_SUCCESS) || ul > 255) {
+            on_scanner_error(scanner);
+            return;
+        }
+        conn->no_addr = (pj_uint8_t)ul;
+
+    }
 
     /* We've got what we're looking for, skip anything until newline */
     pj_scan_skip_line(scanner);


### PR DESCRIPTION
To close #1105, copy pasted here for convenience:
"
Address field in SDP connection info for multicast should support the notation specified by standard, i.e:
```
<base multicast address>[/<ttl>]/<number of addresses>
```

Prior to [r3256](../commit/a3aeb95b0cc4e94ce62fb494b8fb25e3e7612d16), incoming SDP with above notation would cause `pjmedia_sdp_conn.addr` string containing address and its subfields. While pjmedia components expect a clean address string in `pjmedia_sdp_conn.addr`.
"