### PR TITLE
Improve the handling of consecutive ioq accept errors

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -681,13 +681,13 @@
 #endif
 
 /**
- * Maximum consecutive identical error for accept() operation before
+ * Maximum consecutive errors for accept() operation before
  * activesock stops calling the next ioqueue accept.
  *
- * Default: 50
+ * Default: 100
  */
 #ifndef PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR
-#   define PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR 50
+#   define PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR 100
 #endif
 
 /**

--- a/pjlib/src/pj/activesock.c
+++ b/pjlib/src/pj/activesock.c
@@ -863,27 +863,31 @@ static void ioqueue_on_accept_complete(pj_ioqueue_key_t *key,
     struct accept_op *accept_op = (struct accept_op*) op_key;
 
     PJ_UNUSED_ARG(new_sock);
-
+printf("here\n");
     /* Ignore if we've been shutdown */
     if (asock->shutdown)
         return;
 
     do {
-        if (status == asock->last_err && status != PJ_SUCCESS) {
+        if (/*status == asock->last_err && */status != PJ_SUCCESS) {
             asock->err_counter++;
-            if (asock->err_counter >= PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR) {
-                PJ_LOG(3, ("", "Received %d consecutive errors: %d for the accept()"
-                               " operation, stopping further ioqueue accepts.",
-                               asock->err_counter, asock->last_err));
+            asock->last_err = status;
+            if (asock->err_counter >=
+                PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR)
+            {
+                PJ_LOG(3, ("", "Received %d consecutive errors: %d for the "
+                               "accept() operation, stopping further ioqueue "
+                               "accepts.", asock->err_counter,
+                               asock->last_err));
                 
-                if ((status == PJ_STATUS_FROM_OS(OSERR_EWOULDBLOCK)) && 
+                if (/*(status == PJ_STATUS_FROM_OS(OSERR_EWOULDBLOCK)) && */
                     (asock->cb.on_accept_complete2)) 
                 {
                     (*asock->cb.on_accept_complete2)(asock, 
                                                      accept_op->new_sock,
                                                      &accept_op->rem_addr,
                                                      accept_op->rem_addr_len,
-                                                     PJ_ESOCKETSTOP);
+                                                     status);
                 }
                 return;
             }

--- a/pjlib/src/pj/activesock.c
+++ b/pjlib/src/pj/activesock.c
@@ -863,7 +863,7 @@ static void ioqueue_on_accept_complete(pj_ioqueue_key_t *key,
     struct accept_op *accept_op = (struct accept_op*) op_key;
 
     PJ_UNUSED_ARG(new_sock);
-printf("here\n");
+
     /* Ignore if we've been shutdown */
     if (asock->shutdown)
         return;


### PR DESCRIPTION
It is reported that listener can get into a bad state, but there was no log of `Received %d consecutive errors: %d for the accept() operation, stopping further ioqueue accepts.`
Note that the issue happens very rarely, so reproduction may not be straightforward.

There are a couple of potential issues identified:
- The accept errors may not always be identical.
- Application may not always be notified via the callback since currently `on_accept_complete2()` is only called `if status == PJ_STATUS_FROM_OS(OSERR_EWOULDBLOCK)`

There are a few alternatives to fix it:
a. Remove the requirement of errors tracked to be identical (the fix in this PR)
Con: `PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR` spec change
b. Introduce another setting `PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR2` (any better name?) to track non-identical errors.
Con: Too many settings
c. Also track non-identical errors but we don't need additional setting. Instead, we limit the non-identical errors to `c * PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR` (for example, double or triple the value).
Con: Slightly more complicated spec, and `c` is constant.
