### PR TITLE
Implement DTLS-SRTP for RTCP

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -228,6 +228,22 @@ static crypto_suite crypto_suites[] = {
      */
 };
 
+typedef struct srtp_context
+{
+    /* SRTP policy */
+    char                 tx_key[MAX_KEY_LEN];
+    char                 rx_key[MAX_KEY_LEN];
+    pjmedia_srtp_crypto  tx_policy;
+    pjmedia_srtp_crypto  rx_policy;
+
+    /* Temporary policy for negotiation */
+    pjmedia_srtp_crypto  tx_policy_neg;
+    pjmedia_srtp_crypto  rx_policy_neg;
+
+    /* libSRTP contexts */
+    srtp_t               srtp_tx_ctx;
+    srtp_t               srtp_rx_ctx;
+} srtp_context;
 
 /* SRTP transport */
 typedef struct transport_srtp
@@ -241,22 +257,14 @@ typedef struct transport_srtp
     unsigned             media_option;
     pj_bool_t            use_rtcp_mux;      /**< Use RTP& RTCP multiplexing?*/
 
-    /* SRTP policy */
     pj_bool_t            session_inited;
     pj_bool_t            offerer_side;
     pj_bool_t            bypass_srtp;
-    char                 tx_key[MAX_KEY_LEN];
-    char                 rx_key[MAX_KEY_LEN];
-    pjmedia_srtp_crypto  tx_policy;
-    pjmedia_srtp_crypto  rx_policy;
 
-    /* Temporary policy for negotiation */
-    pjmedia_srtp_crypto  tx_policy_neg;
-    pjmedia_srtp_crypto  rx_policy_neg;
-
-    /* libSRTP contexts */
-    srtp_t               srtp_tx_ctx;
-    srtp_t               srtp_rx_ctx;
+    /* SRTP contexts */
+    srtp_context         srtp_ctx;
+    srtp_context         srtp_rtcp;         /**< Separate context for RTCP,
+                                                 if needed, such as for DTLS*/
 
     /* Stream information */
     void                *user_data;
@@ -411,6 +419,14 @@ static int srtp_crypto_cmp(const pjmedia_srtp_crypto* c1,
 
 /* Start SRTP */
 static pj_status_t start_srtp(transport_srtp *srtp);
+/* Create SRTP context */
+static pj_status_t create_srtp_ctx(transport_srtp *srtp,
+                                   srtp_context *ctx,
+                                   const pjmedia_srtp_setting *setting,
+                                   const pjmedia_srtp_crypto *tx,
+                                   const pjmedia_srtp_crypto *rx);
+/* Destroy SRTP context */
+static void destroy_srtp_ctx(transport_srtp *p_srtp, srtp_context *ctx);
 
 
 /* This function may also be used by other module, e.g: pjmedia/errno.c,
@@ -845,15 +861,13 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_modify_setting(
 }
 
 
-/*
- * Initialize and start SRTP session with the given parameters.
- */
-PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
-                           pjmedia_transport *tp,
-                           const pjmedia_srtp_crypto *tx,
-                           const pjmedia_srtp_crypto *rx)
+/* Create SRTP context */
+static pj_status_t create_srtp_ctx(transport_srtp *srtp,
+                                   srtp_context *ctx,
+                                   const pjmedia_srtp_setting *setting,
+                                   const pjmedia_srtp_crypto *tx,
+                                   const pjmedia_srtp_crypto *rx)
 {
-    transport_srtp  *srtp = (transport_srtp*) tp;
     srtp_policy_t    tx_;
     srtp_policy_t    rx_;
     srtp_err_status_t err;
@@ -863,13 +877,10 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
     int              au_rx_idx = 0;
     pj_status_t      status = PJ_SUCCESS;
 
-    PJ_ASSERT_RETURN(tp && tx && rx, PJ_EINVAL);
-
     pj_lock_acquire(srtp->mutex);
 
-    if (srtp->session_inited) {
-        pjmedia_transport_srtp_stop(tp);
-    }
+    if (ctx->srtp_tx_ctx || ctx->srtp_rx_ctx)
+        destroy_srtp_ctx(srtp, ctx);
 
     /* Get encryption and authentication method */
     cr_tx_idx = au_tx_idx = get_crypto_idx(&tx->name);
@@ -894,7 +905,9 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
 
     /* If all options points to 'NULL' method, just bypass SRTP */
     if (cr_tx_idx == 0 && cr_rx_idx == 0 && au_tx_idx == 0 && au_rx_idx == 0) {
-        srtp->bypass_srtp = PJ_TRUE;
+        /* To bypass SRTP: we return PJ_SUCCESS without allocating SRTP
+         * contexts.
+         */
         goto on_return;
     }
 
@@ -908,7 +921,7 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
 
     /* Init transmit direction */
     pj_bzero(&tx_, sizeof(srtp_policy_t));
-    pj_memmove(srtp->tx_key, tx->key.ptr, tx->key.slen);
+    pj_memmove(ctx->tx_key, tx->key.ptr, tx->key.slen);
     if (cr_tx_idx && au_tx_idx)
         tx_.rtp.sec_serv    = sec_serv_conf_and_auth;
     else if (cr_tx_idx)
@@ -917,12 +930,12 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
         tx_.rtp.sec_serv    = sec_serv_auth;
     else
         tx_.rtp.sec_serv    = sec_serv_none;
-    tx_.key                 = (uint8_t*)srtp->tx_key;
-    if (srtp->setting.tx_roc.roc != 0 &&
-        srtp->setting.tx_roc.ssrc != 0)
+    tx_.key                 = (uint8_t*)ctx->tx_key;
+    if (setting->tx_roc.roc != 0 &&
+        setting->tx_roc.ssrc != 0)
     {
         tx_.ssrc.type       = ssrc_specific;
-        tx_.ssrc.value      = srtp->setting.tx_roc.ssrc;
+        tx_.ssrc.value      = setting->tx_roc.ssrc;
     } else {
         tx_.ssrc.type       = ssrc_any_outbound;
         tx_.ssrc.value      = 0;
@@ -935,30 +948,30 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
     tx_.rtcp                = tx_.rtp;
     tx_.rtcp.auth_tag_len   = crypto_suites[au_tx_idx].srtcp_auth_tag_len;
     tx_.next                = NULL;
-    err = srtp_create(&srtp->srtp_tx_ctx, &tx_);
+    err = srtp_create(&ctx->srtp_tx_ctx, &tx_);
     if (err != srtp_err_status_ok) {
         status = PJMEDIA_ERRNO_FROM_LIBSRTP(err);
         goto on_return;
     }
-    if (srtp->setting.tx_roc.roc != 0 &&
-        srtp->setting.tx_roc.ssrc != 0)
+    if (setting->tx_roc.roc != 0 &&
+        setting->tx_roc.ssrc != 0)
     {
-        err = srtp_set_stream_roc(srtp->srtp_tx_ctx,
-                                  srtp->setting.tx_roc.ssrc,
-                                  srtp->setting.tx_roc.roc);
+        err = srtp_set_stream_roc(ctx->srtp_tx_ctx,
+                                  setting->tx_roc.ssrc,
+                                  setting->tx_roc.roc);
         PJ_LOG(4, (THIS_FILE, "Initializing SRTP TX ROC to SSRC %d with "
-                   "ROC %d %s\n", srtp->setting.tx_roc.ssrc,
-                   srtp->setting.tx_roc.roc,
+                   "ROC %d %s\n", setting->tx_roc.ssrc,
+                   setting->tx_roc.roc,
                    (err == srtp_err_status_ok)? "succeeded": "failed"));
     }
-    srtp->tx_policy = *tx;
-    pj_strset(&srtp->tx_policy.key,  srtp->tx_key, tx->key.slen);
-    srtp->tx_policy.name=pj_str(crypto_suites[get_crypto_idx(&tx->name)].name);
+    ctx->tx_policy = *tx;
+    pj_strset(&ctx->tx_policy.key,  ctx->tx_key, tx->key.slen);
+    ctx->tx_policy.name=pj_str(crypto_suites[get_crypto_idx(&tx->name)].name);
 
 
     /* Init receive direction */
     pj_bzero(&rx_, sizeof(srtp_policy_t));
-    pj_memmove(srtp->rx_key, rx->key.ptr, rx->key.slen);
+    pj_memmove(ctx->rx_key, rx->key.ptr, rx->key.slen);
     if (cr_rx_idx && au_rx_idx)
         rx_.rtp.sec_serv    = sec_serv_conf_and_auth;
     else if (cr_rx_idx)
@@ -967,12 +980,12 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
         rx_.rtp.sec_serv    = sec_serv_auth;
     else
         rx_.rtp.sec_serv    = sec_serv_none;
-    rx_.key                 = (uint8_t*)srtp->rx_key;
-    if (srtp->setting.rx_roc.roc != 0 &&
-        srtp->setting.rx_roc.ssrc != 0)
+    rx_.key                 = (uint8_t*)ctx->rx_key;
+    if (setting->rx_roc.roc != 0 &&
+        setting->rx_roc.ssrc != 0)
     {
         rx_.ssrc.type       = ssrc_specific;
-        rx_.ssrc.value      = srtp->setting.rx_roc.ssrc;
+        rx_.ssrc.value      = setting->rx_roc.ssrc;
     } else {
         rx_.ssrc.type       = ssrc_any_inbound;
         rx_.ssrc.value      = 0;
@@ -986,29 +999,26 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
     rx_.rtcp                = rx_.rtp;
     rx_.rtcp.auth_tag_len   = crypto_suites[au_rx_idx].srtcp_auth_tag_len;
     rx_.next                = NULL;
-    err = srtp_create(&srtp->srtp_rx_ctx, &rx_);
+    err = srtp_create(&ctx->srtp_rx_ctx, &rx_);
     if (err != srtp_err_status_ok) {
-        srtp_dealloc(srtp->srtp_tx_ctx);
+        srtp_dealloc(ctx->srtp_tx_ctx);
         status = PJMEDIA_ERRNO_FROM_LIBSRTP(err);
         goto on_return;
     }
-    if (srtp->setting.rx_roc.roc != 0 &&
-        srtp->setting.rx_roc.ssrc != 0)
+    if (setting->rx_roc.roc != 0 &&
+        setting->rx_roc.ssrc != 0)
     {
-        err = srtp_set_stream_roc(srtp->srtp_rx_ctx,
-                                  srtp->setting.rx_roc.ssrc,
-                                  srtp->setting.rx_roc.roc);
+        err = srtp_set_stream_roc(ctx->srtp_rx_ctx,
+                                  setting->rx_roc.ssrc,
+                                  setting->rx_roc.roc);
         PJ_LOG(4, (THIS_FILE, "Initializing SRTP RX ROC from SSRC %d with "
                    "ROC %d %s\n",
-                   srtp->setting.rx_roc.ssrc, srtp->setting.rx_roc.roc,
+                   setting->rx_roc.ssrc, setting->rx_roc.roc,
                    (err == srtp_err_status_ok)? "succeeded": "failed"));
     }
-    srtp->rx_policy = *rx;
-    pj_strset(&srtp->rx_policy.key,  srtp->rx_key, rx->key.slen);
-    srtp->rx_policy.name=pj_str(crypto_suites[get_crypto_idx(&rx->name)].name);
-
-    /* Declare SRTP session initialized */
-    srtp->session_inited = PJ_TRUE;
+    ctx->rx_policy = *rx;
+    pj_strset(&ctx->rx_policy.key,  ctx->rx_key, rx->key.slen);
+    ctx->rx_policy.name=pj_str(crypto_suites[get_crypto_idx(&rx->name)].name);
 
     /* Logging stuffs */
 #if PJ_LOG_MAX_LEVEL >= 5
@@ -1026,8 +1036,8 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
             b64[b64_len] = '\0';
 
         PJ_LOG(5, (srtp->pool->obj_name, "TX: %s key=%s",
-                   srtp->tx_policy.name.ptr, b64));
-        if (srtp->tx_policy.flags) {
+                   ctx->tx_policy.name.ptr, b64));
+        if (ctx->tx_policy.flags) {
             PJ_LOG(5,(srtp->pool->obj_name, "TX: disable%s%s",
                       (cr_tx_idx?"":" enc"),
                       (au_tx_idx?"":" auth")));
@@ -1043,8 +1053,8 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
             b64[b64_len] = '\0';
 
         PJ_LOG(5, (srtp->pool->obj_name, "RX: %s key=%s",
-                   srtp->rx_policy.name.ptr, b64));
-        if (srtp->rx_policy.flags) {
+                   ctx->rx_policy.name.ptr, b64));
+        if (ctx->rx_policy.flags) {
             PJ_LOG(5,(srtp->pool->obj_name,"RX: disable%s%s",
                       (cr_rx_idx?"":" enc"),
                       (au_rx_idx?"":" auth")));
@@ -1058,12 +1068,73 @@ on_return:
 }
 
 /*
+ * Initialize and start SRTP session with the given parameters.
+ */
+PJ_DEF(pj_status_t) pjmedia_transport_srtp_start(
+                           pjmedia_transport *tp,
+                           const pjmedia_srtp_crypto *tx,
+                           const pjmedia_srtp_crypto *rx)
+{
+    transport_srtp  *srtp = (transport_srtp*) tp;
+    pj_status_t status;
+
+    PJ_ASSERT_RETURN(tp && tx && rx, PJ_EINVAL);
+
+    pj_lock_acquire(srtp->mutex);
+
+    if (srtp->session_inited) {
+        pjmedia_transport_srtp_stop(tp);
+    }
+
+    status = create_srtp_ctx(srtp, &srtp->srtp_ctx, &srtp->setting, tx, rx);
+    if (status == PJ_SUCCESS) {
+        if (srtp->srtp_ctx.srtp_tx_ctx && srtp->srtp_ctx.srtp_rx_ctx) {
+            /* Declare SRTP session initialized */
+            srtp->session_inited = PJ_TRUE;
+        } else {
+            srtp->bypass_srtp = PJ_TRUE;
+        }
+    }
+
+    pj_lock_release(srtp->mutex);
+
+    return status;
+}
+
+/* Destroy SRTP context */
+static void destroy_srtp_ctx(transport_srtp *p_srtp, srtp_context *ctx)
+{
+    srtp_err_status_t err;
+
+    if (ctx->srtp_rx_ctx) {
+        err = srtp_dealloc(ctx->srtp_rx_ctx);
+        if (err != srtp_err_status_ok) {
+            PJ_LOG(4, (p_srtp->pool->obj_name,
+                       "Failed to dealloc RX SRTP context: %s",
+                       get_libsrtp_errstr(err)));
+        }
+    }
+    if (ctx->srtp_tx_ctx) {
+        err = srtp_dealloc(ctx->srtp_tx_ctx);
+        if (err != srtp_err_status_ok) {
+            PJ_LOG(4, (p_srtp->pool->obj_name,
+                       "Failed to dealloc TX SRTP context: %s",
+                       get_libsrtp_errstr(err)));
+        }
+    }
+    ctx->srtp_rx_ctx = NULL;
+    ctx->srtp_tx_ctx = NULL;
+
+    pj_bzero(&ctx->rx_policy, sizeof(ctx->rx_policy));
+    pj_bzero(&ctx->tx_policy, sizeof(ctx->tx_policy));
+}
+
+/*
  * Stop SRTP session.
  */
 PJ_DEF(pj_status_t) pjmedia_transport_srtp_stop(pjmedia_transport *srtp)
 {
     transport_srtp *p_srtp = (transport_srtp*) srtp;
-    srtp_err_status_t err;
 
     PJ_ASSERT_RETURN(srtp, PJ_EINVAL);
 
@@ -1074,24 +1145,10 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_stop(pjmedia_transport *srtp)
         return PJ_SUCCESS;
     }
 
-    err = srtp_dealloc(p_srtp->srtp_rx_ctx);
-    if (err != srtp_err_status_ok) {
-        PJ_LOG(4, (p_srtp->pool->obj_name,
-                   "Failed to dealloc RX SRTP context: %s",
-                   get_libsrtp_errstr(err)));
-    }
-    err = srtp_dealloc(p_srtp->srtp_tx_ctx);
-    if (err != srtp_err_status_ok) {
-        PJ_LOG(4, (p_srtp->pool->obj_name,
-                   "Failed to dealloc TX SRTP context: %s",
-                   get_libsrtp_errstr(err)));
-    }
-    p_srtp->srtp_rx_ctx = NULL;
-    p_srtp->srtp_tx_ctx = NULL;
+    destroy_srtp_ctx(p_srtp, &p_srtp->srtp_ctx);
+    destroy_srtp_ctx(p_srtp, &p_srtp->srtp_rtcp);
 
     p_srtp->session_inited = PJ_FALSE;
-    pj_bzero(&p_srtp->rx_policy, sizeof(p_srtp->rx_policy));
-    pj_bzero(&p_srtp->tx_policy, sizeof(p_srtp->tx_policy));
 
     pj_lock_release(p_srtp->mutex);
 
@@ -1102,8 +1159,8 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_stop(pjmedia_transport *srtp)
 static pj_status_t start_srtp(transport_srtp *srtp)
 {
     /* Make sure we have the SRTP policies */
-    if (srtp_crypto_empty(&srtp->tx_policy_neg) ||
-        srtp_crypto_empty(&srtp->rx_policy_neg))
+    if (srtp_crypto_empty(&srtp->srtp_ctx.tx_policy_neg) ||
+        srtp_crypto_empty(&srtp->srtp_ctx.rx_policy_neg))
     {
         srtp->bypass_srtp = PJ_TRUE;
         srtp->peer_use = PJMEDIA_SRTP_DISABLED;
@@ -1121,13 +1178,15 @@ static pj_status_t start_srtp(transport_srtp *srtp)
      * gets updated, e.g: call hold, however we should restart SRTP only
      * when the SRTP policy settings are updated.
      */
-    if (srtp_crypto_cmp(&srtp->tx_policy_neg, &srtp->tx_policy) ||
-        srtp_crypto_cmp(&srtp->rx_policy_neg, &srtp->rx_policy))
+    if (srtp_crypto_cmp(&srtp->srtp_ctx.tx_policy_neg,
+                        &srtp->srtp_ctx.tx_policy) ||
+        srtp_crypto_cmp(&srtp->srtp_ctx.rx_policy_neg,
+                        &srtp->srtp_ctx.rx_policy))
     {
         pj_status_t status;
         status = pjmedia_transport_srtp_start(&srtp->base,
-                                              &srtp->tx_policy_neg,
-                                              &srtp->rx_policy_neg);
+                                              &srtp->srtp_ctx.tx_policy_neg,
+                                              &srtp->srtp_ctx.rx_policy_neg);
         if (status != PJ_SUCCESS)
             return status;
 
@@ -1138,7 +1197,7 @@ static pj_status_t start_srtp(transport_srtp *srtp)
                    "SRTP started, keying=%s, crypto=%s",
                    ((int)srtp->keying[0]->type==PJMEDIA_SRTP_KEYING_SDES?
                     "SDES":"DTLS-SRTP"),
-                   srtp->tx_policy.name.ptr));
+                   srtp->srtp_ctx.tx_policy.name.ptr));
     }
 
     srtp->bypass_srtp = PJ_FALSE;
@@ -1173,25 +1232,25 @@ static pj_status_t transport_get_info(pjmedia_transport *tp,
                      PJMEDIA_TRANSPORT_SPECIFIC_INFO_MAXSIZE, PJ_ENOMEM);
 
     srtp_info.active = srtp->session_inited;
-    srtp_info.rx_policy = srtp->rx_policy;
-    srtp_info.tx_policy = srtp->tx_policy;
+    srtp_info.rx_policy = srtp->srtp_ctx.rx_policy;
+    srtp_info.tx_policy = srtp->srtp_ctx.tx_policy;
     srtp_info.use = srtp->setting.use;
     srtp_info.peer_use = srtp->peer_use;
 
     pj_bzero(&srtp_info.tx_roc, sizeof(srtp_info.tx_roc));
     pj_bzero(&srtp_info.rx_roc, sizeof(srtp_info.rx_roc));
 
-    if (srtp->srtp_rx_ctx && srtp->rx_ssrc != 0) {
+    if (srtp->srtp_ctx.srtp_rx_ctx && srtp->rx_ssrc != 0) {
         srtp_info.rx_roc.ssrc = srtp->rx_ssrc;
-        srtp_get_stream_roc(srtp->srtp_rx_ctx, srtp->rx_ssrc,
+        srtp_get_stream_roc(srtp->srtp_ctx.srtp_rx_ctx, srtp->rx_ssrc,
                             &srtp_info.rx_roc.roc);
     } else if (srtp->setting.rx_roc.ssrc != 0) {
         srtp_info.rx_roc.ssrc = srtp->setting.rx_roc.ssrc;
         srtp_info.rx_roc.roc = srtp->setting.rx_roc.roc;
     }
-    if (srtp->srtp_tx_ctx && srtp->tx_ssrc != 0) {
+    if (srtp->srtp_ctx.srtp_tx_ctx && srtp->tx_ssrc != 0) {
         srtp_info.tx_roc.ssrc = srtp->tx_ssrc;
-        srtp_get_stream_roc(srtp->srtp_tx_ctx, srtp->tx_ssrc,
+        srtp_get_stream_roc(srtp->srtp_ctx.srtp_tx_ctx, srtp->tx_ssrc,
                             &srtp_info.tx_roc.roc);
     } else if (srtp->setting.tx_roc.ssrc != 0) {
         srtp_info.tx_roc.ssrc = srtp->setting.tx_roc.ssrc;
@@ -1308,7 +1367,7 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
 #if TEST_ROC
     if (srtp->setting.tx_roc.ssrc == 0) {
         srtp_err_status_t status;
-        status = srtp_set_stream_roc(srtp->srtp_tx_ctx, srtp->tx_ssrc,
+        status = srtp_set_stream_roc(srtp->srtp_ctx.srtp_tx_ctx, srtp->tx_ssrc,
                                      (srtp->offerer_side? 1: 2));
         if (status == srtp_err_status_ok) {
             srtp->setting.tx_roc.ssrc = srtp->tx_ssrc;
@@ -1319,7 +1378,7 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
     }
 #endif
 
-    err = srtp_protect(srtp->srtp_tx_ctx, srtp->rtp_tx_buffer, &len);
+    err = srtp_protect(srtp->srtp_ctx.srtp_tx_ctx, srtp->rtp_tx_buffer, &len);
     pj_lock_release(srtp->mutex);
 
     if (err == srtp_err_status_ok) {
@@ -1365,7 +1424,10 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
         pj_lock_release(srtp->mutex);
         return PJMEDIA_SRTP_EKEYNOTREADY;
     }
-    err = srtp_protect_rtcp(srtp->srtp_tx_ctx, srtp->rtcp_tx_buffer, &len);
+    err = srtp_protect_rtcp(srtp->srtp_rtcp.srtp_tx_ctx?
+                            srtp->srtp_rtcp.srtp_tx_ctx:
+                            srtp->srtp_ctx.srtp_tx_ctx,
+                            srtp->rtcp_tx_buffer, &len);
     pj_lock_release(srtp->mutex);
 
     if (err == srtp_err_status_ok) {
@@ -1501,7 +1563,7 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
         srtp_err_status_t status;
         
         srtp->rx_ssrc = ntohl(((pjmedia_rtp_hdr*)pkt)->ssrc);
-        status = srtp_set_stream_roc(srtp->srtp_rx_ctx, srtp->rx_ssrc, 
+        status = srtp_set_stream_roc(srtp->srtp_ctx.srtp_rx_ctx, srtp->rx_ssrc,
                                      (srtp->offerer_side? 2: 1));
         if (status == srtp_err_status_ok) {     
             srtp->setting.rx_roc.ssrc = srtp->rx_ssrc;
@@ -1516,7 +1578,7 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
     }
 #endif
     
-    err = srtp_unprotect(srtp->srtp_rx_ctx, (pj_uint8_t*)pkt, &len);
+    err = srtp_unprotect(srtp->srtp_ctx.srtp_rx_ctx, (pj_uint8_t*)pkt, &len);
 
 #if PJMEDIA_SRTP_CHECK_RTP_SEQ_ON_RESTART
     if (srtp->probation_cnt > 0 &&
@@ -1532,8 +1594,8 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
         pjmedia_srtp_crypto tx, rx;
         pj_status_t status;
 
-        tx = srtp->tx_policy;
-        rx = srtp->rx_policy;
+        tx = srtp->srtp_ctx.tx_policy;
+        rx = srtp->srtp_ctx.rx_policy;
 
         /* Stop SRTP first, otherwise srtp_start() will maintain current
          * roll-over counter.
@@ -1546,7 +1608,8 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
             PJ_LOG(5,(srtp->pool->obj_name, "Failed to restart SRTP, err=%s",
                       get_libsrtp_errstr(err)));
         } else if (!srtp->bypass_srtp) {
-            err = srtp_unprotect(srtp->srtp_rx_ctx, (pj_uint8_t*)pkt, &len);
+            err = srtp_unprotect(srtp->srtp_ctx.srtp_rx_ctx,
+                                 (pj_uint8_t*)pkt, &len);
         }
     }
 #if PJMEDIA_SRTP_CHECK_ROC_ON_RESTART
@@ -1563,17 +1626,18 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
         unsigned roc, new_roc;
         srtp_err_status_t status;
 
-        srtp_get_stream_roc(srtp->srtp_rx_ctx, srtp->setting.rx_roc.ssrc,
-                            &roc);
+        srtp_get_stream_roc(srtp->srtp_ctx.srtp_rx_ctx,
+                            srtp->setting.rx_roc.ssrc, &roc);
         new_roc = (roc == srtp->setting.rx_roc.roc?
                    srtp->setting.prev_rx_roc.roc: srtp->setting.rx_roc.roc);
-        status = srtp_set_stream_roc(srtp->srtp_rx_ctx,
+        status = srtp_set_stream_roc(srtp->srtp_ctx.srtp_rx_ctx,
                                      srtp->setting.rx_roc.ssrc, new_roc);
         if (status == srtp_err_status_ok) {
             PJ_LOG(4, (srtp->pool->obj_name,
                        "Retrying to unprotect SRTP from ROC %d to new ROC %d",
                        roc, new_roc));
-            err = srtp_unprotect(srtp->srtp_rx_ctx, (pj_uint8_t*)pkt, &len);
+            err = srtp_unprotect(srtp->srtp_ctx.srtp_rx_ctx, (pj_uint8_t*)pkt,
+                                 &len);
         }
     }
 #endif
@@ -1625,6 +1689,23 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
         return;
     }
 
+    /* Give the packet to keying first by invoking its send_rtcp() op,
+     * in the same way as for RTP packet above.
+     */
+    {
+        unsigned i;
+        pj_status_t status;
+        for (i=0; i < srtp->keying_cnt; i++) {
+            if (!srtp->keying[i]->op->send_rtcp)
+                continue;
+            status = pjmedia_transport_send_rtcp(srtp->keying[i], pkt, size);
+            if (status != PJ_EIGNORED) {
+                /* Packet is already consumed by the keying method */
+                return;
+            }
+        }
+    }
+
     /* Make sure buffer is 32bit aligned */
     PJ_ASSERT_ON_FAIL( (((pj_ssize_t)pkt) & 0x03)==0, return );
 
@@ -1634,7 +1715,10 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
         pj_lock_release(srtp->mutex);
         return;
     }
-    err = srtp_unprotect_rtcp(srtp->srtp_rx_ctx, (pj_uint8_t*)pkt, &len);
+    err = srtp_unprotect_rtcp(srtp->srtp_rtcp.srtp_rx_ctx?
+                              srtp->srtp_rtcp.srtp_rx_ctx:
+                              srtp->srtp_ctx.srtp_rx_ctx,
+                              (pj_uint8_t*)pkt, &len);
     if (err != srtp_err_status_ok) {
         PJ_LOG(5,(srtp->pool->obj_name,
                   "Failed to unprotect SRTCP, pkt size=%ld, err=%s",
@@ -1666,8 +1750,10 @@ static pj_status_t transport_media_create(pjmedia_transport *tp,
 
     PJ_ASSERT_RETURN(tp, PJ_EINVAL);
 
-    pj_bzero(&srtp->rx_policy_neg, sizeof(srtp->rx_policy_neg));
-    pj_bzero(&srtp->tx_policy_neg, sizeof(srtp->tx_policy_neg));
+    pj_bzero(&srtp->srtp_ctx.rx_policy_neg,
+             sizeof(srtp->srtp_ctx.rx_policy_neg));
+    pj_bzero(&srtp->srtp_ctx.tx_policy_neg,
+             sizeof(srtp->srtp_ctx.tx_policy_neg));
 
     srtp->tx_ssrc = srtp->rx_ssrc = 0;
     srtp->media_option = member_tp_option = options;
@@ -1760,8 +1846,10 @@ static pj_status_t transport_encode_sdp(pjmedia_transport *tp,
 
     PJ_ASSERT_RETURN(tp && sdp_pool && sdp_local, PJ_EINVAL);
 
-    pj_bzero(&srtp->rx_policy_neg, sizeof(srtp->rx_policy_neg));
-    pj_bzero(&srtp->tx_policy_neg, sizeof(srtp->tx_policy_neg));
+    pj_bzero(&srtp->srtp_ctx.rx_policy_neg,
+             sizeof(srtp->srtp_ctx.rx_policy_neg));
+    pj_bzero(&srtp->srtp_ctx.tx_policy_neg,
+             sizeof(srtp->srtp_ctx.tx_policy_neg));
 
     srtp->offerer_side = (sdp_remote == NULL);
 
@@ -1892,8 +1980,8 @@ static pj_status_t transport_media_start(pjmedia_transport *tp,
             continue;
         }
 
-        if (!srtp_crypto_empty(&srtp->tx_policy_neg) &&
-            !srtp_crypto_empty(&srtp->rx_policy_neg))
+        if (!srtp_crypto_empty(&srtp->srtp_ctx.tx_policy_neg) &&
+            !srtp_crypto_empty(&srtp->srtp_ctx.rx_policy_neg))
         {
             /* SRTP nego is done */
             srtp->keying_cnt = 1;
@@ -1974,9 +2062,9 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_decrypt_pkt(pjmedia_transport *tp,
     }
 
     if (is_rtp)
-        err = srtp_unprotect(srtp->srtp_rx_ctx, pkt, pkt_len);
+        err = srtp_unprotect(srtp->srtp_ctx.srtp_rx_ctx, pkt, pkt_len);
     else
-        err = srtp_unprotect_rtcp(srtp->srtp_rx_ctx, pkt, pkt_len);
+        err = srtp_unprotect_rtcp(srtp->srtp_ctx.srtp_rx_ctx, pkt, pkt_len);
 
     if (err != srtp_err_status_ok) {
         PJ_LOG(5,(srtp->pool->obj_name,

--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -40,6 +40,16 @@
 /* Set to 1 to enable DTLS-SRTP debugging */
 #define DTLS_DEBUG  0
 
+#define NUM_CHANNEL 2
+
+enum {
+    RTP_CHANNEL = 0,
+    RTCP_CHANNEL = 1
+};
+
+#define CHANNEL_TO_STRING(idx) (idx == RTP_CHANNEL? "RTP channel": \
+                                "RTCP channel")
+
 /* DTLS-SRTP transport op */
 static pj_status_t dtls_media_create  (pjmedia_transport *tp,
                                        pj_pool_t *sdp_pool,
@@ -61,6 +71,9 @@ static pj_status_t dtls_destroy       (pjmedia_transport *tp);
 static pj_status_t dtls_on_recv_rtp   (pjmedia_transport *tp,
                                        const void *pkt,
                                        pj_size_t size);
+static pj_status_t dtls_on_recv_rtcp  (pjmedia_transport *tp,
+                                       const void *pkt,
+                                       pj_size_t size);
 
 static void on_ice_complete2(pjmedia_transport *tp,
                              pj_ice_strans_op op,
@@ -74,7 +87,7 @@ static pjmedia_transport_op dtls_op =
     NULL,
     NULL,
     &dtls_on_recv_rtp,      // originally send_rtp()
-    NULL,
+    &dtls_on_recv_rtcp,     // originally send_rtcp()
     NULL,
     &dtls_media_create,
     &dtls_encode_sdp,
@@ -94,6 +107,13 @@ typedef enum dtls_setup
     DTLS_SETUP_PASSIVE
 } dtls_setup;
 
+typedef struct dtls_srtp dtls_srtp;
+
+typedef struct dtls_srtp_channel
+{
+    dtls_srtp           *dtls_srtp;
+    unsigned             channel;
+} dtls_srtp_channel;
 
 typedef struct dtls_srtp
 {
@@ -104,8 +124,9 @@ typedef struct dtls_srtp
     dtls_setup           setup;
     unsigned long        last_err;
     pj_bool_t            use_ice;
-    pj_bool_t            nego_started;
-    pj_bool_t            nego_completed;
+    dtls_srtp_channel    channel[NUM_CHANNEL];
+    pj_bool_t            nego_started[NUM_CHANNEL];
+    pj_bool_t            nego_completed[NUM_CHANNEL];
     pj_str_t             rem_fingerprint;   /* Remote fingerprint in SDP    */
     pj_status_t          rem_fprint_status; /* Fingerprint verif. status    */
     pj_sockaddr          rem_addr;          /* Remote address (from SDP/RTP)*/
@@ -114,16 +135,16 @@ typedef struct dtls_srtp
                                                nego not done yet, so start
                                                the SRTP once the nego done  */
     pj_bool_t            got_keys;          /* DTLS nego done & keys ready  */
-    pjmedia_srtp_crypto  tx_crypto;
-    pjmedia_srtp_crypto  rx_crypto;
+    pjmedia_srtp_crypto  tx_crypto[NUM_CHANNEL];
+    pjmedia_srtp_crypto  rx_crypto[NUM_CHANNEL];
 
-    char                 buf[PJMEDIA_MAX_MTU];
-    pjmedia_clock       *clock;             /* Timer workaround for retrans */
+    char                 buf[NUM_CHANNEL][PJMEDIA_MAX_MTU];
+    pjmedia_clock       *clock[NUM_CHANNEL];/* Timer workaround for retrans */
 
-    SSL_CTX             *ossl_ctx;
-    SSL                 *ossl_ssl;
-    BIO                 *ossl_rbio;
-    BIO                 *ossl_wbio;
+    SSL_CTX             *ossl_ctx[NUM_CHANNEL];
+    SSL                 *ossl_ssl[NUM_CHANNEL];
+    BIO                 *ossl_rbio[NUM_CHANNEL];
+    BIO                 *ossl_wbio[NUM_CHANNEL];
     pj_lock_t           *ossl_lock;
 } dtls_srtp;
 
@@ -425,14 +446,14 @@ on_error:
 }
 
 /* Create and initialize new SSL context and instance */
-static pj_status_t ssl_create(dtls_srtp *ds)
+static pj_status_t ssl_create(dtls_srtp *ds, unsigned idx)
 {
     SSL_CTX *ctx;
     unsigned i;
     int mode, rc;
 
     /* Check if it is already instantiated */
-    if (ds->ossl_ssl)
+    if (ds->ossl_ssl[idx])
         return PJ_SUCCESS;
 
     /* Create DTLS context */
@@ -488,16 +509,16 @@ static pj_status_t ssl_create(dtls_srtp *ds)
     pj_assert(rc);
 
     /* Create SSL instance */
-    ds->ossl_ctx = ctx;
-    ds->ossl_ssl = SSL_new(ds->ossl_ctx);
-    if (ds->ossl_ssl == NULL) {
+    ds->ossl_ctx[idx] = ctx;
+    ds->ossl_ssl[idx] = SSL_new(ds->ossl_ctx[idx]);
+    if (ds->ossl_ssl[idx] == NULL) {
         SSL_CTX_free(ctx);
         return GET_SSL_STATUS(ds);
     }
 
     /* Set MTU */
 #ifdef DTLS_CTRL_SET_LINK_MTU
-    if (!SSL_ctrl(ds->ossl_ssl, DTLS_CTRL_SET_LINK_MTU, PJMEDIA_MAX_MTU,
+    if (!SSL_ctrl(ds->ossl_ssl[idx], DTLS_CTRL_SET_LINK_MTU, PJMEDIA_MAX_MTU,
                   NULL))
     {
         PJ_LOG(4, (ds->base.name,
@@ -508,51 +529,51 @@ static pj_status_t ssl_create(dtls_srtp *ds)
 
     /* SSL verification options, must be mutual auth */
     mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-    SSL_set_verify(ds->ossl_ssl, mode, &verify_cb);
+    SSL_set_verify(ds->ossl_ssl[idx], mode, &verify_cb);
 
     /* Setup SSL BIOs */
-    ds->ossl_rbio = BIO_new(BIO_s_mem());
-    ds->ossl_wbio = BIO_new(BIO_s_mem());
-    (void)BIO_set_close(ds->ossl_rbio, BIO_CLOSE);
-    (void)BIO_set_close(ds->ossl_wbio, BIO_CLOSE);
-    SSL_set_bio(ds->ossl_ssl, ds->ossl_rbio, ds->ossl_wbio);
+    ds->ossl_rbio[idx] = BIO_new(BIO_s_mem());
+    ds->ossl_wbio[idx] = BIO_new(BIO_s_mem());
+    (void)BIO_set_close(ds->ossl_rbio[idx], BIO_CLOSE);
+    (void)BIO_set_close(ds->ossl_wbio[idx], BIO_CLOSE);
+    SSL_set_bio(ds->ossl_ssl[idx], ds->ossl_rbio[idx], ds->ossl_wbio[idx]);
 
     return PJ_SUCCESS;
 }
 
 
 /* Destroy SSL context and instance */
-static void ssl_destroy(dtls_srtp *ds)
+static void ssl_destroy(dtls_srtp *ds, unsigned idx)
 {
     pj_lock_acquire(ds->ossl_lock);
 
     /* Destroy SSL instance */
-    if (ds->ossl_ssl) {
+    if (ds->ossl_ssl[idx]) {
         /**
          * Avoid calling SSL_shutdown() if handshake wasn't completed.
          * OpenSSL 1.0.2f complains if SSL_shutdown() is called during an
          * SSL handshake, while previous versions always return 0.       
          */
-        if (SSL_in_init(ds->ossl_ssl) == 0) {
-            SSL_shutdown(ds->ossl_ssl);
+        if (SSL_in_init(ds->ossl_ssl[idx]) == 0) {
+            SSL_shutdown(ds->ossl_ssl[idx]);
         }
-        SSL_free(ds->ossl_ssl); /* this will also close BIOs */
-        ds->ossl_ssl = NULL;
+        SSL_free(ds->ossl_ssl[idx]); /* this will also close BIOs */
+        ds->ossl_ssl[idx] = NULL;
         /* thus reset the BIOs as well */
-        ds->ossl_rbio = NULL;
-        ds->ossl_wbio = NULL;
+        ds->ossl_rbio[idx] = NULL;
+        ds->ossl_wbio[idx] = NULL;
     }
 
     /* Destroy SSL context */
-    if (ds->ossl_ctx) {
-        SSL_CTX_free(ds->ossl_ctx);
-        ds->ossl_ctx = NULL;
+    if (ds->ossl_ctx[idx]) {
+        SSL_CTX_free(ds->ossl_ctx[idx]);
+        ds->ossl_ctx[idx] = NULL;
     }
 
     pj_lock_release(ds->ossl_lock);
 }
 
-static pj_status_t ssl_get_srtp_material(dtls_srtp *ds)
+static pj_status_t ssl_get_srtp_material(dtls_srtp *ds, unsigned idx)
 {
     unsigned char material[SRTP_MAX_KEY_LEN * 2];
     SRTP_PROTECTION_PROFILE *profile;
@@ -562,20 +583,20 @@ static pj_status_t ssl_get_srtp_material(dtls_srtp *ds)
 
     pj_lock_acquire(ds->ossl_lock);
 
-    if (!ds->ossl_ssl) {
+    if (!ds->ossl_ssl[idx]) {
         status = PJ_EGONE;
         goto on_return;
     }
 
     /* Get selected crypto-suite */
-    profile = SSL_get_selected_srtp_profile(ds->ossl_ssl);
+    profile = SSL_get_selected_srtp_profile(ds->ossl_ssl[idx]);
     if (!profile) {
         status = PJMEDIA_SRTP_DTLS_ENOCRYPTO;
         goto on_return;
     }
 
-    tx = &ds->tx_crypto;
-    rx = &ds->rx_crypto;
+    tx = &ds->tx_crypto[idx];
+    rx = &ds->rx_crypto[idx];
     pj_bzero(tx, sizeof(*tx));
     pj_bzero(rx, sizeof(*rx));
     for (i=0; i<(int)PJ_ARRAY_SIZE(ossl_profiles); ++i) {
@@ -594,8 +615,9 @@ static pj_status_t ssl_get_srtp_material(dtls_srtp *ds)
     /* Get keying material from DTLS nego. There seems to be no info about
      * material length returned by SSL_export_keying_material()?
      */
-    rc = SSL_export_keying_material(ds->ossl_ssl, material, sizeof(material),
-                                    "EXTRACTOR-dtls_srtp", 19, NULL, 0, 0);
+    rc = SSL_export_keying_material(ds->ossl_ssl[idx], material,
+                                    sizeof(material), "EXTRACTOR-dtls_srtp",
+                                    19, NULL, 0, 0);
     if (rc == 0) {
         status = PJMEDIA_SRTP_EINKEYLEN;
         goto on_return;
@@ -635,7 +657,7 @@ on_return:
 }
 
 /* Match remote fingerprint: SDP vs actual */
-static pj_status_t ssl_match_fingerprint(dtls_srtp *ds)
+static pj_status_t ssl_match_fingerprint(dtls_srtp *ds, unsigned idx)
 {
     X509 *rem_cert;
     pj_bool_t is_sha256;
@@ -655,13 +677,13 @@ static pj_status_t ssl_match_fingerprint(dtls_srtp *ds)
     }
 
     pj_lock_acquire(ds->ossl_lock);
-    if (!ds->ossl_ssl) {
+    if (!ds->ossl_ssl[idx]) {
         pj_lock_release(ds->ossl_lock);
         return PJ_EGONE;
     }
 
     /* Get remote cert & calculate the hash */
-    rem_cert = SSL_get_peer_certificate(ds->ossl_ssl);
+    rem_cert = SSL_get_peer_certificate(ds->ossl_ssl[idx]);
 
     pj_lock_release(ds->ossl_lock);
 
@@ -682,13 +704,17 @@ static pj_status_t ssl_match_fingerprint(dtls_srtp *ds)
 
 
 /* Send data to network */
-static pj_status_t send_raw(dtls_srtp *ds, const void *buf, pj_size_t len)
+static pj_status_t send_raw(dtls_srtp *ds, unsigned idx, const void *buf,
+                            pj_size_t len)
 {
 #if DTLS_DEBUG
-    PJ_LOG(2,(ds->base.name, "DTLS-SRTP sending %d bytes", len));
+    PJ_LOG(2,(ds->base.name, "DTLS-SRTP %s sending %lu bytes",
+                             CHANNEL_TO_STRING(idx), len));
 #endif
 
-    return pjmedia_transport_send_rtp(ds->srtp->member_tp, buf, len);
+    return (idx == RTP_CHANNEL?
+            pjmedia_transport_send_rtp(ds->srtp->member_tp, buf, len):
+            pjmedia_transport_send_rtcp(ds->srtp->member_tp, buf, len));
 }
 
 
@@ -717,26 +743,26 @@ static pj_status_t udp_member_transport_media_start(dtls_srtp *ds)
 
 
 /* Flush write BIO */
-static pj_status_t ssl_flush_wbio(dtls_srtp *ds)
+static pj_status_t ssl_flush_wbio(dtls_srtp *ds, unsigned idx)
 {
     pj_size_t len;
     pj_status_t status = PJ_SUCCESS;
 
     pj_lock_acquire(ds->ossl_lock);
 
-    if (!ds->ossl_wbio) {
+    if (!ds->ossl_wbio[idx]) {
         pj_lock_release(ds->ossl_lock);
         return PJ_EGONE;
     }
 
     /* Check whether there is data to send */
-    if (BIO_ctrl_pending(ds->ossl_wbio) > 0) {
+    if (BIO_ctrl_pending(ds->ossl_wbio[idx]) > 0) {
         /* Yes, get and send it */
-        len = BIO_read(ds->ossl_wbio, ds->buf, sizeof(ds->buf));
+        len = BIO_read(ds->ossl_wbio[idx], ds->buf[idx], sizeof(ds->buf));
         if (len > 0) {
             pj_lock_release(ds->ossl_lock);
 
-            status = send_raw(ds, ds->buf, len);
+            status = send_raw(ds, idx, ds->buf[idx], len);
             if (status != PJ_SUCCESS) {
 #if DTLS_DEBUG
                 pj_perror(2, ds->base.name, status, "Send error");
@@ -749,7 +775,7 @@ static pj_status_t ssl_flush_wbio(dtls_srtp *ds)
         }
     }
 
-    if (!ds->ossl_ssl) {
+    if (!ds->ossl_ssl[idx]) {
         pj_lock_release(ds->ossl_lock);
         return PJ_EGONE;
     }
@@ -757,14 +783,15 @@ static pj_status_t ssl_flush_wbio(dtls_srtp *ds)
     /* Just return if handshake completion procedure (key parsing, fingerprint
      * verification, etc) has been done or handshake is still in progress.
      */
-    if (ds->nego_completed || !SSL_is_init_finished(ds->ossl_ssl)) {
+    if (ds->nego_completed[idx] || !SSL_is_init_finished(ds->ossl_ssl[idx])) {
         pj_lock_release(ds->ossl_lock);
         return PJ_SUCCESS;
     }
 
     /* Yes, SSL handshake is done! */
-    ds->nego_completed = PJ_TRUE;
-    PJ_LOG(2,(ds->base.name, "DTLS-SRTP negotiation completed!"));
+    ds->nego_completed[idx] = PJ_TRUE;
+    PJ_LOG(2,(ds->base.name, "DTLS-SRTP negotiation for %s completed!",
+                             CHANNEL_TO_STRING(idx)));
 
     pj_lock_release(ds->ossl_lock);
 
@@ -772,11 +799,11 @@ static pj_status_t ssl_flush_wbio(dtls_srtp *ds)
      * if this function is called from clock thread context. We'll try again
      * later in socket context.
      */
-    if (ds->clock)
-        pjmedia_clock_stop(ds->clock);
+    if (ds->clock[idx])
+        pjmedia_clock_stop(ds->clock[idx]);
 
     /* Get SRTP key material */
-    status = ssl_get_srtp_material(ds);
+    status = ssl_get_srtp_material(ds, idx);
     if (status != PJ_SUCCESS) {
         pj_perror(4, ds->base.name, status,
                   "Failed to get SRTP material");
@@ -785,7 +812,7 @@ static pj_status_t ssl_flush_wbio(dtls_srtp *ds)
 
     /* Verify remote fingerprint if we've already got one from SDP */
     if (ds->rem_fingerprint.slen && ds->rem_fprint_status == PJ_EPENDING) {
-        ds->rem_fprint_status = status = ssl_match_fingerprint(ds);
+        ds->rem_fprint_status = status = ssl_match_fingerprint(ds, idx);
         if (status != PJ_SUCCESS) {
             pj_perror(4, ds->base.name, status,
                       "Fingerprint specified in remote SDP doesn't match "
@@ -795,21 +822,35 @@ static pj_status_t ssl_flush_wbio(dtls_srtp *ds)
     }
 
     /* If media_start() has been called, start SRTP now */
-    if (ds->pending_start) {
+    if (ds->pending_start && idx == RTP_CHANNEL) {
         ds->pending_start = PJ_FALSE;
         ds->srtp->keying_pending_cnt--;
 
         /* Copy negotiated policy to SRTP */
-        ds->srtp->tx_policy_neg = ds->tx_crypto;
-        ds->srtp->rx_policy_neg = ds->rx_crypto;
+        ds->srtp->srtp_ctx.tx_policy_neg = ds->tx_crypto[idx];
+        ds->srtp->srtp_ctx.rx_policy_neg = ds->rx_crypto[idx];
 
         status = start_srtp(ds->srtp);
         if (status != PJ_SUCCESS)
             pj_perror(4, ds->base.name, status, "Failed starting SRTP");
+    } else if (idx == RTCP_CHANNEL) {
+        pjmedia_srtp_setting setting;
+
+        pjmedia_srtp_setting_default (&setting);
+
+        /* Copy negotiated policy to SRTP */
+        ds->srtp->srtp_rtcp.tx_policy_neg = ds->tx_crypto[idx];
+        ds->srtp->srtp_rtcp.rx_policy_neg = ds->rx_crypto[idx];
+
+        status = create_srtp_ctx(ds->srtp, &ds->srtp->srtp_rtcp,
+                                 &setting, &ds->srtp->srtp_rtcp.tx_policy_neg,
+                                 &ds->srtp->srtp_rtcp.rx_policy_neg);
+        if (status != PJ_SUCCESS)
+            pj_perror(4, ds->base.name, status, "Failed creating SRTP RTCP");
     }
 
 on_return:
-    if (ds->srtp->setting.cb.on_srtp_nego_complete) {
+    if (idx == RTP_CHANNEL && ds->srtp->setting.cb.on_srtp_nego_complete) {
         (*ds->srtp->setting.cb.on_srtp_nego_complete)
                                             (&ds->srtp->base, status);
     }
@@ -820,20 +861,22 @@ on_return:
 
 static void clock_cb(const pj_timestamp *ts, void *user_data)
 {
-    dtls_srtp *ds = (dtls_srtp*)user_data;
+    dtls_srtp_channel *ds_ch = (dtls_srtp_channel*)user_data;
+    dtls_srtp *ds = ds_ch->dtls_srtp;
+    unsigned idx = ds_ch->channel;
 
     PJ_UNUSED_ARG(ts);
 
     pj_lock_acquire(ds->ossl_lock);
 
-    if (!ds->ossl_ssl) {
+    if (!ds->ossl_ssl[idx]) {
         pj_lock_release(ds->ossl_lock);
         return;
     }
 
-    if (DTLSv1_handle_timeout(ds->ossl_ssl) > 0) {
+    if (DTLSv1_handle_timeout(ds->ossl_ssl[idx]) > 0) {
         pj_lock_release(ds->ossl_lock);
-        ssl_flush_wbio(ds);
+        ssl_flush_wbio(ds, idx);
     } else {
         pj_lock_release(ds->ossl_lock);
     }
@@ -841,7 +884,7 @@ static void clock_cb(const pj_timestamp *ts, void *user_data)
 
 
 /* Asynchronous handshake */
-static pj_status_t ssl_handshake(dtls_srtp *ds)
+static pj_status_t ssl_handshake_channel(dtls_srtp *ds, unsigned idx)
 {
     pj_status_t status;
     int err;
@@ -849,32 +892,32 @@ static pj_status_t ssl_handshake(dtls_srtp *ds)
     pj_lock_acquire(ds->ossl_lock);
 
     /* Init DTLS (if not yet) */
-    status = ssl_create(ds);
+    status = ssl_create(ds, idx);
     if (status != PJ_SUCCESS) {
         pj_lock_release(ds->ossl_lock);
         return status;
     }
 
     /* Check if handshake has been initiated or even completed */
-    if (ds->nego_started || SSL_is_init_finished(ds->ossl_ssl)) {
+    if (ds->nego_started[idx] || SSL_is_init_finished(ds->ossl_ssl[idx])) {
         pj_lock_release(ds->ossl_lock);
         return PJ_SUCCESS;
     }
 
     /* Perform SSL handshake */
     if (ds->setup == DTLS_SETUP_ACTIVE) {
-        SSL_set_connect_state(ds->ossl_ssl);
+        SSL_set_connect_state(ds->ossl_ssl[idx]);
     } else {
-        SSL_set_accept_state(ds->ossl_ssl);
+        SSL_set_accept_state(ds->ossl_ssl[idx]);
     }
-    err = SSL_do_handshake(ds->ossl_ssl);
+    err = SSL_do_handshake(ds->ossl_ssl[idx]);
     if (err < 0) {
-        err = SSL_get_error(ds->ossl_ssl, err);
+        err = SSL_get_error(ds->ossl_ssl[idx], err);
 
         pj_lock_release(ds->ossl_lock);
 
         if (err == SSL_ERROR_WANT_READ) {
-            status = ssl_flush_wbio(ds);
+            status = ssl_flush_wbio(ds, idx);
             if (status != PJ_SUCCESS)
                 goto on_return;
         } else if (err != SSL_ERROR_NONE) {
@@ -888,30 +931,46 @@ static pj_status_t ssl_handshake(dtls_srtp *ds)
     }
 
     /* Create and start clock @4Hz for retransmission */
-    if (!ds->clock) {
+    if (!ds->clock[idx]) {
+        ds->channel[idx].dtls_srtp = ds;
+        ds->channel[idx].channel = idx;
         status = pjmedia_clock_create(ds->pool, 4, 1, 1,
                                       PJMEDIA_CLOCK_NO_HIGHEST_PRIO, clock_cb,
-                                      ds, &ds->clock);
+                                      &ds->channel[idx], &ds->clock[idx]);
         if (status != PJ_SUCCESS)
             goto on_return;
     }    
-    status = pjmedia_clock_start(ds->clock);
+    status = pjmedia_clock_start(ds->clock[idx]);
     if (status != PJ_SUCCESS)
         goto on_return;
 
     /* Finally, DTLS nego started! */
-    ds->nego_started = PJ_TRUE;
-    PJ_LOG(4,(ds->base.name, "DTLS-SRTP negotiation initiated as %s",
+    ds->nego_started[idx] = PJ_TRUE;
+    PJ_LOG(4,(ds->base.name, "DTLS-SRTP %s negotiation initiated as %s",
+              CHANNEL_TO_STRING(idx),
               (ds->setup==DTLS_SETUP_ACTIVE? "client":"server")));
 
 on_return:
     if (status != PJ_SUCCESS) {
-        if (ds->clock)
-            pjmedia_clock_stop(ds->clock);
+        if (ds->clock[idx])
+            pjmedia_clock_stop(ds->clock[idx]);
     }
     return status;
 }
 
+static pj_status_t ssl_handshake(dtls_srtp *ds)
+{
+    pj_status_t status;
+
+    status = ssl_handshake_channel(ds, RTP_CHANNEL);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    if (!ds->srtp->use_rtcp_mux)
+        status = ssl_handshake_channel(ds, RTCP_CHANNEL);
+
+    return status;
+}
 
 /* Parse a=setup & a=fingerprint in remote SDP to update DTLS-SRTP states
  * 'setup' and 'rem_fingerprint'.
@@ -1070,7 +1129,7 @@ static pj_status_t get_rem_addrs(dtls_srtp *ds,
 
 
 /* Received packet (SSL handshake) from socket */
-static pj_status_t ssl_on_recv_packet(dtls_srtp *ds,
+static pj_status_t ssl_on_recv_packet(dtls_srtp *ds, unsigned idx,
                                       const void *data, pj_size_t len)
 {
     char tmp[128];
@@ -1078,12 +1137,12 @@ static pj_status_t ssl_on_recv_packet(dtls_srtp *ds,
 
     pj_lock_acquire(ds->ossl_lock);
 
-    if (!ds->ossl_rbio) {
+    if (!ds->ossl_rbio[idx]) {
         pj_lock_release(ds->ossl_lock);
         return PJ_EGONE;
     }
 
-    nwritten = BIO_write(ds->ossl_rbio, data, (int)len);
+    nwritten = BIO_write(ds->ossl_rbio[idx], data, (int)len);
     if (nwritten < len) {
         /* Error? */
         pj_status_t status;
@@ -1095,14 +1154,14 @@ static pj_status_t ssl_on_recv_packet(dtls_srtp *ds,
         return status;
     }
 
-    if (!ds->ossl_ssl) {
+    if (!ds->ossl_ssl[idx]) {
         pj_lock_release(ds->ossl_lock);
         return PJ_EGONE;
     }
 
     /* Consume (and ignore) the packet */
     while (1) {
-        int rc = SSL_read(ds->ossl_ssl, tmp, sizeof(tmp));
+        int rc = SSL_read(ds->ossl_ssl[idx], tmp, sizeof(tmp));
         if (rc <= 0) {
 #if DTLS_DEBUG
             pj_status_t status = GET_SSL_STATUS(ds);
@@ -1116,7 +1175,7 @@ static pj_status_t ssl_on_recv_packet(dtls_srtp *ds,
     pj_lock_release(ds->ossl_lock);
 
     /* Flush anything pending in the write BIO */
-    return ssl_flush_wbio(ds);
+    return ssl_flush_wbio(ds, idx);
 }
 
 
@@ -1147,27 +1206,23 @@ static void on_ice_complete2(pjmedia_transport *tp,
  *
  * *************************************/
 
-/*
- * This callback is called by SRTP transport when incoming rtp is received.
- * Originally this is send_rtp() op.
- */
-static pj_status_t dtls_on_recv_rtp( pjmedia_transport *tp,
-                                     const void *pkt,
-                                     pj_size_t size)
+static pj_status_t dtls_on_recv(pjmedia_transport *tp, unsigned idx,     
+                                const void *pkt, pj_size_t size)
 {
     dtls_srtp *ds = (dtls_srtp*)tp;
 
     /* Destroy the retransmission clock if handshake has been completed. */
-    if (ds->clock && ds->nego_completed) {
-        pjmedia_clock_destroy(ds->clock);
-        ds->clock = NULL;
+    if (ds->clock[idx] && ds->nego_completed[idx]) {
+        pjmedia_clock_destroy(ds->clock[idx]);
+        ds->clock[idx] = NULL;
     }
 
     if (size < 1 || !IS_DTLS_PKT(pkt, size))
         return PJ_EIGNORED;
 
 #if DTLS_DEBUG
-    PJ_LOG(2,(ds->base.name, "DTLS-SRTP receiving %d bytes", size));
+    PJ_LOG(2,(ds->base.name, "DTLS-SRTP %s receiving %lu bytes",
+                             CHANNEL_TO_STRING(idx), size));
 #endif
 
     /* This is DTLS packet, let's process it. Note that if DTLS nego has
@@ -1176,7 +1231,7 @@ static pj_status_t dtls_on_recv_rtp( pjmedia_transport *tp,
      */
 
     /* Check remote address info, reattach member tp if changed */
-    if (!ds->use_ice && !ds->nego_completed) {
+    if (idx == RTP_CHANNEL && !ds->use_ice && !ds->nego_completed[idx]) {
         pjmedia_transport_info info;
         pjmedia_transport_get_info(ds->srtp->member_tp, &info);
         if (pj_sockaddr_cmp(&ds->rem_addr, &info.src_rtp_name)) {
@@ -1222,19 +1277,41 @@ static pj_status_t dtls_on_recv_rtp( pjmedia_transport *tp,
     /* If our setup is ACTPASS, incoming packet may be a client hello,
      * so let's update setup to PASSIVE and initiate DTLS handshake.
      */
-    if (!ds->nego_started &&
+    if (!ds->nego_started[idx] &&
         (ds->setup == DTLS_SETUP_ACTPASS || ds->setup == DTLS_SETUP_PASSIVE))
     {
         pj_status_t status;
         ds->setup = DTLS_SETUP_PASSIVE;
-        status = ssl_handshake(ds);
+        status = ssl_handshake_channel(ds, idx);
         if (status != PJ_SUCCESS)
             return status;
     }
 
     /* Send it to OpenSSL */
-    ssl_on_recv_packet(ds, pkt, size);
+    ssl_on_recv_packet(ds, idx, pkt, size);
     return PJ_SUCCESS;
+}
+
+/*
+ * This callback is called by SRTP transport when incoming rtp is received.
+ * Originally this is send_rtp() op.
+ */
+static pj_status_t dtls_on_recv_rtp( pjmedia_transport *tp,
+                                     const void *pkt,
+                                     pj_size_t size)
+{
+    return dtls_on_recv(tp, RTP_CHANNEL, pkt, size);
+}
+
+/*
+ * This callback is called by SRTP transport when incoming rtcp is received.
+ * Originally this is send_rtcp() op.
+ */
+static pj_status_t dtls_on_recv_rtcp(pjmedia_transport *tp,
+                                     const void *pkt,
+                                     pj_size_t size)
+{
+    return dtls_on_recv(tp, RTCP_CHANNEL, pkt, size);
 }
 
 static pj_status_t dtls_media_create( pjmedia_transport *tp,
@@ -1306,6 +1383,17 @@ on_return:
     }
 #endif
     return status;
+}
+
+static void dtls_media_stop_channel(dtls_srtp *ds, unsigned idx)
+{
+    if (ds->clock[idx])
+        pjmedia_clock_stop(ds->clock[idx]);
+
+    /* Reset DTLS state */
+    ssl_destroy(ds, idx);
+    ds->nego_started[idx] = PJ_FALSE;
+    ds->nego_completed[idx] = PJ_FALSE;
 }
 
 static pj_status_t dtls_encode_sdp( pjmedia_transport *tp,
@@ -1409,9 +1497,8 @@ static pj_status_t dtls_encode_sdp( pjmedia_transport *tp,
              pj_memcmp(&last_rem_fp, &ds->rem_fingerprint, sizeof(pj_str_t)))||
             (rem_addr_changed))
         {
-            ssl_destroy(ds);
-            ds->nego_started = PJ_FALSE;
-            ds->nego_completed = PJ_FALSE;
+            dtls_media_stop_channel(ds, RTP_CHANNEL);
+            dtls_media_stop_channel(ds, RTCP_CHANNEL);
             ds->got_keys = PJ_FALSE;
             ds->rem_fprint_status = PJ_EPENDING;
         }
@@ -1443,7 +1530,7 @@ static pj_status_t dtls_encode_sdp( pjmedia_transport *tp,
         pjmedia_sdp_media_add_attr(m_loc, a);
     }
 
-    if (ds->nego_completed) {
+    if (ds->nego_completed[RTP_CHANNEL]) {
         /* This is subsequent SDP offer/answer and no DTLS re-nego has been
          * signalled.
          */
@@ -1575,9 +1662,8 @@ static pj_status_t dtls_media_start( pjmedia_transport *tp,
             (last_rem_fp.slen &&
              pj_memcmp(&last_rem_fp, &ds->rem_fingerprint, sizeof(pj_str_t))))
         {
-            ssl_destroy(ds);
-            ds->nego_started = PJ_FALSE;
-            ds->nego_completed = PJ_FALSE;
+            dtls_media_stop_channel(ds, RTP_CHANNEL);
+            dtls_media_stop_channel(ds, RTCP_CHANNEL);
             ds->got_keys = PJ_FALSE;
             ds->rem_fprint_status = PJ_EPENDING;
         }
@@ -1597,7 +1683,7 @@ static pj_status_t dtls_media_start( pjmedia_transport *tp,
         if (pj_sockaddr_cmp(&info.sock_info.rtp_addr_name,
                             &info.sock_info.rtcp_addr_name) == 0)
         {
-            use_rtcp_mux = PJ_TRUE;
+            ds->srtp->use_rtcp_mux = use_rtcp_mux = PJ_TRUE;
         }
         ice_info = (pjmedia_ice_transport_info*)
                    pjmedia_transport_info_get_spc_info(
@@ -1612,13 +1698,15 @@ static pj_status_t dtls_media_start( pjmedia_transport *tp,
 
     /* Check if the background DTLS nego has completed */
     if (ds->got_keys) { 
-        ds->srtp->tx_policy_neg = ds->tx_crypto;
-        ds->srtp->rx_policy_neg = ds->rx_crypto;
+        unsigned idx = RTP_CHANNEL;
+
+        ds->srtp->srtp_ctx.tx_policy_neg = ds->tx_crypto[idx];
+        ds->srtp->srtp_ctx.rx_policy_neg = ds->rx_crypto[idx];
 
         /* Verify remote fingerprint (if available) */
         if (ds->rem_fingerprint.slen && ds->rem_fprint_status == PJ_EPENDING)
         {
-            ds->rem_fprint_status = ssl_match_fingerprint(ds);
+            ds->rem_fprint_status = ssl_match_fingerprint(ds, idx);
             if (ds->rem_fprint_status != PJ_SUCCESS) {
                 pj_perror(4, ds->base.name, ds->rem_fprint_status,
                           "Fingerprint specified in remote SDP doesn't match "
@@ -1712,20 +1800,25 @@ static pj_status_t dtls_media_stop(pjmedia_transport *tp)
     PJ_LOG(2,(ds->base.name, "dtls_media_stop()"));
 #endif
 
-    if (ds->clock)
-        pjmedia_clock_stop(ds->clock);
-    
-    /* Reset DTLS state */
-    ssl_destroy(ds);
+    dtls_media_stop_channel(ds, RTP_CHANNEL);
+    dtls_media_stop_channel(ds, RTCP_CHANNEL);
+
     ds->setup = DTLS_SETUP_UNKNOWN;
-        ds->use_ice = PJ_FALSE;
-    ds->nego_started = PJ_FALSE;
-    ds->nego_completed = PJ_FALSE;
+    ds->use_ice = PJ_FALSE;
     ds->got_keys = PJ_FALSE;
     ds->rem_fingerprint.slen = 0;
     ds->rem_fprint_status = PJ_EPENDING;
 
     return PJ_SUCCESS;
+}
+
+static void dtls_destroy_channel(dtls_srtp *ds, unsigned idx)
+{
+    if (ds->clock[idx]) {
+        pjmedia_clock_destroy(ds->clock[idx]);
+        ds->clock[idx] = NULL;
+    }
+    ssl_destroy(ds, idx);
 }
 
 static pj_status_t dtls_destroy(pjmedia_transport *tp)
@@ -1736,9 +1829,8 @@ static pj_status_t dtls_destroy(pjmedia_transport *tp)
     PJ_LOG(2,(ds->base.name, "dtls_destroy()"));
 #endif
 
-    if (ds->clock)
-        pjmedia_clock_destroy(ds->clock);
-    ssl_destroy(ds);
+    dtls_destroy_channel(ds, RTP_CHANNEL);
+    dtls_destroy_channel(ds, RTCP_CHANNEL);
 
     if (ds->ossl_lock) {
         pj_lock_destroy(ds->ossl_lock);
@@ -1816,6 +1908,8 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_dtls_start_nego(
     ap.user_data = ds->srtp;
     pj_sockaddr_cp(&ap.rem_addr, &ds->rem_addr);
     pj_sockaddr_cp(&ap.rem_rtcp, &ds->rem_rtcp);
+    if (pj_sockaddr_cmp(&ds->rem_addr, &ds->rem_rtcp) == 0)
+        ds->srtp->use_rtcp_mux = PJ_TRUE;
     ap.addr_len = pj_sockaddr_get_len(&ap.rem_addr);
     status = pjmedia_transport_attach2(&ds->srtp->base, &ap);
     if (status != PJ_SUCCESS)
@@ -1831,15 +1925,18 @@ PJ_DEF(pj_status_t) pjmedia_transport_srtp_dtls_start_nego(
 #endif
 
     /* Start DTLS handshake */
-    pj_bzero(&srtp->rx_policy_neg, sizeof(srtp->rx_policy_neg));
-    pj_bzero(&srtp->tx_policy_neg, sizeof(srtp->tx_policy_neg));
+    pj_bzero(&srtp->srtp_ctx.rx_policy_neg,
+             sizeof(srtp->srtp_ctx.rx_policy_neg));
+    pj_bzero(&srtp->srtp_ctx.tx_policy_neg,
+             sizeof(srtp->srtp_ctx.tx_policy_neg));
     status = ssl_handshake(ds);
     if (status != PJ_SUCCESS)
         goto on_return;
 
 on_return:
     if (status != PJ_SUCCESS) {
-        ssl_destroy(ds);
+        ssl_destroy(ds, RTP_CHANNEL);
+        ssl_destroy(ds, RTCP_CHANNEL);
     }
     return status;
 }

--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -395,8 +395,8 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
              * crypto-suites in the setting.
              */
             for (i=0; i<srtp->setting.crypto_count; ++i) {
-                if (srtp->tx_policy.name.slen &&
-                    pj_stricmp(&srtp->tx_policy.name,
+                if (srtp->srtp_ctx.tx_policy.name.slen &&
+                    pj_stricmp(&srtp->srtp_ctx.tx_policy.name,
                                &srtp->setting.crypto[i].name) != 0)
                 {
                     continue;
@@ -494,7 +494,7 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
                                 (int)crypto_suites[cs_idx].cipher_key_len)
                                 return PJMEDIA_SRTP_EINKEYLEN;
 
-                            srtp->rx_policy_neg = tmp_rx_crypto;
+                            srtp->srtp_ctx.rx_policy_neg = tmp_rx_crypto;
                             chosen_tag = tags[cr_attr_count];
                             matched_idx = j;
                             break;
@@ -540,7 +540,7 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
             }
 
             /* we have to generate crypto answer,
-             * with srtp->tx_policy_neg matched the offer
+             * with srtp->srtp_ctx.tx_policy_neg matched the offer
              * and rem_tag contains matched offer tag.
              */
             buffer_len = MAXLEN;
@@ -551,7 +551,7 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
             if (status != PJ_SUCCESS)
                 return status;
 
-            srtp->tx_policy_neg = srtp->setting.crypto[matched_idx];
+            srtp->srtp_ctx.tx_policy_neg = srtp->setting.crypto[matched_idx];
 
             /* If buffer_len==0, just skip the crypto attribute. */
             if (buffer_len) {
@@ -653,7 +653,7 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
      * media_encode_sdp(). Check if the key changes on the local SDP.
      */
     if (!srtp->offerer_side) {
-        if (srtp->tx_policy_neg.name.slen == 0)
+        if (srtp->srtp_ctx.tx_policy_neg.name.slen == 0)
             return PJ_SUCCESS;
 
         /* Get the local crypto. */
@@ -662,12 +662,12 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
         if (loc_cryto_cnt == 0)
             return PJ_SUCCESS;
 
-        if ((pj_stricmp(&srtp->tx_policy_neg.name,
+        if ((pj_stricmp(&srtp->srtp_ctx.tx_policy_neg.name,
                         &loc_crypto[0].name) == 0) &&
-            (pj_stricmp(&srtp->tx_policy_neg.key,
+            (pj_stricmp(&srtp->srtp_ctx.tx_policy_neg.key,
                         &loc_crypto[0].key) != 0))
         {
-            srtp->tx_policy_neg = loc_crypto[0];
+            srtp->srtp_ctx.tx_policy_neg = loc_crypto[0];
             for (i = 0; i<srtp->setting.crypto_count ;++i) {
                 if ((pj_stricmp(&srtp->setting.crypto[i].name,
                                 &loc_crypto[0].name) == 0) &&
@@ -752,12 +752,12 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
             if (pj_stricmp(&tmp_tx_crypto.name,
                            &loc_crypto[j].name) == 0)
             {
-                srtp->tx_policy_neg = loc_crypto[j];
+                srtp->srtp_ctx.tx_policy_neg = loc_crypto[j];
                 break;
             }
         }
 
-        srtp->rx_policy_neg = tmp_tx_crypto;
+        srtp->srtp_ctx.rx_policy_neg = tmp_tx_crypto;
     }
 
     if (srtp->setting.use == PJMEDIA_SRTP_DISABLED) {

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -31,7 +31,11 @@
 #define RTP_LEN     PJMEDIA_MAX_MRU
 
 /* Maximum size of incoming RTCP packet */
-#define RTCP_LEN    600
+#if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
+#   define RTCP_LEN    PJMEDIA_MAX_MRU
+#else
+#   define RTCP_LEN    600
+#endif
 
 /* Maximum pending write operations */
 #define MAX_PENDING 4


### PR DESCRIPTION
To close #2124 by implementing DTLS-SRTP for RTCP.

Tested vs linphone.
Without the patch, the call will be marked as insecure and the log will show that the DTLS-RTCP negotiation never completes.

After the patch:
```
[linphone/mediastreamer] MESSAGE DTLS Receive RTCP packet len 67 sessions: 0x7fb07c50c588 rtp session 0x7fb08c074c00
[linphone/mediastreamer] MESSAGE DTLS Handshake process RTCP packet len 67 sessions: 0x7fb07c50c588 rtp session 0x7fb08c074c00 return -0x0
[linphone/mediastreamer] MESSAGE DTLS RTCP Handshake successful, srtp protection profile 1
...
[linphone/ortp] MESSAGE sent rtcp                                    41 packets
[linphone/ortp] MESSAGE received rtcp                                41 packets
```
And the call will receive green shield badge to indicate call is secured with DTLS.

The patch is created to be backward compatible as well, i.e. we can still make call and establish normal media with older version of PJSIP that doesn't initiate negotiation for the RTCP channel.
