### PR TITLE
Prevent crash when reading cert file on Apple's Network framework SSL backend

### DIFF
--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -576,6 +576,7 @@ static pj_status_t create_identity_from_cert(applessl_sock_t *assock,
                 identity = (SecIdentityRef)
                            CFDictionaryGetValue((CFDictionaryRef) item,
                                                 kSecImportItemIdentity);
+                identity = CFRetain(identity);
                 break;
             }
 #if !TARGET_OS_IPHONE


### PR DESCRIPTION
This is to fix #3617.
The crash happened [here](https://github.com/pjsip/pjproject/blob/828d8d19072f694eccba8ab5f4fa9487e1712b28/pjlib/src/pj/ssl_sock_apple.m#L606C1-L606C53).

This is because the object returned (`identity`) might get disposed prior to calling the method. [ref](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-SW1).



