### PR TITLE
pjsua2: add destroyPlayer to AudioMediaPlayer

### DIFF
--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -535,6 +535,8 @@ struct AudioMediaPlayerInfo
      */
     pj_uint32_t         sizeSamples;
 
+    int                 playerId;
+
 public:
     /**
      * Default constructor
@@ -571,6 +573,13 @@ public:
      */
     void createPlayer(const string &file_name,
                       unsigned options=0) PJSUA2_THROW(Error);
+
+    /**
+     * Destroy specific player to get resource immediatly.
+     * @param playerID  The id of the player returned by 
+     *                  AudioMediaPlayerInfo::getInfo()
+    */
+    void destroyPlayer(const int &playerID);
 
     /**
      * Create a file playlist media port, and automatically add the port

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -535,8 +535,6 @@ struct AudioMediaPlayerInfo
      */
     pj_uint32_t         sizeSamples;
 
-    int                 playerId;
-
 public:
     /**
      * Default constructor
@@ -575,11 +573,12 @@ public:
                       unsigned options=0) PJSUA2_THROW(Error);
 
     /**
-     * Destroy specific player to get resource immediatly.
-     * @param playerID  The id of the player returned by 
-     *                  AudioMediaPlayerInfo::getInfo()
+     * Destroy player to get resource immediatly.
+     *
+     * It's the same that making a Dispose, but ideal when using a GC language
+     * that needs to deference the player and wait for GC to acts.
     */
-    void destroyPlayer(const int &playerID);
+    void destroyPlayer();
 
     /**
      * Create a file playlist media port, and automatically add the port

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -362,10 +362,12 @@ AudioMediaPlayer::~AudioMediaPlayer()
     }
 }
 
-void AudioMediaPlayer::destroyPlayer(const int &playerID)
+void AudioMediaPlayer::destroyPlayer()
 {
-    PJ_LOG(4,(THIS_FILE, "Destroying specific player %d", playerID));
-    pjsua_player_destroy(playerId);
+    if (playerId != PJSUA_INVALID_ID) {
+        PJSUA2_CATCH_IGNORE( unregisterMediaPort() );
+        pjsua_player_destroy(playerId);
+    }
 }
 
 void AudioMediaPlayer::createPlayer(const string &file_name,
@@ -463,7 +465,6 @@ AudioMediaPlayerInfo AudioMediaPlayer::getInfo() const PJSUA2_THROW(Error)
     info.payloadBitsPerSample   = pj_info.payload_bits_per_sample;
     info.sizeBytes              = pj_info.size_bytes;
     info.sizeSamples            = pj_info.size_samples;
-    info.playerId               = playerId;
 
     return info;
 }

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -362,6 +362,12 @@ AudioMediaPlayer::~AudioMediaPlayer()
     }
 }
 
+void AudioMediaPlayer::destroyPlayer(const int &playerID)
+{
+    PJ_LOG(4,(THIS_FILE, "Destroying specific player %d", playerID));
+    pjsua_player_destroy(playerId);
+}
+
 void AudioMediaPlayer::createPlayer(const string &file_name,
                                     unsigned options)
                                     PJSUA2_THROW(Error)
@@ -457,6 +463,7 @@ AudioMediaPlayerInfo AudioMediaPlayer::getInfo() const PJSUA2_THROW(Error)
     info.payloadBitsPerSample   = pj_info.payload_bits_per_sample;
     info.sizeBytes              = pj_info.size_bytes;
     info.sizeSamples            = pj_info.size_samples;
+    info.playerId               = playerId;
 
     return info;
 }


### PR DESCRIPTION
With this, the dev can destroy a specific player when needed without wait GC in some languages with not Dispose