### PR TITLE
build: resolve aconfigure location

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,7 @@
 #!/bin/sh
-./aconfigure "$@"
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+"${script_dir}/aconfigure" "$@"
 
 # Note:
 # if you're looking for the old configure script, it has been renamed


### PR DESCRIPTION
Come package managers like Conan prefer to use `configure` over `aconfigure`. Doing so right now fails if the working directory is not in the root of the source tree.