### PR TITLE
Fix warnings

### DIFF
--- a/pjlib-util/src/pjlib-util/stun_simple_client.c
+++ b/pjlib-util/src/pjlib-util/stun_simple_client.c
@@ -345,7 +345,7 @@ PJ_DEF(pj_status_t) pjstun_get_mapped_addr2(pj_pool_factory *pf,
         }
     }
 
-    TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
+    TRACE_((THIS_FILE, "  Pool usage=%ld of %ld", pj_pool_get_used_size(pool),
             pj_pool_get_capacity(pool)));
 
     pj_pool_release(pool);

--- a/pjlib/src/pj/hash.c
+++ b/pjlib/src/pj/hash.c
@@ -187,7 +187,7 @@ static pj_hash_entry **find_entry( pj_pool_t *pool, pj_hash_table_t *ht,
 
         entry = PJ_POOL_ALLOC_T(pool, pj_hash_entry);
         PJ_LOG(6, ("hashtbl", 
-                   "%p: New p_entry %p created, pool used=%u, cap=%u", 
+                   "%p: New p_entry %p created, pool used=%lu, cap=%lu", 
                    ht, entry,  pj_pool_get_used_size(pool), 
                    pj_pool_get_capacity(pool)));
     }

--- a/pjlib/src/pj/pool.c
+++ b/pjlib/src/pj/pool.c
@@ -52,7 +52,7 @@ static pj_pool_block *pj_pool_create_block( pj_pool_t *pool, pj_size_t size)
     PJ_CHECK_STACK();
     pj_assert(size >= sizeof(pj_pool_block));
 
-    LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u", 
+    LOG((pool->obj_name, "create_block(sz=%lu), cur.cap=%lu, cur.used=%lu", 
          size, pool->capacity, pj_pool_get_used_size(pool)));
 
     /* Request memory from allocator. */
@@ -116,8 +116,8 @@ PJ_DEF(void*) pj_pool_allocate_find(pj_pool_t *pool, pj_size_t size)
 
     /* If pool is configured NOT to expand, return error. */
     if (pool->increment_size == 0) {
-        LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
-             "(used=%u, cap=%u)",
+        LOG((pool->obj_name, "Can't expand pool to allocate %lu bytes "
+             "(used=%lu, cap=%lu)",
              size, pj_pool_get_used_size(pool), pool->capacity));
         (*pool->callback)(pool, size);
         return NULL;
@@ -142,7 +142,7 @@ PJ_DEF(void*) pj_pool_allocate_find(pj_pool_t *pool, pj_size_t size)
     }
 
     LOG((pool->obj_name, 
-         "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
+         "%lu bytes requested, resizing pool by %lu bytes (used=%lu, cap=%lu)",
          size, block_size, pj_pool_get_used_size(pool), pool->capacity));
 
     block = pj_pool_create_block(pool, block_size);
@@ -233,7 +233,7 @@ PJ_DEF(pj_pool_t*) pj_pool_create_int( pj_pool_factory *f, const char *name,
     /* Pool initial capacity and used size */
     pool->capacity = initial_size;
 
-    LOG((pool->obj_name, "pool created, size=%u", pool->capacity));
+    LOG((pool->obj_name, "pool created, size=%lu", pool->capacity));
     return pool;
 }
 
@@ -278,7 +278,7 @@ static void reset_pool(pj_pool_t *pool)
  */
 PJ_DEF(void) pj_pool_reset(pj_pool_t *pool)
 {
-    LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)", 
+    LOG((pool->obj_name, "reset(): cap=%ld, used=%ld(%ld%%)", 
         pool->capacity, pj_pool_get_used_size(pool), 
         pj_pool_get_used_size(pool)*100/pool->capacity));
 
@@ -292,7 +292,7 @@ PJ_DEF(void) pj_pool_destroy_int(pj_pool_t *pool)
 {
     pj_size_t initial_size;
 
-    LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p", 
+    LOG((pool->obj_name, "destroy(): cap=%ld, used=%ld(%ld%%), block0=%p-%p", 
         pool->capacity, pj_pool_get_used_size(pool), 
         pj_pool_get_used_size(pool)*100/pool->capacity,
         ((pj_pool_block*)pool->block_list.next)->buf, 

--- a/pjlib/src/pj/pool_caching.c
+++ b/pjlib/src/pj/pool_caching.c
@@ -188,7 +188,7 @@ static pj_pool_t* cpool_create_pool(pj_pool_factory *pf,
             cp->capacity = 0;
         }
 
-        PJ_LOG(6, (pool->obj_name, "pool reused, size=%u", pool->capacity));
+        PJ_LOG(6, (pool->obj_name, "pool reused, size=%lu", pool->capacity));
     }
 
     /* Put in used list. */
@@ -245,7 +245,7 @@ static void cpool_release_pool( pj_pool_factory *pf, pj_pool_t *pool)
     }
 
     /* Reset pool. */
-    PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)", 
+    PJ_LOG(6, (pool->obj_name, "recycle(): cap=%ld, used=%ld(%ld%%)", 
                pool_capacity, pj_pool_get_used_size(pool), 
                pj_pool_get_used_size(pool)*100/pool_capacity));
     pj_pool_reset(pool);

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -381,7 +381,7 @@ static pj_status_t grow_heap(pj_timer_heap_t *ht)
     pj_timer_entry_dup *new_dup;
 #endif
 
-    PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
+    PJ_LOG(6,(THIS_FILE, "Growing heap size from %ld to %ld",
                          ht->max_size, new_size));
 
     // First grow the heap itself.

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -787,7 +787,7 @@ PJ_DEF(pj_status_t) pjsip_endpt_schedule_timer_dbg(pjsip_endpoint *endpt,
                                                     const char *src_file,
                                                     int src_line)
 {
-    PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
+    PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%lu.%lu)",
                          entry, delay->sec, delay->msec));
     return pj_timer_heap_schedule_dbg(endpt->timer_heap, entry, delay,
                                       src_file, src_line);
@@ -817,7 +817,7 @@ PJ_DEF(pj_status_t) pjsip_endpt_schedule_timer_w_grp_lock_dbg(
                                                     int src_line)
 {
     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer_w_grp_lock"
-                          "(entry=%p, delay=%u.%u, grp_lock=%p)",
+                          "(entry=%p, delay=%ld.%ld, grp_lock=%p)",
                           entry, delay->sec, delay->msec, grp_lock));
     return pj_timer_heap_schedule_w_grp_lock_dbg(endpt->timer_heap, entry,
                                                  delay, id_val, grp_lock,


### PR DESCRIPTION
I have following warnings.
Some warnings I have fixed, could you please take a look.
In file included from ../src/pj/hash.c:20:
../src/pj/hash.c: In function ‘find_entry’:
../src/pj/hash.c:190:20: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  190 |                    "%p: New p_entry %p created, pool used=%u, cap=%u",
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  191 |                    ht, entry,  pj_pool_get_used_size(pool),
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                |
      |                                pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/hash.c:189:9: note: in expansion of macro ‘PJ_LOG’
  189 |         PJ_LOG(6, ("hashtbl",
      |         ^~~~~~
../src/pj/hash.c:190:60: note: format string is defined here
  190 |                    "%p: New p_entry %p created, pool used=%u, cap=%u",
      |                                                           ~^
      |                                                            |
      |                                                            unsigned int
      |                                                           %lu
../src/pj/hash.c:190:20: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 6 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  190 |                    "%p: New p_entry %p created, pool used=%u, cap=%u",
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  191 |                    ht, entry,  pj_pool_get_used_size(pool),
  192 |                    pj_pool_get_capacity(pool)));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/hash.c:189:9: note: in expansion of macro ‘PJ_LOG’
  189 |         PJ_LOG(6, ("hashtbl",
      |         ^~~~~~
../src/pj/hash.c:190:68: note: format string is defined here
  190 |                    "%p: New p_entry %p created, pool used=%u, cap=%u",
      |                                                                   ~^
      |                                                                    |
      |                                                                    unsigned int
      |                                                                   %lu
In file included from ../src/pj/pool.c:20:
../src/pj/pool.c: In function ‘pj_pool_create_block’:
../src/pj/pool.c:55:26: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   56 |          size, pool->capacity, pj_pool_get_used_size(pool)));
      |          ~~~~             
      |          |
      |          pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:55:5: note: in expansion of macro ‘LOG’
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |     ^~~
../src/pj/pool.c:55:44: note: format string is defined here
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |                                           ~^
      |                                            |
      |                                            unsigned int
      |                                           %lu
../src/pj/pool.c:55:26: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   56 |          size, pool->capacity, pj_pool_get_used_size(pool)));
      |                ~~~~~~~~~~~~~~
      |                    |
      |                    pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:55:5: note: in expansion of macro ‘LOG’
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |     ^~~
../src/pj/pool.c:55:57: note: format string is defined here
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |                                                        ~^
      |                                                         |
      |                                                         unsigned int
      |                                                        %lu
../src/pj/pool.c:55:26: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   56 |          size, pool->capacity, pj_pool_get_used_size(pool)));
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                |
      |                                pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:55:5: note: in expansion of macro ‘LOG’
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |     ^~~
../src/pj/pool.c:55:70: note: format string is defined here
   55 |     LOG((pool->obj_name, "create_block(sz=%u), cur.cap=%u, cur.used=%u",
      |                                                                     ~^
      |                                                                      |
      |                                                                      unsigned int
      |                                                                     %lu
../src/pj/pool.c: In function ‘pj_pool_allocate_find’:
../src/pj/pool.c:119:30: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  120 |              "(used=%u, cap=%u)",
  121 |              size, pj_pool_get_used_size(pool), pool->capacity));
      |              ~~~~             
      |              |
      |              pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:119:9: note: in expansion of macro ‘LOG’
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |         ^~~
../src/pj/pool.c:119:62: note: format string is defined here
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |                                                             ~^
      |                                                              |
      |                                                              unsigned int
      |                                                             %lu
../src/pj/pool.c:119:30: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  120 |              "(used=%u, cap=%u)",
  121 |              size, pj_pool_get_used_size(pool), pool->capacity));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:119:9: note: in expansion of macro ‘LOG’
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |         ^~~
../src/pj/pool.c:119:30: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  120 |              "(used=%u, cap=%u)",
  121 |              size, pj_pool_get_used_size(pool), pool->capacity));
      |                                                 ~~~~~~~~~~~~~~
      |                                                     |
      |                                                     pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:119:9: note: in expansion of macro ‘LOG’
  119 |         LOG((pool->obj_name, "Can't expand pool to allocate %u bytes "
      |         ^~~
../src/pj/pool.c:145:10: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  146 |          size, block_size, pj_pool_get_used_size(pool), pool->capacity));
      |          ~~~~
      |          |
      |          pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:144:5: note: in expansion of macro ‘LOG’
  144 |     LOG((pool->obj_name,
      |     ^~~
../src/pj/pool.c:145:12: note: format string is defined here
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |           ~^
      |            |
      |            unsigned int
      |           %lu
../src/pj/pool.c:145:10: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  146 |          size, block_size, pj_pool_get_used_size(pool), pool->capacity));
      |                ~~~~~~~~~~
      |                |
      |                pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:144:5: note: in expansion of macro ‘LOG’
  144 |     LOG((pool->obj_name,
      |     ^~~
../src/pj/pool.c:145:49: note: format string is defined here
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |                                                ~^
      |                                                 |
      |                                                 unsigned int
      |                                                %lu
../src/pj/pool.c:145:10: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  146 |          size, block_size, pj_pool_get_used_size(pool), pool->capacity));
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            |
      |                            pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:144:5: note: in expansion of macro ‘LOG’
  144 |     LOG((pool->obj_name,
      |     ^~~
../src/pj/pool.c:145:64: note: format string is defined here
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |                                                               ~^
      |                                                                |
      |                                                                unsigned int
      |                                                               %lu
../src/pj/pool.c:145:10: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 6 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  146 |          size, block_size, pj_pool_get_used_size(pool), pool->capacity));
      |                                                         ~~~~~~~~~~~~~~
      |                                                             |
      |                                                             pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:144:5: note: in expansion of macro ‘LOG’
  144 |     LOG((pool->obj_name,
      |     ^~~
../src/pj/pool.c:145:72: note: format string is defined here
  145 |          "%u bytes requested, resizing pool by %u bytes (used=%u, cap=%u)",
      |                                                                       ~^
      |                                                                        |
      |                                                                        unsigned int
      |                                                                       %lu
../src/pj/pool.c: In function ‘pj_pool_create_int’:
../src/pj/pool.c:236:26: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  236 |     LOG((pool->obj_name, "pool created, size=%u", pool->capacity));
      |                          ^~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~
      |                                                       |
      |                                                       pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:236:5: note: in expansion of macro ‘LOG’
  236 |     LOG((pool->obj_name, "pool created, size=%u", pool->capacity));
      |     ^~~
../src/pj/pool.c:236:47: note: format string is defined here
  236 |     LOG((pool->obj_name, "pool created, size=%u", pool->capacity));
      |                                              ~^
      |                                               |
      |                                               unsigned int
      |                                              %lu
../src/pj/pool.c: In function ‘pj_pool_reset’:
../src/pj/pool.c:281:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  282 |         pool->capacity, pj_pool_get_used_size(pool),
      |         ~~~~~~~~~~~~~~    
      |             |
      |             pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:281:5: note: in expansion of macro ‘LOG’
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |     ^~~
../src/pj/pool.c:281:41: note: format string is defined here
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |                                        ~^
      |                                         |
      |                                         int
      |                                        %ld
../src/pj/pool.c:281:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  282 |         pool->capacity, pj_pool_get_used_size(pool),
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                         |
      |                         pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:281:5: note: in expansion of macro ‘LOG’
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |     ^~~
../src/pj/pool.c:281:50: note: format string is defined here
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |                                                 ~^
      |                                                  |
      |                                                  int
      |                                                 %ld
../src/pj/pool.c:281:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  282 |         pool->capacity, pj_pool_get_used_size(pool),
  283 |         pj_pool_get_used_size(pool)*100/pool->capacity));
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:281:5: note: in expansion of macro ‘LOG’
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |     ^~~
../src/pj/pool.c:281:53: note: format string is defined here
  281 |     LOG((pool->obj_name, "reset(): cap=%d, used=%d(%d%%)",
      |                                                    ~^
      |                                                     |
      |                                                     int
      |                                                    %ld
../src/pj/pool.c: In function ‘pj_pool_destroy_int’:
../src/pj/pool.c:295:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  296 |         pool->capacity, pj_pool_get_used_size(pool),
      |         ~~~~~~~~~~~~~~    
      |             |
      |             pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:295:5: note: in expansion of macro ‘LOG’
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |     ^~~
../src/pj/pool.c:295:43: note: format string is defined here
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |                                          ~^
      |                                           |
      |                                           int
      |                                          %ld
../src/pj/pool.c:295:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  296 |         pool->capacity, pj_pool_get_used_size(pool),
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                         |
      |                         pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:295:5: note: in expansion of macro ‘LOG’
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |     ^~~
../src/pj/pool.c:295:52: note: format string is defined here
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |                                                   ~^
      |                                                    |
      |                                                    int
      |                                                   %ld
../src/pj/pool.c:295:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  296 |         pool->capacity, pj_pool_get_used_size(pool),
  297 |         pj_pool_get_used_size(pool)*100/pool->capacity,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool.c:33:37: note: in expansion of macro ‘PJ_LOG’
   33 | #define LOG(expr)                   PJ_LOG(6,expr)
      |                                     ^~~~~~
../src/pj/pool.c:295:5: note: in expansion of macro ‘LOG’
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |     ^~~
../src/pj/pool.c:295:55: note: format string is defined here
  295 |     LOG((pool->obj_name, "destroy(): cap=%d, used=%d(%d%%), block0=%p-%p",
      |                                                      ~^
      |                                                       |
      |                                                       int
      |                                                      %ld
In file included from ../src/pj/pool_caching.c:21:
../src/pj/pool_caching.c: In function ‘cpool_create_pool’:
../src/pj/pool_caching.c:191:36: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  191 |         PJ_LOG(6, (pool->obj_name, "pool reused, size=%u", pool->capacity));
      |                                    ^~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~
      |                                                                |
      |                                                                pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool_caching.c:191:9: note: in expansion of macro ‘PJ_LOG’
  191 |         PJ_LOG(6, (pool->obj_name, "pool reused, size=%u", pool->capacity));
      |         ^~~~~~
../src/pj/pool_caching.c:191:56: note: format string is defined here
  191 |         PJ_LOG(6, (pool->obj_name, "pool reused, size=%u", pool->capacity));
      |                                                       ~^
      |                                                        |
      |                                                        unsigned int
      |                                                       %lu
../src/pj/pool_caching.c: In function ‘cpool_release_pool’:
../src/pj/pool_caching.c:248:32: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  249 |                pool_capacity, pj_pool_get_used_size(pool),
      |                ~~~~~~~~~~~~~    
      |                |
      |                pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool_caching.c:248:5: note: in expansion of macro ‘PJ_LOG’
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |     ^~~~~~
../src/pj/pool_caching.c:248:49: note: format string is defined here
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |                                                ~^
      |                                                 |
      |                                                 int
      |                                                %ld
../src/pj/pool_caching.c:248:32: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  249 |                pool_capacity, pj_pool_get_used_size(pool),
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                               |
      |                               pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool_caching.c:248:5: note: in expansion of macro ‘PJ_LOG’
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |     ^~~~~~
../src/pj/pool_caching.c:248:58: note: format string is defined here
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |                                                         ~^
      |                                                          |
      |                                                          int
      |                                                         %ld
../src/pj/pool_caching.c:248:32: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  249 |                pool_capacity, pj_pool_get_used_size(pool),
  250 |                pj_pool_get_used_size(pool)*100/pool_capacity));
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/pool_caching.c:248:5: note: in expansion of macro ‘PJ_LOG’
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |     ^~~~~~
../src/pj/pool_caching.c:248:61: note: format string is defined here
  248 |     PJ_LOG(6, (pool->obj_name, "recycle(): cap=%d, used=%d(%d%%)",
      |                                                            ~^
      |                                                             |
      |                                                             int
      |                                                            %ld
In file included from ../src/pj/timer.c:36:
../src/pj/timer.c: In function ‘grow_heap’:
../src/pj/timer.c:384:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  384 |     PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  385 |                          ht->max_size, new_size));
      |                          ~~~~~~~~~~~~
      |                            |
      |                            pj_size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/timer.c:384:5: note: in expansion of macro ‘PJ_LOG’
  384 |     PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
      |     ^~~~~~
../src/pj/timer.c:384:51: note: format string is defined here
  384 |     PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
      |                                                  ~^
      |                                                   |
      |                                                   int
      |                                                  %ld
../src/pj/timer.c:384:26: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  384 |     PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  385 |                          ht->max_size, new_size));
      |                                        ~~~~~~~~
      |                                        |
      |                                        size_t {aka long unsigned int}
../include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pj/timer.c:384:5: note: in expansion of macro ‘PJ_LOG’
  384 |     PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
      |     ^~~~~~
../src/pj/timer.c:384:57: note: format string is defined here
  384 |     PJ_LOG(6,(THIS_FILE, "Growing heap size from %d to %d",
      |                                                        ~^
      |                                                         |
      |                                                         int
      |                                                        %ld
ar: creating ../lib/libpj-x86_64-unknown-linux-gnu.a
( make -C source/pjlib-util/build libpjlib-util-x86_64-unknown-linux-gnu.a >/dev/null ) 
In file included from ../src/pjlib-util/stun_simple_client.c:22:
../src/pjlib-util/stun_simple_client.c: In function ‘pjstun_get_mapped_addr2’:
../src/pjlib-util/stun_simple_client.c:348:24: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  348 |     TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
      |                        ^~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                 |
      |                                                 pj_size_t {aka long unsigned int}
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjlib-util/stun_simple_client.c:36:25: note: in expansion of macro ‘PJ_LOG’
   36 | #define TRACE_(x)       PJ_LOG(6,x)
      |                         ^~~~~~
../src/pjlib-util/stun_simple_client.c:348:5: note: in expansion of macro ‘TRACE_’
  348 |     TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
      |     ^~~~~~
../src/pjlib-util/stun_simple_client.c:348:39: note: format string is defined here
  348 |     TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
      |                                      ~^
      |                                       |
      |                                       int
      |                                      %ld
../src/pjlib-util/stun_simple_client.c:348:24: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘pj_size_t’ {aka ‘long unsigned int’} [-Wformat=]
  348 |     TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
  349 |             pj_pool_get_capacity(pool)));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             |
      |             pj_size_t {aka long unsigned int}
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjlib-util/stun_simple_client.c:36:25: note: in expansion of macro ‘PJ_LOG’
   36 | #define TRACE_(x)       PJ_LOG(6,x)
      |                         ^~~~~~
../src/pjlib-util/stun_simple_client.c:348:5: note: in expansion of macro ‘TRACE_’
  348 |     TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
      |     ^~~~~~
../src/pjlib-util/stun_simple_client.c:348:45: note: format string is defined here
  348 |     TRACE_((THIS_FILE, "  Pool usage=%d of %d", pj_pool_get_used_size(pool),
      |                                            ~^
      |                                             |
      |                                             int
      |                                            %ld
ar: creating ../lib/libpjlib-util-x86_64-unknown-linux-gnu.a
( make -C source/pjsip/build libpjsua-x86_64-unknown-linux-gnu.a >/dev/null ) 
In file included from ../../pjlib/include/pj/except.h:29,
                 from ../src/pjsip/sip_endpoint.c:27:
../src/pjsip/sip_endpoint.c: In function ‘pjsip_endpt_schedule_timer_dbg’:
../src/pjsip/sip_endpoint.c:790:27: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘long int’ [-Wformat=]
  790 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  791 |                          entry, delay->sec, delay->msec));
      |                                 ~~~~~~~~~~
      |                                      |
      |                                      long int
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_endpoint.c:790:5: note: in expansion of macro ‘PJ_LOG’
  790 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
      |     ^~~~~~
../src/pjsip/sip_endpoint.c:790:72: note: format string is defined here
  790 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
      |                                                                       ~^
      |                                                                        |
      |                                                                        unsigned int
      |                                                                       %lu
../src/pjsip/sip_endpoint.c:790:27: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘long int’ [-Wformat=]
  790 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  791 |                          entry, delay->sec, delay->msec));
      |                                             ~~~~~~~~~~~
      |                                                  |
      |                                                  long int
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_endpoint.c:790:5: note: in expansion of macro ‘PJ_LOG’
  790 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
      |     ^~~~~~
../src/pjsip/sip_endpoint.c:790:75: note: format string is defined here
  790 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer(entry=%p, delay=%u.%u)",
      |                                                                          ~^
      |                                                                           |
      |                                                                           unsigned int
      |                                                                          %lu
../src/pjsip/sip_endpoint.c: In function ‘pjsip_endpt_schedule_timer_w_grp_lock_dbg’:
../src/pjsip/sip_endpoint.c:819:27: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘long int’ [-Wformat=]
  819 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer_w_grp_lock"
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  820 |                           "(entry=%p, delay=%u.%u, grp_lock=%p)",
  821 |                           entry, delay->sec, delay->msec, grp_lock));
      |                                  ~~~~~~~~~~
      |                                       |
      |                                       long int
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_endpoint.c:819:5: note: in expansion of macro ‘PJ_LOG’
  819 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer_w_grp_lock"
      |     ^~~~~~
../src/pjsip/sip_endpoint.c:819:27: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘long int’ [-Wformat=]
  819 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer_w_grp_lock"
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  820 |                           "(entry=%p, delay=%u.%u, grp_lock=%p)",
  821 |                           entry, delay->sec, delay->msec, grp_lock));
      |                                              ~~~~~~~~~~~
      |                                                   |
      |                                                   long int
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_endpoint.c:819:5: note: in expansion of macro ‘PJ_LOG’
  819 |     PJ_LOG(6, (THIS_FILE, "pjsip_endpt_schedule_timer_w_grp_lock"
      |     ^~~~~~
In file included from ../src/pjsip/sip_transaction.c:33:
../src/pjsip/sip_transaction.c: In function ‘pjsip_tsx_create_uac2’:
../src/pjsip/sip_transaction.c:1585:31: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 3 has type ‘pj_ssize_t’ {aka ‘long int’} [-Wformat=]
 1585 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                               ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                   |
      |                                                                   pj_ssize_t {aka long int}
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_transaction.c:1585:5: note: in expansion of macro ‘PJ_LOG’
 1585 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |     ^~~~~~
../src/pjsip/sip_transaction.c:1585:42: note: format string is defined here
 1585 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                                        ~~^~
      |                                          |
      |                                          int
../src/pjsip/sip_transaction.c: In function ‘pjsip_tsx_create_uas2’:
../src/pjsip/sip_transaction.c:1744:31: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 3 has type ‘pj_ssize_t’ {aka ‘long int’} [-Wformat=]
 1744 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                               ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                   |
      |                                                                   pj_ssize_t {aka long int}
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_transaction.c:1744:5: note: in expansion of macro ‘PJ_LOG’
 1744 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |     ^~~~~~
../src/pjsip/sip_transaction.c:1744:42: note: format string is defined here
 1744 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                                        ~~^~
      |                                          |
      |                                          int