### PR TITLE
Resolved: VidGUI Sample Application Linking Error

### DIFF
--- a/pjsip-apps/src/vidgui/vidgui.cpp
+++ b/pjsip-apps/src/vidgui/vidgui.cpp
@@ -658,7 +658,7 @@ static void simple_registrar(pjsip_rx_data *rdata)
     srv->hvalue = pj_str((char*)"pjsua simple registrar");
     pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr*)srv);
 
-    pj_status_t status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
+    status = pjsip_endpt_send_response2(pjsua_get_pjsip_endpt(),
                                rdata, tdata, NULL, NULL);
     if (status != PJ_SUCCESS) pjsip_tx_data_dec_ref(tdata);
 }

--- a/pjsip-apps/src/vidgui/vidgui.pro
+++ b/pjsip-apps/src/vidgui/vidgui.pro
@@ -15,7 +15,7 @@ win32 {
   }
   LIBS += Iphlpapi.lib  dsound.lib \
   	  dxguid.lib netapi32.lib mswsock.lib ws2_32.lib odbc32.lib \
-  	  odbccp32.lib ole32.lib user32.lib gdi32.lib advapi32.lib 
+  	  odbccp32.lib ole32.lib user32.lib gdi32.lib advapi32.lib oleaut32.lib
 } else {
   LIBS += $$system(make -f pj-pkgconfig.mak ldflags)
   QMAKE_CXXFLAGS += $$system(make --silent -f pj-pkgconfig.mak cflags)


### PR DESCRIPTION
vidgui sample application fails to compile due to a missing library (**oleaut32.lib**) in windows system, and throws few linking error.