### PR TITLE
Only validate public address when IP address is supplied on TCP/TLS

### DIFF
--- a/pjsip/include/pjsip/sip_transport_tcp.h
+++ b/pjsip/include/pjsip/sip_transport_tcp.h
@@ -71,6 +71,7 @@ typedef struct pjsip_tcp_transport_cfg
     /**
      * Optional published address, which is the address to be
      * advertised as the address of this SIP transport. 
+     * It can be set using IP address or hostname.
      * By default the bound address will be used as the published address.
      */
     pjsip_host_port     addr_name;
@@ -181,6 +182,7 @@ PJ_DECL(pj_status_t) pjsip_tcp_transport_start(pjsip_endpoint *endpt,
  *                      selected by the operating system.
  * @param a_name        Optional published address, which is the address to be
  *                      advertised as the address of this SIP transport. 
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address
  *                      will be used as the published address.
  * @param async_cnt     Number of simultaneous asynchronous accept()
@@ -248,6 +250,7 @@ PJ_DECL(pj_sock_t) pjsip_tcp_transport_get_socket(pjsip_transport *transport);
  *                      selected by the operating system.
  *
  * @param a_name        The published address for the listener. 
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address will 
  *                      be used as the published address.
  *
@@ -272,6 +275,7 @@ PJ_DECL(pj_status_t) pjsip_tcp_transport_lis_start(pjsip_tpfactory *factory,
  *                      selected by the operating system.
  *
  * @param a_name        The published address for the listener. 
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address will
  *                      be used as the published address.
  *

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -491,6 +491,7 @@ PJ_DECL(void) pjsip_tls_setting_wipe_keys(pjsip_tls_setting *opt);
  *                      selected by the operating system.
  * @param a_name        Optional published address, which is the address to be
  *                      advertised as the address of this SIP transport. 
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address
  *                      will be used as the published address.
  * @param async_cnt     Number of simultaneous asynchronous accept()
@@ -529,6 +530,7 @@ PJ_DECL(pj_status_t) pjsip_tls_transport_start(pjsip_endpoint *endpt,
  *                      selected by the operating system.
  * @param a_name        Optional published address, which is the address to be
  *                      advertised as the address of this SIP transport.
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address
  *                      will be used as the published address.
  * @param async_cnt     Number of simultaneous asynchronous accept()
@@ -565,6 +567,7 @@ PJ_DECL(pj_status_t) pjsip_tls_transport_start2(pjsip_endpoint *endpt,
  *                      selected by the operating system.
  *
  * @param a_name        The published address for the listener.
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address will
  *                      be used as the published address.
  *
@@ -590,6 +593,7 @@ PJ_DECL(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
  *                      selected by the operating system.
  *
  * @param a_name        The published address for the listener.
+ *                      It can be set using IP address or hostname.
  *                      If this argument is NULL, then the bound address will
  *                      be used as the published address.
  *

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -274,14 +274,20 @@ static pj_status_t update_factory_addr(struct tcp_listener *listener,
         pj_sockaddr tmp;
         int af = pjsip_transport_type_get_af(listener->factory.type);
 
-        /* Verify that address given in a_name (if any) is valid */
-        status = pj_sockaddr_init(af, &tmp, &addr_name->host,
-                                  (pj_uint16_t)addr_name->port);
-        if (status != PJ_SUCCESS || !pj_sockaddr_has_addr(&tmp) ||
-            (af == pj_AF_INET() && tmp.ipv4.sin_addr.s_addr == PJ_INADDR_NONE))
+        tmp.addr.sa_family = (pj_uint16_t)af;
+
+        /* Validate IP address only */
+        if (pj_inet_pton(af, &addr_name->host, pj_sockaddr_get_addr(&tmp)) == PJ_SUCCESS)
         {
-            /* Invalid address */
-            return PJ_EINVAL;
+            /* Verify that address given in a_name (if any) is valid */
+            status = pj_sockaddr_init(af, &tmp, &addr_name->host,
+                                      (pj_uint16_t)addr_name->port);
+            if (status != PJ_SUCCESS || !pj_sockaddr_has_addr(&tmp) ||
+                (af == pj_AF_INET() && tmp.ipv4.sin_addr.s_addr == PJ_INADDR_NONE))
+            {
+                /* Invalid address */
+                return PJ_EINVAL;
+            }
         }
 
         /* Copy the address */

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -375,13 +375,20 @@ static pj_status_t update_factory_addr(struct tls_listener *listener,
         pj_sockaddr tmp;
         int af = pjsip_transport_type_get_af(listener->factory.type);
 
-        status = pj_sockaddr_init(af, &tmp, &addr_name->host,
-                                  (pj_uint16_t)addr_name->port);
-        if (status != PJ_SUCCESS || !pj_sockaddr_has_addr(&tmp) ||
-            (af == pj_AF_INET() && tmp.ipv4.sin_addr.s_addr == PJ_INADDR_NONE))
+        tmp.addr.sa_family = af;
+
+        /* Validate IP address only */
+        if (pj_inet_pton(af, &addr_name->host, pj_sockaddr_get_addr(&tmp)) == PJ_SUCCESS)
         {
-            /* Invalid address */
-            return PJ_EINVAL;
+            /* Verify that address given in a_name (if any) is valid */
+            status = pj_sockaddr_init(af, &tmp, &addr_name->host,
+                                      (pj_uint16_t)addr_name->port);
+            if (status != PJ_SUCCESS || !pj_sockaddr_has_addr(&tmp) ||
+                (af == pj_AF_INET() && tmp.ipv4.sin_addr.s_addr == PJ_INADDR_NONE))
+            {
+                /* Invalid address */
+                return PJ_EINVAL;
+            }
         }
 
         /* Copy the address */


### PR DESCRIPTION
When public address is supplied when starting TCP/TLS transport(e.g: `pjsip_tcp_transport_start2()`), the address will be validated. 
The validation is not applied to UDP transport.
If the address supplied is unresolvable FQDN address, the transport will fail to start.
This PR will only validate the publish address if it is an IP address.
