### PR TITLE
Call pjmedia_srtp_deinit_lib() when srtp_init() fail

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -539,6 +539,7 @@ PJ_DEF(pj_status_t) pjmedia_srtp_init_lib(pjmedia_endpt *endpt)
         if (err != srtp_err_status_ok) {
             PJ_LOG(4, (THIS_FILE, "Failed to initialize libsrtp: %s",
                        get_libsrtp_errstr(err)));
+            pjmedia_srtp_deinit_lib(endpt);
             return PJMEDIA_ERRNO_FROM_LIBSRTP(err);
         }
     }


### PR DESCRIPTION
This is to fix #3715.
Consider the scenario:
1. Start PJSIP using pjsua_create() + pjsua_init().
1. Failure in srtp_init().
1. Handle the error and call pjsua_destroy().
1. Re-init by calling pjsua_create() + pjsua_init()
1. srtp_init() will fail with `unsupported parameter [status=259801]`