### PR TITLE
Fix docs for broken PJLIB sample links

### DIFF
--- a/pjlib/docs/doxygen.cfg
+++ b/pjlib/docs/doxygen.cfg
@@ -259,6 +259,7 @@ GENERATE_DEPRECATEDLIST= YES
 # You can put \n's in the value part of an alias to insert newlines.
 
 ALIASES                = 
+ALIASES               += src{1}="\verbatim embed:rst:inline :source:`\1` \endverbatim"
 
 # The ENABLED_SECTIONS tag can be used to enable conditional 
 # documentation sections, marked by \if sectionname ... \endif.

--- a/pjlib/include/pj/ioqueue.h
+++ b/pjlib/include/pj/ioqueue.h
@@ -186,9 +186,9 @@ PJ_BEGIN_DECL
  *
  * For some examples on how to use the I/O Queue, please see:
  *
- *  - \ref page_pjlib_ioqueue_tcp_test
- *  - \ref page_pjlib_ioqueue_udp_test
- *  - \ref page_pjlib_ioqueue_perf_test
+ *  - I/O Queue TCP test: \src{pjlib/src/pjlib-test/ioq_tcp.c}
+ *  - I/O Queue UDP test: \src{pjlib/src/pjlib-test/ioq_udp.c}
+ *  - I/O Queue Performance test: \src{pjlib/src/pjlib-test/ioq_perf.c}
  */
 
 

--- a/pjlib/include/pj/os.h
+++ b/pjlib/include/pj/os.h
@@ -136,8 +136,8 @@ PJ_DECL(const pj_sys_info*) pj_get_sys_info(void);
  * \section pj_thread_examples_sec Examples
  *
  * For examples, please see:
- *  - \ref page_pjlib_thread_test
- *  - \ref page_pjlib_sleep_test
+ *  - Thread test: \src{pjlib/src/pjlib-test/thread.c}
+ *  - Sleep, Time, and Timestamp test: \src{pjlib/src/pjlib-test/sleep.c}
  *
  */
 
@@ -1103,7 +1103,7 @@ PJ_DECL(pj_status_t) pj_event_destroy(pj_event_t *event);
  * \section pj_time_examples_sec Examples
  *
  * For examples, please see:
- *  - \ref page_pjlib_sleep_test
+ *  - Sleep, Time, and Timestamp test: \src{pjlib/src/pjlib-test/sleep.c}
  */
 
 /**
@@ -1206,8 +1206,8 @@ PJ_DECL(pj_color_t) pj_term_get_color(void);
  * \section pj_timestamp_examples_sec Examples
  *
  * For examples, please see:
- *  - \ref page_pjlib_sleep_test
- *  - \ref page_pjlib_timestamp_test
+ *  - Sleep, Time, and Timestamp test: \src{pjlib/src/pjlib-test/sleep.c}
+ *  - Timestamp test: \src{pjlib/src/pjlib-test/timestamp.c}
  */
 
 /*

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -49,9 +49,9 @@ PJ_BEGIN_DECL
  *
  * For some examples on how to use the socket API, please see:
  *
- *  - \ref page_pjlib_sock_test
- *  - \ref page_pjlib_select_test
- *  - \ref page_pjlib_sock_perf_test
+ *  - Socket test: \src{pjlib/src/pjlib-test/sock.c}
+ *  - Socket Select() test: \src{pjlib/src/pjlib-test/select.c}
+ *  - Socket Performance test: \src{pjlib/src/pjlib-test/sock_perf.c}
  */
 
 

--- a/pjlib/include/pj/sock_select.h
+++ b/pjlib/include/pj/sock_select.h
@@ -42,7 +42,7 @@ PJ_BEGIN_DECL
  *
  * For some examples on how to use the select API, please see:
  *
- *  - \ref page_pjlib_select_test
+ *  - Socket Select() test: \src{pjlib/src/pjlib-test/select.c}
  */
 
 /**

--- a/pjlib/include/pj/timer.h
+++ b/pjlib/include/pj/timer.h
@@ -61,7 +61,7 @@ PJ_BEGIN_DECL
  *
  * For some examples on how to use the timer heap, please see the link below.
  *
- *  - \ref page_pjlib_timer_test
+ *  - Timer test: \src{pjlib/src/pjlib-test/timer.c}
  */
 
 


### PR DESCRIPTION
Currently the samples are in the form of Doxygen pages and breathe-apidoc does not process/support Doxygen page.