### PR TITLE
Fixed race condition in ACK handling of INVITE message

### DIFF
--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -530,6 +530,18 @@ PJ_DECL(void) pjsip_tsx_layer_dump(pj_bool_t detail);
 PJ_DECL(const char *) pjsip_tsx_state_str(pjsip_tsx_state_e state);
 
 /**
+ * Schedule tsx timer.
+ * @param tsx       The transaction
+ * @param entry     The timer entry
+ * @param delay     The timer delay
+ * @param active_id The timer id
+ */
+PJ_DECL(pj_status_t) pjsip_tsx_schedule_timer(pjsip_transaction *tsx,
+                                              pj_timer_entry *entry,
+                                              const pj_time_val *delay,
+                                              int active_id);
+
+/**
  * Get the role name.
  * @param role  Role.
  */

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -410,9 +410,24 @@ PJ_DECL(pj_status_t) pjsip_tsx_create_key( pj_pool_t *pool,
  *
  * @param tsx       The transaction.
  * @param code      The status code to report.
+ *
+ * @return          PJ_SUCCESS or the appropriate error code.
  */
 PJ_DECL(pj_status_t) pjsip_tsx_terminate( pjsip_transaction *tsx,
                                           int code );
+
+
+/**
+ * Force terminate transaction asynchronously, using the transaction
+ * internal timer.
+ *
+ * @param tsx       The transaction.
+ * @param code      The status code to report.
+ *
+ * @return          PJ_SUCCESS or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsip_tsx_terminate_async(pjsip_transaction *tsx,
+                                               int code );
 
 
 /**
@@ -528,18 +543,6 @@ PJ_DECL(void) pjsip_tsx_layer_dump(pj_bool_t detail);
  * @param state State
  */
 PJ_DECL(const char *) pjsip_tsx_state_str(pjsip_tsx_state_e state);
-
-/**
- * Schedule tsx timer.
- * @param tsx       The transaction
- * @param entry     The timer entry
- * @param delay     The timer delay
- * @param active_id The timer id
- */
-PJ_DECL(pj_status_t) pjsip_tsx_schedule_timer(pjsip_transaction *tsx,
-                                              pj_timer_entry *entry,
-                                              const pj_time_val *delay,
-                                              int active_id);
 
 /**
  * Get the role name.

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -698,13 +698,20 @@ static pj_bool_t mod_inv_on_rx_request(pjsip_rx_data *rdata)
             }
 
             /* Now we can terminate the INVITE transaction */
-            pj_assert(inv->invite_tsx->status_code >= 200);
-            pjsip_tsx_terminate(inv->invite_tsx, 
-                                inv->invite_tsx->status_code);
+
+            /* In the case of an INVITE transaction, if the response was not
+             * 2xx, the ACK is considered part of the transaction, so
+             * should be handled by the transaction.
+             */
+            if (inv->invite_tsx->status_code/100 == 2) {
+                pjsip_tsx_terminate(inv->invite_tsx,
+                                    inv->invite_tsx->status_code);
+            }
             inv->invite_tsx = NULL;
+
             if (inv->last_answer) {
-                    pjsip_tx_data_dec_ref(inv->last_answer);
-                    inv->last_answer = NULL;
+                pjsip_tx_data_dec_ref(inv->last_answer);
+                inv->last_answer = NULL;
             }
         }
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -702,18 +702,15 @@ static pj_bool_t mod_inv_on_rx_request(pjsip_rx_data *rdata)
                 pjsip_tsx_terminate(inv->invite_tsx,
                                     inv->invite_tsx->status_code);
             } else {
-                pj_time_val timeout = { 1, 0 };
-
                 /* If the response was not 2xx, the ACK is considered part of
                  * the INVITE transaction, so should have been handled by
                  * the transaction.
                  * But for best effort, we will also attempt to terminate
-                 * the tsx here. However, we need to schedule it using a timer
+                 * the tsx here. However, we need to do it asynchronously
                  * to avoid deadlock.
                  */
-                pjsip_tsx_schedule_timer(inv->invite_tsx,
-                                         &inv->invite_tsx->timeout_timer,
-                                         &timeout, PJSIP_TSX_STATE_TERMINATED);
+                pjsip_tsx_terminate_async(inv->invite_tsx,
+                                          inv->invite_tsx->status_code);
             }
             inv->invite_tsx = NULL;
 

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -953,6 +953,18 @@ static pj_bool_t mod_tsx_layer_on_rx_request(pjsip_rx_data *rdata)
         return PJ_FALSE;
     }
 
+    /* In the case of an INVITE transaction, if the response was a 2xx,
+     * the ACK is not considered part of the transaction.
+     * Let sip_dialog and sip_inv handle it instead.
+     */
+    if (rdata->msg_info.msg->line.req.method.id == PJSIP_ACK_METHOD &&
+        tsx->method.id == PJSIP_INVITE_METHOD &&
+        tsx->status_code/100 == 2)
+    {
+        pj_mutex_unlock( mod_tsx_layer.mutex);
+        return PJ_FALSE;
+    }
+
     /* Prevent the transaction to get deleted before we have chance to lock it
      * in pjsip_tsx_recv_msg().
      */

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -198,6 +198,8 @@ static pj_status_t tsx_schedule_timer(pjsip_transaction *tsx,
                                       pj_timer_entry *entry,
                                       const pj_time_val *delay,
                                       int active_id);
+static int         tsx_cancel_timer(pjsip_transaction *tsx,
+                                    pj_timer_entry *entry);
 
 
 /* State handlers for UAC, indexed by state */
@@ -250,6 +252,8 @@ PJ_DEF(pj_status_t) pjsip_tsx_schedule_timer( pjsip_transaction *tsx,
                                               const pj_time_val *delay,
                                               int active_id)
 {
+    tsx_cancel_timer(tsx, entry);
+
     return tsx_schedule_timer(tsx, entry, delay, active_id);
 }
 

--- a/tests/pjsua/scripts-sipp/uas-reinv-with-less-media.xml
+++ b/tests/pjsua/scripts-sipp/uas-reinv-with-less-media.xml
@@ -100,7 +100,7 @@
       From: sipp  <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
       To[$3]
       Call-ID: [call_id]
-      Cseq: 1 ACK
+      Cseq: 2 ACK
       Contact: sip:sipp@[local_ip]:[local_port]
       Max-Forwards: 70
       Content-Length: 0


### PR DESCRIPTION
Currently we handle the ACK of INVITE in two places:
- `sip_inv.c`, with the flow:
```
pjsip_endpt_process_rx_data()
mod_ua_on_rx_request()
pjsip_dlg_on_rx_request()->acquire dialog lock
mod_inv_on_rx_request()
pjsip_tsx_terminate()->acquire tsx lock
```
- `sip_tsx.c`, with the flow:
```
pjsip_endpt_process_rx_data()
mod_tsx_layer_on_rx_request()
pjsip_tsx_recv_msg()->acquire tsx lock
tsx_on_state_completed_uas()
tsx_set_state()-mod_ua_on_tsx_state()-pjsip_dlg_on_tsx_state()-acquire dlg lock
```

According to RFC 3261 section 17 (https://datatracker.ietf.org/doc/html/rfc3261#section-17):
"In the case of a transaction where the
   request was an INVITE (known as an INVITE transaction), the
   transaction also includes the ACK only if the final response was not
   a 2xx response.  If the response was a 2xx, the ACK is not considered
   part of the transaction."

But currently we do not enforce this (I assume the reason is for leniency purpose) and allow either component (sip inv or tsx) to handle the ACK, i.e. if the ACK can be matched to INVITE tsx, tsx will handle it, otherwise the dialog will handle it. Unfortunately, if we receive two ACKs, one belonging to INVITE tsx, and one not, this can potentially introduce deadlock as shown above.

The issue is reproducible in a multithreaded environment with the following SIPP scenario:
[uac-double_ack.txt](https://github.com/pjsip/pjproject/files/13213632/uac-double_ack.txt)

Note that the problem is complicated since there doesn't seem any way to ensure the lock ordering between the dialog and tsx. In the first flow, dialog can't acquire tsx lock because the received ACK is not associated with any tsx.

So, the proposed fix is to sacrifice the leniency, i.e. by only allowing one component to handle it as per the RFC. If the INVITE status is 2xx, sip tsx must not handle it and pass it to dialog, while if status is not 2xx, sip dialog must not handle it.

Because of this, there may be potential backward incompatibility consequences.
