### PR TITLE
Modify the DTMF duration default

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -456,7 +456,7 @@
  * units (the default value of PJMEDIA_DTMF_DURATION) is equivalent to 200 ms. 
  */
 #ifndef PJMEDIA_DTMF_DURATION_MSEC              
-#  define PJMEDIA_DTMF_DURATION_MSEC            0
+#  define PJMEDIA_DTMF_DURATION_MSEC            200
 #endif
 
 

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -442,6 +442,9 @@
 /**
  * DTMF/telephone-event duration, in timestamp. To specify the duration in
  * milliseconds, use the setting PJMEDIA_DTMF_DURATION_MSEC instead.
+ *
+ * Note that for a clockrate of 8 KHz, a dtmf duration of 1600 timestamp
+ * units (the default value of PJMEDIA_DTMF_DURATION) is equivalent to 200 ms. 
  */
 #ifndef PJMEDIA_DTMF_DURATION           
 #  define PJMEDIA_DTMF_DURATION                 1600    /* in timestamp */
@@ -451,9 +454,6 @@
 /**
  * DTMF/telephone-event duration, in milliseconds. If the value is greater
  * than zero, than this setting will be used instead of PJMEDIA_DTMF_DURATION.
- *
- * Note that for a clockrate of 8 KHz, a dtmf duration of 1600 timestamp
- * units (the default value of PJMEDIA_DTMF_DURATION) is equivalent to 200 ms. 
  */
 #ifndef PJMEDIA_DTMF_DURATION_MSEC              
 #  define PJMEDIA_DTMF_DURATION_MSEC            200


### PR DESCRIPTION
To close #1542 

Currently, the default of DTMF duration is set at 1600 timestamp, as explained in the doc:
```
 * Note that for a clockrate of 8 KHz, a dtmf duration of 1600 timestamp
 * units (the default value of PJMEDIA_DTMF_DURATION) is equivalent to 200 ms. 
#  define PJMEDIA_DTMF_DURATION                 1600    /* in timestamp */
```

However, for higher clockrate, such as 32 KHz, this will only equate to 50 ms, and with 48 KHz, 33.3 ms. This is way too short, especially if the codec is configured to send multiple frames per packet, such as with ptime=100ms.

Log with the new default value, with `ptime=20 ms` (clock rate 48 KHz):
```
10:00:19.143                 stream  sending dtmf 1 960
10:00:19.163                 stream  sending dtmf 1 1920
10:00:19.183                 stream  sending dtmf 1 2880
10:00:19.203                 stream  sending dtmf 1 3840
10:00:19.223                 stream  sending dtmf 1 4800
10:00:19.243                 stream  sending dtmf 1 5760
10:00:19.263                 stream  sending dtmf 1 6720
10:00:19.283                 stream  sending dtmf 1 7680
10:00:19.303                 stream  sending dtmf 1 8640
10:00:19.323                 stream  sending dtmf 1 9600
10:00:19.343                 stream  sending dtmf 1 9600
10:00:19.363                 stream  sending dtmf 1 9600
```
with ptime=100ms:
```
10:02:27.479                 stream  sending dtmf 1 4800
10:02:27.579                 stream  sending dtmf 1 9600
10:02:27.679                 stream  sending dtmf 1 9600
10:02:27.779                 stream  sending dtmf 1 9600
```
