### PR TITLE
Don't call SSL_shutdown() when receiving SSL_ERROR_SYSCALL or SSL_ERROR_SSL

### DIFF
--- a/pjlib/src/pj/ssl_sock_gtls.c
+++ b/pjlib/src/pj/ssl_sock_gtls.c
@@ -827,6 +827,13 @@ static void ssl_destroy(pj_ssl_sock_t *ssock)
 /* Reset socket state. */
 static void ssl_reset_sock_state(pj_ssl_sock_t *ssock)
 {
+    ssl_reset_sock_state_with_error(ssock, PJ_TRUE);
+}
+
+static void ssl_reset_sock_state_with_error(pj_ssl_sock_t* ssock, pj_bool_t check_error)
+{
+    PJ_UNUSED_ARG(check_error);
+
     pj_lock_acquire(ssock->circ_buf_output_mutex);
     ssock->ssl_state = SSL_STATE_NULL;
     pj_lock_release(ssock->circ_buf_output_mutex);

--- a/pjlib/src/pj/ssl_sock_gtls.c
+++ b/pjlib/src/pj/ssl_sock_gtls.c
@@ -827,13 +827,6 @@ static void ssl_destroy(pj_ssl_sock_t *ssock)
 /* Reset socket state. */
 static void ssl_reset_sock_state(pj_ssl_sock_t *ssock)
 {
-    ssl_reset_sock_state_with_error(ssock, PJ_TRUE);
-}
-
-static void ssl_reset_sock_state_with_error(pj_ssl_sock_t* ssock, pj_bool_t check_error)
-{
-    PJ_UNUSED_ARG(check_error);
-
     pj_lock_acquire(ssock->circ_buf_output_mutex);
     ssock->ssl_state = SSL_STATE_NULL;
     pj_lock_release(ssock->circ_buf_output_mutex);

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -383,7 +383,7 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
                       buf1, buf2));
 
             /* Server disconnected us, possibly due to SSL nego failure */
-            ssl_reset_sock_state(ssock);
+            ssl_reset_sock_state_with_error(ssock, (status!= PJ_ETIMEDOUT));
         }
         if (ssock->param.cb.on_connect_complete) {
             pj_bool_t ret;

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -245,6 +245,7 @@ static void ssl_close_sockets(pj_ssl_sock_t *ssock)
 static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock, 
                                        pj_status_t status)
 {
+    ssock->handshake_status = status;
     /* Cancel handshake timer */
     if (ssock->timer.id == TIMER_HANDSHAKE_TIMEOUT) {
         pj_timer_heap_cancel(ssock->param.timer_heap, &ssock->timer);
@@ -383,7 +384,7 @@ static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
                       buf1, buf2));
 
             /* Server disconnected us, possibly due to SSL nego failure */
-            ssl_reset_sock_state_with_error(ssock, (status!= PJ_ETIMEDOUT));
+            ssl_reset_sock_state(ssock);
         }
         if (ssock->param.cb.on_connect_complete) {
             pj_bool_t ret;

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -112,6 +112,7 @@ struct pj_ssl_sock_t
     pj_ioqueue_op_key_t   shutdown_op_key;
     pj_timer_entry        timer;
     pj_status_t           verify_status;
+    pj_status_t           handshake_status;
 
     pj_bool_t             is_closing;
     unsigned long         last_err;
@@ -255,7 +256,6 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock);
 static void ssl_destroy(pj_ssl_sock_t *ssock);
 /* Reset SSL socket state */
 static void ssl_reset_sock_state(pj_ssl_sock_t *ssock);
-static void ssl_reset_sock_state_with_error(pj_ssl_sock_t* ssock, pj_bool_t check_error);
 
 /* Ciphers and certs */
 static void ssl_ciphers_populate();

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -255,6 +255,7 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock);
 static void ssl_destroy(pj_ssl_sock_t *ssock);
 /* Reset SSL socket state */
 static void ssl_reset_sock_state(pj_ssl_sock_t *ssock);
+static void ssl_reset_sock_state_with_error(pj_ssl_sock_t* ssock, pj_bool_t check_error);
 
 /* Ciphers and certs */
 static void ssl_ciphers_populate();

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1700,7 +1700,7 @@ static void ssl_reset_sock_state(pj_ssl_sock_t *ssock)
 
 static void ssl_reset_sock_state_with_error(pj_ssl_sock_t* ssock, pj_bool_t check_error)
 {
-    ossl_sock_t* ossock = (ossl_sock_t*)ssock;
+    ossl_sock_t *ossock = (ossl_sock_t *)ssock;
 
     /* Detach from SSL instance */
     if (ossock->ossl_ssl) {
@@ -1711,16 +1711,17 @@ static void ssl_reset_sock_state_with_error(pj_ssl_sock_t* ssock, pj_bool_t chec
      * Avoid calling SSL_shutdown() if handshake wasn't completed.
      * OpenSSL 1.0.2f complains if SSL_shutdown() is called during an
      * SSL handshake, while previous versions always return 0.
-     * Don't send notify when the last error is SSL_ERROR_SYSCALL or SSL_ERROR_SSL.
+     * Don't call SSL_shutdown() when the last error is 
+     * SSL_ERROR_SYSCALL or SSL_ERROR_SSL.
      */
     if (ossock->ossl_ssl && SSL_in_init(ossock->ossl_ssl) == 0) {
-        pj_bool_t send_notify = PJ_TRUE;
+        pj_bool_t call_shutdown = PJ_TRUE;
         if (check_error && (ssock->last_err == SSL_ERROR_SYSCALL ||
             ssock->last_err == SSL_ERROR_SSL))
         {
-            send_notify = PJ_FALSE;
+            call_shutdown = PJ_FALSE;
         }
-        if (send_notify) {
+        if (call_shutdown) {
             int ret = SSL_shutdown(ossock->ossl_ssl);
             if (ret == 0) {
                 /* Flush data to send close notify. */


### PR DESCRIPTION
This is to fix #3576.
Before calling `SSL_shutdown()`, a check to SSL_ERROR_SYSCALL and SSL_ERROR_SSL is required.
