### PR TITLE
Fixed DNS SRV response processing when SRV entries contain the same host

### DIFF
--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -385,7 +385,11 @@ static void build_server_entries(pj_dns_srv_async_query *query_job,
                     ++query_job->host_resolved;
 
                 ++query_job->srv[j].addr_cnt;
-                break;
+                
+                /* Continue the loop as other SRV entries may contain
+                 * the same host.
+                 */
+                // break;
             }
         }
 


### PR DESCRIPTION
To fix #656:
"
With this sample DNS SRV entries:

```
turn         CNAME         colinux
colinux      A             192.168.0.2
_turn._udp   SRV 0 0 3478  turn.pjsip.lab.
_turn._udp   SRV 1 0 34780 turn.pjsip.lab.
```

the SRV resolver will put two IP addresses on the first entry, and no IP address on the second entry.
"

I could reproduce the issue but couldn't get the exact result as described. If the A records are put in the Additional Info section, the first SRV entry will get the IP address (but only one, not two) while the second one will not. This is because the loop will stop once it finds the SRV entry with a particular host, while actually, it should not stop and continue through all the entries.
