### PR TITLE
Fix minor error: duplicate link pjmedia lib

### DIFF
--- a/build.mak.in
+++ b/build.mak.in
@@ -323,7 +323,6 @@ export APP_LDLIBS := $(PJSUA_LIB_LDLIB) \
         $(PJMEDIA_LDLIB) \
         $(PJMEDIA_VIDEODEV_LDLIB) \
         $(PJMEDIA_AUDIODEV_LDLIB) \
-        $(PJMEDIA_LDLIB) \
         $(PJNATH_LDLIB) \
         $(PJLIB_UTIL_LDLIB) \
         $(APP_THIRD_PARTY_LIBS)\


### PR DESCRIPTION
APP_LDLIBS  include  PJMEDIA_LDLIB  twice.
(which  affects 'libs' in pkgconfig file libpjproject.pc  )
