### PR TITLE
Use configured bound or public address for outgoing UDP SIP messages

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -354,7 +354,7 @@ typedef struct pjsua_transport_data
 
     pj_bool_t                is_restarting;
     pj_status_t              restart_status;
-    pj_bool_t                has_bound_addr;
+    pj_bool_t                has_cfg_addr;
 } pjsua_transport_data;
 
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3511,7 +3511,7 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
         }
     } else
     /* For UDP transport, check if we need to overwrite the address
-     * with its bound address.
+     * with its configured bound/public address.
      */
     if ((flag & PJSIP_TRANSPORT_DATAGRAM) && tfla2_prm.local_if &&
         tfla2_prm.ret_tp)
@@ -3520,7 +3520,7 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
 
         for (i = 0; i < (int)PJ_ARRAY_SIZE(pjsua_var.tpdata); i++) {
             if (tfla2_prm.ret_tp==(const void *)pjsua_var.tpdata[i].data.tp) {
-                if (pjsua_var.tpdata[i].has_bound_addr) {
+                if (pjsua_var.tpdata[i].has_cfg_addr) {
                     pj_strdup(pool, &addr->host,
                               &pjsua_var.tpdata[i].data.tp->local_name.host);
                     addr->port = (pj_uint16_t)

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -2600,8 +2600,8 @@ PJ_DEF(pj_status_t) pjsua_transport_create( pjsip_transport_type_e type,
         pjsua_var.tpdata[id].local_name = tp->local_name;
         pjsua_var.tpdata[id].data.tp = tp;
         pj_sockaddr_cp(&pjsua_var.tpdata[id].pub_addr, &pub_addr);
-        if (cfg->bound_addr.slen)
-            pjsua_var.tpdata[id].has_bound_addr = PJ_TRUE;
+        if (cfg->bound_addr.slen || cfg->public_addr.slen)
+            pjsua_var.tpdata[id].has_cfg_addr = PJ_TRUE;
 
 #if defined(PJ_HAS_TCP) && PJ_HAS_TCP!=0
 


### PR DESCRIPTION
As reported in #3514, the public address specified in the config to create UDP transport may not be used in the outgoing messages.

Tracing back, we already have #2205 which will use the configured bound address, but we haven't done so for public address.