### PR TITLE
Fix warnings

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -1601,7 +1601,7 @@ PJ_DEF(pj_status_t) pjsip_tsx_create_uac2(pjsip_module *tsx_user,
     tsx->hashed_key = pj_hash_calc_tolower(0, NULL, &tsx->transaction_key);
 #endif
 
-    PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
+    PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", (int)tsx->transaction_key.slen,
                tsx->transaction_key.ptr));
 
     /* Begin with State_Null.
@@ -1760,7 +1760,7 @@ PJ_DEF(pj_status_t) pjsip_tsx_create_uas2(pjsip_module *tsx_user,
     branch = &rdata->msg_info.via->branch_param;
     pj_strdup(tsx->pool, &tsx->branch, branch);
 
-    PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
+    PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", (int)tsx->transaction_key.slen,
                tsx->transaction_key.ptr));
 
 


### PR DESCRIPTION
To fix this warnings:

In file included from ../src/pjsip/sip_transaction.c:33:
../src/pjsip/sip_transaction.c: In function ‘pjsip_tsx_create_uac2’:
../src/pjsip/sip_transaction.c:1585:31: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 3 has type ‘pj_ssize_t’ {aka ‘long int’} [-Wformat=]
 1585 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                               ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                   |
      |                                                                   pj_ssize_t {aka long int}
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_transaction.c:1585:5: note: in expansion of macro ‘PJ_LOG’
 1585 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |     ^~~~~~
../src/pjsip/sip_transaction.c:1585:42: note: format string is defined here
 1585 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                                        ~~^~
      |                                          |
      |                                          int
../src/pjsip/sip_transaction.c: In function ‘pjsip_tsx_create_uas2’:
../src/pjsip/sip_transaction.c:1744:31: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 3 has type ‘pj_ssize_t’ {aka ‘long int’} [-Wformat=]
 1744 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                               ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                   |
      |                                                                   pj_ssize_t {aka long int}
../../pjlib/include/pj/log.h:475:50: note: in definition of macro ‘pj_log_wrapper_6’
  475 |     #define pj_log_wrapper_6(arg)       pj_log_6 arg
      |                                                  ^~~
../src/pjsip/sip_transaction.c:1744:5: note: in expansion of macro ‘PJ_LOG’
 1744 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |     ^~~~~~
../src/pjsip/sip_transaction.c:1744:42: note: format string is defined here
 1744 |     PJ_LOG(6, (tsx->obj_name, "tsx_key=%.*s", tsx->transaction_key.slen,
      |                                        ~~^~
      |                                          |
      |                                          int
