### PR TITLE
Update QoS DSCP map to follow RFC4594 guidelines

### DIFF
--- a/pjlib/src/pj/sock_qos_common.c
+++ b/pjlib/src/pj/sock_qos_common.c
@@ -31,8 +31,8 @@ static const pj_qos_params qos_map[] =
     /* flags    dscp  prio wmm_prio */
     {ALL_FLAGS, 0x00, 0,    PJ_QOS_WMM_PRIO_BULK_EFFORT},   /* BE */
     {ALL_FLAGS, 0x08, 2,    PJ_QOS_WMM_PRIO_BULK},          /* BK */    
-    {ALL_FLAGS, 0x28, 5,    PJ_QOS_WMM_PRIO_VIDEO},         /* VI */
-    {ALL_FLAGS, 0x30, 6,    PJ_QOS_WMM_PRIO_VOICE},         /* VO */
+    {ALL_FLAGS, 0x20, 5,    PJ_QOS_WMM_PRIO_VIDEO},         /* VI */
+    {ALL_FLAGS, 0x2E, 6,    PJ_QOS_WMM_PRIO_VOICE},         /* VO */
     {ALL_FLAGS, 0x38, 7,    PJ_QOS_WMM_PRIO_VOICE},         /* CO */
     {ALL_FLAGS, 0x28, 5,    PJ_QOS_WMM_PRIO_VIDEO}          /* SIG */
 };


### PR DESCRIPTION
In [RFC4594 section 2.3](https://datatracker.ietf.org/doc/html/rfc4594#section-2.3) _Figure 3. DSCP to Service Class Mapping_, the DSCP values for VOICE and VIDEO are `0x2E/101110b` and `0x20/100000b`, while PJLIB QoS DSCP map (high level QoS API) values are `0x30` and `0x28`.

This PR updates the map to use RFC4594 guidelines as described above.

Thanks to Peter Koletzki for the suggestion.