### PR TITLE
Possible infinite loop in iOS replace socket

### DIFF
--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -752,7 +752,7 @@ static pj_status_t replace_udp_sock(pj_ioqueue_key_t *h)
     pj_fd_set_t *fds[3];
     unsigned i, fds_cnt, flags=0;
     pj_qos_params qos_params;
-    unsigned msec;
+    unsigned msec, msec2;
     pj_status_t status = PJ_EUNKNOWN;
 
     pj_lock_acquire(h->ioqueue->lock);
@@ -771,11 +771,10 @@ static pj_status_t replace_udp_sock(pj_ioqueue_key_t *h)
 
     PJ_LOG(4,(THIS_FILE, "Attempting to replace UDP socket %d", old_sock));
 
-    for (msec=20; (msec<1000 && status != PJ_SUCCESS) ;
-         msec<1000? msec=msec*2 : 1000)
+    for (msec=20; (msec<1000 && status != PJ_SUCCESS); msec=msec*2)
     {
         if (msec > 20) {
-            PJ_LOG(4,(THIS_FILE, "Retry to replace UDP socket %d", old_sock));
+            PJ_LOG(4,(THIS_FILE, "Retry to replace UDP socket %d", h->fd));
             pj_thread_sleep(msec);
         }
         
@@ -844,12 +843,12 @@ static pj_status_t replace_udp_sock(pj_ioqueue_key_t *h)
 
         /* The loop is silly, but what else can we do? */
         addr_len = pj_sockaddr_get_len(&local_addr);
-        for (msec=20; msec<1000 ; msec<1000? msec=msec*2 : 1000) {
+        for (msec2=20; msec2<1000 ; msec2=msec2*2) {
             status = pj_sock_bind(new_sock, &local_addr, addr_len);
             if (status != PJ_STATUS_FROM_OS(EADDRINUSE))
                 break;
             PJ_LOG(4,(THIS_FILE, "Address is still in use, retrying.."));
-            pj_thread_sleep(msec);
+            pj_thread_sleep(msec2);
         }
 
         if (status != PJ_SUCCESS)


### PR DESCRIPTION
The replace socket mechanism uses nested loops, the outer loop state may be reset by the inner loop that may cause such infinite loop.

Thanks to Marcus Froeschl for the report and the suggestion.