### PR TITLE
Add custom headers to invite/response in pjsua

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -297,9 +297,12 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
                              pjsip_rx_data *rdata)
 {
     pjsua_call_info call_info;
+    pjsua_msg_data msg_data;
 
     PJ_UNUSED_ARG(acc_id);
     PJ_UNUSED_ARG(rdata);
+
+    pjsua_msg_data_init(&msg_data);
 
     pjsua_call_get_info(call_id, &call_info);
 
@@ -321,8 +324,14 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
         opt.aud_cnt = app_config.aud_cnt;
         opt.vid_cnt = app_config.vid.vid_cnt;
 
+        for (int i=0; i<app_config.res_hdr_cnt; ++i) {
+            pjsip_generic_string_hdr *hdr;
+            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.res_hname_cfg[i],  &app_config.res_hvalue_cfg[i]);
+            pj_list_push_back(&msg_data.hdr_list, hdr);
+        }
+
         pjsua_call_answer2(call_id, &opt, app_config.auto_answer, NULL,
-                           NULL);
+                           &msg_data);
     }
     
     if (app_config.auto_answer < 200) {

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -326,7 +326,9 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
 
         for (int i=0; i<app_config.res_hdr_cnt; ++i) {
             pjsip_generic_string_hdr *hdr;
-            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.res_hname_cfg[i],  &app_config.res_hvalue_cfg[i]);
+            hdr = pjsip_generic_string_hdr_create(app_config.pool,
+                                                &app_config.res_hname_cfg[i],
+                                                &app_config.res_hvalue_cfg[i]);
             pj_list_push_back(&msg_data.hdr_list, hdr);
         }
 

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -1537,6 +1537,13 @@ static pj_status_t cmd_make_single_call(pj_cli_cmd_val *cval)
 
         pjsua_msg_data_init(&msg_data);
         TEST_MULTIPART(&msg_data);
+
+        for (int i=0; i<app_config.inv_hdr_cnt; ++i) {
+            pjsip_generic_string_hdr *hdr;
+            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.inv_hname_cfg[i],  &app_config.inv_hvalue_cfg[i]);
+            pj_list_push_back(&msg_data.hdr_list, hdr);
+        }
+
         pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
                              &msg_data, &current_call);
 
@@ -1647,6 +1654,12 @@ static pj_status_t cmd_answer_call(pj_cli_cmd_val *cval)
         if (current_call == PJSUA_INVALID_ID) {
             const pj_str_t err_msg = pj_str("Call has been disconnected\n");
             pj_cli_sess_write_msg(cval->sess, err_msg.ptr, err_msg.slen);
+        }
+
+        for (int i=0; i<app_config.res_hdr_cnt; ++i) {
+            pjsip_generic_string_hdr *hdr;
+            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.res_hname_cfg[i],  &app_config.res_hvalue_cfg[i]);
+            pj_list_push_back(&msg_data.hdr_list, hdr);
         }
 
         pjsua_call_answer2(current_call, &call_opt, st_code, NULL, &msg_data);

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -1540,7 +1540,9 @@ static pj_status_t cmd_make_single_call(pj_cli_cmd_val *cval)
 
         for (int i=0; i<app_config.inv_hdr_cnt; ++i) {
             pjsip_generic_string_hdr *hdr;
-            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.inv_hname_cfg[i],  &app_config.inv_hvalue_cfg[i]);
+            hdr = pjsip_generic_string_hdr_create(app_config.pool,
+                                                &app_config.inv_hname_cfg[i],
+                                                &app_config.inv_hvalue_cfg[i]);
             pj_list_push_back(&msg_data.hdr_list, hdr);
         }
 
@@ -1658,7 +1660,9 @@ static pj_status_t cmd_answer_call(pj_cli_cmd_val *cval)
 
         for (int i=0; i<app_config.res_hdr_cnt; ++i) {
             pjsip_generic_string_hdr *hdr;
-            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.res_hname_cfg[i],  &app_config.res_hvalue_cfg[i]);
+            hdr = pjsip_generic_string_hdr_create(app_config.pool,
+                                                &app_config.res_hname_cfg[i],
+                                                &app_config.res_hvalue_cfg[i]);
             pj_list_push_back(&msg_data.hdr_list, hdr);
         }
 

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -92,12 +92,12 @@ typedef struct pjsua_app_config
     pjsua_buddy_config      buddy_cfg[PJSUA_MAX_BUDDIES];
 
     unsigned                inv_hdr_cnt;
-    pj_str_t                inv_hname_cfg[16];
-    pj_str_t                inv_hvalue_cfg[16];
+    pj_str_t                inv_hname_cfg[PJSUA_MAX_CUSTOM_HEADERS];
+    pj_str_t                inv_hvalue_cfg[PJSUA_MAX_CUSTOM_HEADERS];
 
     unsigned                res_hdr_cnt;
-    pj_str_t                res_hname_cfg[16];
-    pj_str_t                res_hvalue_cfg[16];
+    pj_str_t                res_hname_cfg[PJSUA_MAX_CUSTOM_HEADERS];
+    pj_str_t                res_hvalue_cfg[PJSUA_MAX_CUSTOM_HEADERS];
 
     app_call_data           call_data[PJSUA_MAX_CALLS];
 

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -91,6 +91,14 @@ typedef struct pjsua_app_config
     unsigned                buddy_cnt;
     pjsua_buddy_config      buddy_cfg[PJSUA_MAX_BUDDIES];
 
+    unsigned                inv_hdr_cnt;
+    pj_str_t                inv_hname_cfg[16];
+    pj_str_t                inv_hvalue_cfg[16];
+
+    unsigned                res_hdr_cnt;
+    pj_str_t                res_hname_cfg[16];
+    pj_str_t                res_hvalue_cfg[16];
+
     app_call_data           call_data[PJSUA_MAX_CALLS];
 
     pj_pool_t              *pool;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -373,7 +373,8 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_100REL, OPT_USE_IMS, OPT_REALM, OPT_USERNAME, OPT_PASSWORD,
            OPT_REG_RETRY_INTERVAL, OPT_REG_USE_PROXY,
            OPT_MWI, OPT_NAMESERVER, OPT_STUN_SRV, OPT_UPNP, OPT_OUTB_RID,
-           OPT_ADD_BUDDY, OPT_ADD_INVITE_HEADER, OPT_ADD_RESPONSE_HEADER, OPT_OFFER_X_MS_MSG, OPT_NO_PRESENCE,
+           OPT_ADD_BUDDY, OPT_OFFER_X_MS_MSG, OPT_NO_PRESENCE,
+           OPT_ADD_INVITE_HEADER, OPT_ADD_RESPONSE_HEADER,
            OPT_AUTO_ANSWER, OPT_AUTO_PLAY, OPT_AUTO_PLAY_HANGUP, OPT_AUTO_LOOP,
            OPT_AUTO_CONF, OPT_CLOCK_RATE, OPT_SND_CLOCK_RATE, OPT_STEREO,
            OPT_USE_ICE, OPT_ICE_REGULAR, OPT_ICE_TRICKLE,
@@ -982,7 +983,9 @@ static pj_status_t parse_args(int argc, char *argv[],
 
             inv_pcol = (char*)pj_memchr(inv_hname.ptr, ':', inv_hname.slen);
             inv_hvalue.ptr = inv_hname.ptr;
-            inv_hvalue.slen = inv_pcol ? inv_pcol - inv_hname.ptr : inv_hname.slen;
+            inv_hvalue.slen = inv_pcol ? 
+                                inv_pcol - inv_hname.ptr : 
+                                inv_hname.slen;
 
             if (inv_pcol) {
                 inv_hvalue.ptr = inv_pcol + 1;
@@ -1012,7 +1015,9 @@ static pj_status_t parse_args(int argc, char *argv[],
 
             res_pcol = (char*)pj_memchr(res_hname.ptr, ':', res_hname.slen);
             res_hvalue.ptr = res_hname.ptr;
-            res_hvalue.slen = res_pcol ? res_pcol - res_hname.ptr : res_hname.slen;
+            res_hvalue.slen = res_pcol ? 
+                                res_pcol - res_hname.ptr : 
+                                res_hname.slen;
 
             if (res_pcol) {
                 res_hvalue.ptr = res_pcol + 1;

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -732,6 +732,13 @@ static void ui_make_new_call()
 
         pjsua_msg_data_init(&msg_data_);
         TEST_MULTIPART(&msg_data_);
+
+        for (int i=0; i<app_config.inv_hdr_cnt; ++i) {
+            pjsip_generic_string_hdr *hdr;
+            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.inv_hname_cfg[i],  &app_config.inv_hvalue_cfg[i]);
+            pj_list_push_back(&msg_data_.hdr_list, hdr);
+        }
+
         pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
                              &msg_data_, &current_call);
 
@@ -912,6 +919,12 @@ static void ui_answer_call()
             puts("Call has been disconnected");
             fflush(stdout);
             return;
+        }
+
+        for (int i=0; i<app_config.res_hdr_cnt; ++i) {
+            pjsip_generic_string_hdr *hdr;
+            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.res_hname_cfg[i],  &app_config.res_hvalue_cfg[i]);
+            pj_list_push_back(&msg_data_.hdr_list, hdr);
         }
 
         pjsua_call_answer2(current_call, &call_opt, st_code, NULL, &msg_data_);

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -735,7 +735,9 @@ static void ui_make_new_call()
 
         for (int i=0; i<app_config.inv_hdr_cnt; ++i) {
             pjsip_generic_string_hdr *hdr;
-            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.inv_hname_cfg[i],  &app_config.inv_hvalue_cfg[i]);
+            hdr = pjsip_generic_string_hdr_create(app_config.pool,
+                                                &app_config.inv_hname_cfg[i],
+                                                &app_config.inv_hvalue_cfg[i]);
             pj_list_push_back(&msg_data_.hdr_list, hdr);
         }
 
@@ -923,7 +925,9 @@ static void ui_answer_call()
 
         for (int i=0; i<app_config.res_hdr_cnt; ++i) {
             pjsip_generic_string_hdr *hdr;
-            hdr = pjsip_generic_string_hdr_create(app_config.pool, &app_config.res_hname_cfg[i],  &app_config.res_hvalue_cfg[i]);
+            hdr = pjsip_generic_string_hdr_create(app_config.pool,
+                                                &app_config.res_hname_cfg[i],
+                                                &app_config.res_hvalue_cfg[i]);
             pj_list_push_back(&msg_data_.hdr_list, hdr);
         }
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6286,6 +6286,12 @@ pjsua_call_get_med_transport_info(pjsua_call_id call_id,
 #   define PJSUA_MAX_BUDDIES        256
 #endif
 
+/**
+ * Max custom headers.
+ */
+#ifndef PJSUA_MAX_CUSTOM_HEADERS
+#   define PJSUA_MAX_CUSTOM_HEADERS 16
+#endif
 
 /**
  * This specifies how long the library should wait before retrying failed


### PR DESCRIPTION
Add custom headers to invite/200 OK response in pjsua.
Those parameters can be called more than once.
To add a custom invite header append the following to pjsua --add-invite-header "header:value"
To add a custom response header, append the following to pjsua --add-response-header "header:value"