### PR TITLE
Fixed PIDF XML processing if nodes are namespaced

### DIFF
--- a/pjlib-util/src/pjlib-util/xml.c
+++ b/pjlib-util/src/pjlib-util/xml.c
@@ -358,6 +358,15 @@ PJ_DEF(void) pj_xml_add_attr( pj_xml_node *node, pj_xml_attr *attr )
     pj_list_push_back(&node->attr_head, attr);
 }
 
+static int node_name_cmp(pj_str_t *node_name, pj_str_t *name)
+{
+    pj_str_t node;
+
+    node.ptr = node_name->ptr + (node_name->slen - name->slen);
+    node.slen = name->slen;
+    return pj_stricmp(&node, name);
+}
+
 PJ_DEF(pj_xml_node*) pj_xml_find_node(const pj_xml_node *parent, 
                                       const pj_str_t *name)
 {
@@ -366,7 +375,7 @@ PJ_DEF(pj_xml_node*) pj_xml_find_node(const pj_xml_node *parent,
     PJ_CHECK_STACK();
 
     while (node != (void*)&parent->node_head) {
-        if (pj_stricmp(&node->name, name) == 0)
+        if (node_name_cmp(&node->name, name) == 0)
             return (pj_xml_node*)node;
         node = node->next;
     }
@@ -382,7 +391,7 @@ PJ_DEF(pj_xml_node*) pj_xml_find_node_rec(const pj_xml_node *parent,
 
     while (node != (void*)&parent->node_head) {
         pj_xml_node *found;
-        if (pj_stricmp(&node->name, name) == 0)
+        if (node_name_cmp(&node->name, name) == 0)
             return (pj_xml_node*)node;
         found = pj_xml_find_node_rec(node, name);
         if (found)
@@ -400,7 +409,7 @@ PJ_DEF(pj_xml_node*) pj_xml_find_next_node( const pj_xml_node *parent,
 
     node = node->next;
     while (node != (void*)&parent->node_head) {
-        if (pj_stricmp(&node->name, name) == 0)
+        if (node_name_cmp(&node->name, name) == 0)
             return (pj_xml_node*)node;
         node = node->next;
     }
@@ -442,7 +451,7 @@ PJ_DEF(pj_xml_node*) pj_xml_find( const pj_xml_node *parent,
 
     while (node != (const pj_xml_node*) &parent->node_head) {
         if (name) {
-            if (pj_stricmp(&node->name, name)!=0) {
+            if (node_name_cmp(&node->name, name)!=0) {
                 node = node->next;
                 continue;
             }
@@ -474,7 +483,7 @@ PJ_DEF(pj_xml_node*) pj_xml_find_rec( const pj_xml_node *parent,
         pj_xml_node *found;
 
         if (name) {
-            if (pj_stricmp(&node->name, name)==0) {
+            if (node_name_cmp(&node->name, name)==0) {
                 if (match) {
                     if (match(node, data))
                         return (pj_xml_node*)node;


### PR DESCRIPTION
To close #1150.

Note that the proposed fix here utilizes the same method as the one used in: https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip-simple/pidf.c#L348
```
PJ_DEF(pjpidf_pres*) pjpidf_parse(pj_pool_t *pool, char *text, int len)
{
    pjpidf_pres *pres = pj_xml_parse(pool, text, len);
    if (pres && pres->name.slen >= 8) {
        pj_str_t name;

        name.ptr = pres->name.ptr + (pres->name.slen - 8);
        name.slen = 8;

        if (pj_stricmp(&name, &PRESENCE) == 0)
            return pres;
    }
```
i.e. it will do the string comparison from the back and assumes that everything in front is the namespace, or prefix.

A proper solution would be to parse the namespace itself, but since the feature is never requested, let me know if you think it would be better for us to leave the current master unchanged and mark the issue as `not planned/won't fix`.


