### PR TITLE
Add SIP transport data received callback

### DIFF
--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1662,6 +1662,27 @@ PJ_DECL(pj_status_t) pjsip_tpmgr_set_drop_data_cb(pjsip_tpmgr *mgr,
 
 
 /**
+ * Type of callback to custom parser.
+ *
+ * @param data          The dropped data.
+ */
+typedef pj_status_t (*pjsip_tp_on_custom_parser_cb)(pjsip_transport *tp, char *data, pj_size_t size, pj_size_t *fragment_size);
+
+
+/**
+ * Set callback for custom parser. The caller will be notified whenever any
+ * new received data are in the receive buffer
+ * This is useful for filter out custom massages before they are parsed in normal way
+ * 
+ * @param mgr       Transport manager.
+ * @param cb        The callback function, set to NULL to reset the callback.
+ *
+ * @return          PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsip_tpmgr_set_custom_parser_cb(pjsip_tpmgr *mgr,
+                                                  pjsip_tp_on_custom_parser_cb cb);
+
+/**
  * @}
  */
 

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1679,25 +1679,11 @@ typedef struct pjsip_tp_rx_data
 
     /**
      * The data length.
-     * If the status field below is set to PJ_SUCCESS, it means
-     * that application has done its own processing of the data and can set
-     * the len to the number of bytes that it has processed.
+     * If application wishes to discard some data of len p, it can pass
+     * the remaining data back to PJSIP to be processed by setting the len
+     * to (len - p).
      */
     pj_size_t        len;
-
-    /**
-     * The status of the callback.
-     * On input, it will be set to PJ_EIGNORED, which means that application
-     * opts to ignore the data received and pass it back to PJSIP to
-     * be processed.
-     *
-     * Application can change the status to PJ_SUCCESS to indicate that it
-     * has performed its own processing of the data and does not wish for
-     * PJSIP to prosess it. In this case, application should set the field
-     * data length len above to the number of bytes of the data it has
-     * processed.
-     */
-    pj_status_t      status;
 
 } pjsip_tp_rx_data;
 
@@ -1705,7 +1691,7 @@ typedef struct pjsip_tp_rx_data
 /**
  * Type of callback to data received notifications.
  *
- * @param data          The received data.
+ * @param data      The received data.
  */
 typedef pj_status_t (*pjsip_tp_on_rx_data_cb)(pjsip_tp_rx_data *data);
 
@@ -1713,8 +1699,7 @@ typedef pj_status_t (*pjsip_tp_on_rx_data_cb)(pjsip_tp_rx_data *data);
 /**
  * Set callback to be called whenever any data is received by a stream
  * oriented transport. This can be useful for application to do its own
- * processing, parsing, filtering, or logging of potential malicious
- * activities.
+ * verification, filtering, or logging of potential malicious activities.
  * 
  * @param mgr       Transport manager.
  * @param cb        The callback function, set to NULL to reset the callback.

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1682,6 +1682,10 @@ typedef struct pjsip_tp_rx_data
      * If application wishes to discard some data of len p, it can pass
      * the remaining data back to PJSIP to be processed by setting the len
      * to (len - p).
+     * If application wants to shutdown the transport from within the
+     * callback (for example after if finds out that the data is
+     * suspicious/garbage), app must set the len to zero to prevent
+     * further processing of the data.
      */
     pj_size_t        len;
 

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1662,25 +1662,67 @@ PJ_DECL(pj_status_t) pjsip_tpmgr_set_drop_data_cb(pjsip_tpmgr *mgr,
 
 
 /**
- * Type of callback to custom parser.
- *
- * @param data          The dropped data.
+ * Structure of received data that will be passed to data received
+ * notification callback.
  */
-typedef pj_status_t (*pjsip_tp_on_custom_parser_cb)(pjsip_transport *tp, char *data, pj_size_t size, pj_size_t *fragment_size);
+typedef struct pjsip_tp_rx_data
+{
+    /**
+     * The transport receiving the data.
+     */
+    pjsip_transport *tp;
+
+    /**
+     * The data.
+     */
+    void            *data;
+
+    /**
+     * The data length.
+     * If the status field below is set to PJ_SUCCESS, it means
+     * that application has done its own processing of the data and can set
+     * the len to the number of bytes that it has processed.
+     */
+    pj_size_t        len;
+
+    /**
+     * The status of the callback.
+     * On input, it will be set to PJ_EIGNORED, which means that application
+     * opts to ignore the data received and pass it back to PJSIP to
+     * be processed.
+     *
+     * Application can change the status to PJ_SUCCESS to indicate that it
+     * has performed its own processing of the data and does not wish for
+     * PJSIP to prosess it. In this case, application should set the field
+     * data length len above to the number of bytes of the data it has
+     * processed.
+     */
+    pj_status_t      status;
+
+} pjsip_tp_rx_data;
 
 
 /**
- * Set callback for custom parser. The caller will be notified whenever any
- * new received data are in the receive buffer
- * This is useful for filter out custom massages before they are parsed in normal way
+ * Type of callback to data received notifications.
+ *
+ * @param data          The received data.
+ */
+typedef pj_status_t (*pjsip_tp_on_rx_data_cb)(pjsip_tp_rx_data *data);
+
+
+/**
+ * Set callback to be called whenever any data is received by a stream
+ * oriented transport. This can be useful for application to do its own
+ * processing, parsing, filtering, or logging of potential malicious
+ * activities.
  * 
  * @param mgr       Transport manager.
  * @param cb        The callback function, set to NULL to reset the callback.
  *
  * @return          PJ_SUCCESS on success, or the appropriate error code.
  */
-PJ_DECL(pj_status_t) pjsip_tpmgr_set_custom_parser_cb(pjsip_tpmgr *mgr,
-                                                  pjsip_tp_on_custom_parser_cb cb);
+PJ_DECL(pj_status_t) pjsip_tpmgr_set_recv_data_cb(pjsip_tpmgr *mgr,
+                                                  pjsip_tp_on_rx_data_cb cb);
 
 /**
  * @}

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -144,6 +144,7 @@ struct pjsip_tpmgr
     pj_status_t    (*on_tx_msg)(pjsip_endpoint*, pjsip_tx_data*);
     pjsip_tp_state_callback tp_state_cb;
     pjsip_tp_on_rx_dropped_cb tp_drop_data_cb;
+    pjsip_tp_on_custom_parser_cb tp_custom_parser_cb;
 
     /* Transmit data list, for transmit data cleanup when transport manager
      * is destroyed.
@@ -2066,6 +2067,15 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
         /* For TCP transport, check if the whole message has been received. */
         if ((tr->flag & PJSIP_TRANSPORT_DATAGRAM) == 0) {
             pj_status_t msg_status;
+
+            if(mgr->tp_custom_parser_cb) {
+               if( PJ_SUCCESS == (*mgr->tp_custom_parser_cb)(tr, current_pkt, remaining_len, &msg_fragment_size)) {
+                    total_processed += msg_fragment_size;
+                    current_pkt += msg_fragment_size;
+                    remaining_len -= msg_fragment_size;
+                    continue;
+               }
+            }
             msg_status = pjsip_find_msg(current_pkt, remaining_len, PJ_FALSE, 
                                         &msg_fragment_size);
             if (msg_status != PJ_SUCCESS) {
@@ -2838,3 +2848,18 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_set_drop_data_cb(pjsip_tpmgr *mgr,
 
     return PJ_SUCCESS;
 }
+
+/*
+ * Set callback for custom parser
+ */
+
+PJ_DEF(pj_status_t) pjsip_tpmgr_set_custom_parser_cb(pjsip_tpmgr *mgr,
+                                                     pjsip_tp_on_custom_parser_cb cb)
+{
+    PJ_ASSERT_RETURN(mgr, PJ_EINVAL);
+
+    mgr->tp_custom_parser_cb = cb;
+
+    return PJ_SUCCESS;
+}
+

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2077,11 +2077,10 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
 
                 (*mgr->tp_rx_data_cb)(&rd);
                 if (rd.len < remaining_len) {
-                    remaining_len = rd.len;
-
                     msg_fragment_size = remaining_len - rd.len;
                     total_processed += msg_fragment_size;
                     current_pkt += msg_fragment_size;
+                    remaining_len = rd.len;
                     continue;
                 }
             }

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2074,15 +2074,14 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
                 rd.tp = tr;
                 rd.data = current_pkt;
                 rd.len = remaining_len;
-                rd.status = PJ_EIGNORED;
 
-                if ((*mgr->tp_rx_data_cb)(&rd) == PJ_SUCCESS) {
-                    /* Sanity check */
-                    if (rd.len > remaining_len)
-                        rd.len = remaining_len;
-                    total_processed += rd.len;
-                    current_pkt += rd.len;
-                    remaining_len -= rd.len;
+                (*mgr->tp_rx_data_cb)(&rd);
+                if (rd.len < remaining_len) {
+                    remaining_len = rd.len;
+
+                    msg_fragment_size = remaining_len - rd.len;
+                    total_processed += msg_fragment_size;
+                    current_pkt += msg_fragment_size;
                     continue;
                 }
             }

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2864,8 +2864,8 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_set_drop_data_cb(pjsip_tpmgr *mgr,
  * Set callback for custom parser
  */
 
-PJ_DEF(pj_status_t) pjsip_tpmgr_set_rx_data_cb(pjsip_tpmgr *mgr,
-                                               pjsip_tp_on_rx_data_cb cb)
+PJ_DEF(pj_status_t) pjsip_tpmgr_set_recv_data_cb(pjsip_tpmgr *mgr,
+                                                 pjsip_tp_on_rx_data_cb cb)
 {
     PJ_ASSERT_RETURN(mgr, PJ_EINVAL);
 


### PR DESCRIPTION
Initial patch provided by Peter Koletzki in the first commit:
Add callback `pjsip_tp_on_custom_parser_cb()` and API `pjsip_tpmgr_set_custom_parser_cb()` for custom parsing.

Proposed modification in the subsequent commits:
* Change the cb and API names to `pjsip_tp_on_rx_data_cb()` and `pjsip_tpmgr_set_recv_data_cb()`, in order to:
  - make it more general purpose. The callback is not specifically for parsing, but can also be used for other purposes such as filtering, logging of potential malicious activities, or other processing
  - make the name more similar to the existing `pjsip_tp_on_rx_dropped_cb()` and `pjsip_tpmgr_set_drop_data_cb()`.
* Also put the callback parameters into a struct `pjsip_tp_rx_data`, for extensibility purpose.
