### PR TITLE
Check for buffer EOF in scanner

### DIFF
--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -277,11 +277,7 @@ PJ_DEF(void) pj_scan_get( pj_scanner *scanner,
 
     do {
         ++s;
-    } while (pj_cis_match(spec, *s));
-    /* No need to check EOF here (PJ_SCAN_CHECK_EOF(s)) because
-     * buffer is NULL terminated and pj_cis_match(spec,0) should be
-     * false.
-     */
+    } while (pj_cis_match(spec, *s) && !pj_scan_is_eof(scanner));
 
     pj_strset3(out, scanner->curptr, s);
 

--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -277,7 +277,7 @@ PJ_DEF(void) pj_scan_get( pj_scanner *scanner,
 
     do {
         ++s;
-    } while (pj_cis_match(spec, *s) && PJ_SCAN_CHECK_EOF(s));
+    } while (PJ_SCAN_CHECK_EOF(s) && pj_cis_match(spec, *s));
 
     pj_strset3(out, scanner->curptr, s);
 

--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -277,13 +277,15 @@ PJ_DEF(void) pj_scan_get( pj_scanner *scanner,
 
     do {
         ++s;
-    } while (pj_cis_match(spec, *s) && !pj_scan_is_eof(scanner));
+    } while (pj_cis_match(spec, *s) && PJ_SCAN_CHECK_EOF(s));
 
     pj_strset3(out, scanner->curptr, s);
 
     scanner->curptr = s;
 
-    if (PJ_SCAN_IS_PROBABLY_SPACE(*s) && scanner->skip_ws) {
+    if (!pj_scan_is_eof(scanner) &&
+        PJ_SCAN_IS_PROBABLY_SPACE(*s) && scanner->skip_ws)
+    {
         pj_scan_skip_whitespace(scanner);    
     }
 }
@@ -337,7 +339,9 @@ PJ_DEF(void) pj_scan_get_unescape( pj_scanner *scanner,
     scanner->curptr = s;
     out->slen = (dst - out->ptr);
 
-    if (PJ_SCAN_IS_PROBABLY_SPACE(*s) && scanner->skip_ws) {
+    if (!pj_scan_is_eof(scanner) &&
+        PJ_SCAN_IS_PROBABLY_SPACE(*s) && scanner->skip_ws)
+    {
         pj_scan_skip_whitespace(scanner);    
     }
 }
@@ -418,7 +422,9 @@ PJ_DEF(void) pj_scan_get_quotes(pj_scanner *scanner,
 
     scanner->curptr = s;
 
-    if (PJ_SCAN_IS_PROBABLY_SPACE(*s) && scanner->skip_ws) {
+    if (!pj_scan_is_eof(scanner) &&
+        PJ_SCAN_IS_PROBABLY_SPACE(*s) && scanner->skip_ws)
+    {
         pj_scan_skip_whitespace(scanner);
     }
 }

--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -152,6 +152,7 @@ PJ_DEF(void) pj_scan_skip_whitespace( pj_scanner *scanner )
         for (; PJ_SCAN_CHECK_EOF(s); ) {
             if (*s == '\r') {
                 ++s;
+                if (!PJ_SCAN_CHECK_EOF(s)) break;
                 if (*s == '\n') ++s;
                 ++scanner->line;
                 scanner->curptr = scanner->start_line = s;
@@ -162,7 +163,7 @@ PJ_DEF(void) pj_scan_skip_whitespace( pj_scanner *scanner )
             } else if (PJ_SCAN_IS_SPACE(*s)) {
                 do {
                     ++s;
-                } while (PJ_SCAN_IS_SPACE(*s));
+                } while (PJ_SCAN_CHECK_EOF(s) && PJ_SCAN_IS_SPACE(*s));
             } else {
                 break;
             }


### PR DESCRIPTION
In continuation of https://github.com/pjsip/pjproject/security/advisories/GHSA-fq45-m3f7-3mhj, we are striving to incorporate an EOF check within our scanner. This initiative is aimed at achieving the following objectives:
- Improving the robustness of the scanner (and reducing dependence on NULL buffer termination)
- Addressing our internal issues resulting from our own failures in conforming to the specification that mandates the use of a NULL-terminated buffer while invoking the API.

The EOF check has already been employed in similar functions such as `pj_scan_get_until()`, `pj_scan_get_until_ch()`, `pj_scan_get_until_chr()`.

Thanks to Peter Koletzki for the report and Rene Heuven for the initial patch.
