### PR TITLE
Fixed incorrect RTCP stat calculation

### DIFF
--- a/pjmedia/include/pjmedia/rtcp.h
+++ b/pjmedia/include/pjmedia/rtcp.h
@@ -250,6 +250,7 @@ typedef struct pjmedia_rtcp_session
 
     unsigned                clock_rate; /**< Clock rate of the stream       */
     unsigned                pkt_size;   /**< Avg pkt size, in samples.      */
+    unsigned                dec_pkt_size;/**< Decoding pkt size, in samples.*/
     pj_uint32_t             received;   /**< # pkt received                 */
     pj_uint32_t             exp_prior;  /**< # pkt expected at last interval*/
     pj_uint32_t             rx_prior;   /**< # pkt received at last interval*/
@@ -289,6 +290,7 @@ typedef struct pjmedia_rtcp_session_setting
     char            *name;              /**< RTCP session name.         */
     unsigned         clock_rate;        /**< Sequence.                  */
     unsigned         samples_per_frame; /**< Timestamp.                 */
+    unsigned         dec_samples_per_frame; /**< Timestamp.             */
     pj_uint32_t      ssrc;              /**< Sender SSRC.               */
     pj_uint32_t      rtp_ts_base;       /**< Base RTP timestamp.        */
 } pjmedia_rtcp_session_setting;
@@ -336,6 +338,19 @@ PJ_DECL(void) pjmedia_rtcp_init( pjmedia_rtcp_session *session,
  */
 PJ_DECL(void) pjmedia_rtcp_init2(pjmedia_rtcp_session *session,
                                  const pjmedia_rtcp_session_setting *settings);
+
+
+/**
+ * Update RTCP session with the new settings. Note that any setting field
+ * that has a value of zero will not be updated.
+ *
+ * @param session           The session
+ * @param settings          The new RTCP session settings.
+ *                          Set a field to zero to leave it unchanged.
+ */
+PJ_DECL(void)
+pjmedia_rtcp_update(pjmedia_rtcp_session *session,
+                    const pjmedia_rtcp_session_setting *settings);
 
 
 /**

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2099,7 +2099,8 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
             setting.dec_samples_per_frame =
                 PJMEDIA_SPF(stream->codec_param.info.clock_rate,
                             stream->dec_ptime,
-                            stream->codec_param.info.channel_cnt);
+                            stream->codec_param.info.channel_cnt) /
+                stream->dec_ptime_denum;
             pjmedia_rtcp_update(&stream->rtcp, &setting);
 
             PJ_LOG(4, (stream->port.info.name.ptr, "codec decode "

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2098,9 +2098,9 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
             pjmedia_rtcp_session_setting_default(&setting);
             setting.dec_samples_per_frame =
                 PJMEDIA_SPF(stream->codec_param.info.clock_rate,
-                            stream->dec_ptime,
-                            stream->codec_param.info.channel_cnt) /
-                stream->dec_ptime_denum;
+                            stream->dec_ptime * 1000 /
+                            stream->dec_ptime_denum,
+                            stream->codec_param.info.channel_cnt);
             pjmedia_rtcp_update(&stream->rtcp, &setting);
 
             PJ_LOG(4, (stream->port.info.name.ptr, "codec decode "


### PR DESCRIPTION
To fix #1198, based on the discussion in #3538.

In summary, there are issues with RTCP stat calculation:
- for incoming/decoding direction, since the packet size can differ from the encoding direction and also, the decoding ptime can change.
- specific for G722 encoding direction: when multiple frames per packet is used

The fix is to:
- Add setting `pjmedia_rtcp_session_setting.dec_samples_per_frame`
- Add API `pjmedia_rtcp_update()` to update RTCP session, for example upon the scenario of decoding ptime change
- For G722: multiply samples_per_frame by `stream->codec_param.setting.frm_per_pkt`
