### PR TITLE
Add configuration for default incoming payload type number for telephone-event

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -459,6 +459,16 @@
 #  define PJMEDIA_DTMF_DURATION_MSEC            200
 #endif
 
+/**
+ * The payload type number of the DTMF/telephone-event is set dynamically out-of-band. 
+ * In case that remote endpoint doesn't specify the the payload type number 
+ * in the SDP, the incoming DTMF might be ignored (bad RTP PT number). Set this as the 
+ * default payload type number for incoming DTMF/telephone-event if no payload type number
+ * is specified on the SDP.
+ */
+#ifndef PJMEDIA_DTMF_TEL_EVENT_RX_PT
+#  define PJMEDIA_DTMF_TEL_EVENT_RX_PT         -1
+#endif
 
 /**
  * Number of RTP packets received from different source IP address from the

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -304,7 +304,7 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
 
 
     /* Get incomming payload type for telephone-events */
-    si->rx_event_pt = -1;
+    si->rx_event_pt = PJMEDIA_DTMF_TEL_EVENT_RX_PT;
     for (i=0; i<local_m->attr_count; ++i) {
         pjmedia_sdp_rtpmap r;
 


### PR DESCRIPTION
RFC [2833](https://datatracker.ietf.org/doc/html/rfc2833#section-3.3) specify that payload type number for telephone-event/DTMF is set dynamically and out-of-band.
```
  The RTP payload format is designated as "telephone-event", the MIME
   type as "audio/telephone-event". The default timestamp rate is 8000
   Hz, but other rates may be defined. In accordance with current
   practice, this payload format does not have a static payload type
   number, but uses a RTP payload type number established dynamically
   and out-of-band.
```

And further, RFC [4733](https://datatracker.ietf.org/doc/html/rfc4733#section-2.5.1.1) stated this:
```
   For example, if the payload format uses the payload type number 100,
   and the implementation can handle the DTMF tones (events 0 through
   15) and the dial and ringing tones (assuming as an example that these
   were defined as events with codes 66 and 70, respectively), it would
   include the following description in its SDP message:

      m=audio 12346 RTP/AVP 100
      a=rtpmap:100 telephone-event/8000
      a=fmtp:100 0-15,66,70
```

Unfortunately, some endpoint doesn't specify the payload type number of the telephone-event in its SDP.
Hence, the incoming DTMF might be ignored.
This patch will introduce a new configuration to set the default incoming telephone-event/DTMF payload type number.
