### PR TITLE
Fixed memory leak while decoding video packet with ffmpeg

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1993,6 +1993,7 @@ static pj_status_t ffmpeg_codec_decode_whole(pjmedia_vid_codec *codec,
         output->size = 0;
     }
 
+    av_frame_unref(&avframe);
     return PJ_SUCCESS;
 }
 

--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1855,7 +1855,7 @@ static pj_status_t ffmpeg_frame_unref(AVFrame *frame)
 #ifdef PJMEDIA_USE_OLD_FFMPEG
     (void)frame;
 #else
-    av_frame_unref(&frame);
+    av_frame_unref(frame);
 #endif
 }
 


### PR DESCRIPTION
In function `ffmpeg_codec_decode_whole()` AVFrame `avframe` is used to receive a frame from the decoder codec context. The frame data is copied in the output `pjmedia_frame` but `avframe` is never unreferenced. This is causing serious memory leaks and a freeze of the whole system. Using `ffmpeg` version `N-109430-g7af947c0c0 Copyright (c) 2000-2022`.