### PR TITLE
Fix frame copy for stereo mode in WebRTC-AEC3

### DIFF
--- a/pjmedia/src/pjmedia/echo_webrtc_aec3.cpp
+++ b/pjmedia/src/pjmedia/echo_webrtc_aec3.cpp
@@ -188,7 +188,7 @@ PJ_DEF(pj_status_t) webrtc_aec3_cancel_echo(void *state,
     PJ_ASSERT_RETURN(echo && rec_frm && play_frm, PJ_EINVAL);
 
     for (i = 0; i < echo->samples_per_frame;
-         i += echo->frame_length)
+         i += (echo->frame_length * echo->channel_count))
     {
         StreamConfig scfg(echo->clock_rate, echo->channel_count);
 


### PR DESCRIPTION
Reported that when opening sound device in stereo/multichannel with AEC using WebRTC-AEC2, assertion is raised:
```
pj_assert("STACK OVERFLOW!! " && (usage <= thread->stk_size - 128));
```

Thanks to Adam Wientzek for the report.