### PR TITLE
Fixed deadlock between SIP transaction and dialog

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1728,6 +1728,11 @@ void pjsip_dlg_on_rx_request( pjsip_dialog *dlg, pjsip_rx_data *rdata )
     if (pjsip_rdata_get_tsx(rdata) == NULL &&
         rdata->msg_info.msg->line.req.method.id != PJSIP_ACK_METHOD)
     {
+        /* Create tsx lock first so we can lock it before creating
+         * the transaction. This is to avoid deadlock by preventing
+         * the newly created transaction to process messages before
+         * this function returns.
+         */
         status = pj_grp_lock_create(dlg->pool, NULL, &tsx_lock);
         if (status == PJ_SUCCESS) {
             pj_grp_lock_add_ref(tsx_lock);


### PR DESCRIPTION
It is reported that deadlock can occur when a dialog receives a request and its retransmission at the same time. The stack trace is as follows:
```
      PjSipDll.dll!grp_lock_acquire(void * p=0x06ae9d3c) Line 297 C
      PjSipDll.dll!pjsip_tsx_recv_msg(pjsip_transaction * tsx=0x01dff41c, pjsip_rx_data * rdata=0x01e945ac) Line 1902   C
      PjSipDll.dll!pjsip_dlg_on_rx_request(pjsip_dialog * dlg=0x01dfc3ec, pjsip_rx_data * rdata=0x01e945ac) Line 1785   C
      PjSipDll.dll!mod_ua_on_rx_request(pjsip_rx_data * rdata=0x01e945ac) Line 748  C
      PjSipDll.dll!pjsip_endpt_process_rx_data(pjsip_endpoint * endpt=0x03fb7084, pjsip_rx_data * rdata=0x01e945ac, pjsip_process_rdata_param * p=0x04c2278c, int * p_handled=0x04c2272c) Line 929    C
      PjSipDll.dll!endpt_on_rx_msg(pjsip_endpoint * endpt=0x03fb7084, int status=66810160, pjsip_rx_data * rdata=0x01e945ac) Line 1079    C
      PjSipDll.dll!pjsip_tpmgr_receive_packet(pjsip_tpmgr * mgr=0x01e86d5c, pjsip_rx_data * rdata=0x01e945ac) Line 2199 C
      PjSipDll.dll!udp_on_read_complete(pj_ioqueue_key_t * key=0x0404c9f8, pj_ioqueue_op_key_t * op_key, long bytes_read=465) Line 202    C
      PjSipDll.dll!ioqueue_dispatch_read_event(pj_ioqueue_t * ioqueue=0x0402f27c, pj_ioqueue_key_t * h=0x0404c9f8) Line 609   C
```

```
      [Inline Frame] PjSipDll.dll!pjsip_dlg_inc_lock(pjsip_dialog *) Line 928 C
      PjSipDll.dll!pjsip_dlg_on_tsx_state(pjsip_dialog * dlg=0x01dfc3ec, pjsip_transaction * tsx=0x01dff41c, pjsip_event * e=0x04fe24dc) Line 2135    C
>     PjSipDll.dll!mod_ua_on_tsx_state(pjsip_transaction * tsx=0x01dff41c, pjsip_event * e=0x04fe24dc) Line 186   C
      PjSipDll.dll!tsx_on_state_null(pjsip_transaction * tsx=0x01dff41c, pjsip_event * event=0x04fe2514) Line 2599      C
      PjSipDll.dll!pjsip_tsx_recv_msg(pjsip_transaction * tsx=0x01dff41c, pjsip_rx_data * rdata=0x01ec65bc) Line 1903   C
      PjSipDll.dll!mod_tsx_layer_on_rx_request(pjsip_rx_data * rdata=0x01ec65bc) Line 880 C
      PjSipDll.dll!pjsip_endpt_process_rx_data(pjsip_endpoint * endpt=0x03fb7084, pjsip_rx_data * rdata=0x01ec65bc, pjsip_process_rdata_param * p=0x04fe2620, int * p_handled=0x04fe25c0) Line 929    C
      PjSipDll.dll!endpt_on_rx_msg(pjsip_endpoint * endpt=0x03fb7084, int status=66810160, pjsip_rx_data * rdata=0x01ec65bc) Line 1079    C
      PjSipDll.dll!pjsip_tpmgr_receive_packet(pjsip_tpmgr * mgr=0x01e86d5c, pjsip_rx_data * rdata=0x01ec65bc) Line 2199 C
      PjSipDll.dll!udp_on_read_complete(pj_ioqueue_key_t * key=0x0404c9f8, pj_ioqueue_op_key_t * op_key, long bytes_read=465) Line 202    C
      PjSipDll.dll!ioqueue_dispatch_read_event(pj_ioqueue_t * ioqueue=0x0402f27c, pj_ioqueue_key_t * h=0x0404c9f8) Line 609   C
```

So when handling the original request: `pjsip_dlg_on_rx_request()` will lock dialog, create tsx, and then pass the message to the tsx, which will try to acquire the tsx lock.
While at the same time, during the handling of the retransmission: `mod_tsx_layer_on_rx_request()` will lock the tsx, change its tsx state, which will trigger sip dialog's `on_tsx_state()`, which will then try to acquire the dialog's lock.

The problem can be reproduced with the following SIPP scenario that will send double BYE:
[uac-double_bye.txt](https://github.com/pjsip/pjproject/files/12680695/uac-double_bye.txt)
Note that the issue obviously only occurs if you use multiple worker threads:
[multithread.txt](https://github.com/pjsip/pjproject/files/12680701/multithread.txt)
