### PR TITLE
Fix pjsip_mwi_notify() may be called without body

### DIFF
--- a/pjsip/include/pjsip-simple/mwi.h
+++ b/pjsip/include/pjsip-simple/mwi.h
@@ -159,7 +159,9 @@ PJ_DECL(pj_status_t) pjsip_mwi_accept( pjsip_evsub *sub,
  * @param reason        Specify reason if new state is terminated, otherwise
  *                      put NULL.
  * @param mime_type     MIME type/content type of the message body.
- * @param body          Message body to be included in the NOTIFY request.
+ * @param body          Message body to be included in the NOTIFY request,
+ *                      if NULL, the last body will be used. Note that
+ *                      the mime_type must also be set when body is not NULL.
  * @param p_tdata       Pointer to receive the request.
  *
  * @return              PJ_SUCCESS on success.

--- a/pjsip/src/pjsip-simple/mwi.c
+++ b/pjsip/src/pjsip-simple/mwi.c
@@ -366,11 +366,17 @@ PJ_DEF(pj_status_t) pjsip_mwi_notify(  pjsip_evsub *sub,
     pj_status_t status;
     
     /* Check arguments. */
-    PJ_ASSERT_RETURN(sub && mime_type && body && p_tdata, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sub && p_tdata, PJ_EINVAL);
 
     /* Get the mwi object. */
     mwi = (pjsip_mwi*) pjsip_evsub_get_mod_data(sub, mod_mwi.id);
     PJ_ASSERT_RETURN(mwi != NULL, PJ_EINVALIDOP);
+
+    /* Make sure both mime_type & body are-being/have-been set. */
+    PJ_ASSERT_RETURN((mime_type && body) ||
+                     (!body &&
+                      mwi->mime_type.type.slen && mwi->body.slen),
+                     PJ_EINVAL);
 
     /* Lock object. */
     pjsip_dlg_inc_lock(mwi->dlg);
@@ -381,12 +387,11 @@ PJ_DEF(pj_status_t) pjsip_mwi_notify(  pjsip_evsub *sub,
         goto on_return;
 
     /* Update the cached message body */
-    if (mime_type || body)
+    if (mime_type && body) {
         pj_pool_reset(mwi->body_pool);
-    if (mime_type)
         pjsip_media_type_cp(mwi->body_pool, &mwi->mime_type, mime_type);
-    if (body)
         pj_strdup(mwi->body_pool, &mwi->body, body);
+    }
 
     /* Create message body */
     status = mwi_create_msg_body( mwi, tdata );


### PR DESCRIPTION
Reported that `pjsip_mwi_notify()` function in `pjsip/src/pjsip-simple/mwi.c` asserts that the body parameter cannot be null.
However, the function is called twice in the same file and both times the body argument is null.

This patch changes the assertion line to allow a null body as long as the body has been set before, so the generated SIP NOTIFY message will use the last body. Note that the two `pjsip_mwi_notify()` invocations without body are done for subscription timeout/termination scenario, so I guess it is safe to assume that the body has been set (accepting a subscription should trigger some SIP NOTIFY which should contain body).

Thanks to Bogdan Vasilescu for the report.