### PR TITLE
Send RTCP even if the media stream is inactive

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1401,6 +1401,14 @@ static pj_status_t put_frame_imp( pjmedia_port *port,
         /* Update RTCP stats with last RTP timestamp. */
         stream->rtcp.stat.rtp_tx_last_ts = pj_ntohl(channel->rtp.out_hdr.ts);
 
+        /* Check if now is the time to transmit RTCP SR/RR report.
+         * We only do this when the decoder is paused,
+         * because otherwise check_tx_rtcp() will be handled by on_rx_rtp().
+         */
+        if (stream->dec->paused) {
+            check_tx_rtcp(stream, pj_ntohl(channel->rtp.out_hdr.ts));
+        }
+
         return PJ_SUCCESS;
     }
 


### PR DESCRIPTION
Currently, we still send RTCP if the call is held in one direction (local/remote hold), but not if it's double held (inactive stream).

RFC 4566 says that:
```
a=inactive
... No media is sent over an
         inactive media stream.  Note that an RTP-based system SHOULD
         still send RTCP, even if started inactive.
```
