### PR TITLE
Fix tdata leak when pjsip_inv_initial_answer() return error

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2664,8 +2664,8 @@ PJ_DEF(pj_status_t) pjsip_inv_initial_answer(   pjsip_inv_session *inv,
         pj_status_t status2;
 
         status2 = pjsip_dlg_modify_response(inv->dlg, tdata, st_code2, NULL);
+        pjsip_tx_data_dec_ref(tdata);
         if (status2 != PJ_SUCCESS) {
-            pjsip_tx_data_dec_ref(tdata);
             goto on_return;
         }
         status2 = pjsip_timer_update_resp(inv, tdata);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5552,6 +5552,9 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
                                               (pjsip_rx_data *)param->rdata,
                                               100, NULL, NULL, &response);
             if (status != PJ_SUCCESS) {
+                if (response) {
+                    pjsip_tx_data_dec_ref(response);
+                }
                 PJ_PERROR(3, (THIS_FILE, status,
                               "Failed to create initial answer"));
                 goto on_return;


### PR DESCRIPTION
When `pjsip_inv_initial_answer()` return error, it might set the `tdata` to be sent. 
This will lead to leaked `tdata` if the caller doesn't manually destroy it (e.g: calling `pjsip_tx_data_dec_ref()` or sending the `tdata` using `pjsip_inv_send_msg()`).
The issues related to this:
1. The call to `pjsip_dlg_modify_response()` in https://github.com/pjsip/pjproject/blob/43dd94f4ec257993959f381ea46091ece7aaf85d/pjsip/src/pjsip-ua/sip_inv.c#L2666
will add the reference to the returned `tdata`. This will lead to a leak.
1.  In the case of receiving new offer on the re-INVTE. The tdata returned from `pjsip_inv_initial_answer()` is not checked and lead to a leak.
https://github.com/pjsip/pjproject/blob/43dd94f4ec257993959f381ea46091ece7aaf85d/pjsip/src/pjsua-lib/pjsua_call.c#L5551