### PR TITLE
Fixed Coverity and build warnings

### DIFF
--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -345,7 +345,7 @@ pj_bool_t ioqueue_dispatch_write_event( pj_ioqueue_t *ioqueue,
                     h->fd_type==pj_SOCK_DGRAM())
                 {
                     PJ_PERROR(4,(THIS_FILE, send_rc,
-                                 "Send error for socket %d, retrying",
+                                 "Send error for socket %ld, retrying",
                                  h->fd));
                     send_rc = replace_udp_sock(h);
                     continue;
@@ -1037,7 +1037,7 @@ retry_on_restart:
                 {
                     if (!restart_retry) {
                         PJ_PERROR(4, (THIS_FILE, status,
-                                      "Send error for socket %d, retrying",
+                                      "Send error for socket %ld, retrying",
                                       key->fd));
                         status = replace_udp_sock(key);
                         if (status == PJ_SUCCESS) {

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -769,12 +769,12 @@ static pj_status_t replace_udp_sock(pj_ioqueue_key_t *h)
     /* Can only replace UDP socket */
     pj_assert(h->fd_type == pj_SOCK_DGRAM());
 
-    PJ_LOG(4,(THIS_FILE, "Attempting to replace UDP socket %d", old_sock));
+    PJ_LOG(4,(THIS_FILE, "Attempting to replace UDP socket %ld", old_sock));
 
     for (msec=20; (msec<1000 && status != PJ_SUCCESS); msec=msec*2)
     {
         if (msec > 20) {
-            PJ_LOG(4,(THIS_FILE, "Retry to replace UDP socket %d", h->fd));
+            PJ_LOG(4,(THIS_FILE, "Retry to replace UDP socket %ld", h->fd));
             pj_thread_sleep(msec);
         }
         
@@ -920,7 +920,7 @@ on_error:
     }
 
     h->fd = PJ_INVALID_SOCKET;
-    PJ_PERROR(1,(THIS_FILE, status, "Error replacing socket %d", old_sock));
+    PJ_PERROR(1,(THIS_FILE, status, "Error replacing socket %ld", old_sock));
     pj_lock_release(h->ioqueue->lock);
     return PJ_ESOCKETSTOP;
 }

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1134,7 +1134,6 @@ static pj_bool_t ssock_on_accept_complete (pj_ssl_sock_t *ssock_parent,
                                                    ssock->param.grp_lock);
         if (status != PJ_SUCCESS) {
             ssock->timer.id = TIMER_NONE;
-            status = PJ_SUCCESS;
         }
     }
 

--- a/pjlib/src/pjlib-test/ioq_tcp.c
+++ b/pjlib/src/pjlib-test/ioq_tcp.c
@@ -402,10 +402,6 @@ static int compliance_test_0(const pj_ioqueue_cfg *cfg)
                 return -52;
             }
             pending_op -= status;
-
-            if (pending_op == 0) {
-                status = 0;
-            }
         }
     }
 

--- a/pjnath/src/pjnath-test/ice_test.c
+++ b/pjnath/src/pjnath-test/ice_test.c
@@ -679,7 +679,7 @@ static int perform_test2(const char *title,
     if (sess->caller.result.init_status != PJ_SUCCESS ||
         sess->callee.result.init_status != PJ_SUCCESS)
     {
-        rc = 0;
+        // rc = 0;
         goto on_return;
     }
     /* Init ICE on caller */

--- a/pjsip/src/pjsip-simple/rpid.c
+++ b/pjsip/src/pjsip-simple/rpid.c
@@ -127,7 +127,6 @@ PJ_DEF(pj_status_t) pjrpid_add_element(pjpidf_pres *pres,
             nd_note = pj_xml_node_new(pool, &NOTE);
             pj_strdup(pool, &nd_note->content, &elem->note);
             pj_xml_add_node(nd_tuple? nd_tuple: pres, nd_note);
-            nd_note = NULL;
         }
     }
 

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2104,7 +2104,7 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
              */
             if (tmp.slen) {
                 PJ_LOG(2, (THIS_FILE,
-                      "Dropping %d bytes packet from %s %s:%d %.*s\n",
+                      "Dropping %ld bytes packet from %s %s:%d %.*s\n",
                       msg_fragment_size,
                       rdata->tp_info.transport->type_name,
                       rdata->pkt_info.src_name,

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -268,6 +268,7 @@ AudioMedia* AudioMedia::typecastFromMedia(Media *media)
 AudioMediaPort::AudioMediaPort()
 : pool(NULL)
 {
+    pj_bzero(&port, sizeof(port));
 }
 
 AudioMediaPort::~AudioMediaPort()


### PR DESCRIPTION
Fixed various Coverity and build warnings:
- Unused variable values
- Uninitialised AudioMediaPort class members
- printf warnings
