### PR TITLE
add PJSUA_DETECT_MERGED_REQUEST parameter

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -427,14 +427,14 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #endif
 
 /**
- * Defines is PJSUA will detect merged requests per RFC 3261 section 8.2.2.2.
- * In a case of merged request appears, PJSUA will respond with 482 - Loop Detected
- * This option is needed in a case of legit accepting different branches of a same transaction.
+ * Specify if PJSUA should check for merged requests as per RFC 3261 section
+ * 8.2.2.2. If a merged request is detected, PJSUA will automatically reply
+ * with a 482 - Loop Detected.
  *
- * Default: Yes
+ * Default: 1 (enabled)
  */
-#ifndef PJSUA_DETECT_MERGED_REQUEST
-#   define PJSUA_DETECT_MERGED_REQUEST  1
+#ifndef PJSUA_DETECT_MERGED_REQUESTS
+#   define PJSUA_DETECT_MERGED_REQUESTS  1
 #endif
 
 /**

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -426,6 +426,16 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #   define PJSUA_TRICKLE_ICE_NEW_CAND_CHECK_INTERVAL    100
 #endif
 
+/**
+ * Defines is PJSUA will detect merged requests per RFC 3261 section 8.2.2.2.
+ * In a case of merged request appears, PJSUA will respond with 482 - Loop Detected
+ * This option is needed in a case of legit accepting different branches of a same transaction.
+ *
+ * Default: Yes
+ */
+#ifndef PJSUA_DETECT_MERGED_REQUEST
+#   define PJSUA_DETECT_MERGED_REQUEST  1
+#endif
 
 /**
  * This enumeration represents pjsua state.

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -663,7 +663,7 @@ static pj_bool_t mod_pjsua_on_rx_request(pjsip_rx_data *rdata)
 {
     pj_bool_t processed = PJ_FALSE;
 
-#if PJSUA_DETECT_MERGED_REQUEST
+#if PJSUA_DETECT_MERGED_REQUESTS
     if (pjsip_tsx_detect_merged_requests(rdata)) {
         PJ_LOG(4, (THIS_FILE, "Merged request detected"));
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -663,6 +663,7 @@ static pj_bool_t mod_pjsua_on_rx_request(pjsip_rx_data *rdata)
 {
     pj_bool_t processed = PJ_FALSE;
 
+#if PJSUA_DETECT_MERGED_REQUEST
     if (pjsip_tsx_detect_merged_requests(rdata)) {
         PJ_LOG(4, (THIS_FILE, "Merged request detected"));
 
@@ -673,6 +674,7 @@ static pj_bool_t mod_pjsua_on_rx_request(pjsip_rx_data *rdata)
 
         return PJ_TRUE;
     }
+#endif
 
     PJSUA_LOCK();
 


### PR DESCRIPTION
In my case I'm using pjsua as a test tool, and I need to accept all type of calls including same transaction calls, but different branches. As Merged Requests mechanism is relies on From tag,   Call-ID, and CSeq, different branches are detected as Merged request.
This option adds a possibility to control it in compile-time.