### PR TITLE
Include PJSIP module data in cloning pjsip_rx_data

### DIFF
--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -511,7 +511,7 @@ PJ_DECL(char*) pjsip_rx_data_get_info(pjsip_rx_data *rdata);
  * fills the \a endpt_info (i.e. the \a mod_data) with zeros.
  *
  * @param src       The source to be cloned.
- * @param flags     The clone flags, see pjsip_rx_data_clone_flag.
+ * @param flags     The clone flags, see #pjsip_rx_data_clone_flag.
  * @param p_rdata   Pointer to receive the cloned rdata.
  *
  * @return          PJ_SUCCESS on success or the appropriate error.

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -463,6 +463,33 @@ struct pjsip_rx_data
 
 };
 
+
+/**
+ * This enumerator describes the options for cloning pjsip_rx_data.
+ */
+typedef enum pjsip_rx_data_clone_flag
+{
+    /**
+     * The clone will copy transport pointer in \a tp_info, duplicates
+     * the \a pkt_info, perform deep clone of the \a msg_info parts of
+     * the rdata, and fills the \a endpt_info (i.e. the \a mod_data)
+     * with zeros.
+     */
+    PJSIP_RX_DATA_CLONE_DEFAULT         = 0,
+
+    /**
+     * The clone behavior will be the same as PJSIP_RX_DATA_CLONE_DEFAULT,
+     * except this will also copy the \a endpt_info (i.e. the \a mod_data).
+     *
+     * The mod_data is used by PJSIP module to store its data, for example
+     * the transaction module uses it to link pjsip_rx_data to transaction
+     * instance (see pjsip_rdata_get_tsx()).
+     */
+    PJSIP_RX_DATA_CLONE_ENDPT_INFO      = 1
+
+} pjsip_rx_data_clone_flag;
+
+
 /**
  * Get printable information about the message in the rdata.
  *
@@ -484,7 +511,7 @@ PJ_DECL(char*) pjsip_rx_data_get_info(pjsip_rx_data *rdata);
  * fills the \a endpt_info (i.e. the \a mod_data) with zeros.
  *
  * @param src       The source to be cloned.
- * @param flags     Optional flags. Must be zero for now.
+ * @param flags     The clone flags, see pjsip_rx_data_clone_flag.
  * @param p_rdata   Pointer to receive the cloned rdata.
  *
  * @return          PJ_SUCCESS on success or the appropriate error.

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -781,7 +781,8 @@ PJ_DEF(pj_status_t) pjsip_rx_data_clone( const pjsip_rx_data *src,
     pjsip_rx_data *dst;
     pjsip_hdr *hdr;
 
-    PJ_ASSERT_RETURN(src && flags==0 && p_rdata, PJ_EINVAL);
+    PJ_ASSERT_RETURN(src && p_rdata, PJ_EINVAL);
+    PJ_ASSERT_RETURN(flags <= PJSIP_RX_DATA_CLONE_ENDPT_INFO, PJ_EINVAL);
 
     pool = pj_pool_create(src->tp_info.pool->factory,
                           "rtd%p",
@@ -838,6 +839,11 @@ PJ_DEF(pj_status_t) pjsip_rx_data_clone( const pjsip_rx_data *src,
 
 #undef GET_MSG_HDR
 #undef GET_MSG_HDR2
+
+    /* Copy endpt_info */
+    if (flags == PJSIP_RX_DATA_CLONE_ENDPT_INFO) {
+        pj_memcpy(&dst->endpt_info, &src->endpt_info, sizeof(src->endpt_info));
+    }
 
     *p_rdata = dst;
 


### PR DESCRIPTION
Currently `pjsip_rx_data_clone()` always excludes PJSIP module data field (i.e: `endpt_info/mod_data`) in cloning `pjsip_rx_data`. This PR introduce a new flag `PJSIP_RX_DATA_CLONE_ENDPT_INFO` to also copy that field.