### PR TITLE
Check STUN tdata before sending the message

### DIFF
--- a/pjnath/src/pjnath/stun_session.c
+++ b/pjnath/src/pjnath/stun_session.c
@@ -507,6 +507,9 @@ static pj_status_t stun_tsx_on_send_msg(pj_stun_client_tsx *tsx,
     pj_status_t status;
 
     tdata = (pj_stun_tx_data*) pj_stun_client_tsx_get_data(tsx);
+    if (!tdata)
+        return PJ_EGONE;
+     
     sess = tdata->sess;
 
     /* Lock the session and prevent user from destroying us in the callback */

--- a/pjnath/src/pjnath/stun_transaction.c
+++ b/pjnath/src/pjnath/stun_transaction.c
@@ -411,11 +411,7 @@ static void retransmit_timer_callback(pj_timer_heap_t *timer_heap,
 PJ_DEF(pj_status_t) pj_stun_client_tsx_retransmit(pj_stun_client_tsx *tsx,
                                                   pj_bool_t mod_count)
 {
-    if (tsx->destroy_timer.id != 0) {
-        return PJ_SUCCESS;
-    }
-
-    if (tsx->is_destroying)
+    if (tsx->destroy_timer.id != 0 || tsx->is_destroying)
         return PJ_SUCCESS;
 
     if (mod_count) {


### PR DESCRIPTION
It is reported that a crash might happen on `stun_tsx_on_send_msg()`
```
    0x100fb2118 <+28>:  bl     0x100fb5794               ; pj_stun_client_tsx_get_data
->  0x100fb2124 <+40>:  ldr    x8, [x8, #0x18]
    0x100fb2134 <+56>:  bl     0x100ebfac4               ; pj_grp_lock_acquire
    0x100fb2150 <+84>:  bl     0x100ebfb0c               ; pj_grp_lock_release
```

```
pjsua_0 (14)#0	0x0000000100fb2124 in stun_tsx_on_send_msg ()
#1	0x0000000100fb5d64 in tsx_transmit_msg ()
#2	0x0000000100fb527c in retransmit_timer_callback ()
#3	0x0000000100ed48d0 in pj_timer_heap_poll ()
#4	0x00000001011d73e8 in pjsip_endpt_handle_events2 ()
#5	0x000000010118cfac in pjsua_handle_events ()
#6	0x000000010118c3c0 in worker_thread ()
#7	0x0000000100eb2f28 in thread_main ()
#8	0x00000001da496060 in _pthread_start ()
```

The log:
```
00:16:55.995        utsx0x1068f5628  .STUN client transaction created
00:16:55.995        utsx0x1068f5628  .STUN sending message (transmit count=1)
00:16:56.656         stun_session.c  .tdata 0x1068f54a8 destroy request, force=0, tsx=0x1068f5628, destroying=0
00:16:56.657        utsx0x1068f5628  .STUN transaction 0x1068f5628 schedule destroy
00:16:56.958        utsx0x1068f5628 !STUN client transaction 0x1068f5628 stopped, ref_cnt=15
00:16:57.321         stun_session.c !tdata 0x1068f54a8 destroy request, force=1, tsx=0x1068f5628, destroying=0
00:16:57.321        utsx0x1068f5628  STUN client transaction 0x1068f5628 stopped, ref_cnt=12
00:16:57.321         stun_session.c  STUN transaction 0x1068f5628 destroyed
00:16:57.321        utsx0x1068f5628 !STUN sending message (transmit count=2)
```

This indicates that while STUN transaction is destroyed.

https://github.com/pjsip/pjproject/blob/9a7d4d17202fb7821f3fbf1736c4f1468bdacb36/pjnath/src/pjnath/stun_session.c#L145-L163

The retransmit callback is called but blocked waiting for the group lock:
https://github.com/pjsip/pjproject/blob/9a7d4d17202fb7821f3fbf1736c4f1468bdacb36/pjnath/src/pjnath/stun_transaction.c#L347-L354

Afterwards, the tdata was reset to NULL and after the retransmit will resume and crash caused by invalid tdata.