### PR TITLE
sdp.c: don't pass NULL pointer to log string format

### DIFF
--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -611,13 +611,13 @@ PJ_DEF(pj_status_t) pjmedia_sdp_rtpmap_to_attr(pj_pool_t *pool,
     len = pj_ansi_snprintf(tempbuf, sizeof(tempbuf), 
                            "%.*s %.*s/%u%s%.*s",
                            (int)rtpmap->pt.slen,
-                           rtpmap->pt.ptr,
+                           rtpmap->pt.ptr ? rtpmap->pt.ptr : "(null)",
                            (int)rtpmap->enc_name.slen,
-                           rtpmap->enc_name.ptr,
+                           rtpmap->enc_name.ptr ? rtpmap->enc_name.ptr : "(null)",
                            rtpmap->clock_rate,
                            (rtpmap->param.slen ? "/" : ""),
                            (int)rtpmap->param.slen,
-                           rtpmap->param.ptr);
+                           rtpmap->param.ptr ? rtpmap->param.ptr : "(null)");
 
     if (len < 1 || len >= (int)sizeof(tempbuf))
         return PJMEDIA_SDP_ERTPMAPTOOLONG;

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -597,8 +597,8 @@ PJ_DEF(pj_status_t) pjmedia_sdp_rtpmap_to_attr(pj_pool_t *pool,
     PJ_ASSERT_RETURN(pool && rtpmap && p_attr, PJ_EINVAL);
 
     /* Check that mandatory attributes are specified. */
-    PJ_ASSERT_RETURN(rtpmap->enc_name.slen && rtpmap->clock_rate,
-                     PJMEDIA_SDP_EINRTPMAP);
+    PJ_ASSERT_RETURN(rtpmap->pt.slen && rtpmap->enc_name.slen &&
+                     rtpmap->clock_rate, PJMEDIA_SDP_EINRTPMAP);
 
 
     attr = PJ_POOL_ALLOC_T(pool, pjmedia_sdp_attr);
@@ -611,13 +611,13 @@ PJ_DEF(pj_status_t) pjmedia_sdp_rtpmap_to_attr(pj_pool_t *pool,
     len = pj_ansi_snprintf(tempbuf, sizeof(tempbuf), 
                            "%.*s %.*s/%u%s%.*s",
                            (int)rtpmap->pt.slen,
-                           rtpmap->pt.ptr ? rtpmap->pt.ptr : "(null)",
+                           rtpmap->pt.ptr,
                            (int)rtpmap->enc_name.slen,
-                           rtpmap->enc_name.ptr ? rtpmap->enc_name.ptr : "(null)",
+                           rtpmap->enc_name.ptr,
                            rtpmap->clock_rate,
                            (rtpmap->param.slen ? "/" : ""),
                            (int)rtpmap->param.slen,
-                           rtpmap->param.ptr ? rtpmap->param.ptr : "(null)");
+                           rtpmap->param.slen ? rtpmap->param.ptr : "");
 
     if (len < 1 || len >= (int)sizeof(tempbuf))
         return PJMEDIA_SDP_ERTPMAPTOOLONG;


### PR DESCRIPTION
Passing a NULL pointer to log string format will result in a crash on OpenBSD.

https://flak.tedunangst.com/post/its-hard-work-printing-nothing