### PR TITLE
Fix race condition in registration in updating last transport used

### DIFF
--- a/pjsip/include/pjsip-ua/sip_regc.h
+++ b/pjsip/include/pjsip-ua/sip_regc.h
@@ -117,7 +117,9 @@ struct pjsip_regc_info
     pj_bool_t   auto_reg;   /**< Will register automatically?               */
     unsigned    interval;   /**< Registration interval (seconds).           */
     unsigned    next_reg;   /**< Time until next registration (seconds).    */
-    pjsip_transport *transport; /**< Last transport used.                   */
+    pjsip_transport *transport; /**< Last transport used, for informational
+                                     purpose only (e.g: comparing pointers),
+                                     the transport may be invalid already.  */
 };
 
 /**

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1341,11 +1341,11 @@ static pj_status_t destroy_transport( pjsip_tpmgr *mgr,
                         pj_hash_set_np(mgr->table, &tp_next->tp->key, key_len,
                                        hval, tp_next->tp_buf, tp_next);
                         TRACE_((THIS_FILE, "Hash entry updated after "
-                                           "transport %d being destroyed",
+                                           "transport %s being destroyed",
                                            tp->obj_name));
                     } else {
                         TRACE_((THIS_FILE, "Hash entry deleted after "
-                                           "transport %d being destroyed",
+                                           "transport %s being destroyed",
                                            tp->obj_name));
                     }
                 }


### PR DESCRIPTION
Reported that when initiating registration, a crash occurred when the transport connection attempt was refused, the call stack trace is as follow:
```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
    r0 00000000  r1 85e6dc68  r2 ffffffe4  r3 00000000
    r4 00000000  r5 00000014  r6 865da418  r7 00004e17
    r8 86375e00  r9 00000d38  sl 00000001  fp 00000001
    ip 9032afb4  sp bef25fa0  lr 9023a407  pc 90284cc8  cpsr 60000030

backtrace:
    #00 pc 00172cc8  /system/lib/libpjsua2-jni.so (pj_atomic_inc_and_get+3)
    #01 pc 00128403  /system/lib/libpjsua2-jni.so (pjsip_transport_add_ref+50)
    #02 pc 00114bbf  /system/lib/libpjsua2-jni.so (pjsip_regc_send+322)
    #03 pc 000ed897  /system/lib/libpjsua2-jni.so (pjsua_acc_set_registration+1486)
    #04 pc 000ed111  /system/lib/libpjsua2-jni.so (pjsua_acc_add+2160)
```

The scenario seems to be: in `pjsip_regc_send()`, after the `pjsip_endpt_send_request()` returned but before the `pjsip_transport_add_ref()` was executed, context switch happened and the transport was destroyed (due to connection attempt getting refused). So when it switched back to the previous context, `tdata->tp_info.transport` was invalid and performing any operation on it (including add ref) will cause crash.

The `regc->last_transport` in `sip_reg.c` seems to serve two purposes:
- for keeping the transport from getting destroyed (due to idle) for registration refreshes, and
- for registration info (`pjsip_regc_get_info()`).

For the first purpose, it should be fine to just set/update `regc->last_transport` when registration transaction completes (in `regc_tsx_callback()`), the code is already there, it is even safer as it gets the transport from transaction (as transaction keeps the transport). While for the second purpose, it seems that the PJSUA-LIB uses the transport info to check when there is a disconnected transport, whether the transport is being used by some accounts so reregistration need be to be initiated. And for this checking, PJSUA does not seem to directly access the transport, only comparing the transport pointers.
So simply omitting the problematic `pjsip_transport_add_ref()` seems to be a proper solution.

Thank you Johannes Westhuis for the report.
