### PR TITLE
Add SSL socket info to TLS verification callback

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -682,6 +682,10 @@ typedef struct pj_ssl_sock_cb
      * Certification info can be obtained from #pj_ssl_sock_info. Currently
      * it's only implemented for OpenSSL backend.
      *
+     * Note that this callback will not be called if peer certificate
+     * verification is disabled (i.e: pj_ssl_sock_param.verify_peer is
+     * set to PJ_FALSE).
+     *
      * @param ssock     The secure socket.
      * @param is_server PJ_TRUE to indicate an incoming connection.
      *

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1574,10 +1574,10 @@ PJ_DEF(pj_status_t) pj_ssl_sock_get_info (pj_ssl_sock_t *ssock,
     
     if (info->established) {
         info->cipher = ssl_get_cipher(ssock);
-
-        /* Verification status */
-        info->verify_status = ssock->verify_status;
     }
+
+    /* Verification status */
+    info->verify_status = ssock->verify_status;
 
     /* Last known SSL error code */
     info->last_native_err = ssock->last_err;

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -384,6 +384,10 @@ typedef struct pjsip_tls_setting
      * Callback to be called to verify a new connection.  Currently it's only 
      * implemented for OpenSSL backend.
      *
+     * Note that this callback will not be called if peer certificate
+     * verification is disabled (i.e: pjsip_tls_setting.verify_client/
+     * verify_server is set to PJ_FALSE).
+     *
      * @param param         The parameter to the callback.
      * 
      * @return              Return PJ_TRUE if succesfully verified. 

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -132,6 +132,11 @@ typedef struct pjsip_tls_on_verify_param {
      */
     pj_ssl_cert_info *remote_cert_info;
 
+    /**
+     * SSL socket info.
+     */
+    pj_ssl_sock_info *ssl_sock_info;
+
 } pjsip_tls_on_verify_param;
 
 

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -1621,6 +1621,7 @@ static pj_bool_t on_verify_cb(pj_ssl_sock_t* ssock, pj_bool_t is_server)
         param.local_cert_info = info.local_cert_info;
         param.remote_cert_info = info.remote_cert_info;
         param.tp_dir = is_server?PJSIP_TP_DIR_INCOMING:PJSIP_TP_DIR_OUTGOING;
+        param.ssl_sock_info = &info;
         
         return (*verify_cb)(&param);
     }


### PR DESCRIPTION
The TLS verification callback, `pjsip_tls_setting.on_verify_cb`, can be used by app to implement its own TLS verification. Currently the callback pass some TLS info via callback param `pjsip_tls_on_verify_param` and there is a request for an additional info: pre-verification status of peer certificate. This PR add SSL socket info (which also contains pre-verification status) to the callback param, so application can make use all available info for its verification logic.

This PR also modify the behavior of verification callback in SSL socket and TLS transport, i.e: the callback will not be called if verification is disabled (i.e: `pj_ssl_sock_param.verify_peer==PJ_FALSE`, `pjsip_tls_setting.verify_client/server==PJ_FALSE`).

Thanks Peter Koletzki for the request/feedback.
