### PR TITLE
Fixed buffer overflow when using Video Toolbox

### DIFF
--- a/pjmedia/src/pjmedia-codec/vid_toolbox.m
+++ b/pjmedia/src/pjmedia-codec/vid_toolbox.m
@@ -164,7 +164,7 @@ typedef struct vtool_codec_data
     pj_uint8_t                  *dec_buf;
     unsigned                     dec_buf_size;
     CMFormatDescriptionRef       dec_format;
-    OSStatus             dec_status;
+    OSStatus                     dec_status;
 
     unsigned                     dec_sps_size;
     unsigned                     dec_pps_size;
@@ -1042,7 +1042,7 @@ static void decode_cb(void *decompressionOutputRefCon,
                       CMTime presentationDuration)
 {
     struct vtool_codec_data *vtool_data;
-    pj_size_t width, height, len;
+    pj_size_t width, height, len = 0;
     
     /* This callback can be called from another, unregistered thread.
      * So do not call pjlib functions here.
@@ -1068,7 +1068,12 @@ static void decode_cb(void *decompressionOutputRefCon,
         vtool_data->dec_fmt_change = PJ_FALSE;
     }
 
-    len = process_i420(imageBuffer, (pj_uint8_t *)vtool_data->dec_frame->buf);
+    if (vtool_data->dec_frame->size >= width * height * 3 / 2) {
+        len = process_i420(imageBuffer,
+                           (pj_uint8_t *)vtool_data->dec_frame->buf);
+    } else {
+        vtool_data->dec_status = (OSStatus)PJMEDIA_CODEC_EFRMTOOSHORT;
+    }
     vtool_data->dec_frame->size = len;
 
     CVPixelBufferUnlockBaseAddress(imageBuffer,0);
@@ -1308,6 +1313,7 @@ static pj_status_t vtool_codec_decode(pjmedia_vid_codec *codec,
             
             if (ret == noErr) {
                 vtool_data->dec_frame = output;
+                vtool_data->dec_frame->size = out_size;
                 ret = VTDecompressionSessionDecodeFrame(
                           vtool_data->dec, sample_buf, 0,
                           NULL, NULL);
@@ -1345,8 +1351,9 @@ static pj_status_t vtool_codec_decode(pjmedia_vid_codec *codec,
                 }
 
                 if ((ret != noErr) || (vtool_data->dec_status != noErr)) {
-            char *ret_err = (ret != noErr)?"decode err":"cb err";
-            OSStatus err_code = (ret != noErr)?ret:vtool_data->dec_status;
+                    char *ret_err = (ret != noErr)?"decode err":"cb err";
+                    OSStatus err_code = (ret != noErr)? ret:
+                                        vtool_data->dec_status;
 
                     PJ_LOG(5,(THIS_FILE, "Failed to decode frame %d of size "
                                  "%d %s:%d", nalu_type, frm_size, ret_err,

--- a/pjsip-apps/src/pjsua/ios/ipjsua.xcodeproj/project.pbxproj
+++ b/pjsip-apps/src/pjsua/ios/ipjsua.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -22,7 +22,6 @@
 		3AA3200018F3FB4C00112C3D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA31FF318F3FB4C00112C3D /* Foundation.framework */; };
 		3AA3200118F3FB4C00112C3D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA31FF418F3FB4C00112C3D /* CoreGraphics.framework */; };
 		3AA3200218F3FB4C00112C3D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA31FF518F3FB4C00112C3D /* UIKit.framework */; };
-		3AD55D5B2AD6B67500F21D83 /* libpj.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AD55D5A2AD6B67500F21D83 /* libpj.xcframework */; };
 		3ADCCD171715338D0007BE8E /* pjsua.png in Resources */ = {isa = PBXBuildFile; fileRef = 3ADCCD161715338D0007BE8E /* pjsua.png */; };
 		3ADCCD2D172E40120007BE8E /* pjsua_app_cli.c in Sources */ = {isa = PBXBuildFile; fileRef = 3ADCCD28172E40120007BE8E /* pjsua_app_cli.c */; };
 		3ADCCD2E172E40120007BE8E /* pjsua_app_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 3ADCCD29172E40120007BE8E /* pjsua_app_common.c */; };
@@ -45,6 +44,7 @@
 		E5E991E61B67A45500017E67 /* libg7221codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D41B67A45500017E67 /* libg7221codec.a */; };
 		E5E991E71B67A45500017E67 /* libgsmcodec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D51B67A45500017E67 /* libgsmcodec.a */; };
 		E5E991E81B67A45500017E67 /* libilbccodec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D61B67A45500017E67 /* libilbccodec.a */; };
+		E5E991E91B67A45500017E67 /* libpj.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D71B67A45500017E67 /* libpj.a */; };
 		E5E991EA1B67A45500017E67 /* libpjlib-util.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D81B67A45500017E67 /* libpjlib-util.a */; };
 		E5E991EB1B67A45500017E67 /* libpjmedia-audiodev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D91B67A45500017E67 /* libpjmedia-audiodev.a */; };
 		E5E991EC1B67A45500017E67 /* libpjmedia-codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991DA1B67A45500017E67 /* libpjmedia-codec.a */; };
@@ -77,7 +77,6 @@
 		3AA31FF318F3FB4C00112C3D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		3AA31FF418F3FB4C00112C3D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		3AA31FF518F3FB4C00112C3D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		3AD55D5A2AD6B67500F21D83 /* libpj.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libpj.xcframework; path = ../../../../xcf/libpj.xcframework; sourceTree = "<group>"; };
 		3ADCCD161715338D0007BE8E /* pjsua.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = pjsua.png; sourceTree = "<group>"; };
 		3ADCCD28172E40120007BE8E /* pjsua_app_cli.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pjsua_app_cli.c; path = ../../pjsua_app_cli.c; sourceTree = "<group>"; };
 		3ADCCD29172E40120007BE8E /* pjsua_app_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pjsua_app_common.c; path = ../../pjsua_app_common.c; sourceTree = "<group>"; };
@@ -106,6 +105,7 @@
 		E5E991D41B67A45500017E67 /* libg7221codec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libg7221codec.a; sourceTree = "<group>"; };
 		E5E991D51B67A45500017E67 /* libgsmcodec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libgsmcodec.a; sourceTree = "<group>"; };
 		E5E991D61B67A45500017E67 /* libilbccodec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libilbccodec.a; sourceTree = "<group>"; };
+		E5E991D71B67A45500017E67 /* libpj.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpj.a; sourceTree = "<group>"; };
 		E5E991D81B67A45500017E67 /* libpjlib-util.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjlib-util.a"; sourceTree = "<group>"; };
 		E5E991D91B67A45500017E67 /* libpjmedia-audiodev.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjmedia-audiodev.a"; sourceTree = "<group>"; };
 		E5E991DA1B67A45500017E67 /* libpjmedia-codec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjmedia-codec.a"; sourceTree = "<group>"; };
@@ -140,7 +140,6 @@
 				3AF253001EFBD15E00213893 /* libyuv.a in Frameworks */,
 				3AA31FF718F3FB4C00112C3D /* AVFoundation.framework in Frameworks */,
 				3AA31FFE18F3FB4C00112C3D /* OpenGLES.framework in Frameworks */,
-				3AD55D5B2AD6B67500F21D83 /* libpj.xcframework in Frameworks */,
 				3AA3200018F3FB4C00112C3D /* Foundation.framework in Frameworks */,
 				E5E991E71B67A45500017E67 /* libgsmcodec.a in Frameworks */,
 				E5E991F31B67A45500017E67 /* libpjsua.a in Frameworks */,
@@ -154,6 +153,7 @@
 				3AA3200218F3FB4C00112C3D /* UIKit.framework in Frameworks */,
 				3AA31FFA18F3FB4C00112C3D /* CoreFoundation.framework in Frameworks */,
 				E5E991F01B67A45500017E67 /* libpjsip-simple.a in Frameworks */,
+				E5E991E91B67A45500017E67 /* libpj.a in Frameworks */,
 				E5E991F71B67A45500017E67 /* libsrtp.a in Frameworks */,
 				3AA31FFC18F3FB4C00112C3D /* CoreMedia.framework in Frameworks */,
 				E5E991F21B67A45500017E67 /* libpjsip.a in Frameworks */,
@@ -202,7 +202,6 @@
 		3AF0580716F050770046B835 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3AD55D5A2AD6B67500F21D83 /* libpj.xcframework */,
 				3A6FDEEF223B3BEC001726FD /* Security.framework */,
 				7485A6B01F09B2D500122F1A /* SystemConfiguration.framework */,
 				3AF253011EFBD36E00213893 /* VideoToolbox.framework */,
@@ -262,6 +261,7 @@
 				3A31F1B11DA4F568007C23A3 /* libwebrtc.a */,
 				E5E991D51B67A45500017E67 /* libgsmcodec.a */,
 				E5E991D61B67A45500017E67 /* libilbccodec.a */,
+				E5E991D71B67A45500017E67 /* libpj.a */,
 				E5E991D81B67A45500017E67 /* libpjlib-util.a */,
 				E5E991D91B67A45500017E67 /* libpjmedia-audiodev.a */,
 				E5E991DA1B67A45500017E67 /* libpjmedia-codec.a */,
@@ -310,6 +310,11 @@
 				CLASSPREFIX = ipjsua;
 				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Teluu;
+				TargetAttributes = {
+					3AF0580316F050770046B835 = {
+						DevelopmentTeam = 93NHJQ455P;
+					};
+				};
 			};
 			buildConfigurationList = 3AF057FE16F050770046B835 /* Build configuration list for PBXProject "ipjsua" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -496,7 +501,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 93NHJQ455P;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ipjsua/ipjsua-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -536,7 +540,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 93NHJQ455P;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ipjsua/ipjsua-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (

--- a/pjsip-apps/src/pjsua/ios/ipjsua.xcodeproj/project.pbxproj
+++ b/pjsip-apps/src/pjsua/ios/ipjsua.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -22,6 +22,7 @@
 		3AA3200018F3FB4C00112C3D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA31FF318F3FB4C00112C3D /* Foundation.framework */; };
 		3AA3200118F3FB4C00112C3D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA31FF418F3FB4C00112C3D /* CoreGraphics.framework */; };
 		3AA3200218F3FB4C00112C3D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA31FF518F3FB4C00112C3D /* UIKit.framework */; };
+		3AD55D5B2AD6B67500F21D83 /* libpj.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AD55D5A2AD6B67500F21D83 /* libpj.xcframework */; };
 		3ADCCD171715338D0007BE8E /* pjsua.png in Resources */ = {isa = PBXBuildFile; fileRef = 3ADCCD161715338D0007BE8E /* pjsua.png */; };
 		3ADCCD2D172E40120007BE8E /* pjsua_app_cli.c in Sources */ = {isa = PBXBuildFile; fileRef = 3ADCCD28172E40120007BE8E /* pjsua_app_cli.c */; };
 		3ADCCD2E172E40120007BE8E /* pjsua_app_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 3ADCCD29172E40120007BE8E /* pjsua_app_common.c */; };
@@ -44,7 +45,6 @@
 		E5E991E61B67A45500017E67 /* libg7221codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D41B67A45500017E67 /* libg7221codec.a */; };
 		E5E991E71B67A45500017E67 /* libgsmcodec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D51B67A45500017E67 /* libgsmcodec.a */; };
 		E5E991E81B67A45500017E67 /* libilbccodec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D61B67A45500017E67 /* libilbccodec.a */; };
-		E5E991E91B67A45500017E67 /* libpj.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D71B67A45500017E67 /* libpj.a */; };
 		E5E991EA1B67A45500017E67 /* libpjlib-util.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D81B67A45500017E67 /* libpjlib-util.a */; };
 		E5E991EB1B67A45500017E67 /* libpjmedia-audiodev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991D91B67A45500017E67 /* libpjmedia-audiodev.a */; };
 		E5E991EC1B67A45500017E67 /* libpjmedia-codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E991DA1B67A45500017E67 /* libpjmedia-codec.a */; };
@@ -77,6 +77,7 @@
 		3AA31FF318F3FB4C00112C3D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		3AA31FF418F3FB4C00112C3D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		3AA31FF518F3FB4C00112C3D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		3AD55D5A2AD6B67500F21D83 /* libpj.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libpj.xcframework; path = ../../../../xcf/libpj.xcframework; sourceTree = "<group>"; };
 		3ADCCD161715338D0007BE8E /* pjsua.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = pjsua.png; sourceTree = "<group>"; };
 		3ADCCD28172E40120007BE8E /* pjsua_app_cli.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pjsua_app_cli.c; path = ../../pjsua_app_cli.c; sourceTree = "<group>"; };
 		3ADCCD29172E40120007BE8E /* pjsua_app_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pjsua_app_common.c; path = ../../pjsua_app_common.c; sourceTree = "<group>"; };
@@ -105,7 +106,6 @@
 		E5E991D41B67A45500017E67 /* libg7221codec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libg7221codec.a; sourceTree = "<group>"; };
 		E5E991D51B67A45500017E67 /* libgsmcodec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libgsmcodec.a; sourceTree = "<group>"; };
 		E5E991D61B67A45500017E67 /* libilbccodec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libilbccodec.a; sourceTree = "<group>"; };
-		E5E991D71B67A45500017E67 /* libpj.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpj.a; sourceTree = "<group>"; };
 		E5E991D81B67A45500017E67 /* libpjlib-util.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjlib-util.a"; sourceTree = "<group>"; };
 		E5E991D91B67A45500017E67 /* libpjmedia-audiodev.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjmedia-audiodev.a"; sourceTree = "<group>"; };
 		E5E991DA1B67A45500017E67 /* libpjmedia-codec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjmedia-codec.a"; sourceTree = "<group>"; };
@@ -140,6 +140,7 @@
 				3AF253001EFBD15E00213893 /* libyuv.a in Frameworks */,
 				3AA31FF718F3FB4C00112C3D /* AVFoundation.framework in Frameworks */,
 				3AA31FFE18F3FB4C00112C3D /* OpenGLES.framework in Frameworks */,
+				3AD55D5B2AD6B67500F21D83 /* libpj.xcframework in Frameworks */,
 				3AA3200018F3FB4C00112C3D /* Foundation.framework in Frameworks */,
 				E5E991E71B67A45500017E67 /* libgsmcodec.a in Frameworks */,
 				E5E991F31B67A45500017E67 /* libpjsua.a in Frameworks */,
@@ -153,7 +154,6 @@
 				3AA3200218F3FB4C00112C3D /* UIKit.framework in Frameworks */,
 				3AA31FFA18F3FB4C00112C3D /* CoreFoundation.framework in Frameworks */,
 				E5E991F01B67A45500017E67 /* libpjsip-simple.a in Frameworks */,
-				E5E991E91B67A45500017E67 /* libpj.a in Frameworks */,
 				E5E991F71B67A45500017E67 /* libsrtp.a in Frameworks */,
 				3AA31FFC18F3FB4C00112C3D /* CoreMedia.framework in Frameworks */,
 				E5E991F21B67A45500017E67 /* libpjsip.a in Frameworks */,
@@ -202,6 +202,7 @@
 		3AF0580716F050770046B835 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3AD55D5A2AD6B67500F21D83 /* libpj.xcframework */,
 				3A6FDEEF223B3BEC001726FD /* Security.framework */,
 				7485A6B01F09B2D500122F1A /* SystemConfiguration.framework */,
 				3AF253011EFBD36E00213893 /* VideoToolbox.framework */,
@@ -261,7 +262,6 @@
 				3A31F1B11DA4F568007C23A3 /* libwebrtc.a */,
 				E5E991D51B67A45500017E67 /* libgsmcodec.a */,
 				E5E991D61B67A45500017E67 /* libilbccodec.a */,
-				E5E991D71B67A45500017E67 /* libpj.a */,
 				E5E991D81B67A45500017E67 /* libpjlib-util.a */,
 				E5E991D91B67A45500017E67 /* libpjmedia-audiodev.a */,
 				E5E991DA1B67A45500017E67 /* libpjmedia-codec.a */,
@@ -310,11 +310,6 @@
 				CLASSPREFIX = ipjsua;
 				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Teluu;
-				TargetAttributes = {
-					3AF0580316F050770046B835 = {
-						DevelopmentTeam = 93NHJQ455P;
-					};
-				};
 			};
 			buildConfigurationList = 3AF057FE16F050770046B835 /* Build configuration list for PBXProject "ipjsua" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -501,6 +496,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 93NHJQ455P;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ipjsua/ipjsua-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -540,6 +536,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 93NHJQ455P;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ipjsua/ipjsua-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (


### PR DESCRIPTION
As reported in #3654, PJSIP will crash when using Video Toolbox codec and remote sends a video with resolution higher than supported.

Although the issue was caused by the remote sending video with resolution higher than signalled, PJSIP shouldn't crash. The crash is caused due to lack of checking of the frame buffer size that's supposed to hold the decoded frame.

With the patch, it will print "Failed to decode frame" instead (log level 5).
