### PR TITLE
Fixed pjmedia wsola test failure

### DIFF
--- a/pjmedia/src/pjmedia/wsola.c
+++ b/pjmedia/src/pjmedia/wsola.c
@@ -632,11 +632,15 @@ static void expand(pjmedia_wsola *wsola, unsigned needed)
         templ = reg1 + reg1_len - wsola->hanning_size;
         CHECK_(templ - reg1 >= wsola->hist_size);
 
-        start = find_pitch(templ, 
-                           templ - wsola->expand_sr_max_dist, 
-                           templ - wsola->expand_sr_min_dist,
-                           wsola->templ_size, 
-                           1);
+        if ((wsola->options & PJMEDIA_WSOLA_NO_PLC) == 0) {
+            start = find_pitch(templ,
+                               templ - wsola->expand_sr_max_dist,
+                               templ - wsola->expand_sr_min_dist,
+                               wsola->templ_size,
+                               1);
+        } else {
+            start = PJ_MAX(templ - needed + generated, reg1);
+        }
 
         /* Should we make sure that "start" is really aligned to
          * channel #0, in case of stereo? Probably not necessary, as

--- a/pjmedia/src/test/mips_test.c
+++ b/pjmedia/src/test/mips_test.c
@@ -1022,7 +1022,7 @@ static pj_status_t wsola_plc_get_frame(struct pjmedia_port *this_port,
     pj_status_t status;
 
 
-    if ((pj_rand() % 100) > wp->loss_pct) {
+    if ((pj_rand() % 100) >= wp->loss_pct) {
         status = pjmedia_port_get_frame(wp->gen_port, frame);
         pj_assert(status == PJ_SUCCESS);
 


### PR DESCRIPTION
To fix #3638 .

There are a couple of issues identified here:
- Bug in the unit test itself, which will still call `pjmedia_wsola_generate()` even though `loss_pct` is 0.
- Infinite loop in `wsola` if `pjmedia_wsola_generate()` is called when `wsola` is created with option `PJMEDIA_WSOLA_NO_PLC`. This is because `expand_sr_min_dist` and `expand_sr_max_dist` are only initialised if the option is not specified:
```
    if ((options & PJMEDIA_WSOLA_NO_PLC) == 0) {
        wsola->min_extra = wsola->hanning_size;
        wsola->expand_sr_min_dist = (pj_uint16_t)
                                    (EXP_MIN_DIST * wsola->samples_per_frame);
        wsola->expand_sr_max_dist = (pj_uint16_t)
                                    (EXP_MAX_DIST * wsola->samples_per_frame);
    }
```
so `find_pitch(pj_int16_t *frm, pj_int16_t *beg, pj_int16_t *end, ...)` will be called with `beginning` equalling `end`, and get stuck in infinite loop: `find_pitch(templ, templ - wsola->expand_sr_max_dist, templ - wsola->expand_sr_min_dist, ...)`. 

This PR will fix both.

