### PR TITLE
Fix minor error: ffmpeg_frame_unref() missing return statement

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1850,7 +1850,7 @@ static pj_status_t check_decode_result(pjmedia_vid_codec *codec,
 /*
  * Unreference AVFrame.
  */
-static pj_status_t ffmpeg_frame_unref(AVFrame *frame)
+static void ffmpeg_frame_unref(AVFrame *frame)
 {
 #ifdef PJMEDIA_USE_OLD_FFMPEG
     (void)frame;


### PR DESCRIPTION
This error was introduced by #3539 