### PR TITLE
Fixed potentially duplicate RTCP FB attribute on response

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2961,8 +2961,10 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
                              call_id, mi));
             }
 
-            /* Add any other RTCP-FB setting configured in account setting */
-            if (acc->cfg.rtcp_fb_cfg.cap_count) {
+            /* For offer, add any other RTCP-FB setting configured in account
+             * setting.
+             */
+            if (!rem_sdp && acc->cfg.rtcp_fb_cfg.cap_count) {
                 pj_bool_t tmp = rtcp_cfg.dont_use_avpf;
                 rtcp_cfg = acc->cfg.rtcp_fb_cfg;
                 rtcp_cfg.dont_use_avpf = tmp;


### PR DESCRIPTION
To fix #3642.

For answer, we will list all the capabilities in RTCP FB settings twice, which result in duplication.
