### PR TITLE
base64: support encode/decode with URL and Filename Safe Alphabet

### DIFF
--- a/pjlib-util/include/pjlib-util/base64.h
+++ b/pjlib-util/include/pjlib-util/base64.h
@@ -93,6 +93,18 @@ PJ_DECL(pj_status_t) pj_base64url_encode(const pj_uint8_t *input, int in_len,
 PJ_DECL(pj_status_t) pj_base64_decode(const pj_str_t *input, 
                                       pj_uint8_t *out, int *out_len);
 
+/**
+ * Decode base64 (URL and Filename Safe) string.
+ *
+ * @param input     Input string.
+ * @param out       Buffer to store the output. Caller must allocate
+ *                  this buffer with the appropriate size.
+ * @param out_len   On entry, it specifies the length of the output buffer. 
+ *                  Upon return, this will be filled with the actual
+ *                  length of the output.
+ */
+PJ_DECL(pj_status_t) pj_base64url_decode(const pj_str_t *input, 
+                                         pj_uint8_t *out, int *out_len);
 
 
 /**

--- a/pjlib-util/include/pjlib-util/base64.h
+++ b/pjlib-util/include/pjlib-util/base64.h
@@ -64,6 +64,21 @@ PJ_BEGIN_DECL
 PJ_DECL(pj_status_t) pj_base64_encode(const pj_uint8_t *input, int in_len,
                                      char *output, int *out_len);
 
+/**
+ * Encode a buffer into base64 (URL and Filename Safe) encoding.
+ *
+ * @param input     The input buffer.
+ * @param in_len    Size of the input buffer.
+ * @param output    Output buffer. Caller must allocate this buffer with
+ *                  the appropriate size.
+ * @param out_len   On entry, it specifies the length of the output buffer. 
+ *                  Upon return, this will be filled with the actual
+ *                  length of the output buffer.
+ *
+ * @return          PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pj_base64url_encode(const pj_uint8_t *input, int in_len,
+                                         char *output, int *out_len);
 
 /**
  * Decode base64 string.

--- a/pjlib-util/src/pjlib-util/base64.c
+++ b/pjlib-util/src/pjlib-util/base64.c
@@ -44,7 +44,7 @@ static const char base64url_char[] = {
     '8', '9', '-', '_' 
 };
 
-static int base256_char(char c)
+static int base256_char(char c, pj_bool_t url)
 {
     if (c >= 'A' && c <= 'Z')
         return (c - 'A');
@@ -52,9 +52,9 @@ static int base256_char(char c)
         return (c - 'a' + 26);
     else if (c >= '0' && c <= '9')
         return (c - '0' + 52);
-    else if (c == '+' || c == '-')
+    else if ((!url && c == '+') || (url && c == '-'))
         return (62);
-    else if (c == '/' || c == '_')
+    else if ((!url && c == '/') || (url && c == '_'))
         return (63);
     else {
         /* It *may* happen on bad input, so this is not a good idea.
@@ -132,7 +132,8 @@ static pj_status_t b64_encode(const pj_uint8_t *input, int in_len,
 }
 
 static pj_status_t b64_decode(const pj_str_t *input,
-                              pj_uint8_t *out, int *out_len)
+                              pj_uint8_t *out, int *out_len,
+                              pj_bool_t url)
 {
     const char *buf;
     int len;
@@ -153,7 +154,7 @@ static pj_status_t b64_decode(const pj_str_t *input,
         /* Fill up c, silently ignoring invalid characters */
         for (k=0; k<4 && i<len; ++k) {
             do {
-                c[k] = base256_char(buf[i++]);
+                c[k] = base256_char(buf[i++], url);
             } while (c[k]==INV && i<len);
         }
 
@@ -194,5 +195,11 @@ PJ_DEF(pj_status_t) pj_base64url_encode(const pj_uint8_t *input, int in_len,
 PJ_DEF(pj_status_t) pj_base64_decode(const pj_str_t *input,
                                      pj_uint8_t *out, int *out_len)
 {
-    return b64_decode(input, out, out_len);
+    return b64_decode(input, out, out_len, PJ_FALSE);
+}
+
+PJ_DEF(pj_status_t) pj_base64url_decode(const pj_str_t *input,
+                                        pj_uint8_t *out, int *out_len)
+{
+    return b64_decode(input, out, out_len, PJ_TRUE);
 }

--- a/pjlib-util/src/pjlib-util/base64.c
+++ b/pjlib-util/src/pjlib-util/base64.c
@@ -33,6 +33,17 @@ static const char base64_char[] = {
     '8', '9', '+', '/' 
 };
 
+/* Base 64 Encoding with URL and Filename Safe Alphabet (RFC 4648 section 5) */
+static const char base64url_char[] = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+    'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+    'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+    'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+    'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+    'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+    '8', '9', '-', '_' 
+};
+
 static int base256_char(char c)
 {
     if (c >= 'A' && c <= 'Z')
@@ -41,9 +52,9 @@ static int base256_char(char c)
         return (c - 'a' + 26);
     else if (c >= '0' && c <= '9')
         return (c - '0' + 52);
-    else if (c == '+')
+    else if (c == '+' || c == '-')
         return (62);
-    else if (c == '/')
+    else if (c == '/' || c == '_')
         return (63);
     else {
         /* It *may* happen on bad input, so this is not a good idea.
@@ -55,17 +66,18 @@ static int base256_char(char c)
 
 
 static void base256to64(pj_uint8_t c1, pj_uint8_t c2, pj_uint8_t c3, 
-                        int padding, char *output)
+                        int padding, char *output, pj_bool_t url)
 {
-    *output++ = base64_char[c1>>2];
-    *output++ = base64_char[((c1 & 0x3)<< 4) | ((c2 & 0xF0) >> 4)];
+    const char *b64 = url ? base64url_char : base64_char;
+    *output++ = b64[c1>>2];
+    *output++ = b64[((c1 & 0x3)<< 4) | ((c2 & 0xF0) >> 4)];
     switch (padding) {
     case 0:
-        *output++ = base64_char[((c2 & 0xF) << 2) | ((c3 & 0xC0) >>6)];
-        *output = base64_char[c3 & 0x3F];
+        *output++ = b64[((c2 & 0xF) << 2) | ((c3 & 0xC0) >>6)];
+        *output = b64[c3 & 0x3F];
         break;
     case 1:
-        *output++ = base64_char[((c2 & 0xF) << 2) | ((c3 & 0xC0) >>6)];
+        *output++ = b64[((c2 & 0xF) << 2) | ((c3 & 0xC0) >>6)];
         *output = PADDING;
         break;
     case 2:
@@ -76,9 +88,9 @@ static void base256to64(pj_uint8_t c1, pj_uint8_t c2, pj_uint8_t c3,
     }
 }
 
-
-PJ_DEF(pj_status_t) pj_base64_encode(const pj_uint8_t *input, int in_len,
-                                     char *output, int *out_len)
+static pj_status_t b64_encode(const pj_uint8_t *input, int in_len,
+                              char *output, int *out_len,
+                              pj_bool_t url)
 {
     const pj_uint8_t *pi = input;
     pj_uint8_t c1, c2, c3;
@@ -94,7 +106,7 @@ PJ_DEF(pj_status_t) pj_base64_encode(const pj_uint8_t *input, int in_len,
         ++i;
 
         if (i == in_len) {
-            base256to64(c1, 0, 0, 2, po);
+            base256to64(c1, 0, 0, 2, po, url);
             po += 4;
             break;
         } else {
@@ -102,13 +114,13 @@ PJ_DEF(pj_status_t) pj_base64_encode(const pj_uint8_t *input, int in_len,
             ++i;
 
             if (i == in_len) {
-                base256to64(c1, c2, 0, 1, po);
+                base256to64(c1, c2, 0, 1, po, url);
                 po += 4;
                 break;
             } else {
                 c3 = *pi++;
                 ++i;
-                base256to64(c1, c2, c3, 0, po);
+                base256to64(c1, c2, c3, 0, po, url);
             }
         }
 
@@ -119,9 +131,8 @@ PJ_DEF(pj_status_t) pj_base64_encode(const pj_uint8_t *input, int in_len,
     return PJ_SUCCESS;
 }
 
-
-PJ_DEF(pj_status_t) pj_base64_decode(const pj_str_t *input, 
-                                     pj_uint8_t *out, int *out_len)
+static pj_status_t b64_decode(const pj_str_t *input,
+                              pj_uint8_t *out, int *out_len)
 {
     const char *buf;
     int len;
@@ -168,4 +179,20 @@ PJ_DEF(pj_status_t) pj_base64_decode(const pj_str_t *input,
     return PJ_SUCCESS;
 }
 
+PJ_DEF(pj_status_t) pj_base64_encode(const pj_uint8_t *input, int in_len,
+                                     char *output, int *out_len)
+{
+    return b64_encode(input, in_len, output, out_len, PJ_FALSE);
+}
 
+PJ_DEF(pj_status_t) pj_base64url_encode(const pj_uint8_t *input, int in_len,
+                                        char *output, int *out_len)
+{
+    return b64_encode(input, in_len, output, out_len, PJ_TRUE);
+}
+
+PJ_DEF(pj_status_t) pj_base64_decode(const pj_str_t *input,
+                                     pj_uint8_t *out, int *out_len)
+{
+    return b64_decode(input, out, out_len);
+}


### PR DESCRIPTION
as title

[rfc4648 section-5, Base 64 Encoding with URL and Filename Safe Alphabet](https://datatracker.ietf.org/doc/html/rfc4648#section-5)