### PR TITLE
build: use C++ compiler for linking

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -4848,7 +4848,7 @@ fi
 
 if test "$AR_FLAGS" = ""; then AR_FLAGS="rv"; fi
 
-if test "$LD" = ""; then LD="$CC"; fi
+if test "$LD" = ""; then LD="$CXX"; fi
 
 if test "$LDOUT" = ""; then LDOUT="-o "; fi
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -46,7 +46,7 @@ AC_CHECK_TOOLS([AR], [ar gar], :)
 
 if test "$AR_FLAGS" = ""; then AR_FLAGS="rv"; fi
 AC_SUBST(AR_FLAGS)
-if test "$LD" = ""; then LD="$CC"; fi
+if test "$LD" = ""; then LD="$CXX"; fi
 AC_SUBST(LD)
 if test "$LDOUT" = ""; then LDOUT="-o "; fi
 AC_SUBST(LDOUT)


### PR DESCRIPTION
When building with Clang and enabled Sanitizer for Undefined Behavior it is important to use the C++ (and not the C) compiler to drive linking.

Otherwise linking fails with errors like:

```
/usr/bin/ld: output/pjsua2-test-x86_64-unknown-linux-gnu/main.o: in function `main':
main.cpp:(.text+0xaa): undefined reference to `__ubsan_vptr_type_cache'
```

To reproduce use something like that:
```
export CC="/usr/lib/llvm-14/bin/clang"
export CXX="/usr/lib/llvm-14/bin/clang++"
export CPPFLAGS="$CPPFLAGS -DNDEBUG"
export CXXFLAGS="$CXXFLAGS -stdlib=libstdc++ -std=gnu++17 -m64 -fPIC -O3 -fsanitize=undefined"
export CFLAGS="$CFLAGS -m64 -fPIC -O3 -fsanitize=undefined"
export LDFLAGS="$LDFLAGS -m64 -fsanitize=undefined"

./configure --disable-shared --enable-static --enable-epoll --disable-sound --disable-video --disable-speex-aec --disable-l16-codec --disable-gsm-codec --disable-g7221-codec --disable-speex-codec --disable-ilbc-codec --disable-sdl --disable-ffmpeg --disable-v4l2 --disable-openh264 --disable-opencore-amr --disable-silk --disable-opus --disable-bcg729 --disable-libyuv --disable-libwebrtc
make -C pjsip/build pjsua2-test -j24
```