### PR TITLE
Locking fix so that SSL_shutdown and SSL_write are not called at same time

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2452,9 +2452,6 @@ static pj_status_t ssl_read(pj_ssl_sock_t *ssock, void *data, int *size)
                 pj_lock_release(ssock->write_mutex);
                 /* Unfortunately we can't hold the lock here to reset all the state.
                   * We probably should though.
-                  *
-                  * TODO: if we get an SSL_ERROR_SSL or SSL_ERROR_SYSCALL, we need to not perform
-                  *       an SSL_shutdown in ssl_reset_sock_state according to openssl docs (due to some CVE or other)
                   */
                 ssl_reset_sock_state(ssock);
                 return status;


### PR DESCRIPTION
Adds locking to prevent simultaneous execution of SSL_write and SSL_shutdown.  OpenSSL documentation says that multiple threads simultaneously calling SSL_* related functions on the same SSL object is not supported.

It'd be nice if this bug fix got into 2.13.x as well.

Fix for #3575