### PR TITLE
Fix late PJSUA2 object destroy on Android

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1901,8 +1901,8 @@ public:
 private:
     static Endpoint             *instance_;     // static instance
     LogWriter                   *writer;        // Custom writer, if any
-    AudDevManager                audioDevMgr;
-    VidDevManager                videoDevMgr;
+    AudDevManager               *audioDevMgr;
+    VidDevManager               *videoDevMgr;
 #if !DEPRECATED_FOR_TICKET_2232
     CodecInfoVector              codecInfoList;
     CodecInfoVector              videoCodecInfoList;

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -594,6 +594,9 @@ mainThread(NULL), pendingJobSize(0)
         PJSUA2_RAISE_ERROR(PJ_EEXISTS);
     }
 
+    audioDevMgr = new AudDevManager();
+    videoDevMgr = new VidDevManager();
+
     instance_ = this;
 }
 
@@ -616,6 +619,9 @@ Endpoint::~Endpoint()
     clearCodecInfoList(codecInfoList);
     clearCodecInfoList(videoCodecInfoList);
 #endif
+
+    delete audioDevMgr;
+    delete videoDevMgr;
 
     try {
         libDestroy();
@@ -2411,12 +2417,12 @@ bool Endpoint::mediaExists(const AudioMedia &media) const
 
 AudDevManager &Endpoint::audDevManager()
 {
-    return audioDevMgr;
+    return *audioDevMgr;
 }
 
 VidDevManager &Endpoint::vidDevManager()
 {
-    return videoDevMgr;
+    return *videoDevMgr;
 }
 
 /*


### PR DESCRIPTION
`audioDevMgr` (class `DevAudioMedia`) is a member of `Endpoint`, so its destructor is executed after the `Endpoint` destructor. When the `DevAudioMedia` destructor invokes `AudioMedia::unregisterMediaPort()`, exception is triggered when invoking `Endpoint::instance()`, as the `Endpoint::instance_` has been set to `NULL`, and the exception invokes `pj_log()` while PJLIB has been deinitialized, so the assertion shown below occurs.

The fix idea is simply to destroy `audioDevMgr` in `Endpoint` destructor before `Endpoint::instance_` is set to `NULL` and before PJLIB is deinitialized.

Here is the log and stack trace:

```
../src/pj/os_core_unix.c:859: pj_thread_t *pj_thread_this(void): assertion "!"Calling pjlib from unknown/external thread. You must " "register external threads with pj_thread_register() " "before calling any pjlib functions."" failed
Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 20216 (jsip.pjsua2.app), pid 20216 (jsip.pjsua2.app)
bufferpool2 0x6e6207de28 : 0(0 size) total buffers - 0(0 size) used buffers - 0/4 (recycle/alloc) - 4/35 (fetch/transfer)
evictor expired: 1, evicted: 1
Cmdline: org.pjsip.pjsua2.app
pid: 20216, tid: 20216, name: jsip.pjsua2.app  >>> org.pjsip.pjsua2.app <<<
      #02 pc 00000000006e43e8  libpjsua2.so (pj_thread_this+64) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #03 pc 00000000006f07fc  libpjsua2.so (pj_log+1272) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #04 pc 00000000006f0dec  libpjsua2.so (pj_log_1+160) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #05 pc 0000000000417980  libpjsua2.so (pj::Endpoint::instance()+220) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #06 pc 00000000004376c0  libpjsua2.so (pj::AudioMedia::unregisterMediaPort()+104) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #07 pc 000000000043c918  libpjsua2.so (DevAudioMedia::~DevAudioMedia()+52) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #08 pc 000000000043c99c  libpjsua2.so (DevAudioMedia::~DevAudioMedia()+36) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #09 pc 000000000043ca0c  libpjsua2.so (pj::AudDevManager::~AudDevManager()+64) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #10 pc 0000000000417b50  libpjsua2.so (pj::Endpoint::~Endpoint()+272) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #11 pc 0000000000322224  libpjsua2.so (SwigDirector_Endpoint::~SwigDirector_Endpoint()+88) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #12 pc 000000000032229c  libpjsua2.so (SwigDirector_Endpoint::~SwigDirector_Endpoint()+36) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #13 pc 00000000003ac930  libpjsua2.so (Java_org_pjsip_pjsua2_pjsua2JNI_delete_1Endpoint+64) (BuildId: 2aea8bc2d493a43e502575374f5b919687549ac1)
      #21 pc 000000000002978c  [anon:dalvik-classes2.dex extracted in memory from classes2.dex] (org.pjsip.pjsua2.Endpoint.delete+32)
      #27 pc 000000000000466a  /data/data/org.pjsip.pjsua2.app/code_cache/.overlay/base.apk/classes5.dex (org.pjsip.pjsua2.app.MyApp.deinit+94)
      #33 pc 000000000000341e  /data/data/org.pjsip.pjsua2.app/code_cache/.overlay/base.apk/classes5.dex (org.pjsip.pjsua2.app.MainActivity.handleMessage+14)
```