### PR TITLE
Enable PendingJob use in PJSUA2 swig generated wrapper class

### DIFF
--- a/pjsip-apps/src/swig/java/sample.java
+++ b/pjsip-apps/src/swig/java/sample.java
@@ -19,9 +19,6 @@
 package org.pjsip.pjsua2.app;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.concurrent.ThreadLocalRandom;
-
 import org.pjsip.pjsua2.*;
 import org.pjsip.pjsua2.app.*;
 

--- a/pjsip-apps/src/swig/java/sample.java
+++ b/pjsip-apps/src/swig/java/sample.java
@@ -91,43 +91,26 @@ class MyObserver implements MyAppObserver {
 
 class MyJob extends PendingJob
 {
-    private MyJobHub hub;
-    public int id;
-
     @Override
     public void execute(boolean is_pending) {
-        System.out.println("Executing job id:" + id);
-        hub.delJob(this.id);
+        System.out.println("Executing job is_pending:" + is_pending);
     }
 
     protected void finalize() {
         System.out.println("Job deleted");
-    }
-
-    public MyJob(MyJobHub inHub) {
-        super(false);
-        hub = inHub;
-        id = ThreadLocalRandom.current().nextInt(1, 100000 + 1);
     }
 }
 
 class MyJobHub
 {
     Endpoint ep;
-    HashMap<Integer, MyJob> jobMap;
     public MyJobHub(Endpoint inEp) {
         ep = inEp;
-        jobMap = new HashMap();
     }
 
     public void setNewJob() {
-        MyJob job = new MyJob(this);
-        jobMap.put(job.id, job);
+        MyJob job = new MyJob();
         ep.utilAddPendingJob(job);
-    }
-
-    public void delJob(int id) {
-        jobMap.remove(id);
     }
 }
 
@@ -205,6 +188,7 @@ public class sample {
                 } catch (Exception e) {}
 
                 jobHub.setNewJob();
+                System.gc();
 
                 while (!Thread.currentThread().isInterrupted()) {
                         // Handle events

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -121,6 +121,7 @@ using namespace pj;
 %feature("director") FindBuddyMatch;
 %feature("director") AudioMediaPlayer;
 %feature("director") AudioMediaPort;
+%feature("director") PendingJob;
 
 //
 // STL stuff.

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -185,6 +185,9 @@ using namespace pj;
 %template(RtcpFbCapVector)              std::vector<pj::RtcpFbCap>;
 %template(SslCertNameVector)            std::vector<pj::SslCertName>;
 
+%refobject    pj::RefCountObj "$this->addRef();"
+%unrefobject  pj::RefCountObj "$this->delRef();"
+
 #if defined(__ANDROID__)
    %ignore pj::WindowHandle::display;
    %ignore pj::WindowHandle::window;

--- a/pjsip-apps/src/swig/python/test.py
+++ b/pjsip-apps/src/swig/python/test.py
@@ -4,6 +4,7 @@ import time
 from collections import deque
 from random import randint
 import struct
+import gc
 
 write=sys.stdout.write
 
@@ -227,14 +228,19 @@ class TestJob(pj.PendingJob):
      def __del__(self):
          print("Job deleted")
 
-class JobHub() :
+class MyJob(pj.PendingJob):
+     def __init__(self):
+        super().__init__()
+
+     def execute(self, is_pending):
+         print("Executing job, is_pending: ", is_pending)
+
+class MyJobHub() :
      def __init__(self, ep):
-         self.__jobList__ = {}
          self.__ep__ = ep
 
      def setNewJob(self):
-         job = TestJob(self)
-         self.__jobList__[job.getId()] = job
+         job = MyJob()
          self.__ep__.utilAddPendingJob(job)
 
      def delJob(self, id):
@@ -250,8 +256,10 @@ def ua_pending_job_test():
     ep.libInit(ep_cfg)
     ep.libStart()
 
-    hub = JobHub(ep)
+    hub = MyJobHub(ep)
     hub.setNewJob()
+    gc.collect()
+
     ep.libDestroy()
 
 #

--- a/pjsip-apps/src/swig/python/test.py
+++ b/pjsip-apps/src/swig/python/test.py
@@ -2,7 +2,6 @@ import pjsua2 as pj
 import sys
 import time
 from collections import deque
-from random import randint
 import struct
 import gc
 

--- a/pjsip-apps/src/swig/python/test.py
+++ b/pjsip-apps/src/swig/python/test.py
@@ -2,6 +2,7 @@ import pjsua2 as pj
 import sys
 import time
 from collections import deque
+from random import randint
 import struct
 
 write=sys.stdout.write
@@ -210,6 +211,49 @@ def ua_tonegen_test():
 
     ep.libDestroy()
 
+class TestJob(pj.PendingJob):
+     def __init__(self, hub):
+        super().__init__(False)
+        self.__id__ = randint(0, 100000)
+        self.__hub__ = hub
+
+     def execute(self, is_pending):
+         print("executing job id: ", self.__id__)
+         self.__hub__.delJob(self.__id__)
+
+     def getId(self):
+         return self.__id__
+
+     def __del__(self):
+         print("Job deleted")
+
+class JobHub() :
+     def __init__(self, ep):
+         self.__jobList__ = {}
+         self.__ep__ = ep
+
+     def setNewJob(self):
+         job = TestJob(self)
+         self.__jobList__[job.getId()] = job
+         self.__ep__.utilAddPendingJob(job)
+
+     def delJob(self, id):
+         del self.__jobList__[id]
+
+def ua_pending_job_test():
+    jobs = {}
+    write("PendingJob test.." + "\r\n")
+    ep_cfg = pj.EpConfig()
+
+    ep = pj.Endpoint()
+    ep.libCreate()
+    ep.libInit(ep_cfg)
+    ep.libStart()
+
+    hub = JobHub(ep)
+    hub.setNewJob()
+    ep.libDestroy()
+
 #
 # main()
 #
@@ -219,6 +263,7 @@ if __name__ == "__main__":
     ua_run_log_test()
     ua_run_ua_test()
     ua_tonegen_test()
+    ua_pending_job_test()
     sys.exit(0)
 
 

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1164,17 +1164,22 @@ struct PendingJob
 {
     PendingJob():autoDelete(true){};
 
-    /**
-     * If this is set to true, the job will be automatically be deleted
-     * after the job is executed.
-     */
-    bool    autoDelete;
+    PendingJob(bool autoDel):autoDelete(autoDel) {};
 
     /** Perform the job */
     virtual void execute(bool is_pending) = 0;
 
+    bool getAutoDelete() { return autoDelete; };
+
     /** Virtual destructor */
     virtual ~PendingJob() {}
+
+private:
+    /**
+     * If this is set to true, the job will be automatically be deleted
+     * after the job is executed.
+     */
+    bool autoDelete;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1159,27 +1159,41 @@ struct EpConfig : public PersistentObject
 
 };
 
+/* This will add reference counting capability. It is useful to enable
+ * object destruction based on reference counting.
+ */
+struct RefCountObj {
+    /** Return the current reference count. */
+    int refCount() const { return count; }
+
+    /** Add the reference count. */
+    int addRef() const { return add_ref(); }
+
+    /**
+     * Remove or delete reference count. This might delete the object if
+     * the reference count is 0.
+     */
+    int delRef() const;
+
+protected:
+    virtual ~RefCountObj() = 0;
+
+    int add_ref() const { return ++count; }
+
+    int del_ref() const { return --count; }
+
+private:
+    mutable int count;
+};
+
 /* This represents posted job */
-struct PendingJob
+struct PendingJob : public RefCountObj
 {
-    PendingJob():autoDelete(true){};
-
-    PendingJob(bool autoDel):autoDelete(autoDel) {};
-
     /** Perform the job */
     virtual void execute(bool is_pending) = 0;
 
-    bool getAutoDelete() { return autoDelete; };
-
     /** Virtual destructor */
     virtual ~PendingJob() {}
-
-private:
-    /**
-     * If this is set to true, the job will be automatically be deleted
-     * after the job is executed.
-     */
-    bool autoDelete;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1162,6 +1162,14 @@ struct EpConfig : public PersistentObject
 /* This represents posted job */
 struct PendingJob
 {
+    PendingJob():autoDelete(true){};
+
+    /**
+     * If this is set to true, the job will be automatically be deleted
+     * after the job is executed.
+     */
+    bool    autoDelete;
+
     /** Perform the job */
     virtual void execute(bool is_pending) = 0;
 


### PR DESCRIPTION
In order for PendingJob to be utilized, it must function as a base class. This patch will enable the use of PendingJob in SWIG generated wrapper class (e.g: java, cs, python).