### PR TITLE
Fixed PJSIP Developer's Guide link in sip_module doc

### DIFF
--- a/pjsip/include/pjsip/sip_module.h
+++ b/pjsip/include/pjsip/sip_module.h
@@ -41,7 +41,7 @@ PJ_BEGIN_DECL
  * structure, and register the structure to PJSIP with 
  * #pjsip_endpt_register_module().
  *
- * The <A HREF="/docs.htm">PJSIP Developer's Guide</A>
+ * The <A HREF="/en/latest/api/pjsip/guide.html">PJSIP Developer's Guide</A>
  * has a thorough discussion on this subject, and readers are encouraged
  * to read the document for more information.
  */


### PR DESCRIPTION
It is reported that the link is broken:
https://docs.pjsip.org/en/latest/api/generated/pjsip/group/group__PJSIP__MOD.html

which should point to:
https://docs.pjsip.org/en/latest/api/pjsip/guide.html

Another alternative is to remove the link altogether so we don't need to update the link in case that the doc is migrated in the future.