### PR TITLE
Allow app gets the native SSL socket instance in TLS verification callback

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -682,6 +682,10 @@ typedef struct pj_ssl_sock_cb
      * Certification info can be obtained from #pj_ssl_sock_info. Currently
      * it's only implemented for OpenSSL backend.
      *
+     * If this is set, the callback will always be invoked, even when peer
+     * verification is disabled (pj_ssl_sock_param.verify_peer set to
+     * PJ_FALSE).
+     *
      * @param ssock     The secure socket.
      * @param is_server PJ_TRUE to indicate an incoming connection.
      *
@@ -808,6 +812,12 @@ typedef struct pj_ssl_sock_info
      * Group lock assigned to the ioqueue key.
      */
     pj_grp_lock_t *grp_lock;
+
+    /**
+     * Native TLS/SSL instance of the backend. Currently only available for
+     * OpenSSL backend (this will contain the OpenSSL "SSL" instance).
+     */
+    void *native_ssl;
 
 } pj_ssl_sock_info;
 

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1574,16 +1574,25 @@ PJ_DEF(pj_status_t) pj_ssl_sock_get_info (pj_ssl_sock_t *ssock,
     
     if (info->established) {
         info->cipher = ssl_get_cipher(ssock);
-
-        /* Verification status */
-        info->verify_status = ssock->verify_status;
     }
+
+    /* Verification status */
+    info->verify_status = ssock->verify_status;
 
     /* Last known SSL error code */
     info->last_native_err = ssock->last_err;
 
     /* Group lock */
     info->grp_lock = ssock->param.grp_lock;
+
+    /* Native SSL object */
+#if defined(PJ_HAS_SSL_SOCK) && PJ_HAS_SSL_SOCK != 0 && \
+    (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+    {
+        ossl_sock_t *ossock = (ossl_sock_t *)ssock;
+        info->native_ssl = ossock->ossl_ssl;
+    }
+#endif
 
     return PJ_SUCCESS;
 }

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -132,6 +132,11 @@ typedef struct pjsip_tls_on_verify_param {
      */
     pj_ssl_cert_info *remote_cert_info;
 
+    /**
+     * The SSL socket instance.
+     */
+    pj_ssl_sock_t *ssock;
+
 } pjsip_tls_on_verify_param;
 
 
@@ -378,6 +383,10 @@ typedef struct pjsip_tls_setting
     /**
      * Callback to be called to verify a new connection.  Currently it's only 
      * implemented for OpenSSL backend.
+     *
+     * If this is set, the callback will always be invoked, even when peer
+     * verification is disabled (pjsip_tls_setting.verify_server/verify_client
+     * set to PJ_FALSE).
      *
      * @param param         The parameter to the callback.
      * 

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -1621,6 +1621,7 @@ static pj_bool_t on_verify_cb(pj_ssl_sock_t* ssock, pj_bool_t is_server)
         param.local_cert_info = info.local_cert_info;
         param.remote_cert_info = info.remote_cert_info;
         param.tp_dir = is_server?PJSIP_TP_DIR_INCOMING:PJSIP_TP_DIR_OUTGOING;
+        param.ssock = ssock;
         
         return (*verify_cb)(&param);
     }


### PR DESCRIPTION
The TLS verification callback, `pjsip_tls_setting.on_verify_cb`, can be used by app to implement its own TLS verification. And there is a request to allow app to set/override the TLS Alert code (for TLS close_notify) when it fails the app's verification (while it passes the OpenSSL verification, so alert code is 0).

So, this PR adds the native SSL socket instance to the verification callback which allow app to directly access the native SSL socket, which hopefully it can override the verification result (via `SSL_set_verify_result()`?) and do some other things too if needed.

Application using PJLIB SSL socket can get the native SSL socket instance from PJLIB SSL socket info (`pj_ssl_sock_info`).
Application using PJSIP TLS transport first gets the PJLIB SSL socket instance from `pjsip_tls_on_verify_param`, then use it to query the PJLIB SSL socket info.

Thanks Peter Koletzki for the request/feedback.