### PR TITLE
Update transport config docs regarding QoS settings for TLS

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3097,6 +3097,9 @@ typedef struct pjsua_transport_config
      * to apply QoS tagging to the transport, it's preferable to set this
      * field rather than \a qos_param fields since this is more portable.
      *
+     * For TLS transport, this field will be ignored, the QoS traffic type
+     * can be set via tls_setting.
+     *
      * Default is QoS not set.
      */
     pj_qos_type         qos_type;
@@ -3106,12 +3109,18 @@ typedef struct pjsua_transport_config
      * level operation than setting the \a qos_type field and may not be
      * supported on all platforms.
      *
+     * For TLS transport, this field will be ignored, the low level QoS
+     * parameters can be set via tls_setting.
+     *
      * Default is QoS not set.
      */
     pj_qos_params       qos_params;
 
     /**
      * Specify options to be set on the transport. 
+     *
+     * For TLS transport, this field will be ignored, the socket options
+     * can be set via tls_setting.
      *
      * By default there is no options.
      * 

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -380,6 +380,9 @@ struct TransportConfig : public PersistentObject
      * to apply QoS tagging to the transport, it's preferable to set this
      * field rather than \a qosParam fields since this is more portable.
      *
+     * For TLS transport, this field will be ignored, the QoS traffic type
+     * can be set via tlsConfig.
+     *
      * Default is QoS not set.
      */
     pj_qos_type         qosType;
@@ -388,6 +391,9 @@ struct TransportConfig : public PersistentObject
      * Set the low level QoS parameters to the transport. This is a lower
      * level operation than setting the \a qosType field and may not be
      * supported on all platforms.
+     *
+     * For TLS transport, this field will be ignored, the low level QoS
+     * parameters can be set via tlsConfig.
      *
      * Default is QoS not set.
      */


### PR DESCRIPTION
For TLS transports, QoS and socket options settings should be configured via `pjsua_transport_config.tls_setting` instead of the `pjsua_transport_config`. Also in PJSUA2 they should be configured via `TransportConfig.tlsConfig` instead of `TransportConfig`. This PR update the docs to avoid confusion.