### PR TITLE
Add TLS initial receive timeout for server connection

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -677,16 +677,17 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
- * Initial timeout interval to be applied to incoming transports (i.e. server
- * side) when no data received after a successful connection for TLS. 
- * Value is in seconds. Disable the timeout by setting it to 0.
+ * Initial timeout interval to be applied to incoming TCP/TLS transports
+ * (i.e. server side) when no valid data received after a successful
+ * connection. Value is in seconds. Disable the timeout by setting it to 0.
  *
- * For TCP, refer to a\ PJSIP_TCP_INITIAL_TIMEOUT
- * 
  * Note that even when this is disable, the connection might still get closed
  * when it is idle or not referred anymore. Have a look at \a
- * PJSIP_TRANSPORT_SERVER_IDLE_TIME
+ * PJSIP_TRANSPORT_SERVER_IDLE_TIME.
  * 
+ * Notes:
+ * - keep-alive packet is not considered as a valid message.
+ *
  * Default: 0
 */
 #ifndef PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST
@@ -803,14 +804,19 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
- * Initial timeout interval to be applied to incoming transports (i.e. server
- * side) when no data received after a successful connection. Value is in
- * seconds. Disable the timeout by setting it to 0.
+ * Initial timeout interval to be applied to incoming TCP transports
+ * (i.e. server side) when no valid data received after a successful
+ * connection. Value is in seconds. Disable the timeout by setting it to 0.
  *
  * Note that even when this is disable, the connection might still get closed
  * when it is idle or not referred anymore. Have a look at \a
- * PJSIP_TRANSPORT_SERVER_IDLE_TIME
+ * PJSIP_TRANSPORT_SERVER_IDLE_TIME.
  *
+ * Notes:
+ * - keep-alive packet is not considered as a valid message.
+ * - This macro is exclusive to TCP usage. It will be prioritize over
+ *   a\ PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST if both are set.
+ * 
  * Default: 0 (disabled)
  */
 #ifndef PJSIP_TCP_INITIAL_TIMEOUT

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -677,6 +677,23 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
+ * Initial timeout interval to be applied to incoming transports (i.e. server
+ * side) when no data received after a successful connection for TLS. 
+ * Value is in seconds. Disable the timeout by setting it to 0.
+ *
+ * For TCP, refer to a\ PJSIP_TCP_INITIAL_TIMEOUT
+ * 
+ * Note that even when this is disable, the connection might still get closed
+ * when it is idle or not referred anymore. Have a look at \a
+ * PJSIP_TRANSPORT_SERVER_IDLE_TIME
+ * 
+ * Default: 0
+*/
+#ifndef PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST
+#   define PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST     0
+#endif
+
+/**
  * Maximum number of usages for a transport before a new transport is
  * created. This only applies for ephemeral transports such as TCP.
  *

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -677,11 +677,12 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
- * Initial timeout interval to be applied to incoming TCP/TLS transports
- * (i.e. server side) when no valid data received after a successful
- * connection. Value is in seconds. Disable the timeout by setting it to 0.
+ * The initial timeout interval for incoming TCP/TLS transports
+ * (i.e. server side) in the event that no valid SIP message is received
+ * following a successful connection. The value is in seconds.
+ * Disable the timeout by setting it to 0.
  *
- * Note that even when this is disable, the connection might still get closed
+ * Note that even if this is disabled, the connection might still get closed
  * when it is idle or not referred anymore. Have a look at \a
  * PJSIP_TRANSPORT_SERVER_IDLE_TIME.
  * 
@@ -804,18 +805,19 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
- * Initial timeout interval to be applied to incoming TCP transports
- * (i.e. server side) when no valid data received after a successful
- * connection. Value is in seconds. Disable the timeout by setting it to 0.
+ * The initial timeout interval for incoming TCP transports
+ * (i.e. server side) in the event that no valid SIP message is received
+ * following a successful connection. The value is in seconds.
+ * Disable the timeout by setting it to 0.
  *
- * Note that even when this is disable, the connection might still get closed
+ * Note that even if this is disabled, the connection might still get closed
  * when it is idle or not referred anymore. Have a look at \a
  * PJSIP_TRANSPORT_SERVER_IDLE_TIME.
  *
  * Notes:
  * - keep-alive packet is not considered as a valid message.
- * - This macro is exclusive to TCP usage. It will be prioritize over
- *   a\ PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST if both are set.
+ * - This macro is specific to TCP usage and takes precedence over
+ *   a\ PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST when both are set.
  * 
  * Default: 0 (disabled)
  */

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -870,6 +870,11 @@ struct pjsip_transport
     pj_size_t               last_recv_len;  /**< Last received data length. */
 
     void                   *data;           /**< Internal transport data.   */
+    unsigned                initial_timeout;/**< Initial timeout interval
+                                                 to be applied to incoming
+                                                 TCP/TLS transports when no
+                                                 valid data received after
+                                                 a successful connection.   */
 
     /**
      * Function to be called by transport manager to send SIP message.

--- a/pjsip/include/pjsip/sip_transport_tcp.h
+++ b/pjsip/include/pjsip/sip_transport_tcp.h
@@ -115,7 +115,8 @@ typedef struct pjsip_tcp_transport_cfg
 
     /**
      * Intial timeout interval to be applied to incoming transports 
-     * (i.e. server side) when no data received after a successful connection.
+     * (i.e. server side) when no valid data received after a successful
+     * connection.
      *
      * Default: PJSIP_TCP_INITIAL_TIMEOUT
      */

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -325,6 +325,15 @@ typedef struct pjsip_tls_setting
     pj_time_val timeout;
 
     /**
+     * Intial timeout interval to be applied to incoming transports
+     * (i.e. server side) when no valid data received after a successful
+     * connection.
+     *
+     * Default: PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST
+     */
+    unsigned    initial_timeout;
+
+    /**
      * Should SO_REUSEADDR be used for the listener socket.
      * Default value is PJSIP_TLS_TRANSPORT_REUSEADDR.
      */
@@ -437,6 +446,7 @@ PJ_INLINE(void) pjsip_tls_setting_default(pjsip_tls_setting *tls_opt)
     tls_opt->sockopt_ignore_error = PJ_TRUE;
     tls_opt->proto = PJSIP_SSL_DEFAULT_PROTO;
     tls_opt->enable_renegotiation = PJ_TRUE;
+    tls_opt->initial_timeout = PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST;
 }
 
 

--- a/pjsip/src/pjsip/sip_config.c
+++ b/pjsip/src/pjsip/sip_config.c
@@ -102,8 +102,10 @@ PJ_DEF(void) pjsip_dump_config(void)
                PJSIP_MAX_TIMED_OUT_ENTRIES));
     PJ_LOG(3, (id, " PJSIP_TRANSPORT_IDLE_TIME                          : %d", 
                PJSIP_TRANSPORT_IDLE_TIME));
-    PJ_LOG(3, (id, " PJSIP_TRANSPORT_SERVER_IDLE_TIME                   : %d", 
+    PJ_LOG(3, (id, " PJSIP_TRANSPORT_SERVER_IDLE_TIME                   : %d",
                PJSIP_TRANSPORT_SERVER_IDLE_TIME));
+    PJ_LOG(3, (id, " PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST             : %d",
+               PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST));
     PJ_LOG(3, (id, " PJSIP_MAX_TRANSPORT_USAGE                          : %d", 
                PJSIP_MAX_TRANSPORT_USAGE));
     PJ_LOG(3, (id, " PJSIP_TCP_TRANSPORT_BACKLOG                        : %d", 

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1186,9 +1186,17 @@ PJ_DEF(pj_status_t) pjsip_transport_dec_ref( pjsip_transport *tp )
             if (tp->is_shutdown) {
                 delay.sec = delay.msec = 0;
             } else {
-                delay.sec = (tp->dir==PJSIP_TP_DIR_OUTGOING) ?
-                                PJSIP_TRANSPORT_IDLE_TIME :
-                                PJSIP_TRANSPORT_SERVER_IDLE_TIME;
+                if (tp->dir == PJSIP_TP_DIR_OUTGOING) {
+                    delay.sec = PJSIP_TRANSPORT_IDLE_TIME;
+                } else {
+                    if (tp->last_recv_ts.u64 == 0 && 
+                        PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST != 0) 
+                    {
+                        delay.sec = PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST;
+                    } else {
+                        delay.sec = PJSIP_TRANSPORT_SERVER_IDLE_TIME;
+                    }
+                }
                 delay.msec = 0;
             }
 

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -727,9 +727,8 @@ static pj_status_t tcp_create( struct tcp_listener *listener,
     pj_ioqueue_op_key_init(&tcp->ka_op_key.key, sizeof(pj_ioqueue_op_key_t));
     pj_strdup(tcp->base.pool, &tcp->ka_pkt, &ka_pkt);
 
-    /* Initialize initial timer. */
     if (is_server && listener->initial_timeout) {
-        /* Initiate initial idle timer. */
+        /* Initialize initial timer. */
         pjsip_transport_add_ref(&tcp->base);
         pjsip_transport_dec_ref(&tcp->base);
     }

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -124,8 +124,6 @@ struct tcp_transport
     /* Group lock to be used by TCP transport and ioqueue key */
     pj_grp_lock_t           *grp_lock;
 
-    /* Initial timer. */
-    pj_timer_entry           initial_timer;
 };
 
 
@@ -235,7 +233,8 @@ PJ_DEF(void) pjsip_tcp_transport_cfg_default(pjsip_tcp_transport_cfg *cfg,
     pj_sockaddr_init(cfg->af, &cfg->bind_addr, NULL, 0);
     cfg->async_cnt = 1;
     cfg->reuse_addr = PJSIP_TCP_TRANSPORT_REUSEADDR;
-    cfg->initial_timeout = PJSIP_TCP_INITIAL_TIMEOUT;
+    cfg->initial_timeout = (PJSIP_TCP_INITIAL_TIMEOUT!=0)?
+              PJSIP_TCP_INITIAL_TIMEOUT:PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST;
 }
 
 
@@ -605,9 +604,6 @@ static pj_bool_t on_connect_complete(pj_activesock_t *asock,
 /* TCP keep-alive timer callback */
 static void tcp_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e);
 
-/* TCP initial timer callback */
-static void tcp_initial_timer(pj_timer_heap_t *th, pj_timer_entry *e);
-
 /* Clean up TCP resources */
 static void tcp_on_destroy(void *arg);
 
@@ -688,6 +684,7 @@ static pj_status_t tcp_create( struct tcp_listener *listener,
     tcp->base.do_shutdown = &tcp_shutdown;
     tcp->base.destroy = &tcp_destroy_transport;
     tcp->base.factory = &listener->factory;
+    tcp->base.initial_timeout = listener->initial_timeout;
 
     /* Create group lock */
     status = pj_grp_lock_create_w_handler(pool, NULL, tcp, &tcp_on_destroy,
@@ -732,16 +729,9 @@ static pj_status_t tcp_create( struct tcp_listener *listener,
 
     /* Initialize initial timer. */
     if (is_server && listener->initial_timeout) {
-        pj_time_val delay = { 0 };
-
-        tcp->initial_timer.user_data = (void*)tcp;
-        tcp->initial_timer.cb = &tcp_initial_timer;
-        
-        delay.sec = listener->initial_timeout;
-        pjsip_endpt_schedule_timer(listener->endpt, 
-                                    &tcp->initial_timer, 
-                                    &delay);
-        tcp->initial_timer.id = PJ_TRUE;
+        /* Initiate initial idle timer. */
+        pjsip_transport_add_ref(&tcp->base);
+        pjsip_transport_dec_ref(&tcp->base);
     }
 
     /* Done setting up basic transport. */
@@ -846,12 +836,6 @@ static pj_status_t tcp_destroy(pjsip_transport *transport,
     if (tcp->ka_timer.id) {
         pjsip_endpt_cancel_timer(tcp->base.endpt, &tcp->ka_timer);
         tcp->ka_timer.id = PJ_FALSE;
-    }
-
-    /* Stop initial timer. */
-    if (tcp->initial_timer.id) {
-        pjsip_endpt_cancel_timer(tcp->base.endpt, &tcp->initial_timer);
-        tcp->initial_timer.id = PJ_FALSE;
     }
 
     /* Cancel all delayed transmits */
@@ -1394,12 +1378,6 @@ static pj_status_t tcp_shutdown(pjsip_transport *transport)
         tcp->ka_timer.id = PJ_FALSE;
     }
 
-    /* Stop initial timer. */
-    if (tcp->initial_timer.id) {
-        pjsip_endpt_cancel_timer(tcp->base.endpt, &tcp->initial_timer);
-        tcp->initial_timer.id = PJ_FALSE;
-    }
-
     return PJ_SUCCESS;
 }
 
@@ -1426,11 +1404,6 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
     if (tcp->is_closing) {
         tcp->is_closing++;
         return PJ_FALSE;
-    }
-
-    if (tcp->initial_timer.id) {
-        pjsip_endpt_cancel_timer(tcp->base.endpt, &tcp->initial_timer);
-        tcp->initial_timer.id = PJ_FALSE;
     }
 
     /* Houston, we have packet! Report the packet to transport manager
@@ -1650,16 +1623,6 @@ static void tcp_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
     tcp->ka_timer.id = PJ_TRUE;
 }
 
-/* Transport keep-alive timer callback */
-static void tcp_initial_timer(pj_timer_heap_t *th, pj_timer_entry *e)
-{
-    pj_status_t status = PJ_ETIMEDOUT;
-    struct tcp_transport *tcp = (struct tcp_transport*) e->user_data;
-
-    PJ_UNUSED_ARG(th);
-
-    tcp_init_shutdown(tcp, status);
-}
 
 PJ_DEF(pj_sock_t) pjsip_tcp_transport_get_socket(pjsip_transport *transport)
 {

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -907,6 +907,7 @@ static pj_status_t tls_create( struct tls_listener *listener,
     tls->base.do_shutdown = &tls_shutdown;
     tls->base.destroy = &tls_destroy_transport;
     tls->base.factory = &listener->factory;
+    tls->base.initial_timeout = listener->tls_setting.initial_timeout;
 
     tls->ssock = ssock;
     tls->on_verify_cb = listener->tls_setting.on_verify_cb;


### PR DESCRIPTION
For TCP there is a setting to close the incoming connection if there's no data received after a successful accept (`PJSIP_TCP_INITIAL_TIMEOUT`).

There is `PJSIP_TRANSPORT_SERVER_IDLE_TIME` which will close the connection when it's idle or not referred anymore.
However a different/shorter timeout (after connection is established) is useful to protect against any DDOS attempt trying to exhaust resources. 

