### PR TITLE
Set default values in tonegen sample

### DIFF
--- a/pjsip-apps/src/samples/tonegen.c
+++ b/pjsip-apps/src/samples/tonegen.c
@@ -85,16 +85,19 @@ int main()
         tones[0].freq2 = 0;
         tones[0].on_msec = ON_DURATION;
         tones[0].off_msec = OFF_DURATION;
+        tones[0].volume = PJMEDIA_TONEGEN_VOLUME;
 
         tones[1].freq1 = 400;
         tones[1].freq2 = 0;
         tones[1].on_msec = ON_DURATION;
         tones[1].off_msec = OFF_DURATION;
+        tones[1].volume = PJMEDIA_TONEGEN_VOLUME;
 
         tones[2].freq1 = 800;
         tones[2].freq2 = 0;
         tones[2].on_msec = ON_DURATION;
         tones[2].off_msec = OFF_DURATION;
+        tones[2].volume = PJMEDIA_TONEGEN_VOLUME;
 
         status = pjmedia_tonegen_play(port, 3, tones, 0);
         PJ_ASSERT_RETURN(status==PJ_SUCCESS, 1);
@@ -106,10 +109,12 @@ int main()
         digits[0].digit = '0';
         digits[0].on_msec = ON_DURATION;
         digits[0].off_msec = OFF_DURATION;
+        digits[0].volume = PJMEDIA_TONEGEN_VOLUME;
 
         digits[1].digit = '0';
         digits[1].on_msec = ON_DURATION;
         digits[1].off_msec = OFF_DURATION;
+        digits[1].volume = PJMEDIA_TONEGEN_VOLUME;
 
         status = pjmedia_tonegen_play_digits(port, 2, digits, 0);
         PJ_ASSERT_RETURN(status==PJ_SUCCESS, 1);


### PR DESCRIPTION
I had problems with the tonegen sample. It turned out that the volume variables are not initialized and filled with garbage.

For example, code:
```c        pjmedia_tone_desc tones[3];

        printf("Vol1 = %d %d %d\n", tones[0].volume, tones[1].volume, tones[2].volume);

        tones[0].freq1 = 200;
        tones[0].freq2 = 0;
        tones[0].on_msec = ON_DURATION;
        tones[0].off_msec = OFF_DURATION;
        tones[0].volume = PJMEDIA_TONEGEN_VOLUME;

        tones[1].freq1 = 400;
        tones[1].freq2 = 0;
        tones[1].on_msec = ON_DURATION;
        tones[1].off_msec = OFF_DURATION;
        tones[1].volume = PJMEDIA_TONEGEN_VOLUME;

        tones[2].freq1 = 800;
        tones[2].freq2 = 0;
        tones[2].on_msec = ON_DURATION;
        tones[2].off_msec = OFF_DURATION;
        tones[2].volume = PJMEDIA_TONEGEN_VOLUME;

        printf("Vol2 = %d %d %d\n", tones[0].volume, tones[1].volume, tones[2].volume);
```

Output:

```
➜  pjproject git:(master) ✗ ./pjsip-apps/bin/samples/x86_64-unknown-linux-gnu/tonegen    
16:57:55.013         os_core_unix.c !pjlib 2.13-dev for POSIX initialized
16:57:55.014                  pjlib  select() I/O Queue created (0x558ed66da668)
Vol1 = -21776 32561 3090
Vol2 = 12288 12288 12288
```