### PR TITLE
Fixed RTCP packet lost calculation

### DIFF
--- a/pjmedia/src/pjmedia/rtcp.c
+++ b/pjmedia/src/pjmedia/rtcp.c
@@ -376,7 +376,6 @@ PJ_DEF(void) pjmedia_rtcp_rx_rtp2(pjmedia_rtcp_session *sess,
     /* Calculate packet lost and loss periods. */
     if (!seq_st.status.flag.probation && !seq_st.status.flag.outorder) {
         unsigned count = 0, loss = 0;
-        unsigned period;
         pj_uint32_t last_seq, expected;
 
         last_seq = sess->seq_ctrl.max_seq +
@@ -388,14 +387,16 @@ PJ_DEF(void) pjmedia_rtcp_rx_rtp2(pjmedia_rtcp_session *sess,
 
         if (loss > sess->stat.rx.loss)
             count = loss - sess->stat.rx.loss;
-        period = count * sess->dec_pkt_size * 1000 / sess->clock_rate;
-        period *= 1000;
 
         sess->stat.rx.loss = loss;
 
         /* Update loss period stat */
         if (count > 0) {
+            unsigned period;
+
             TRACE_((sess->name, "%d packet(s) lost", count));
+            period = count * sess->dec_pkt_size * 1000 / sess->clock_rate;
+            period *= 1000;
             pj_math_stat_update(&sess->stat.rx.loss_period, period);
         }
     }

--- a/pjmedia/src/pjmedia/rtcp.c
+++ b/pjmedia/src/pjmedia/rtcp.c
@@ -369,8 +369,9 @@ PJ_DEF(void) pjmedia_rtcp_rx_rtp2(pjmedia_rtcp_session *sess,
         return;
     }
 
-    /* Only mark "good" packets */
-    ++sess->received;
+    /* Only mark "good" packets. Do this after we're no longer in probation. */
+    if (!seq_st.status.flag.probation)
+        ++sess->received;
 
     /* Calculate packet lost and loss periods.
      * We should not calculate packet lost here and do it when we're sending

--- a/pjmedia/src/pjmedia/rtp.c
+++ b/pjmedia/src/pjmedia/rtp.c
@@ -315,6 +315,7 @@ void pjmedia_rtp_seq_update( pjmedia_rtp_seq_session *sess,
     
     /* Init status */
     st.status.value = 0;
+    st.status.flag.probation = 0;
     st.diff = 0;
 
     /*
@@ -331,7 +332,8 @@ void pjmedia_rtp_seq_update( pjmedia_rtp_seq_session *sess,
             sess->probation--;
             sess->max_seq = seq;
             if (sess->probation == 0) {
-                st.status.flag.probation = 0;
+                /* Init base seq, as per the RFC 3550. */
+                sess->base_seq = seq;
             }
         } else {
 

--- a/pjmedia/src/pjmedia/rtp.c
+++ b/pjmedia/src/pjmedia/rtp.c
@@ -326,7 +326,7 @@ void pjmedia_rtp_seq_update( pjmedia_rtp_seq_session *sess,
 
         st.status.flag.probation = -1;
 
-        if (seq == sess->max_seq+ 1) {
+        if (seq == (pj_uint16_t)(sess->max_seq + 1)) {
             /* packet is in sequence */
             st.diff = 1;
             sess->probation--;


### PR DESCRIPTION
Suppose RTP packets arrive in the following order: seq 5, 10, 6, 7, 8, 9

Currently, upon receiving seq 10, we will calculate it as 4 lost packets (6 until 9) in `pjmedia_rtcp_rx_rtp2()`: `sess->stat.rx.loss += (seq_st.diff - 1)`.

According to the RFC https://datatracker.ietf.org/doc/html/rfc3550#appendix-A.3, we should calculate it as `lost = expected - s->received` instead. But we commented this code in https://github.com/pjsip/pjproject/commit/84f45890c4afb189bc06f835902ed41cce6e6ab5 because we have done the calculation earlier in `pjmedia_rtcp_rx_rtp2()`. So we probably should use the later calculation instead.
