### PR TITLE
Enable returning IPv4 mapped IPv6 address on getaddrinfo()

### DIFF
--- a/pjlib/src/pj/addr_resolv_sock.c
+++ b/pjlib/src/pj/addr_resolv_sock.c
@@ -178,6 +178,9 @@ PJ_DEF(pj_status_t) pj_getaddrinfo(int af, const pj_str_t *nodename,
     /* Call getaddrinfo() */
     pj_bzero(&hint, sizeof(hint));
     hint.ai_family = af;
+    if (af == PJ_AF_INET6) {
+        hint.ai_flags = AI_V4MAPPED | AI_ALL;
+    }
     /* Zero value of ai_socktype means the implementation shall attempt
      * to resolve the service name for all supported socket types */
     hint.ai_socktype = 0;


### PR DESCRIPTION
This is to fix #3681 

This ticket will add `AI_V4MAPPED` and `AI_ALL` to `ai_flags` when calling `getaddrinfo()` for IPv6.
It will enable `getaddrinfo()` to return IPv4 mapped IPv6 addresses, by default it will return the AAAA IPv6 only addresses.

```
If the AI_ALL flag is used in conjunction with the AI_V4MAPPED flag,
         and only used with the IPv6 address family.  When AI_ALL is logically
         or'd with AI_V4MAPPED flag then the caller wants all addresses: IPv6
         and IPv4-mapped IPv6.  A query is first made for AAAA records and if
         successful, the IPv6 addresses are returned.  Another query is then
         made for A records and any found are returned as IPv4-mapped IPv6
         addresses.  h_length will be 16.  Only if both queries fail does the
         function return a NULL pointer.  This flag is ignored unless af
         equals AF_INET6.  If both AI_ALL and AI_V4MAPPED are specified,
         AI_ALL takes precedence.
```
[ref](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/getipnodebyname.3.html)