### PR TITLE
don't assert when attempting to set PJ_DNS_RESOLVER_MAX_NS nameservers

### DIFF
--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -542,7 +542,7 @@ PJ_DEF(pj_status_t) pj_dns_resolver_set_ns( pj_dns_resolver *resolver,
     pj_status_t status;
 
     PJ_ASSERT_RETURN(resolver && count && servers, PJ_EINVAL);
-    PJ_ASSERT_RETURN(count < PJ_DNS_RESOLVER_MAX_NS, PJ_EINVAL);
+    PJ_ASSERT_RETURN(count <= PJ_DNS_RESOLVER_MAX_NS, PJ_EINVAL);
 
     pj_grp_lock_acquire(resolver->grp_lock);
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -542,7 +542,7 @@ PJ_DEF(pj_status_t) pj_dns_resolver_set_ns( pj_dns_resolver *resolver,
     pj_status_t status;
 
     PJ_ASSERT_RETURN(resolver && count && servers, PJ_EINVAL);
-    PJ_ASSERT_RETURN(count <= PJ_DNS_RESOLVER_MAX_NS, PJ_EINVAL);
+    PJ_ASSERT_RETURN(count <= PJ_DNS_RESOLVER_MAX_NS, PJ_ETOOMANY);
 
     pj_grp_lock_acquire(resolver->grp_lock);
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -546,9 +546,6 @@ PJ_DEF(pj_status_t) pj_dns_resolver_set_ns( pj_dns_resolver *resolver,
 
     pj_grp_lock_acquire(resolver->grp_lock);
 
-    if (count > PJ_DNS_RESOLVER_MAX_NS)
-        count = PJ_DNS_RESOLVER_MAX_NS;
-
     resolver->ns_count = 0;
     pj_bzero(resolver->ns, sizeof(resolver->ns));
 


### PR DESCRIPTION
In Debug builds the function https://github.com/pjsip/pjproject/blob/e210c69104a871cdcaa9dc9747a684a4fa7e8b20/pjlib-util/src/pjlib-util/resolver.c#L535 asserts when trying to set the maximum number of nameservers allowed.