### PR TITLE
Fix bug in PJSUA2 media port signal adjustment info

### DIFF
--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -77,8 +77,8 @@ void ConfPortInfo::fromPj(const pjsua_conf_port_info &port_info)
     portId = port_info.slot_id;
     name = pj2Str(port_info.name);
     format.fromPj(port_info.format);
-    txLevelAdj = port_info.tx_level_adj;
-    rxLevelAdj = port_info.rx_level_adj;
+    txLevelAdj = port_info.rx_level_adj;
+    rxLevelAdj = port_info.tx_level_adj;
 
     /*
     format.id = PJMEDIA_FORMAT_PCM;


### PR DESCRIPTION
The audio `TX` & `RX` terms are inverted between PJSUA & PJSUA2 due to different point of views, i.e: PJSUA API uses conference bridge PoV, while PJSUA2 uses media port PoV. The PJSUA2 media port info imported from PJSUA conference port info does not seem to be converted correctly.

Thanks to Oliver Epper for the report.