### PR TITLE
Changed DTLS transport to use recursive mutex, instead of a simple one

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -293,7 +293,7 @@ static pj_status_t dtls_create(transport_srtp *srtp,
         pj_grp_lock_add_ref(grp_lock);
         pj_grp_lock_add_handler(grp_lock, pool, ds, &dtls_on_destroy);
     } else {
-        status = pj_lock_create_simple_mutex(ds->pool, "dtls_ssl_lock%p",
+        status = pj_lock_create_recursive_mutex(ds->pool, "dtls_ssl_lock%p",
                                              &ds->ossl_lock);
         if (status != PJ_SUCCESS)
             return status;


### PR DESCRIPTION
As reported in the comment https://github.com/pjsip/pjproject/commit/6dc9b8c181aff39845f02b4626e0812820d4ef0d#r129061968
we should use recursive mutex for DTLS transport, instead of simple one.

Note that all our media transports are currently already equipped with a group lock, so this change should affect only those who implement their own custom media transport without utilising the group lock. To avoid deadlock, app is recommended to use group lock instead.
