### PR TITLE
Fixed incorrect RTCP stat calculation for G722

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2746,10 +2746,15 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
 
 #if defined(PJMEDIA_HANDLE_G722_MPEG_BUG) && (PJMEDIA_HANDLE_G722_MPEG_BUG!=0)
         /* Special case for G.722 */
+        /* Update: We don't need to do this as this causes miscalculation
+         * inside RTCP.
+         */
+        /*
         if (info->fmt.pt == PJMEDIA_RTP_PT_G722) {
             rtcp_setting.clock_rate = 8000;
             rtcp_setting.samples_per_frame = 160;
         }
+        */
 #endif
 
         pjmedia_rtcp_init2(&stream->rtcp, &rtcp_setting);


### PR DESCRIPTION
To fix #1198

From the description in #1198, it's not obvious whether the issue occurs in general, or only specific for G722.
The title `Wrong RTCP loss period calculation with multiple frames per RTP packet` seems to suggest this is a general problem, however the calculation in `stream.c` seems to be already correct:
```
    afd->frame_time_usec = stream->codec_param.info.frm_ptime *
                           stream->codec_param.setting.frm_per_pkt * 1000;
...
    rtcp_setting.samples_per_frame = PJMEDIA_AFD_SPF(afd);
```
i.e. it already takes into account `frm_per_pkt`. It's true that the name is incorrect, it should be samples_per_packet, as it seems to be the case with `stream->enc_samples_per_pkt = PJMEDIA_AFD_SPF(afd);`.

But despite the misleading name,  the calculation looks right when I tested it here with multiple frames per pkt. For `ptime=100` and `clock_rate=48KHz`, here are the numbers:
```
frm_per_pkt = 5
sess_pkt_size = 4800
period/count = sess->pkt_size * 1000 / sess->clock_rate =100
```

If it's only for G722 though, it shouldn't be specific for multiple frames per packet, since the `clock rate` and `samples_per_frame` forced modification should also affect single frame per packet.

Conclusion:
- there's no issue with the general codec
- since it only affects G722 and not critical, let me know if it's better to merge the PR (quite low risk anyway) or we should mark the issue as `won't fix`.
