### PR TITLE
redeclared variable error fixed

### DIFF
--- a/pjsip-apps/src/vidgui/vidgui.cpp
+++ b/pjsip-apps/src/vidgui/vidgui.cpp
@@ -658,7 +658,7 @@ static void simple_registrar(pjsip_rx_data *rdata)
     srv->hvalue = pj_str((char*)"pjsua simple registrar");
     pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)srv);
 
-    pj_status_t status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
+    status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
                                rdata, tdata, NULL, NULL);
     if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 }


### PR DESCRIPTION
The variable 'pj_status_t' is declared twice in the same scope, which is causing the 'vidgui' sample application to fail to compile.