### PR TITLE
Fixed stack buffer underflow if crypto is zero

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -597,7 +597,7 @@ static pj_status_t fill_local_crypto(pj_pool_t *pool,
         if (status != PJ_SUCCESS)
             return status;
 
-        if (loc_tag > *count)
+        if (loc_tag <= 0 || loc_tag > *count)
             return PJMEDIA_SRTP_ESDPINCRYPTOTAG;
 
         loc_crypto[loc_tag-1] = tmp_crypto;


### PR DESCRIPTION
The test `scripts-sendto/300_srtp_receive_crypto_tag_zero.py`
will trigger the issue:
```
ERROR: AddressSanitizer: stack-buffer-underflow on address 0x00017003f960 at pc 0x000102150f7c bp 0x00017003f730 sp 0x00017003eef0
WRITE of size 40 at 0x00017003f960 thread T9
    #0 0x102150f78 in __asan_memcpy+0x240 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x40f78) (BuildId: f0a7ac5c49bc3abc851181b6f92b308a32000000200000000100000000000b00)
    #1 0x1006f7ad4 in fill_local_crypto transport_srtp_sdes.c:603
    #2 0x1006f448c in sdes_media_start transport_srtp_sdes.c:660
```
