### PR TITLE
Fixed assertion when starting video preview

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1539,8 +1539,11 @@ PJ_DEF(pj_status_t) pjsua_vid_preview_start(pjmedia_vid_dev_index id,
 
     rend_id = prm->rend_id;
 
-    if (prm->format.detail_type == PJMEDIA_FORMAT_DETAIL_VIDEO)
+    if (prm->format.type == PJMEDIA_TYPE_VIDEO &&
+        prm->format.detail_type == PJMEDIA_FORMAT_DETAIL_VIDEO)
+    {
         fmt = &prm->format;
+    }
     status = create_vid_win(PJSUA_WND_TYPE_PREVIEW, fmt, rend_id, id,
                             prm->show, prm->wnd_flags,
                             (prm->wnd.info.window? &prm->wnd: NULL), &wid);


### PR DESCRIPTION
After #3547, there will be an assertion when starting video preview:
```
I/System.out: 15:20:13.327            pjsua_vid.c  .Creating video window: type=preview, cap_id=-1, rend_id=-2
A/libc: ../src/pjmedia/vid_port.c:525: pj_status_t pjmedia_vid_port_create(pj_pool_t *, const pjmedia_vid_port_param *, pjmedia_vid_port **): 
assertion "prm->vidparam.fmt.type == PJMEDIA_TYPE_VIDEO && prm->vidparam.dir != PJMEDIA_DIR_NONE && 
prm->vidparam.dir != PJMEDIA_DIR_CAPTURE_RENDER" failed
A/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 18646 (jsip.pjsua2.app), pid 18646 (jsip.pjsua2.app)
```

This is the flow:
`VideoPreviewOpParam::VideoPreviewOpParam()`->`pjsua_vid_preview_param_default()` ->`pj_bzero(&p->format, sizeof(p->format))`. Then in `MediaFormatVideo::fromPj()`-> `MediaFormatVideo.type` becomes `PJMEDIA_TYPE_UNKNOWN`.

This causes `pjsua_vid_preview_start()` to assert in `create_vid_win()`->`pjmedia_vid_port_create()` since the passed format is of unknown type (`prm->vidparam.fmt.type` is `PJMEDIA_TYPE_UNKNOWN`).
