### PR TITLE
Add PJSUA2 interface to get and put audio frames

### DIFF
--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -52,14 +52,14 @@ class MyAccount;
 
 class MyAudioMediaPort: public AudioMediaPort
 {
-    virtual void getFrame(MediaFrame &frame)
+    virtual void onFrameRequested(MediaFrame &frame)
     {
         // Give the input frame here
         frame.type = PJMEDIA_FRAME_TYPE_AUDIO;
         // frame.buf.assign('c', frame.size);
     }
 
-    virtual void putFrame(MediaFrame &frame)
+    virtual void onFrameReceived(MediaFrame &frame)
     {
         // Process the incoming frame here
     }

--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -56,7 +56,7 @@ class MyAudioMediaPort: public AudioMediaPort
     {
         // Give the input frame here
         frame.type = PJMEDIA_FRAME_TYPE_AUDIO;
-        // frame.buf.assign('c', frame.size);
+        // frame.buf.assign(frame.size, 'c');
     }
 
     virtual void onFrameReceived(MediaFrame &frame)

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -118,6 +118,7 @@ using namespace pj;
 
 %template(StringVector)			std::vector<std::string>;
 %template(IntVector) 			std::vector<int>;
+%template(ByteVector) 			std::vector<unsigned char>;
 %template(StringToStringMap) 			std::map<string, string>;
 
 //

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -104,6 +104,7 @@ using namespace pj;
 %feature("director") Buddy;
 %feature("director") FindBuddyMatch;
 %feature("director") AudioMediaPlayer;
+%feature("director") AudioMediaPort;
 
 //
 // STL stuff.

--- a/pjsip-apps/src/swig/python/Makefile
+++ b/pjsip-apps/src/swig/python/Makefile
@@ -26,7 +26,7 @@ SWIG_FLAGS=-I../../../../pjlib/include \
 SRC_DIR=../../../../pjsip/include
 SRCS=$(SRC_DIR)/pjsua2/endpoint.hpp $(SRC_DIR)/pjsua2/types.hpp
 
-#USE_THREADS = -threads -DSWIG_NO_EXPORT_ITERATOR_METHODS
+USE_THREADS = -threads -DSWIG_NO_EXPORT_ITERATOR_METHODS
 SWIG_FLAGS += -w312 $(USE_THREADS)
 
 .PHONY: all install uninstall

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -427,6 +427,14 @@ typedef enum pjmedia_orient
   PJMEDIA_ORIENT_ROTATE_270DEG
 } pjmedia_orient;
 
+typedef enum pjmedia_frame_type
+{
+    PJMEDIA_FRAME_TYPE_NONE,
+    PJMEDIA_FRAME_TYPE_AUDIO,
+    PJMEDIA_FRAME_TYPE_EXTENDED,
+    PJMEDIA_FRAME_TYPE_VIDEO
+} pjmedia_frame_type;
+
 typedef enum pjmedia_format_id
 {
   PJMEDIA_FORMAT_L16 = 0,

--- a/pjsip-apps/src/swig/symbols.lst
+++ b/pjsip-apps/src/swig/symbols.lst
@@ -17,6 +17,7 @@ pjmedia-audiodev/audiodev.h 	pjmedia_aud_dev_route pjmedia_aud_dev_cap
 pjmedia/wav_port.h              pjmedia_file_writer_option pjmedia_file_player_option
 pjmedia/tonegen.h		pjmedia_tone_digit pjmedia_tone_digit_map pjmedia_tone_desc
 pjmedia/types.h                 pjmedia_type pjmedia_dir pjmedia_tp_proto pjmedia_orient
+pjmedia/frames.h		pjmedia_frame_type
 pjmedia/format.h		pjmedia_format_id
 pjmedia/vid_codec.h		pjmedia_vid_packing
 pjmedia/rtcp_fb.h		pjmedia_rtcp_fb_type

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -477,8 +477,8 @@ public:
     /**
      * This callback is called to request a frame from this port. On input,
      * frame.size indicates the capacity of the frame buffer and frame.buf
-     * will initially be an empty string. Application can then set the frame
-     * type, fill the string buffer, and set the string's length.
+     * will initially be an empty vector. Application can then set the frame
+     * type and fill the vector.
      *
      * @param frame       The frame.
      */
@@ -487,8 +487,8 @@ public:
 
     /**
      * This callback is called when this port receives a frame. The frame
-     * content will be provided in frame.buf, and the frame size can be
-     * found in either frame.size or the string buffer's length (both
+     * content will be provided in frame.buf vector, and the frame size
+     * can be found in either frame.size or the vector's size (both
      * have the same value).
      *
      * @param frame       The frame.

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -479,7 +479,7 @@ public:
      *
      * @param frame       The frame.
      */
-    virtual void getFrame(MediaFrame &frame)
+    virtual void onFrameRequested(MediaFrame &frame)
     { PJ_UNUSED_ARG(frame); }
 
     /**
@@ -487,7 +487,7 @@ public:
      *
      * @param frame       The frame.
      */
-    virtual void putFrame(MediaFrame &frame)
+    virtual void onFrameReceived(MediaFrame &frame)
     { PJ_UNUSED_ARG(frame); }
 
 private:

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -427,6 +427,75 @@ typedef std::vector<AudioMedia*> AudioMediaVector;
 typedef std::vector<AudioMedia> AudioMediaVector2;
 
 /**
+ * This structure describes a media frame.
+ */
+struct MediaFrame
+{
+    pjmedia_frame_type   type;      /**< Frame type.                        */
+    string               buf;       /**< Frame buffer content.              */
+    unsigned             size;      /**< Frame size in bytes.               */
+
+public:
+    /**
+     * Default constructor
+     */
+    MediaFrame()
+    : type(PJMEDIA_FRAME_TYPE_NONE),
+      size(0)
+    {}
+};
+
+/**
+ * Audio Media Port.
+ */
+class AudioMediaPort : public AudioMedia
+{
+public:
+    /**
+     * Constructor.
+     */
+    AudioMediaPort();
+
+    /**
+     * Destructor. This will unregister the audio media port from the
+     * conference bridge.
+     */
+    virtual ~AudioMediaPort();
+
+    /**
+     * Create an audio media port and register it to the conference bridge.
+     *
+     * @param name      The port name.
+     * @param fmt       The audio format.
+     */
+    void createPort(const string &name, MediaFormatAudio &fmt)
+                    PJSUA2_THROW(Error);
+
+    /*
+     * Callbacks
+     */
+    /**
+     * Get a frame from the port.
+     *
+     * @param frame       The frame.
+     */
+    virtual void getFrame(MediaFrame &frame)
+    { PJ_UNUSED_ARG(frame); }
+
+    /**
+     * Put a frame to the port.
+     *
+     * @param frame       The frame.
+     */
+    virtual void putFrame(MediaFrame &frame)
+    { PJ_UNUSED_ARG(frame); }
+
+private:
+    pj_pool_t *pool;
+    pjmedia_port port;
+};
+
+/**
  * This structure contains additional info about AudioMediaPlayer.
  */
 struct AudioMediaPlayerInfo

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -432,7 +432,7 @@ typedef std::vector<AudioMedia> AudioMediaVector2;
 struct MediaFrame
 {
     pjmedia_frame_type   type;      /**< Frame type.                        */
-    string               buf;       /**< Frame buffer content.              */
+    ByteVector           buf;       /**< Frame buffer content.              */
     unsigned             size;      /**< Frame size in bytes.               */
 
 public:

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -475,7 +475,10 @@ public:
      * Callbacks
      */
     /**
-     * Get a frame from the port.
+     * This callback is called to request a frame from this port. On input,
+     * frame.size indicates the capacity of the frame buffer and frame.buf
+     * will initially be an empty string. Application can then set the frame
+     * type, fill the string buffer, and set the string's length.
      *
      * @param frame       The frame.
      */
@@ -483,7 +486,10 @@ public:
     { PJ_UNUSED_ARG(frame); }
 
     /**
-     * Put a frame to the port.
+     * This callback is called when this port receives a frame. The frame
+     * content will be provided in frame.buf, and the frame size can be
+     * found in either frame.size or the string buffer's length (both
+     * have the same value).
      *
      * @param frame       The frame.
      */

--- a/pjsip/include/pjsua2/types.hpp
+++ b/pjsip/include/pjsua2/types.hpp
@@ -52,6 +52,9 @@ typedef std::vector<std::string> StringVector;
 /** Array of integers */
 typedef std::vector<int> IntVector;
 
+/** Array of bytes */
+typedef std::vector<unsigned char> ByteVector;
+
 /** Map string to string */
 typedef std::map<std::string, std::string> StringToStringMap;
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -265,6 +265,78 @@ AudioMedia* AudioMedia::typecastFromMedia(Media *media)
 
 ///////////////////////////////////////////////////////////////////////////////
 
+AudioMediaPort::AudioMediaPort()
+: pool(NULL)
+{
+}
+
+AudioMediaPort::~AudioMediaPort()
+{
+    if (pool) {
+        PJSUA2_CATCH_IGNORE( unregisterMediaPort() );
+        pj_pool_release(pool);
+        pool = NULL;
+    }
+}
+
+static pj_status_t get_frame(pjmedia_port *port, pjmedia_frame *frame)
+{
+    AudioMediaPort *mport = (AudioMediaPort *) port->port_data.pdata;
+    MediaFrame frame_;
+
+    frame_.size = frame->size;
+    mport->getFrame(frame_);
+    frame->type = frame_.type;
+    frame->size = PJ_MIN(frame_.buf.size(), frame_.size);
+    pj_memcpy(frame->buf, frame_.buf.c_str(), frame->size);
+
+    return PJ_SUCCESS;
+}
+
+static pj_status_t put_frame(pjmedia_port *port, pjmedia_frame *frame)
+{
+    AudioMediaPort *mport = (AudioMediaPort *) port->port_data.pdata;
+    MediaFrame frame_;
+
+    frame_.type = frame->type;
+    frame_.buf.assign((char *)frame->buf, frame->size);
+    frame_.size = frame->size;
+    mport->putFrame(frame_);
+
+    return PJ_SUCCESS;
+}
+
+void AudioMediaPort::createPort(const string &name, MediaFormatAudio &fmt)
+                                PJSUA2_THROW(Error)
+{
+    pj_str_t name_;
+    pjmedia_format fmt_;
+
+    if (pool) {
+        PJSUA2_RAISE_ERROR(PJ_EEXISTS);
+    }
+
+    pool = pjsua_pool_create( "amport%p", 512, 512);
+    if (!pool) {
+        PJSUA2_RAISE_ERROR(PJ_ENOMEM);
+    }
+
+    /* Init port. */
+    pj_strdup2_with_null(pool, &name_, name.c_str());
+    fmt_ = fmt.toPj();
+    pjmedia_port_info_init2(&port.info, &name_,
+                            PJMEDIA_SIG_CLASS_APP ('A', 'M', 'P'),
+                            PJMEDIA_DIR_ENCODING_DECODING, &fmt_);
+
+    port.port_data.pdata = this;
+    port.put_frame = &put_frame;
+    port.get_frame = &get_frame;
+
+    registerMediaPort2(&port, pool);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 AudioMediaPlayer::AudioMediaPlayer()
 : playerId(PJSUA_INVALID_ID)
 {

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -288,7 +288,7 @@ static pj_status_t get_frame(pjmedia_port *port, pjmedia_frame *frame)
     mport->onFrameRequested(frame_);
     frame->type = frame_.type;
     frame->size = PJ_MIN(frame_.buf.size(), frame_.size);
-    frame_.buf.copy((char *)frame->buf, frame->size);
+    pj_memcpy(frame->buf, frame_.buf.data(), frame->size);
 
     return PJ_SUCCESS;
 }
@@ -299,7 +299,7 @@ static pj_status_t put_frame(pjmedia_port *port, pjmedia_frame *frame)
     MediaFrame frame_;
 
     frame_.type = frame->type;
-    frame_.buf.assign((char *)frame->buf, frame->size);
+    frame_.buf.assign((char *)frame->buf, ((char *)frame->buf) + frame->size);
     frame_.size = frame->size;
     mport->onFrameReceived(frame_);
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -288,7 +288,7 @@ static pj_status_t get_frame(pjmedia_port *port, pjmedia_frame *frame)
     mport->onFrameRequested(frame_);
     frame->type = frame_.type;
     frame->size = PJ_MIN(frame_.buf.size(), frame_.size);
-    pj_memcpy(frame->buf, frame_.buf.c_str(), frame->size);
+    frame_.buf.copy((char *)frame->buf, frame->size);
 
     return PJ_SUCCESS;
 }

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -285,7 +285,7 @@ static pj_status_t get_frame(pjmedia_port *port, pjmedia_frame *frame)
     MediaFrame frame_;
 
     frame_.size = frame->size;
-    mport->getFrame(frame_);
+    mport->onFrameRequested(frame_);
     frame->type = frame_.type;
     frame->size = PJ_MIN(frame_.buf.size(), frame_.size);
     pj_memcpy(frame->buf, frame_.buf.c_str(), frame->size);
@@ -301,7 +301,7 @@ static pj_status_t put_frame(pjmedia_port *port, pjmedia_frame *frame)
     frame_.type = frame->type;
     frame_.buf.assign((char *)frame->buf, frame->size);
     frame_.size = frame->size;
-    mport->putFrame(frame_);
+    mport->onFrameReceived(frame_);
 
     return PJ_SUCCESS;
 }


### PR DESCRIPTION
To implement #2352.

Application can extend the class `AudioMediaPort` to get the callbacks `onFrameRequested()` and `onFrameReceived()`.

An example usage for C++ and Python can be found in `pjsua2_demo.cpp` and `test.py`.
