### PR TITLE
Add option to disable renegotiation on TLSv1.2 or earlier

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -1089,6 +1089,13 @@ typedef struct pj_ssl_sock_param
     */
     pj_bool_t sock_cloexec;
 
+    /**
+     * Specify if renegotiation is enabled for TLSv1.2 or earlier.
+     * 
+     * Default: PJ_TRUE
+     */
+    pj_bool_t enable_renegotiation;
+
 } pj_ssl_sock_param;
 
 

--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -994,7 +994,7 @@ static pj_status_t network_create_params(pj_ssl_sock_t * ssock,
         }
         
         sec_protocol_options_set_tls_renegotiation_enabled(sec_options,
-                                                           true);
+                                            ssock->param.enable_renegotiation);
         /* This must be disabled, otherwise server may think this is
          * a resumption of a previously closed connection, and our
          * verify block may never be invoked!

--- a/pjlib/src/pj/ssl_sock_common.c
+++ b/pjlib/src/pj/ssl_sock_common.c
@@ -48,6 +48,7 @@ PJ_DEF(void) pj_ssl_sock_param_default(pj_ssl_sock_param *param)
 
     param->sockopt_ignore_error = PJ_TRUE;
     param->sock_cloexec = PJ_TRUE;
+    param->enable_renegotiation = PJ_TRUE;
 
     /* Security config */
     param->proto = PJ_SSL_SOCK_PROTO_DEFAULT;

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -95,11 +95,6 @@
 #      define USING_BORINGSSL 0
 #endif
 
-/* Specify whether renegotiation is disable. */
-#ifndef SSL_DISABLE_RENEGOTIATION
-#       define SSL_DISABLE_RENEGOTIATION 0
-#endif
-
 #if !USING_LIBRESSL && !defined(OPENSSL_NO_EC) \
         && OPENSSL_VERSION_NUMBER >= 0x1000200fL
 

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1238,12 +1238,10 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
         }
     }
 
-#if SSL_DISABLE_RENEGOTIATION
-
 #ifdef SSL_OP_NO_RENEGOTIATION
-    ssl_opt |= SSL_OP_NO_RENEGOTIATION;
-#endif
-
+    if (!ssock->param.enable_renegotiation) {
+        ssl_opt |= SSL_OP_NO_RENEGOTIATION;
+    }
 #endif
 
     if (ssl_opt)

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -95,6 +95,11 @@
 #      define USING_BORINGSSL 0
 #endif
 
+/* Specify whether renegotiation is disable. */
+#ifndef SSL_DISABLE_RENEGOTIATION
+#       define SSL_DISABLE_RENEGOTIATION 0
+#endif
+
 #if !USING_LIBRESSL && !defined(OPENSSL_NO_EC) \
         && OPENSSL_VERSION_NUMBER >= 0x1000200fL
 
@@ -1232,6 +1237,14 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
                                   "context. Session reuse will not work."));
         }
     }
+
+#if SSL_DISABLE_RENEGOTIATION
+
+#ifdef SSL_OP_NO_RENEGOTIATION
+    ssl_opt |= SSL_OP_NO_RENEGOTIATION;
+#endif
+
+#endif
 
     if (ssl_opt)
         SSL_CTX_set_options(ctx, ssl_opt);

--- a/pjnath/include/pjnath/turn_sock.h
+++ b/pjnath/include/pjnath/turn_sock.h
@@ -237,6 +237,7 @@ typedef struct pj_turn_sock_tls_cfg
      * - timeout
      * - sockopt_params
      * - sockopt_ignore_error
+     * - enable_renegotiation
      */
     pj_ssl_sock_param ssock_param;
 

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -369,6 +369,13 @@ typedef struct pjsip_tls_setting
     pj_bool_t sockopt_ignore_error;
 
     /**
+     * Specify if renegotiation is enabled for TLSv1.2 or earlier.
+     *
+     * Default: PJ_TRUE
+     */
+    pj_bool_t enable_renegotiation;
+
+    /**
      * Callback to be called when a accept operation of the TLS listener fails.
      *
      * @param param         The parameter to the callback.
@@ -419,6 +426,7 @@ PJ_INLINE(void) pjsip_tls_setting_default(pjsip_tls_setting *tls_opt)
     tls_opt->qos_ignore_error = PJ_TRUE;
     tls_opt->sockopt_ignore_error = PJ_TRUE;
     tls_opt->proto = PJSIP_SSL_DEFAULT_PROTO;
+    tls_opt->enable_renegotiation = PJ_TRUE;
 }
 
 

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -281,6 +281,13 @@ struct TlsConfig : public PersistentObject
      */
     bool                qosIgnoreError;
 
+    /**
+     * Specify if renegotiation is enabled for TLSv1.2 or earlier.
+     *
+     * Default: PJ_TRUE
+     */
+    bool                enableRenegotiation;
+
 public:
     /** Default constructor initialises with default values */
     TlsConfig();

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -338,6 +338,9 @@ static void set_ssock_param(pj_ssl_sock_param *ssock_param,
 
     ssock_param->sockopt_ignore_error =
                                     listener->tls_setting.sockopt_ignore_error;
+
+    ssock_param->enable_renegotiation =
+                                    listener->tls_setting.enable_renegotiation;
     /* Copy the sockopt */
     pj_memcpy(&ssock_param->sockopt_params,
               &listener->tls_setting.sockopt_params,
@@ -1227,6 +1230,8 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
 
     ssock_param.sockopt_ignore_error = 
                                      listener->tls_setting.sockopt_ignore_error;
+
+    ssock_param.enable_renegotiation = listener->tls_setting.enable_renegotiation;
     /* Copy the sockopt */
     pj_memcpy(&ssock_param.sockopt_params, 
               &listener->tls_setting.sockopt_params,

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -207,6 +207,7 @@ pjsip_tls_setting TlsConfig::toPj() const
     ts.qos_type         = this->qosType;
     ts.qos_params       = this->qosParams;
     ts.qos_ignore_error = this->qosIgnoreError;
+    ts.enable_renegotiation = this->enableRenegotiation;
 
     return ts;
 }
@@ -232,6 +233,7 @@ void TlsConfig::fromPj(const pjsip_tls_setting &prm)
     this->qosType       = prm.qos_type;
     this->qosParams     = prm.qos_params;
     this->qosIgnoreError = PJ2BOOL(prm.qos_ignore_error);
+    this->enableRenegotiation = PJ2BOOL(prm.enable_renegotiation);
 }
 
 void TlsConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)


### PR DESCRIPTION
It is useful to prevent the issue described in [CVE-2011-1473](https://nvd.nist.gov/vuln/detail/CVE-2011-1473).