### PR TITLE
Add option to set RX telephone-event PT

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1161,7 +1161,7 @@ typedef struct pjsua_callback
      * called *after* the session has been created). The application may change
      * some stream info parameter values, i.e: jb_init, jb_min_pre, jb_max_pre,
      * jb_max, use_ka, rtcp_sdes_bye_disabled, jb_discard_algo (audio),
-     * codec_param->enc_fmt (video).
+     * rx_event_pt (audio), codec_param->enc_fmt (video).
      *
      * @param call_id       Call identification.
      * @param param         The on stream precreate callback parameter.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -599,6 +599,16 @@ struct StreamInfo
      * Incoming codec payload type.
      */
     unsigned            rxPt;
+
+    /**
+     * Outgoing pt for audio telephone-events.
+     */
+    int                 audTxEventPt;
+
+    /**
+     * Incoming pt for audio telephone-events.
+     */
+    int                 audRxEventPt;
     
     /**
      * Codec name.

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -753,6 +753,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             si->use_ka = prm.stream_info.info.aud.use_ka;
 #endif
             si->rtcp_sdes_bye_disabled = prm.stream_info.info.aud.rtcp_sdes_bye_disabled;
+            si->rx_event_pt = prm.stream_info.info.aud.rx_event_pt;
         }
 
         /* Create session based on session info. */

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -343,6 +343,8 @@ void StreamInfo::fromPj(const pjsua_stream_info &info)
         remoteRtcpAddress = straddr;
         txPt = info.info.aud.tx_pt;
         rxPt = info.info.aud.rx_pt;
+        audTxEventPt = info.info.aud.tx_event_pt;
+        audRxEventPt = info.info.aud.rx_event_pt;
         codecName = pj2Str(info.info.aud.fmt.encoding_name);
         codecClockRate = info.info.aud.fmt.clock_rate;
         audCodecParam.fromPj(*info.info.aud.param);

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1240,6 +1240,7 @@ void Endpoint::on_stream_precreate(pjsua_call_id call_id,
         param->stream_info.info.aud.use_ka = prm.streamInfo.useKa;
 #endif
         param->stream_info.info.aud.rtcp_sdes_bye_disabled = prm.streamInfo.rtcpSdesByeDisabled;
+        param->stream_info.info.aud.rx_event_pt = prm.streamInfo.audRxEventPt;
     } else if (param->stream_info.type == PJMEDIA_TYPE_VIDEO) {
         param->stream_info.info.vid.jb_init = prm.streamInfo.jbInit;
         param->stream_info.info.vid.jb_min_pre = prm.streamInfo.jbMinPre;


### PR DESCRIPTION
To implement the proposal by @nanangizz as described in #3661:
Allow app overriding `si->rx_event_pt` via PJSUA callback `on_stream_precreate()` (and PJSUA2). This can be useful for cases such as:
- if remote doesn't specify telephone-event in its SDP answer
- if remote sends tel-event PT different than the one negotiated in the SDP

To avoid multiple PTs offered, it is recommended to disable `PJMEDIA_TELEPHONE_EVENT_ALL_CLOCKRATES`. Then application can simply override `param->stream_info.info.aud.rx_event_pt` to `PJMEDIA_RTP_PT_TELEPHONE_EVENTS` or the PT expected to be sent by remote.

To fix #3700 as well.

Tested here and it seems to work as expected:
Before patch (if remote sends DTMF PT different than the SDP):
```
14:00:33.055        strm0x10c9b1928  Bad RTP pt 122 (expecting 96)
14:00:33.075        strm0x10c9b1928  Bad RTP pt 122 (expecting 96)
14:00:33.094        strm0x10c9b1928  Bad RTP pt 122 (expecting 96)
14:00:33.114        strm0x10c9b1928  Bad RTP pt 122 (expecting 96)
```

After patch:
```
14:04:55.036            pjsua_app.c  .Incoming DTMF on call 0: 1, using RFC2833 method
14:04:55.276            pjsua_app.c  .Incoming DTMF on call 0: 2, using RFC2833 method
14:04:55.517            pjsua_app.c  .Incoming DTMF on call 0: 3, using RFC2833 method
```
