### PR TITLE
Add device id in audio device info

### DIFF
--- a/pjmedia/include/pjmedia/audiodev.h
+++ b/pjmedia/include/pjmedia/audiodev.h
@@ -292,6 +292,11 @@ typedef enum pjmedia_aud_dev_route
 typedef struct pjmedia_aud_dev_info
 {
     /** 
+     * The device ID
+     */
+    pjmedia_aud_dev_index id;
+
+    /** 
      * The device name 
      */
     char name[PJMEDIA_AUD_DEV_INFO_NAME_LEN];

--- a/pjmedia/src/pjmedia/audiodev.c
+++ b/pjmedia/src/pjmedia/audiodev.c
@@ -427,6 +427,10 @@ PJ_DEF(pj_status_t) pjmedia_aud_dev_get_info(pjmedia_aud_dev_index id,
     if (status != PJ_SUCCESS)
         return status;
 
+    /* Make sure device ID is the real ID (not PJMEDIA_AUD_DEFAULT_*_DEV) */
+    info->id = index;
+    make_global_index(f->sys.drv_idx, &info->id);
+
     return f->op->get_dev_info(f, index, info);
 }
 

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1417,7 +1417,7 @@ static pj_status_t app_init(void)
         pj_pool_release(tmp_pool);
         return status;
     }
-
+    
     /* Initialize our module to handle otherwise unhandled request */
     status = pjsip_endpt_register_module(pjsua_get_pjsip_endpt(),
                                          &mod_default_handler);

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1417,7 +1417,7 @@ static pj_status_t app_init(void)
         pj_pool_release(tmp_pool);
         return status;
     }
-    
+
     /* Initialize our module to handle otherwise unhandled request */
     status = pjsip_endpt_register_module(pjsua_get_pjsip_endpt(),
                                          &mod_default_handler);

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -808,6 +808,11 @@ private:
 struct AudioDevInfo
 {
     /**
+     * The device ID
+     */
+    pjmedia_aud_dev_index id;
+
+    /**
      * The device name
      */
     string name;

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -624,6 +624,7 @@ void ToneGenerator::setDigitMap(const ToneDigitMapVector &digit_map)
 ///////////////////////////////////////////////////////////////////////////////
 void AudioDevInfo::fromPj(const pjmedia_aud_dev_info &dev_info)
 {
+    id = dev_info.id;
     name = dev_info.name;
     inputCount = dev_info.input_count;
     outputCount = dev_info.output_count;


### PR DESCRIPTION
To implement #3551.

Similar to the video counterpart, adding device ID in `pjmedia_aud_dev_info` can be useful since application can pass defaults such as `PJMEDIA_AUD_DEFAULT_CAPTURE_DEV` to `pjmedia_aud_dev_get_info()` and easily obtain the real device ID.
