### PR TITLE
Fixed coverity warning and various warnings

### DIFF
--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -641,7 +641,7 @@ pj_status_t pj_thread_init(void)
  */
 static void set_thread_display_name(const char *name)
 {
-#if (defined(PJ_LINUX) && PJ_LINUX != 0) ||                                    \
+#if (defined(PJ_LINUX) && PJ_LINUX != 0) || \
     (defined(PJ_ANDROID) && PJ_ANDROID != 0)
     char xname[16];
     // On linux, thread display name length is restricted to 16 (include '\0')
@@ -661,7 +661,7 @@ static void set_thread_display_name(const char *name)
 #elif defined(PJ_HAS_PTHREAD_SET_NAME_NP) && PJ_HAS_PTHREAD_SET_NAME_NP != 0
     pthread_set_name_np(pthread_self(), name);
 #else
-#   warning "OS not support set thread display name"
+// #   warning "OS does not support set thread display name"
     PJ_UNUSED_ARG(name);
 #endif
 }

--- a/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
@@ -381,17 +381,17 @@ static pj_status_t configure_codec(and_media_private_t *and_media_data,
     am_status = AMediaCodec_configure(codec, aud_fmt, NULL, NULL, is_encoder);
     AMediaFormat_delete(aud_fmt);
     if (am_status != AMEDIA_OK) {
-        PJ_LOG(4, (THIS_FILE, "%s [0x%x] configure failed, status=%d",
+        PJ_LOG(4, (THIS_FILE, "%s [0x%p] configure failed, status=%d",
                is_encoder?"Encoder":"Decoder", codec, am_status));
         return PJMEDIA_CODEC_EFAILED;
     }
     am_status = AMediaCodec_start(codec);
     if (am_status != AMEDIA_OK) {
-        PJ_LOG(4, (THIS_FILE, "%s [0x%x] start failed, status=%d",
+        PJ_LOG(4, (THIS_FILE, "%s [0x%p] start failed, status=%d",
                is_encoder?"Encoder":"Decoder", codec, am_status));
         return PJMEDIA_CODEC_EFAILED;
     }
-    PJ_LOG(4, (THIS_FILE, "%s [0x%x] started", is_encoder?"Encoder":"Decoder",
+    PJ_LOG(4, (THIS_FILE, "%s [0x%p] started", is_encoder?"Encoder":"Decoder",
            codec));
     return PJ_SUCCESS;
 }
@@ -602,8 +602,8 @@ static pj_bool_t codec_exists(const pj_str_t *codec_name)
 
     codec = AMediaCodec_createCodecByName(codec_txt);
     if (!codec) {
-        PJ_LOG(4, (THIS_FILE, "Failed creating codec : %.*s", codec_name->slen,
-                   codec_name->ptr));
+        PJ_LOG(4, (THIS_FILE, "Failed creating codec : %.*s",
+                   (int)codec_name->slen, codec_name->ptr));
         return PJ_FALSE;
     }
     AMediaCodec_delete(codec);
@@ -687,8 +687,8 @@ static pj_status_t and_media_enum_codecs(pjmedia_codec_factory *factory,
         codecs[*count].channel_cnt = and_media_codec[i].channel_count;
         and_media_codec[i].enabled = PJ_TRUE;
         PJ_LOG(4, (THIS_FILE, "Found encoder [%d]: %.*s and decoder: %.*s ",
-                   *count, enc_name->slen, enc_name->ptr, dec_name->slen,
-                   dec_name->ptr));
+                   *count, (int)enc_name->slen, enc_name->ptr,
+                   (int)dec_name->slen, dec_name->ptr));
         ++*count;
     }
 
@@ -707,7 +707,7 @@ static void create_codec(and_media_private_t *and_media_data)
         if (!and_media_data->enc) {
             PJ_LOG(4, (THIS_FILE, "Failed creating encoder: %s", enc_name));
         }
-        PJ_LOG(4, (THIS_FILE, "Done creating encoder: %s [0x%x]", enc_name,
+        PJ_LOG(4, (THIS_FILE, "Done creating encoder: %s [0x%p]", enc_name,
                and_media_data->enc));
     }
 
@@ -716,7 +716,7 @@ static void create_codec(and_media_private_t *and_media_data)
         if (!and_media_data->dec) {
             PJ_LOG(4, (THIS_FILE, "Failed creating decoder: %s", dec_name));
         }
-        PJ_LOG(4, (THIS_FILE, "Done creating decoder: %s [0x%x]", dec_name,
+        PJ_LOG(4, (THIS_FILE, "Done creating decoder: %s [0x%p]", dec_name,
                and_media_data->dec));
     }
 }
@@ -1140,13 +1140,13 @@ static pj_status_t and_media_codec_encode(pjmedia_codec *codec,
                                          "returns no input buff"));
                 } else {
                     PJ_LOG(4,(THIS_FILE, "Encoder getInputBuffer "
-                                         "size: %d, expecting %d.",
-                                         input_buf, output_size, input_size));
+                                         "size: %lu, expecting %d.",
+                                         output_size, input_size));
                 }
                 goto on_return;
             }
         } else {
-            PJ_LOG(4,(THIS_FILE, "Encoder dequeueInputBuffer failed[%d]",
+            PJ_LOG(4,(THIS_FILE, "Encoder dequeueInputBuffer failed[%ld]",
                       buf_idx));
             goto on_return;
         }
@@ -1164,7 +1164,7 @@ static pj_status_t and_media_codec_encode(pjmedia_codec *codec,
         }
 
         if (buf_idx < 0) {
-            PJ_LOG(4, (THIS_FILE, "Encoder dequeueOutputBuffer failed %d",
+            PJ_LOG(4, (THIS_FILE, "Encoder dequeueOutputBuffer failed %ld",
                    buf_idx));
             goto on_return;
         }
@@ -1252,7 +1252,7 @@ static pj_status_t and_media_codec_decode(pjmedia_codec *codec,
                                              CODEC_DEQUEUE_TIMEOUT);
 
     if (buf_idx < 0) {
-        PJ_LOG(4,(THIS_FILE, "Decoder dequeueInputBuffer failed return %d",
+        PJ_LOG(4,(THIS_FILE, "Decoder dequeueInputBuffer failed return %ld",
                   buf_idx));
         goto on_return;
     }
@@ -1262,7 +1262,7 @@ static pj_status_t and_media_codec_decode(pjmedia_codec *codec,
                                            &input_size);
     if (input_buf == 0) {
         PJ_LOG(4,(THIS_FILE, "Decoder getInputBuffer failed "
-                  "return input_buf=%d, size=%d", input_buf, input_size));
+                  "return input_buf=%d, size=%lu", *input_buf, input_size));
         goto on_return;
     }
 
@@ -1300,7 +1300,7 @@ static pj_status_t and_media_codec_decode(pjmedia_codec *codec,
         }
     }
     if (buf_idx < 0) {
-        PJ_LOG(5, (THIS_FILE, "Decoder dequeueOutputBuffer failed [%d]",
+        PJ_LOG(5, (THIS_FILE, "Decoder dequeueOutputBuffer failed [%ld]",
                    buf_idx));
         goto on_return;
     }

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -600,8 +600,8 @@ static pj_bool_t codec_exists(const pj_str_t *codec_name)
 
     codec = AMediaCodec_createCodecByName(codec_txt);
     if (!codec) {
-        PJ_LOG(4, (THIS_FILE, "Failed creating codec : %.*s", codec_name->slen,
-                   codec_name->ptr));
+        PJ_LOG(4, (THIS_FILE, "Failed creating codec : %.*s",
+                   (int)codec_name->slen, codec_name->ptr));
         return PJ_FALSE;
     }
     AMediaCodec_delete(codec);
@@ -777,8 +777,8 @@ static pj_status_t and_media_enum_info(pjmedia_vid_codec_factory *factory,
         and_media_codec[i].encoder_name = enc_name;
         and_media_codec[i].decoder_name = dec_name;
         PJ_LOG(4, (THIS_FILE, "Found encoder [%d]: %.*s and decoder: %.*s ",
-                   *count, enc_name->slen, enc_name->ptr, dec_name->slen,
-                   dec_name->ptr));
+                   *count, (int)enc_name->slen, enc_name->ptr,
+                   (int)dec_name->slen, dec_name->ptr));
         add_codec(&and_media_codec[*count], count, info);
         and_media_codec[i].enabled = PJ_TRUE;
     }
@@ -1032,13 +1032,14 @@ static pj_status_t and_media_codec_encode_begin(pjmedia_vid_codec *codec,
                                      "returns no input buff"));
             } else {
                 PJ_LOG(4,(THIS_FILE, "Encoder getInputBuffer "
-                                     "size: %d, expecting %d.",
-                                     input_buf, output_size, input->size));
+                                     "size: %lu, expecting %lu.",
+                                     output_size, input->size));
             }
             goto on_return;
         }
     } else {
-        PJ_LOG(4,(THIS_FILE, "Encoder dequeueInputBuffer failed[%d]", buf_idx));
+        PJ_LOG(4,(THIS_FILE, "Encoder dequeueInputBuffer failed[%ld]",
+                             buf_idx));
         goto on_return;
     }
 
@@ -1143,7 +1144,7 @@ static pj_status_t and_media_codec_encode_begin(pjmedia_vid_codec *codec,
 
             AMediaFormat_delete(vid_fmt);
         } else {
-            PJ_LOG(4, (THIS_FILE, "Encoder dequeueOutputBuffer failed[%d]",
+            PJ_LOG(4, (THIS_FILE, "Encoder dequeueOutputBuffer failed[%ld]",
                        buf_idx));
         }
         goto on_return;
@@ -1243,7 +1244,7 @@ static void and_media_get_input_buffer(
                                              CODEC_DEQUEUE_TIMEOUT);
 
     if (buf_idx < 0) {
-        PJ_LOG(4,(THIS_FILE, "Decoder dequeueInputBuffer failed return %d",
+        PJ_LOG(4,(THIS_FILE, "Decoder dequeueInputBuffer failed return %ld",
                   buf_idx));
 
         and_media_data->dec_input_buf = NULL;
@@ -1290,7 +1291,7 @@ static pj_status_t and_media_decode(pjmedia_vid_codec *codec,
                                             input_ts->u32.lo,
                                             buf_flag);
         if (am_status != AMEDIA_OK) {
-            PJ_LOG(4,(THIS_FILE, "Decoder queueInputBuffer idx[%d] return %d",
+            PJ_LOG(4,(THIS_FILE, "Decoder queueInputBuffer idx[%ld] return %d",
                     and_media_data->dec_input_buf_idx, am_status));
             return status;
         }
@@ -1403,7 +1404,7 @@ static pj_status_t and_media_decode(pjmedia_vid_codec *codec,
                                   PJMEDIA_EVENT_PUBLISH_DEFAULT);
         }
     } else {
-        PJ_LOG(4,(THIS_FILE, "Decoder dequeueOutputBuffer failed [%d]",
+        PJ_LOG(4,(THIS_FILE, "Decoder dequeueOutputBuffer failed [%ld]",
                   buf_idx));
     }
     return status;

--- a/pjmedia/src/pjmedia-videodev/android_dev.c
+++ b/pjmedia/src/pjmedia-videodev/android_dev.c
@@ -1316,7 +1316,8 @@ static void JNICALL OnGetFrame2(JNIEnv *env, jobject obj,
         PJ_LOG(1,(THIS_FILE, "Unrecognized image format from Android camera2, "
                              "please report the following plane format:"));
         PJ_LOG(1,(THIS_FILE, " Planes (buf/len/row_stride/pix_stride):"
-                             " p0=%p/%d/%d/%d p1=%p/%d/%d/%d p2=%p/%d/%d/%d",
+                             " p0=%p/%ld/%d/%d p1=%p/%ld/%d/%d "
+                             "p2=%p/%ld/%d/%d",
                              p0, p0_len, rowStride0, pixStride0,
                              p1, p1_len, rowStride1, pixStride1,
                              p2, p2_len, rowStride2, pixStride2));

--- a/pjmedia/src/pjmedia/wsola.c
+++ b/pjmedia/src/pjmedia/wsola.c
@@ -683,6 +683,7 @@ static void expand(pjmedia_wsola *wsola, unsigned needed)
         generated += dist;
 
         if (generated >= needed) {
+            PJ_UNUSED_ARG(rep);
             TRACE_((THIS_FILE, "WSOLA frame expanded after %d iterations", 
                     rep));
             break;
@@ -734,6 +735,7 @@ static unsigned compress(pjmedia_wsola *wsola, pj_int16_t *buf, unsigned count,
         samples_del += dist;
 
         if (samples_del >= del_cnt) {
+            PJ_UNUSED_ARG(rep);
             TRACE_((THIS_FILE, 
                     "Erased %d of %d requested after %d iteration(s)",
                     samples_del, del_cnt, rep));

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -88,6 +88,14 @@ struct MediaFormatAudio : public MediaFormat
      * Export to pjmedia_format.
      */
     pjmedia_format toPj() const;
+
+public:
+    /**
+     * Default constructor
+     */
+    MediaFormatAudio() : clockRate(0), channelCount(0), frameTimeUsec(0),
+                         bitsPerSample(0), avgBps(0), maxBps(0)
+    {}
 };
 
 /**

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -322,6 +322,7 @@ void AudioMediaPort::createPort(const string &name, MediaFormatAudio &fmt)
     }
 
     /* Init port. */
+    pj_bzero(&port, sizeof(port));
     pj_strdup2_with_null(pool, &name_, name.c_str());
     fmt_ = fmt.toPj();
     pjmedia_port_info_init2(&port.info, &name_,


### PR DESCRIPTION
Fixed coverity warnings and various warnings, such as:
* warning: variable 'rep' set but not used
* Using uninitialized value "fmt.maxBps" when calling "createPort".
* Non-static class member "port.on_destroy" is not initialized in this constructor nor in any functions that it calls.
* printf formatting warnings on Android
