### PR TITLE
Use of uninitialized values

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -3362,7 +3362,7 @@ PJ_DEF(pj_status_t) pjsua_verify_sip_url(const char *c_url)
     pool = pj_pool_create(&pjsua_var.cp.factory, "check%p", 1024, 0, NULL);
     if (!pool) return PJ_ENOMEM;
 
-    url = (char*) pj_pool_alloc(pool, len+1);
+    url = (char*) pj_pool_calloc(pool, 1, len+1);
     pj_ansi_strxcpy(url, c_url, len+1);
 
     p = pjsip_parse_uri(pool, url, len, 0);


### PR DESCRIPTION
Make pjsua_verify_sip_url() initialzied url to 0.

When running Valgrind in our apps we got the following issues reported:
```
==3012942== 3 errors in context 1 of 12:
==3012942== Conditional jump or move depends on uninitialised value(s)
==3012942==    at 0x49E18B3: pj_ansi_strxcpy (in ../git/libsipd_check.so)
==3012942==    by 0x49293AA: pjsua_verify_sip_url (in ../git/libsipd_check.so)
```
and was able to track it down to url not being initialized in _**pjsua_verify_sip_url()**_ but still being used in _**pj_ansi_strxcpy()**_. 
Fixed it by using calloc instead of alloc.