### PR TITLE
Add API to limit retransmission count for outgoing requests in transaction layer

### DIFF
--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -454,22 +454,48 @@ PJ_DECL(pj_status_t) pjsip_tsx_stop_retransmit(pjsip_transaction *tsx);
 PJ_DECL(pj_status_t) pjsip_tsx_set_timeout(pjsip_transaction *tsx,
                                            unsigned millisec);
 
+
 /**
  * Change timer values used by transaction layer. Currently scheduled
  * timers will not be changed. Any value set to 0 will be left
  * unchanged.
  *
- * @param t1 - Transaction T1 timeout, in msec
- * @param t2 - Transaction T2 timeout, in msec
- * @param t4 - Transaction completed timer for non-INVITE, in msec
- * @param td - Transaction completed timer for INVITE, in msec
+ * @param t1        Transaction T1 timeout, in msec
+ * @param t2        Transaction T2 timeout, in msec
+ * @param t4        Transaction completed timer for non-INVITE, in msec
+ * @param td        Transaction completed timer for INVITE, in msec
  */
-PJ_DECL(void) pjsip_tsx_set_timers(unsigned t1, unsigned t2, unsigned t4, unsigned td);
+PJ_DECL(void) pjsip_tsx_set_timers(unsigned t1, unsigned t2, unsigned t4,
+                                   unsigned td);
+
 
 /**
  * (Re)Initializes timer values from pjsip_cfg().
  */
 PJ_DECL(void) pjsip_tsx_initialize_timer_values(void);
+
+
+/**
+ * Set maximum retransmission count in transaction layer for outgoing
+ * requests. When retransmission counter reaches the specified number,
+ * the transaction will be considered timeout. This will affect any
+ * ongoing transactions immediately.
+ *
+ * By default (or when this is set to -1), retransmission number will
+ * not cause a transaction to be timeout, only the timer settings will
+ * cause transaction timeout. Also, this will not override the timer
+ * settings, i.e: if the timeout timer occurs before the maximum
+ * retransmission is reached, the transaction will still gets timeout.
+ *
+ * When this is set to zero or possitive number P, a transaction timeout
+ * will occur right before the retransmission number (P+1). For example,
+ * if this is set to 1 there will be two transmissions: the initial
+ * transmission and one retransmission, before the transaction gets timeout.
+ *
+ * @param max       Maximum retransmission count.
+ */
+PJ_DECL(void) pjsip_tsx_set_max_retransmit_count(int max);
+
 
 /**
  * Get the transaction instance in the incoming message. If the message


### PR DESCRIPTION
This PR introduces a new API `pjsip_tsx_set_max_retransmit_count()`, docs:
```
 * Set maximum retransmission count in transaction layer for outgoing
 * requests. When retransmission counter reaches the specified number,
 * the transaction will be considered timeout. This will affect any
 * ongoing transactions immediately.
 *
 * By default (or when this is set to -1), retransmission number will
 * not cause a transaction to be timeout, only the timer settings will
 * cause transaction timeout. Also, this will not override the timer
 * settings, i.e: if the timeout timer occurs before the maximum
 * retransmission is reached, the transaction will still gets timeout.
 *
 * When this is set to zero or possitive number P, a transaction timeout
 * will occur right before the retransmission number (P+1). For example,
 * if this is set to 1 there will be two transmissions: the initial
 * transmission and one retransmission, before the transaction gets timeout.
```