### PR TITLE
Fix bug that causes typeError when encoding sipURI in python

### DIFF
--- a/pjsip-apps/src/python/pjsua.py
+++ b/pjsip-apps/src/python/pjsua.py
@@ -672,7 +672,7 @@ class SIPUri:
             output = output + self.user + "@"
         output = output + self.host
         if self.port:
-            output = output + ":" + output(self.port)
+            output = output + ":" + str(self.port)
         if self.transport:
             output = output + ";transport=" + self.transport
         return output


### PR DESCRIPTION
Instead of adding port as a string this if block tried to call the port as a function.