### PR TITLE
Implement merged requests detection

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1069,6 +1069,23 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #endif
 
 /**
+ * Setting to determine if we need to detect merged requests, as
+ * recommended by RFC 3261 section 8.2.2.2.
+ * Since the merged requests detection requires checking against all
+ * ongoing transactions, which can be inefficient, this setting will
+ * determine if we should skip the detection process if the current
+ * number of ongoing transactions is greater than the value specified.
+ *
+ * Setting it to 0 will disable the feature.
+ *
+ * Default: 20 (we detect merged requests only if the number of
+ *              transactions is at most 20)
+ */
+#ifndef PJSIP_TSX_DETECT_MERGED_REQUESTS
+#   define PJSIP_TSX_DETECT_MERGED_REQUESTS 20
+#endif
+
+/**
  * Setting to determine if certain SIP UAS transaction, such as
  * INVITE UAS tsx that hasn't been confirmed, is allowed to continue
  * upon transport error. If disabled, the transaction will always be

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1069,23 +1069,6 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #endif
 
 /**
- * Setting to determine if we need to detect merged requests, as
- * recommended by RFC 3261 section 8.2.2.2.
- * Since the merged requests detection requires checking against all
- * ongoing transactions, which can be inefficient, this setting will
- * determine if we should skip the detection process if the current
- * number of ongoing transactions is greater than the value specified.
- *
- * Setting it to 0 will disable the feature.
- *
- * Default: 20 (we detect merged requests only if the number of
- *              transactions is at most 20)
- */
-#ifndef PJSIP_TSX_DETECT_MERGED_REQUESTS
-#   define PJSIP_TSX_DETECT_MERGED_REQUESTS 20
-#endif
-
-/**
  * Setting to determine if certain SIP UAS transaction, such as
  * INVITE UAS tsx that hasn't been confirmed, is allowed to continue
  * upon transport error. If disabled, the transaction will always be

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -71,7 +71,7 @@ typedef enum pjsip_tsx_state_e
     PJSIP_TSX_STATE_MAX         /**< Number of states.                      */
 } pjsip_tsx_state_e;
 
-#define PJSIP_TSX_DETECT_MERGED_REQUESTS 100
+
 /**
  * This structure describes SIP transaction object. The transaction object
  * is used to handle both UAS and UAC transaction.

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -98,13 +98,10 @@ struct pjsip_transaction
     pjsip_method                method;         /**< The method.            */
     pj_int32_t                  cseq;           /**< The CSeq               */
     pj_str_t                    transaction_key;/**< Hash table key.        */
+    pj_str_t                    transaction_key2;/**< Hash table key (2).   */
     pj_uint32_t                 hashed_key;     /**< Key's hashed value.    */
+    pj_uint32_t                 hashed_key2;    /**< Key's hashed value (2).*/
     pj_str_t                    branch;         /**< The branch Id.         */
-#if defined(PJSIP_TSX_DETECT_MERGED_REQUESTS) && \
-    PJSIP_TSX_DETECT_MERGED_REQUESTS != 0
-    pj_str_t                    from_tag;       /**< The From tag.          */
-    pj_str_t                    call_id ;       /**< The Call ID.           */
-#endif
 
     /*
      * State and status.
@@ -301,6 +298,22 @@ PJ_DECL(pj_status_t) pjsip_tsx_create_uas2(pjsip_module *tsx_user,
                                            pjsip_rx_data *rdata,
                                            pj_grp_lock_t *grp_lock,
                                            pjsip_transaction **p_tsx );
+
+/**
+ * Detect merged requests according to RFC 3261 section 8.2.2.2:
+ * If the request has no tag in the To header field, the function will
+ * check the request against ongoing transactions.  If the From tag,
+ * Call-ID, and CSeq exactly match those associated with an ongoing
+ * transaction, but the request does not match that transaction based
+ * on the matching rules described in section 17.2.3, the function
+ * will return that transaction.
+ *
+ * @param rdata     The received incoming request.
+ *
+ * @return          The matching transaction, if any, or NULL.
+ */
+PJ_DECL(pjsip_transaction *)
+pjsip_tsx_detect_merged_requests(pjsip_rx_data *rdata);
 
 /**
  * Lock/bind transaction to a specific transport/listener. This is optional,

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -98,7 +98,9 @@ struct pjsip_transaction
     pjsip_method                method;         /**< The method.            */
     pj_int32_t                  cseq;           /**< The CSeq               */
     pj_str_t                    transaction_key;/**< Hash table key.        */
-    pj_str_t                    transaction_key2;/**< Hash table key (2).   */
+    pj_str_t                    transaction_key2;/**< Hash table key (2)   
+                                                     for merged requests
+                                                     tsx lookup.            */
     pj_uint32_t                 hashed_key;     /**< Key's hashed value.    */
     pj_uint32_t                 hashed_key2;    /**< Key's hashed value (2).*/
     pj_str_t                    branch;         /**< The branch Id.         */

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -71,7 +71,7 @@ typedef enum pjsip_tsx_state_e
     PJSIP_TSX_STATE_MAX         /**< Number of states.                      */
 } pjsip_tsx_state_e;
 
-
+#define PJSIP_TSX_DETECT_MERGED_REQUESTS 100
 /**
  * This structure describes SIP transaction object. The transaction object
  * is used to handle both UAS and UAC transaction.
@@ -100,6 +100,11 @@ struct pjsip_transaction
     pj_str_t                    transaction_key;/**< Hash table key.        */
     pj_uint32_t                 hashed_key;     /**< Key's hashed value.    */
     pj_str_t                    branch;         /**< The branch Id.         */
+#if defined(PJSIP_TSX_DETECT_MERGED_REQUESTS) && \
+    PJSIP_TSX_DETECT_MERGED_REQUESTS != 0
+    pj_str_t                    from_tag;       /**< The From tag.          */
+    pj_str_t                    call_id ;       /**< The Call ID.           */
+#endif
 
     /*
      * State and status.

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -870,6 +870,8 @@ pjsip_tsx_detect_merged_requests(pjsip_rx_data *rdata)
     pj_uint32_t hval = 0;
     pj_status_t status;
 
+    PJ_ASSERT_RETURN(rdata->msg_info.msg->type == PJSIP_REQUEST_MSG, NULL);
+
     /* If the request has no tag in the To header field, the UAS core MUST
      * check the request against ongoing transactions.
      */

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -661,33 +661,12 @@ static pj_bool_t mod_pjsua_on_rx_request(pjsip_rx_data *rdata)
     pj_bool_t processed = PJ_FALSE;
 
     if (pjsip_tsx_detect_merged_requests(rdata)) {
-        pjsip_transaction *new_tsx;
-        pjsip_tx_data *tdata;
-        pj_status_t status;
-
         PJ_LOG(4, (THIS_FILE, "Merged request detected"));
 
-        /* Create new tsx and answer with 482 (Loop Detected) */
-        status = pjsip_tsx_create_uas(&pjsua_var.mod, rdata,
-                                      &new_tsx);
-        if (status != PJ_SUCCESS)
-            return PJ_TRUE;
-
-        new_tsx->mod_data[pjsua_var.mod.id] = &pjsua_var.mod;
-
-        pjsip_tsx_recv_msg(new_tsx, rdata);
-
-        status = pjsip_endpt_create_response(pjsua_var.endpt, rdata,
-                                             PJSIP_SC_LOOP_DETECTED,
-                                             NULL, &tdata);
-        if (status == PJ_SUCCESS) {
-            status = pjsip_tsx_send_msg(new_tsx, tdata);
-            if (status != PJ_SUCCESS)
-                pjsip_tx_data_dec_ref(tdata);
-        }
-
-        /* Terminate the transaction. */
-        pjsip_tsx_terminate(new_tsx, PJSIP_SC_LOOP_DETECTED);
+        /* Respond with 482 (Loop Detected) */
+        pjsip_endpt_respond(pjsua_var.endpt, NULL, rdata,
+                            PJSIP_SC_LOOP_DETECTED, NULL,
+                            NULL, NULL, NULL);
 
         return PJ_TRUE;
     }


### PR DESCRIPTION
To close #378.

Merged request is described in [RFC 3261 Section 8.2.2.2](https://datatracker.ietf.org/doc/html/rfc3261.html#section-8.2.2.2):

```
8.2.2.2 Merged Requests

   If the request has no tag in the To header field, the UAS core MUST
   check the request against ongoing transactions.  If the From tag,
   Call-ID, and CSeq exactly match those associated with an ongoing
   transaction, but the request does not match that transaction (based
   on the matching rules in Section 17.2.3), the UAS core SHOULD
   generate a 482 (Loop Detected) response and pass it to the server
   transaction.

      The same request has arrived at the UAS more than once, following
      different paths, most likely due to forking.  The UAS processes
      the first such request received and responds with a 482 (Loop
      Detected) to the rest of them.
```

The detection turns out to be expensive, with the transaction now having to store From tag and Call-ID, and the fact that we now need to check **ALL** incoming requests with no Tag against existing transactions. Note that this checking requires a time complexity of O(n) as compared to our typical comparison which utilises the hash table that only needs O(1). Hence, I introduce the setting `PJSIP_TSX_DETECT_MERGED_REQUESTS`.
 