### PR TITLE
Enable specifying format video when opening video preview using PJSUA2 API

### DIFF
--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1938,9 +1938,9 @@ struct VideoPreviewOpParam {
     unsigned                windowFlags;
 
     /**
-     * Media format. If left unitialized, this parameter will not be used.
+     * Media format video. If left unitialized, this parameter will not be used.
      */
-    MediaFormat             format;
+    MediaFormatVideo        format;
 
     /**
      * Optional output window to be used to display the video preview.

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1938,7 +1938,10 @@ struct VideoPreviewOpParam {
     unsigned                windowFlags;
 
     /**
-     * Media format video. If left unitialized, this parameter will not be used.
+     * Media format video. If left uninitialized, this parameter will not be used and 
+     * the capture device will be opened using PJMEDIA wrapper default format, 
+     * e.g: on Android it is PJMEDIA_FORMAT_I420, on iOS it is PJMEDIA_FORMAT_BGRA.
+     * Note that when the preview is already opened, this setting will be ignored.
      */
     MediaFormatVideo        format;
 

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1940,7 +1940,9 @@ struct VideoPreviewOpParam {
     /**
      * Media format video. If left uninitialized, this parameter will not be used and 
      * the capture device will be opened using PJMEDIA wrapper default format, 
-     * e.g: on Android it is PJMEDIA_FORMAT_I420, on iOS it is PJMEDIA_FORMAT_BGRA.
+     * e.g: 
+     * - Android : PJMEDIA_FORMAT_I420 using the first supported size and 15fps
+     * - iOS : PJMEDIA_FORMAT_BGRA using size 352x288 and 15fps
      * Note that when the preview is already opened, this setting will be ignored.
      */
     MediaFormatVideo        format;

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1320,10 +1320,9 @@ void VideoPreviewOpParam::fromPj(const pjsua_vid_preview_param &prm)
     this->rendId                    = prm.rend_id;
     this->show                      = PJ2BOOL(prm.show);
     this->windowFlags               = prm.wnd_flags;
-    this->format.id                 = prm.format.id;
-    this->format.type               = prm.format.type;
     this->window.type               = prm.wnd.type;
     this->window.handle.window      = prm.wnd.info.window;
+    this->format.fromPj(prm.format);
 #else
     PJ_UNUSED_ARG(prm);
 #endif
@@ -1337,10 +1336,9 @@ pjsua_vid_preview_param VideoPreviewOpParam::toPj() const
     param.rend_id           = this->rendId;
     param.show              = this->show;
     param.wnd_flags         = this->windowFlags;
-    param.format.id         = this->format.id;
-    param.format.type       = this->format.type;
     param.wnd.type          = this->window.type;
     param.wnd.info.window   = this->window.handle.window;
+    param.format            = this->format.toPj();
 #endif
     return param;
 }


### PR DESCRIPTION
The ticket in #1786 add the capability to specify format video and video window when opening video preview.
However, this currently doesn't work on PJSUA2 API since `VideoPreviewOpParam` is using `MediaFormat` field.
This PR will change the `MediaFormat` to `MediaFormatVideo` and enable the capability.


Note: minor API break: `MediaFormat` field in `VideoPreviewOpParam` no longer exists.