### PR TITLE
ACK not sent using an existing TLS transport

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1878,6 +1878,11 @@ static void dlg_update_routeset(pjsip_dialog *dlg, const pjsip_rx_data *rdata)
         {
             pj_strdup(dlg->pool, &dlg->initial_dest,
                       &rdata->tp_info.transport->remote_name.host);
+        } else {
+            /* Reset the stored remote name if the transport is a server
+             * transport.
+             */
+            dlg->initial_dest.slen = 0;
         }
 
         /* Ignore subsequent request from remote */


### PR DESCRIPTION
### Scenario
1. connect to a remote TLS server & send INVITE
2. receive 100 & 180 responses
3. TLS connection dropped (due to IP change), so remote initiates a new TLS connection from a different IP address
4. receive 200 response
5. send ACK will initiate another TLS connection instead of reusing the existing (established in step 3).

### Analysis
The dialog will store the remote name in `dlg->intial_dest` in step 1 (see #3310)  by `dlg_update_routeset()`:
https://github.com/pjsip/pjproject/blob/c224f26420f2f17c6a67a186e84127fecbd37331/pjsip/src/pjsip/sip_dialog.c#L1876-L1881
And in step 4, the remote name is supposed to be updated/reset by the same code above, but it does not happen as the transport used by 200 response is a server transport. So in sending the ACK in step 5, the transport manager won't find/reuse the transport created in step 3 because it is being requested for remote address in step 3 but with wrong/old remote name (set by step 1). Note that a TLS transport can be reused if it matches both: remote address and remote name (for TLS verification).

Resetting the dialog's remote name should be sufficient because later it will be initialized to the target address by `pjsip_endpt_send_request_stateless()` (or `pjsip_endpt_send_response()` if it is a response).

Thanks to Peter Koletzki for the report.
