### PR TITLE
Fixed segmentation fault in pjmedia_vid_stream_destroy

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2976,7 +2976,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_destroy( pjmedia_stream *stream )
     PJ_ASSERT_RETURN(stream != NULL, PJ_EINVAL);
 
     /* Send RTCP BYE (also SDES & XR) */
-    if (stream->transport && !stream->rtcp_sdes_bye_disabled) {
+    if (stream->transport && stream->jb_mutex && !stream->rtcp_sdes_bye_disabled) {
 #if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
         send_rtcp(stream, PJ_TRUE, PJ_TRUE, stream->rtcp.xr_enabled, PJ_FALSE);
 #else
@@ -2988,7 +2988,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_destroy( pjmedia_stream *stream )
      * RFC 2833 RTP packet with 'End' flag set.
      */
     if (stream->tx_dtmf_count && stream->tx_dtmf_buf[0].duration != 0 &&
-        stream->transport) 
+        stream->transport && stream->jb_mutex)
     {
         pjmedia_frame frame_out;
         pjmedia_channel *channel = stream->enc;

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -2191,7 +2191,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
     pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream, &stream->rtcp);
 
     /* Send RTCP BYE (also SDES) */
-    if (stream->transport && !stream->rtcp_sdes_bye_disabled) {
+    if (stream->transport && stream->grp_lock && !stream->rtcp_sdes_bye_disabled) {
         send_rtcp(stream, PJ_TRUE, PJ_TRUE, PJ_FALSE, PJ_FALSE);
     }
 


### PR DESCRIPTION
In the function `pjmedia_vid_stream_destroy`, the variable `stream->grp_lock` can be `NULL` when `send_rtcp` is called and this is causing a segmentation fault, because `send_rtcp` tries to acquire the lock with it. Even in the `pjmedia_vid_stream_destroy` function, there is a comment below

```C
    /* This function may be called when stream is partly initialized,
     * i.e: group lock may not be created yet.
     */
````