### PR TITLE
Set default SSL sockopt param to have TCP_NODELAY for GnuTLS backend

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -1078,7 +1078,8 @@ typedef struct pj_ssl_sock_param
     /**
      * Specify options to be set on the transport. 
      *
-     * By default there is no options.
+     * For GnuTLS backend, by default TCP_NODELAY will be set. For other
+     * SSL backends, the default is no options.
      * 
      */
     pj_sockopt_params sockopt_params;

--- a/pjlib/src/pj/ssl_sock_common.c
+++ b/pjlib/src/pj/ssl_sock_common.c
@@ -34,9 +34,20 @@ PJ_DEF(void) pj_ssl_sock_param_default(pj_ssl_sock_param *param)
     param->async_cnt = 1;
     param->concurrency = -1;
     param->whole_data = PJ_TRUE;
+
+    {
+        static pj_int32_t val = 1;
+        param->sockopt_params.cnt = 1;
+        param->sockopt_params.options[0].level = pj_SOL_TCP();
+        param->sockopt_params.options[0].optname = pj_TCP_NODELAY();
+        param->sockopt_params.options[0].optval = &val;
+        param->sockopt_params.options[0].optlen = sizeof(pj_int32_t);
+    }
+
 #if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_GNUTLS)
     /* GnuTLS is allowed to send bigger chunks.*/
     param->send_buffer_size = 65536;
+
 #else
     param->send_buffer_size = 8192;
 #endif

--- a/pjlib/src/pj/ssl_sock_common.c
+++ b/pjlib/src/pj/ssl_sock_common.c
@@ -35,7 +35,12 @@ PJ_DEF(void) pj_ssl_sock_param_default(pj_ssl_sock_param *param)
     param->concurrency = -1;
     param->whole_data = PJ_TRUE;
 
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_GNUTLS)
+    /* GnuTLS is allowed to send bigger chunks.*/
+    param->send_buffer_size = 65536;
+
     {
+        /* For GnuTLS, TCP_NODELAY is needed to avoid polling delay. */
         static pj_int32_t val = 1;
         param->sockopt_params.cnt = 1;
         param->sockopt_params.options[0].level = pj_SOL_TCP();
@@ -43,10 +48,6 @@ PJ_DEF(void) pj_ssl_sock_param_default(pj_ssl_sock_param *param)
         param->sockopt_params.options[0].optval = &val;
         param->sockopt_params.options[0].optlen = sizeof(pj_int32_t);
     }
-
-#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_GNUTLS)
-    /* GnuTLS is allowed to send bigger chunks.*/
-    param->send_buffer_size = 65536;
 
 #else
     param->send_buffer_size = 8192;

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -359,7 +359,8 @@ typedef struct pjsip_tls_setting
     /**
      * Specify options to be set on the transport. 
      *
-     * By default there is no options.
+     * By default, this is unset, which means that the underlying sockopt
+     * params as returned by #pj_ssl_sock_param_default() will be used.
      * 
      */
     pj_sockopt_params sockopt_params;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -342,9 +342,11 @@ static void set_ssock_param(pj_ssl_sock_param *ssock_param,
     ssock_param->enable_renegotiation =
                                     listener->tls_setting.enable_renegotiation;
     /* Copy the sockopt */
-    pj_memcpy(&ssock_param->sockopt_params,
-              &listener->tls_setting.sockopt_params,
-              sizeof(listener->tls_setting.sockopt_params));
+    if (listener->tls_setting.sockopt_params.cnt > 0) {
+        pj_memcpy(&ssock_param->sockopt_params, 
+                  &listener->tls_setting.sockopt_params,
+                  sizeof(listener->tls_setting.sockopt_params));
+    }
 
     sip_ssl_method = listener->tls_setting.method;
     sip_ssl_proto = listener->tls_setting.proto;
@@ -1233,9 +1235,11 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
 
     ssock_param.enable_renegotiation = listener->tls_setting.enable_renegotiation;
     /* Copy the sockopt */
-    pj_memcpy(&ssock_param.sockopt_params, 
-              &listener->tls_setting.sockopt_params,
-              sizeof(listener->tls_setting.sockopt_params));
+    if (listener->tls_setting.sockopt_params.cnt > 0) {
+        pj_memcpy(&ssock_param.sockopt_params, 
+                  &listener->tls_setting.sockopt_params,
+                  sizeof(listener->tls_setting.sockopt_params));
+    }
 
     sip_ssl_method = listener->tls_setting.method;
     sip_ssl_proto = listener->tls_setting.proto;


### PR DESCRIPTION
To fix #3703.
To avoid the delay, the patch proposed in the PR will add the flag `TCP_NODELAY` only for GnuTLS backend.

An alternative patch presented in the original report will set the flag for all TCP and TLS sockets.
https://github.com/savoirfairelinux/pjproject/commit/97f45c2040c2b0cf6f3349a365b0e900a2267333.patch
```
---
 pjlib/src/pj/sock_bsd.c | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

diff --git a/pjlib/src/pj/sock_bsd.c b/pjlib/src/pj/sock_bsd.c
index a27fce775..94ce7bf27 100644
--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -601,7 +601,8 @@ PJ_DEF(pj_status_t) pj_sock_socket(int af,
 	    pj_sock_setsockopt(*sock, pj_SOL_TCP(), pj_TCP_USER_TIMEOUT(),
 			       &val, sizeof(val));
 	    val = 1;
-
+		pj_sock_setsockopt(*sock, pj_SOL_TCP(), pj_TCP_NODELAY(),
+				&val, sizeof(val));
 	}
 #if defined(PJ_SOCK_HAS_IPV6_V6ONLY) && PJ_SOCK_HAS_IPV6_V6ONLY != 0
 	if (af == PJ_AF_INET6) {
```

Please refer to #3703 for more detailed discussion of the pros and cons of the flag and let me know whether you think it's better for the flag to be enabled for all stream sockets, or only for GnuTLS.
