### PR TITLE
Update video handling in Android PJSUA2/SWIG sample apps

### DIFF
--- a/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdk 33
 
     defaultConfig {
         applicationId "org.pjsip.pjsua2.app_kotlin"
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
@@ -27,6 +27,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'org.pjsip.pjsua2.app_kotlin'
 }
 
 dependencies {

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/AndroidManifest.xml
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/AndroidManifest.xml
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.pjsip.pjsua2.app_kotlin">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.READ_LOGS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature android:glEsVersion="0x00020000" android:required="false" />
 
@@ -28,7 +17,6 @@
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/AndroidManifest.xml
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Android">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/java/org/pjsip/pjsua2/app_kotlin/MainActivity.kt
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/java/org/pjsip/pjsua2/app_kotlin/MainActivity.kt
@@ -1,17 +1,59 @@
 package org.pjsip.pjsua2.app_kotlin
 
+import android.Manifest
+import android.hardware.camera2.CameraManager
 import android.os.Bundle
+import android.os.Handler
+import android.os.Message
+import android.support.v4.app.ActivityCompat
 import android.support.v7.app.AppCompatActivity
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.view.View
 import android.widget.Button
+import android.widget.RelativeLayout
+import android.widget.TextView
+import org.pjsip.PjCameraInfo2
 import org.pjsip.pjsua2.*
+import java.lang.ref.WeakReference
+
+/* Configs */
+
+// Account ID
+const val ACC_ID_URI    = "sip:localhost"
+
+// Peer to call
+const val CALL_DST_URI  = "sip:192.168.1.9"
+
+// Camera ID used for video call.
+// Use VidDevManager::enumDev2() to get available cameras & IDs.
+const val VIDEO_CAPTURE_DEVICE_ID = -1
+
+// SIP transport listening port
+const val SIP_LISTENING_PORT = 6000
+
+/* Constants */
+const val MSG_UPDATE_CALL_INFO      = 1
+const val MSG_SHOW_REMOTE_VIDEO     = 2
+const val MSG_SHOW_LOCAL_VIDEO      = 3
+
 
 /* Global objects */
 internal object g {
     /* Maintain reference to avoid auto garbage collecting */
     lateinit var logWriter: MyLogWriter
 
+    /* Message handler for updating UI */
+    lateinit var uiHandler: Handler
+
     val ep = Endpoint()
     val acc = MyAccount()
+    var call: MyCall? = null
+
+    val localVideoHandler = VideoSurfaceHandler()
+    val remoteVideoHandler = VideoSurfaceHandler()
+
+    var previewStarted = false
 }
 
 /* Log writer, redirects logs to stdout */
@@ -26,48 +68,62 @@ internal class MyAccount : Account() {
     override fun onIncomingCall(prm: OnIncomingCallParam) {
         /* Auto answer with 200 for incoming calls  */
         val call = MyCall(g.acc, prm.callId)
-        val ansPrm = CallOpParam()
-        ansPrm.statusCode = pjsip_status_code.PJSIP_SC_OK
+        val ansPrm = CallOpParam(true)
+        ansPrm.statusCode = if (g.call == null) pjsip_status_code.PJSIP_SC_OK else pjsip_status_code.PJSIP_SC_BUSY_HERE
         try {
             call.answer(ansPrm)
+            if (g.call == null)
+                g.call = call
         } catch (e: Exception) {
             println(e)
         }
     }
 }
 
+private fun getCallInfo(call: Call): CallInfo? {
+    var ci : CallInfo? = null
+    try {
+        ci = call.info
+    } catch (e: Exception) {
+        println("Failed getting call info: $e")
+    }
+    return ci
+}
+
 /* Call implementation */
 internal class MyCall(acc: Account, call_id: Int) : Call(acc, call_id) {
-    override fun onCallState(prm: OnCallStateParam?) {
-        val ci : CallInfo
-        try {
-            ci = info
-        } catch (e: Exception) {
-            println(e)
-            return
-        }
 
-        g.ep.utilLogWrite(3, "MyCall", "Call state changed to: " + ci.getStateText())
+    override fun onCallState(prm: OnCallStateParam?) {
+        val ci : CallInfo = getCallInfo(this) ?: return
+
+        g.ep.utilLogWrite(3, "MyCall", "Call state changed to: " + ci.stateText)
+        val m = Message.obtain(g.uiHandler, MSG_UPDATE_CALL_INFO, ci)
+        m.sendToTarget()
+
         if (ci.state == pjsip_inv_state.PJSIP_INV_STATE_DISCONNECTED) {
+            g.call = null
+            g.localVideoHandler.resetVideoWindow()
+            g.remoteVideoHandler.resetVideoWindow()
+            if (g.previewStarted) {
+                try {
+                    VideoPreview(VIDEO_CAPTURE_DEVICE_ID).stop()
+                } catch (e: Exception) {
+                    println("Failed stopping video preview" + e.message)
+                }
+                g.previewStarted = false
+            }
             g.ep.utilLogWrite(3, "MyCall", this.dump(true, ""))
         }
     }
 
     override fun onCallMediaState(prm: OnCallMediaStateParam?) {
-        val ci : CallInfo
-        try {
-            ci = info
-        } catch (e: Exception) {
-            println(e)
-            return
-        }
-
+        val ci : CallInfo = getCallInfo(this) ?: return
         val cmiv = ci.media
         for (i in cmiv.indices) {
             val cmi = cmiv[i]
             if (cmi.type == pjmedia_type.PJMEDIA_TYPE_AUDIO &&
-                    (cmi.status == pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE ||
-                            cmi.status == pjsua_call_media_status.PJSUA_CALL_MEDIA_REMOTE_HOLD))
+                (cmi.status == pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE ||
+                 cmi.status == pjsua_call_media_status.PJSUA_CALL_MEDIA_REMOTE_HOLD))
             {
                 /* Connect ports */
                 try {
@@ -76,17 +132,114 @@ internal class MyCall(acc: Account, call_id: Int) : Call(acc, call_id) {
                     am.startTransmit(g.ep.audDevManager().playbackDevMedia)
                 } catch (e: Exception) {
                     println("Failed connecting media ports" + e.message)
-                    continue
                 }
+            } else if ((cmi.type == pjmedia_type.PJMEDIA_TYPE_VIDEO) &&
+                       (cmi.status == pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE) &&
+                       (cmi.dir and pjmedia_dir.PJMEDIA_DIR_ENCODING) != 0)
+            {
+                val m = Message.obtain(g.uiHandler, MSG_SHOW_LOCAL_VIDEO, cmi)
+                m.sendToTarget()
             }
+        }
+    }
+
+    override fun onCallMediaEvent(prm: OnCallMediaEventParam?) {
+        if (prm!!.ev.type == pjmedia_event_type.PJMEDIA_EVENT_FMT_CHANGED) {
+            val ci : CallInfo = getCallInfo(this) ?: return
+            if (prm.medIdx < 0 || prm.medIdx >= ci.media.size)
+                return
+
+            /* Check if this event is from incoming video */
+            val cmi = ci.media[prm.medIdx.toInt()]
+            if (cmi.type != pjmedia_type.PJMEDIA_TYPE_VIDEO ||
+                    cmi.status != pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE ||
+                    cmi.videoIncomingWindowId == pjsua2.INVALID_ID)
+                return
+
+            /* Currently this is a new incoming video */
+            println("Got remote video format change = " +prm.ev.data.fmtChanged.newWidth + "x" + prm.ev.data.fmtChanged.newHeight)
+            val m = Message.obtain(g.uiHandler, MSG_SHOW_REMOTE_VIDEO, cmi)
+            m.sendToTarget()
+        }
+    }
+
+}
+
+class VideoSurfaceHandler : SurfaceHolder.Callback {
+    lateinit var holder: SurfaceHolder
+    private var videoWindow : WeakReference<VideoWindow>? = null
+    private var active = false
+
+    fun setVideoWindow(vw: VideoWindow) {
+        videoWindow = WeakReference<VideoWindow>(vw);
+        active = true
+        setSurfaceHolder(holder)
+    }
+
+    fun resetVideoWindow() {
+        active = false
+        videoWindow = null
+    }
+
+    private fun setSurfaceHolder(holder: SurfaceHolder?) {
+        if (!active) return
+
+        try {
+            val wh = VideoWindowHandle()
+            wh.handle.setWindow(holder?.surface)
+            videoWindow?.get()?.setWindow(wh)
+        } catch (e: java.lang.Exception) {
+            println(e)
+        }
+    }
+
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, w: Int, h: Int) {
+        setSurfaceHolder(holder)
+    }
+
+    override fun surfaceCreated(holder: SurfaceHolder) {}
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
+        try {
+            setSurfaceHolder(null)
+        } catch (e: java.lang.Exception) {
+            println(e)
         }
     }
 }
 
-class MainActivity : AppCompatActivity() {
+
+class MainActivity : AppCompatActivity(), android.os.Handler.Callback {
+
+    private fun checkPermissions() {
+        val permissions = arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO
+        )
+        ActivityCompat.requestPermissions(this@MainActivity, permissions, 0)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        /* Check permissions */
+        checkPermissions()
+
+        /* Set Camera Manager for PJMEDIA video */
+        val cm = getSystemService(CAMERA_SERVICE) as CameraManager
+        PjCameraInfo2.SetCameraManager(cm)
+
+        /* Set surface view callback */
+        val svLocalVideo = findViewById<View>(R.id.svLocalVideo) as SurfaceView
+        val svRemoteVideo = findViewById<View>(R.id.svRemoteVideo) as SurfaceView
+        g.localVideoHandler.holder = svLocalVideo.holder
+        g.remoteVideoHandler.holder = svRemoteVideo.holder
+        svLocalVideo.holder.addCallback(g.localVideoHandler)
+        svRemoteVideo.holder.addCallback(g.remoteVideoHandler)
+
+        /* Setup UI handler */
+        g.uiHandler = Handler(this)
 
         /* Setup Start button */
         val buttonStart = findViewById<Button>(R.id.button_start)
@@ -116,12 +269,15 @@ class MainActivity : AppCompatActivity() {
             /* Create transports and account. */
             try {
                 val sipTpConfig = TransportConfig()
-                sipTpConfig.port = 5060
+                sipTpConfig.port = SIP_LISTENING_PORT.toLong()
                 g.ep.transportCreate(pjsip_transport_type_e.PJSIP_TRANSPORT_UDP,
                         sipTpConfig)
 
                 val accCfg = AccountConfig()
-                accCfg.idUri = "sip:localhost"
+                accCfg.idUri = ACC_ID_URI
+                accCfg.videoConfig.autoShowIncoming = true
+                accCfg.videoConfig.autoTransmitOutgoing = true
+                accCfg.videoConfig.defaultCaptureDevice = VIDEO_CAPTURE_DEVICE_ID
                 g.acc.create(accCfg, true)
             } catch (e: Exception) {
                 println(e)
@@ -133,6 +289,30 @@ class MainActivity : AppCompatActivity() {
             } catch (e: Exception) {
                 println(e)
             }
+            findViewById<TextView>(R.id.text_info).text = "Library started"
+
+            /* Fix camera orientation to portrait mode (for front camera) */
+            try {
+                g.ep.vidDevManager().setCaptureOrient(VIDEO_CAPTURE_DEVICE_ID,
+                        pjmedia_orient.PJMEDIA_ORIENT_ROTATE_270DEG, true)
+
+                /* Also adjust size in H264 encoding param */
+                var codecs = g.ep.videoCodecEnum2()
+                var codecId = "H264/"
+                for (c in codecs) {
+                    if (c.codecId.startsWith(codecId)) {
+                        codecId = c.codecId
+                        break
+                    }
+                }
+                var vcp = g.ep.getVideoCodecParam(codecId)
+                vcp.encFmt.width = 240
+                vcp.encFmt.height = 320
+                g.ep.setVideoCodecParam(codecId, vcp)
+            } catch (e: Exception) {
+                println(e)
+            }
+
         }
 
         /* Setup Call button */
@@ -141,27 +321,152 @@ class MainActivity : AppCompatActivity() {
             if (g.ep.libGetState() != pjsua_state.PJSUA_STATE_RUNNING)
                 return@setOnClickListener
 
-            try {
-                /* Setup null audio (good for emulator) */
-                g.ep.audDevManager().setNullDev()
+            if (g.call == null) {
+                try {
+                    /* Setup null audio (good for emulator) */
+                    g.ep.audDevManager().setNullDev()
 
-                /* Make call (to itself) */
-                val call = MyCall(g.acc, -1)
-                call.makeCall("sip:localhost", CallOpParam(true))
-            } catch (e: Exception) {
-                println(e)
+                    /* Make call (to itself) */
+                    val call = MyCall(g.acc, -1)
+                    val prm = CallOpParam(true)
+                    call.makeCall(CALL_DST_URI, prm)
+                    g.call = call
+                } catch (e: Exception) {
+                    println(e)
+                }
+            } else {
+                try {
+                    g.ep.hangupAllCalls()
+                } catch (e: Exception) {
+                    println(e)
+                }
             }
         }
 
         /* Setup Stop button */
         val buttonStop = findViewById<Button>(R.id.button_stop)
         buttonStop.setOnClickListener {
+            if (g.ep.libGetState() == pjsua_state.PJSUA_STATE_NULL)
+                return@setOnClickListener
+
             /* Destroy PJSUA2 */
             try {
+                g.ep.hangupAllCalls()
                 g.ep.libDestroy()
             } catch (e: Exception) {
                 println(e)
             }
+            findViewById<TextView>(R.id.text_info).text = "Library stopped"
         }
     }
+
+    override fun handleMessage(m: Message): Boolean {
+        if (m.what == MSG_UPDATE_CALL_INFO) {
+            val ci = m.obj as CallInfo
+
+            /* Update button text */
+            val buttonCall = findViewById<Button>(R.id.button_call)
+            if (ci.state == pjsip_inv_state.PJSIP_INV_STATE_DISCONNECTED)
+                buttonCall.text = "Call"
+            else if (ci.state > pjsip_inv_state.PJSIP_INV_STATE_NULL)
+                buttonCall.text = "Hangup"
+
+            /* Update call state text */
+            val textInfo = findViewById<TextView>(R.id.text_info)
+            textInfo.text = ci.stateText
+
+            /* Hide video windows upon disconnection */
+            if (ci.state == pjsip_inv_state.PJSIP_INV_STATE_DISCONNECTED) {
+                val svLocalVideo = findViewById<View>(R.id.svLocalVideo) as SurfaceView
+                val svRemoteVideo = findViewById<View>(R.id.svRemoteVideo) as SurfaceView
+                svLocalVideo.visibility = View.INVISIBLE
+                svRemoteVideo.visibility = View.INVISIBLE
+            }
+
+        } else if (m.what == MSG_SHOW_LOCAL_VIDEO) {
+            try {
+                if (g.previewStarted)
+                    return false;
+
+                /* Start preview, position it in the bottom right of the screen */
+                val vp = VideoPreview(VIDEO_CAPTURE_DEVICE_ID)
+                vp.start(VideoPreviewOpParam())
+                g.previewStarted = true
+
+                val videoLayout = findViewById<View>(R.id.video_layout) as RelativeLayout
+                val vwi = vp.videoWindow.info
+                var w = vwi.size.w.toInt()
+                var h = vwi.size.h.toInt()
+
+                /* Adjust width to match the parent layout */
+                h = (videoLayout.measuredWidth.toDouble() / 2 / w * h).toInt()
+                w = videoLayout.measuredWidth / 2
+
+                /* Also adjust height to match the parent layout */
+                if (h > videoLayout.measuredHeight / 2) {
+                    w = (videoLayout.measuredHeight.toDouble() / 2 / h * w).toInt()
+                    h = videoLayout.measuredHeight / 2
+                }
+                println("Layout size=" + videoLayout.measuredWidth + "x" + videoLayout.measuredHeight)
+                println("Local video size=" + vwi.size.w + "x" + vwi.size.h + " -> " + w + "x" + h)
+
+                /* Resize the preview surface */
+                val svLocalVideo = findViewById<View>(R.id.svLocalVideo) as SurfaceView
+                var params = RelativeLayout.LayoutParams(w, h)
+                params.leftMargin = videoLayout.measuredWidth - w
+                params.topMargin = videoLayout.measuredHeight - h
+                svLocalVideo.layoutParams = params
+                svLocalVideo.visibility = View.VISIBLE
+
+                /* Link the video window to the surface view */
+                g.localVideoHandler.setVideoWindow(vp.videoWindow)
+            } catch (e: Exception) {
+                println("Failed showing local video" + e.message)
+            }
+
+        } else if (m.what == MSG_SHOW_REMOTE_VIDEO) {
+            val cmi = m.obj as CallMediaInfo
+            val si: StreamInfo = g.call!!.getStreamInfo(g.call!!.vidGetStreamIdx().toLong())
+            try {
+                val videoLayout = findViewById<View>(R.id.video_layout) as RelativeLayout
+                var w = si.vidCodecParam.decFmt.width.toInt()
+                var h = si.vidCodecParam.decFmt.height.toInt()
+
+                /* Adjust width to match the parent layout */
+                h = (videoLayout.measuredWidth.toDouble() / w * h).toInt()
+                w = videoLayout.measuredWidth
+
+                /* Also adjust height to match the parent layout */
+                if (h > videoLayout.measuredHeight) {
+                    w = (videoLayout.measuredHeight.toDouble() / h * w).toInt()
+                    h = videoLayout.measuredHeight
+                }
+                println("Remote video size=" + si.vidCodecParam.decFmt.width + "x" + si.vidCodecParam.decFmt.height + " -> " + w + "x" + h)
+
+                /* Resize the remote video surface */
+                val svRemoteVideo = findViewById<View>(R.id.svRemoteVideo) as SurfaceView
+                var params = RelativeLayout.LayoutParams(w, h)
+                params.leftMargin = if (w == videoLayout.measuredWidth) 0 else (videoLayout.measuredWidth-w)/2
+                params.topMargin = 0
+                svRemoteVideo.layoutParams = params
+                svRemoteVideo.visibility = View.VISIBLE
+
+                /* Put local preview always on top */
+                val svLocalVideo = findViewById<View>(R.id.svLocalVideo) as SurfaceView
+                svLocalVideo.visibility = View.VISIBLE
+
+                /* Link the video window to the surface view */
+                g.remoteVideoHandler.setVideoWindow(cmi.videoWindow)
+            } catch (e: Exception) {
+                println("Failed showing remote video" + e.message)
+            }
+
+        } else {
+
+            /* Message not handled */
+            return false
+        }
+        return true
+    }
+
 }

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/java/org/pjsip/pjsua2/app_kotlin/MainActivity.kt
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/java/org/pjsip/pjsua2/app_kotlin/MainActivity.kt
@@ -23,7 +23,7 @@ import java.lang.ref.WeakReference
 const val ACC_ID_URI    = "sip:localhost"
 
 // Peer to call
-const val CALL_DST_URI  = "sip:192.168.1.9"
+const val CALL_DST_URI  = "sip:192.168.1.9:6000"
 
 // Camera ID used for video call.
 // Use VidDevManager::enumDev2() to get available cameras & IDs.
@@ -239,7 +239,7 @@ class MainActivity : AppCompatActivity(), android.os.Handler.Callback {
         svRemoteVideo.holder.addCallback(g.remoteVideoHandler)
 
         /* Setup UI handler */
-        g.uiHandler = Handler(this)
+        g.uiHandler = Handler(this.mainLooper, this)
 
         /* Setup Start button */
         val buttonStart = findViewById<Button>(R.id.button_start)

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/res/layout/activity_main.xml
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/res/layout/activity_main.xml
@@ -1,35 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/relativeLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_gravity="center_horizontal"
-    android:gravity="center_horizontal"
+    android:background="#000000"
     tools:context=".MainActivity">
+
 
     <Button
         android:id="@+id/button_start"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="76dp"
-        android:gravity="center_horizontal"
-        android:text="Start" />
-
-    <Button
-        android:id="@+id/button_call"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="192dp"
-        android:gravity="center_horizontal"
-        android:text="Call" />
+        android:layout_height="50dp"
+        android:gravity="center"
+        android:text="Start"
+        app:layout_constraintBaseline_toBaselineOf="@+id/button_stop"
+        app:layout_constraintEnd_toStartOf="@+id/button_stop"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <Button
         android:id="@+id/button_stop"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="308dp"
-        android:gravity="center_horizontal"
-        android:text="Stop" />
+        android:layout_height="50dp"
+        android:gravity="center"
+        android:text="Stop"
+        app:layout_constraintEnd_toStartOf="@+id/button_call"
+        app:layout_constraintStart_toEndOf="@+id/button_start"
+        app:layout_constraintTop_toTopOf="parent" />
 
-</RelativeLayout>
+    <Button
+        android:id="@+id/button_call"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:gravity="center"
+        android:text="Call"
+        app:layout_constraintBaseline_toBaselineOf="@+id/button_stop"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/button_stop" />
+
+    <TextView
+        android:id="@+id/text_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Library not started"
+        android:textColor="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button_stop" />
+
+    <RelativeLayout
+        android:id="@+id/video_layout"
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_info">
+
+        <SurfaceView
+            android:id="@+id/svRemoteVideo"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginTop="8dp" />
+
+        <SurfaceView
+            android:id="@+id/svLocalVideo"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginLeft="300dp"
+            android:layout_marginTop="400dp" />
+
+    </RelativeLayout>
+
+
+</android.support.constraint.ConstraintLayout>

--- a/pjsip-apps/src/swig/java/android/app/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app/build.gradle
@@ -15,8 +15,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+    namespace 'org.pjsip.pjsua2.app'
 }
 
 dependencies {
     implementation project(path: ':pjsua2')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 }

--- a/pjsip-apps/src/swig/java/android/app/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdk 33
 
     defaultConfig {
         applicationId "org.pjsip.pjsua2.app"
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 33
     }
 
     buildTypes {

--- a/pjsip-apps/src/swig/java/android/app/src/main/AndroidManifest.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/AndroidManifest.xml
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.pjsip.pjsua2.app"
     android:versionCode="1"
     android:versionName="1.0" >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     
     <uses-feature android:glEsVersion="0x00020000" android:required="false" />

--- a/pjsip-apps/src/swig/java/android/app/src/main/AndroidManifest.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="org.pjsip.pjsua2.app.MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
@@ -1,4 +1,3 @@
-/* $Id: CallActivity.java 5138 2015-07-30 06:23:35Z ming $ */
 /*
  * Copyright (C) 2013 Teluu Inc. (http://www.teluu.com)
  *

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -1,4 +1,3 @@
-/* $Id: MainActivity.java 5022 2015-03-25 03:41:21Z nanang $ */
 /*
  * Copyright (C) 2013 Teluu Inc. (http://www.teluu.com)
  *

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -18,18 +18,21 @@
  */
 package org.pjsip.pjsua2.app;
 
+import android.Manifest;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ApplicationInfo;
 import android.hardware.camera2.CameraManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.app.Activity;
-import android.app.AlertDialog;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.pm.ApplicationInfo;
-import android.content.BroadcastReceiver;
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -40,15 +43,23 @@ import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
+import android.support.v4.app.ActivityCompat;
+
+import org.pjsip.PjCameraInfo2;
+import org.pjsip.pjsua2.AccountConfig;
+import org.pjsip.pjsua2.AuthCredInfo;
+import org.pjsip.pjsua2.AuthCredInfoVector;
+import org.pjsip.pjsua2.BuddyConfig;
+import org.pjsip.pjsua2.CallInfo;
+import org.pjsip.pjsua2.CallOpParam;
+import org.pjsip.pjsua2.OnCallMediaEventParam;
+import org.pjsip.pjsua2.StringVector;
+import org.pjsip.pjsua2.pjsip_inv_state;
+import org.pjsip.pjsua2.pjsip_status_code;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.pjsip.PjCameraInfo2;
-import org.pjsip.pjsua2.*;
 
 public class MainActivity extends Activity
                           implements Handler.Callback, MyAppObserver
@@ -75,6 +86,7 @@ public class MainActivity extends Activity
         public final static int BUDDY_STATE = 4;
         public final static int CALL_MEDIA_STATE = 5;
         public final static int CHANGE_NETWORK = 6;
+        public final static int CALL_MEDIA_EVENT = 7;
     }
 
     private class MyBroadcastReceiver extends BroadcastReceiver {
@@ -124,11 +136,22 @@ public class MainActivity extends Activity
         startActivity(intent);
     }
 
+    private void checkPermissions() {
+        String permissions[] = {
+            Manifest.permission.CAMERA,
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.ACCESS_NETWORK_STATE
+        };
+        ActivityCompat.requestPermissions(MainActivity.this, permissions, 0);
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        checkPermissions();
 
         CameraManager cm = (CameraManager)getSystemService(Context.CAMERA_SERVICE);
         PjCameraInfo2.SetCameraManager(cm);
@@ -299,17 +322,15 @@ public class MainActivity extends Activity
 
             /* Incoming call */
             final MyCall call = (MyCall) m.obj;
-            CallOpParam prm = new CallOpParam();
+            CallOpParam prm = new CallOpParam(true);
 
             /* Only one call at anytime */
             if (currentCall != null) {
-                /*
                 prm.setStatusCode(pjsip_status_code.PJSIP_SC_BUSY_HERE);
                 try {
-                call.hangup(prm);
+                    call.hangup(prm);
                 } catch (Exception e) {}
-                */
-                // TODO: set status code
+
                 call.delete();
                 return true;
             }
@@ -638,6 +659,16 @@ public class MainActivity extends Activity
     {
         Message m = Message.obtain(handler, MSG_TYPE.CHANGE_NETWORK, null);
         m.sendToTarget();
+    }
+
+    public void notifyCallMediaEvent(MyCall call, OnCallMediaEventParam prm)
+    {
+        /* Forward the message to CallActivity */
+        if (CallActivity.handler_ != null) {
+            Message m = Message.obtain(CallActivity.handler_,
+                MSG_TYPE.CALL_MEDIA_EVENT, prm);
+            m.sendToTarget();
+        }
     }
 
     /* === end of MyAppObserver ==== */

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MyApp.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MyApp.java
@@ -33,6 +33,7 @@ interface MyAppObserver
     abstract void notifyCallMediaState(MyCall call);
     abstract void notifyBuddyState(MyBuddy buddy);
     abstract void notifyChangeNetwork();
+    abstract void notifyCallMediaEvent(MyCall call, OnCallMediaEventParam prm);
 }
 
 
@@ -51,10 +52,14 @@ class MyCall extends Call
     public VideoWindow vidWin;
     public VideoPreview vidPrev;
 
+    public boolean vidPrevStarted;
+
     MyCall(MyAccount acc, int call_id)
     {
         super(acc, call_id);
         vidWin = null;
+        vidPrev = null;
+        vidPrevStarted = false;
     }
 
     @Override
@@ -65,6 +70,9 @@ class MyCall extends Call
             if (ci.getState() == 
                 pjsip_inv_state.PJSIP_INV_STATE_DISCONNECTED)
             {
+                if (vidPrevStarted)
+                    vidPrev.stop();
+
                 MyApp.ep.utilLogWrite(3, "MyCall", this.dump(true, ""));
             }
         } catch (Exception e) {
@@ -109,16 +117,43 @@ class MyCall extends Call
                     continue;
                 }
             } else if (cmi.getType() == pjmedia_type.PJMEDIA_TYPE_VIDEO &&
-                       cmi.getStatus() == 
-                            pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE &&
-                       cmi.getVideoIncomingWindowId() != pjsua2.INVALID_ID)
+                       cmi.getStatus() == pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE)
             {
-                vidWin = new VideoWindow(cmi.getVideoIncomingWindowId());
-                vidPrev = new VideoPreview(cmi.getVideoCapDev());
+                /* If videoPreview was started, stop it first in case capture device has changed */
+                if (vidPrevStarted) {
+                    try {
+                        vidPrevStarted = false;
+                        vidPrev.stop();
+                        vidPrev.delete();
+                        vidPrev = null;
+                    } catch (Exception e) {}
+                }
+
+                if (cmi.getVideoIncomingWindowId() != pjsua2.INVALID_ID)
+                    vidWin = new VideoWindow(cmi.getVideoIncomingWindowId());
+
+                if ((cmi.getDir() & pjmedia_dir.PJMEDIA_DIR_ENCODING) != 0) {
+                    vidPrev = new VideoPreview(cmi.getVideoCapDev());
+                    if (!vidPrevStarted) {
+                        try {
+                            vidPrev.start(new VideoPreviewOpParam());
+                            vidPrevStarted = true;
+                        } catch (Exception e) {
+                            System.out.println("Failed start video preview" +
+                                e.getMessage());
+                            continue;
+                        }
+                    }
+                }
             }
         }
 
         MyApp.observer.notifyCallMediaState(this);
+    }
+
+    @Override
+    public void onCallMediaEvent(OnCallMediaEventParam prm) {
+        MyApp.observer.notifyCallMediaEvent(this, prm);
     }
 }
 
@@ -373,6 +408,9 @@ class MyApp extends pjsua2 {
             System.out.println(e);
         }
 
+        // TCP & TLS transports with default SIP ports
+        // sometimes not working fine on Android somehow.
+        /*
         try {
             ep.transportCreate(pjsip_transport_type_e.PJSIP_TRANSPORT_TCP,
                                sipTpConfig);
@@ -387,6 +425,7 @@ class MyApp extends pjsua2 {
         } catch (Exception e) {
             System.out.println(e);
         }
+        */
 
         /* Set SIP port back to default for JSON saved config */
         sipTpConfig.setPort(SIP_PORT);
@@ -420,6 +459,24 @@ class MyApp extends pjsua2 {
             ep.libStart();
         } catch (Exception e) {
             return;
+        }
+
+        /* Also adjust encoding size in H264 to portrait 240x320 */
+        try {
+            CodecInfoVector2 codecs = ep.videoCodecEnum2();
+            String codecId = "H264/";
+            for (CodecInfo c : codecs) {
+                if (c.getCodecId().startsWith(codecId)) {
+                    codecId = c.getCodecId();
+                    break;
+                }
+            }
+            VidCodecParam vcp = ep.getVideoCodecParam(codecId);
+            vcp.getEncFmt().setWidth(240);
+            vcp.getEncFmt().setHeight(320);
+            ep.setVideoCodecParam(codecId, vcp);
+        } catch (Exception e) {
+            System.out.println(e);
         }
     }
 
@@ -558,5 +615,5 @@ class MyApp extends pjsua2 {
         */
         ep.delete();
         ep = null;
-    } 
+    }
 }

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MyApp.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MyApp.java
@@ -408,9 +408,6 @@ class MyApp extends pjsua2 {
             System.out.println(e);
         }
 
-        // TCP & TLS transports with default SIP ports
-        // sometimes not working fine on Android somehow.
-        /*
         try {
             ep.transportCreate(pjsip_transport_type_e.PJSIP_TRANSPORT_TCP,
                                sipTpConfig);
@@ -425,7 +422,6 @@ class MyApp extends pjsua2 {
         } catch (Exception e) {
             System.out.println(e);
         }
-        */
 
         /* Set SIP port back to default for JSON saved config */
         sipTpConfig.setPort(SIP_PORT);

--- a/pjsip-apps/src/swig/java/android/app/src/main/res/layout/activity_call.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/res/layout/activity_call.xml
@@ -23,51 +23,52 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:text="Call state" />
-    
-	<LinearLayout 
+
+    <LinearLayout
+        android:id="@+id/top_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">    
-        
-        <LinearLayout 
+        android:orientation="horizontal">
+
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_weight=".50">    
-	    	    
+            android:layout_weight=".50"
+            android:orientation="vertical">
+
             <Button
                 android:id="@+id/buttonAccept"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:onClick="acceptCall"
                 android:text="Accept" />
-		
+
             <Button
                 android:id="@+id/buttonHangup"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:onClick="hangupCall"
                 android:text="Reject" />
-		    
-            <Button
-                android:id="@+id/buttonShowPreview"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"		        
-                android:onClick="showPreview"
-                android:text="@+string/show_preview" />
-	    
+
         </LinearLayout>
+
+    </LinearLayout>
+
+    <RelativeLayout
+        android:id="@+id/bottom_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <SurfaceView
+            android:id="@+id/surfaceIncomingVideo"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
         <SurfaceView
             android:id="@+id/surfacePreviewCapture"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight=".50" />			    
-	    
-    </LinearLayout>
-   
-    <SurfaceView
-       	android:id="@+id/surfaceIncomingVideo"
-       	android:layout_width="match_parent"
-       	android:layout_height="match_parent" />
-	
+            android:layout_height="0dp" />
+    </RelativeLayout>
+
 </LinearLayout>

--- a/pjsip-apps/src/swig/java/android/build.gradle
+++ b/pjsip-apps/src/swig/java/android/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = '1.3.72'
+        kotlin_version = '1.6.21'
     }
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/pjsip-apps/src/swig/java/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pjsip-apps/src/swig/java/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
+++ b/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 33
 
 
         ndk {

--- a/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
+++ b/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
@@ -34,5 +34,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'org.pjsip.pjsua2'
 }
 

--- a/pjsip-apps/src/swig/java/android/pjsua2/src/main/AndroidManifest.xml
+++ b/pjsip-apps/src/swig/java/android/pjsua2/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.pjsip.pjsua2"
     android:versionCode="1"
     android:versionName="1.0" >
 </manifest>

--- a/pjsip-apps/src/swig/java/sample.java
+++ b/pjsip-apps/src/swig/java/sample.java
@@ -56,6 +56,7 @@ class MyObserver implements MyAppObserver {
         public void notifyCallMediaState(MyCall call) {
         }
 
+        @Override
         public void notifyCallState(MyCall call) {
                 if (currentCall == null || call.getId() != currentCall.getId())
                         return;
@@ -80,6 +81,9 @@ class MyObserver implements MyAppObserver {
 
         @Override
         public void notifyChangeNetwork() {}
+        
+        @Override
+        public void notifyCallMediaEvent(MyCall call, OnCallMediaEventParam prm) {}
 }
 
 class MyShutdownHook extends Thread {

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -735,7 +735,7 @@ class DevAudioMedia : public AudioMedia
 {
 public:
     DevAudioMedia();
-    ~DevAudioMedia();
+    virtual ~DevAudioMedia();
 };
 
 DevAudioMedia::DevAudioMedia()


### PR DESCRIPTION
The update includes:
- simplify the code for readibility (combine surface callback handler for incoming video & local preview, remove show/hide preview button, etc)
- remote video surface is shown after format change event (usually indication of first successful decoding) to avoid black/green screen
- maintain video aspect ratio for both incoming video and local preview
- add video capability in Kotlin sample app
- add run-time Android permission check
- update the Android build config version (gradle version, etc)
