### PR TITLE
Fixed local address returned by API pjsip_tpmgr_find_local_addr()

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1697,6 +1697,11 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_find_local_addr2(pjsip_tpmgr *tpmgr,
         prm->tp_sel->u.transport)
     {
         const pjsip_transport *tp = prm->tp_sel->u.transport;
+        /* If transport selector is specified, we can use the transport's
+         * address instead of using the address obtained from
+         * get_net_interface().
+         */
+        /*
         if (prm->local_if) {
             status = get_net_interface((pjsip_transport_type_e)tp->key.type,
                                        &prm->dst_host, &tmp_str);
@@ -1705,7 +1710,8 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_find_local_addr2(pjsip_tpmgr *tpmgr,
             pj_strdup(pool, &prm->ret_addr, &tmp_str);
             prm->ret_port = pj_sockaddr_get_port(&tp->local_addr);
             prm->ret_tp = tp;
-        } else {
+        } else */
+        {
             pj_strdup(pool, &prm->ret_addr, &tp->local_name.host);
             prm->ret_port = (pj_uint16_t)tp->local_name.port;
         }
@@ -1714,13 +1720,19 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_find_local_addr2(pjsip_tpmgr *tpmgr,
     } else if (prm->tp_sel && prm->tp_sel->type == PJSIP_TPSELECTOR_LISTENER &&
                prm->tp_sel->u.listener)
     {
+        /* If transport selector is specified, we can use the listener's
+         * address instead of using the address obtained from
+         * get_net_interface().
+         */
+        /*
         if (prm->local_if) {
             status = get_net_interface(prm->tp_sel->u.listener->type,
                                        &prm->dst_host, &tmp_str);
             if (status != PJ_SUCCESS)
                 goto on_return;
             pj_strdup(pool, &prm->ret_addr, &tmp_str);
-        } else {
+        } else */
+        {
             pj_strdup(pool, &prm->ret_addr,
                       &prm->tp_sel->u.listener->addr_name.host);
         }


### PR DESCRIPTION
Complete title: **Fixed local address returned by API pjsip_tpmgr_find_local_addr()/pjsip_tpmgr_find_local_addr2() when transport selector is specified, in environment with multiple interfaces.**

To fix #3526.

I can reproduce the issue here.
For example, the machine has two interfaces, `interface 1` and `interface 2`. Even if the account is bound to transport of `interface 1`, the message can contain contact with address from `interface 2`.

The current flow to get the contact address is as follows:
`pjsua_acc_get_uac/uas_addr()->pjsip_tpmgr_find_local_addr2()->get_net_interface((pjsip_transport_type_e)tp->key.type, &prm->dst_host, &tmp_str)`

So we will use the result from get_net_interface() to get the interface address used to contact the destination address and use it as the contact address, as described in https://trac.pjsip.org/repos/wiki/FAQ#multihomed, which is the correct mechanism if user has no preference of which interface to use.

But if user already explicitly sets the transport selector `tp_sel`, I believe we should just directly use that transport/listener's address instead, since the address obtained from `get_net_interface()` can be different from the one specified as the transport/listener's address.
