### PR TITLE
Fix minor error: duplicate link pjmedia lib

### DIFF
--- a/build.mak.in
+++ b/build.mak.in
@@ -320,7 +320,6 @@ export APP_LDLIBS := $(PJSUA_LIB_LDLIB) \
         $(PJSIP_SIMPLE_LDLIB) \
         $(PJSIP_LDLIB) \
         $(PJMEDIA_CODEC_LDLIB) \
-        $(PJMEDIA_LDLIB) \
         $(PJMEDIA_VIDEODEV_LDLIB) \
         $(PJMEDIA_AUDIODEV_LDLIB) \
         $(PJMEDIA_LDLIB) \


### PR DESCRIPTION
APP_LDLIBS include PJMEDIA_LDLIB twice.
(which affects 'libs' in pkgconfig file libpjproject.pc )