### PR TITLE
Fixed deadlock between stream and ICE

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1090,7 +1090,8 @@ static pj_status_t send_rtcp(pjmedia_stream *stream,
      * of rtcp packet buffer. And to avoid deadlock with media transport,
      * we use the transport's group lock.
      */
-    pj_grp_lock_acquire(stream->transport->grp_lock);
+    if (stream->transport->grp_lock)
+        pj_grp_lock_acquire(stream->transport->grp_lock);
 
     /* Build RTCP RR/SR packet */
     pjmedia_rtcp_build_rtcp(&stream->rtcp, &sr_rr_pkt, &len);
@@ -1211,7 +1212,8 @@ static pj_status_t send_rtcp(pjmedia_stream *stream,
         }
     }
 
-    pj_grp_lock_release(stream->transport->grp_lock);
+    if (stream->transport->grp_lock)
+        pj_grp_lock_release(stream->transport->grp_lock);
 
     return status;
 }

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -161,7 +161,6 @@ struct pjmedia_stream
     pj_uint32_t              tx_duration;   /**< TX duration in timestamp.  */
 
     pj_mutex_t              *jb_mutex;
-    pj_mutex_t              *rtcp_mutex;
     pjmedia_jbuf            *jb;            /**< Jitter buffer.             */
     char                     jb_last_frm;   /**< Last frame type from jb    */
     unsigned                 jb_last_frm_cnt;/**< Last JB frame type counter*/
@@ -1088,9 +1087,10 @@ static pj_status_t send_rtcp(pjmedia_stream *stream,
     pj_status_t status;
 
     /* We need to prevent data race since there is only a single instance
-     * of rtcp packet buffer.
+     * of rtcp packet buffer. And to avoid deadlock with media transport,
+     * we use the transport's group lock.
      */
-    pj_mutex_lock(stream->rtcp_mutex);
+    pj_grp_lock_acquire(stream->transport->grp_lock);
 
     /* Build RTCP RR/SR packet */
     pjmedia_rtcp_build_rtcp(&stream->rtcp, &sr_rr_pkt, &len);
@@ -1211,7 +1211,7 @@ static pj_status_t send_rtcp(pjmedia_stream *stream,
         }
     }
 
-    pj_mutex_unlock(stream->rtcp_mutex);
+    pj_grp_lock_release(stream->transport->grp_lock);
 
     return status;
 }
@@ -2533,12 +2533,8 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
     }
 
     /* Create mutex to protect jitter buffer: */
-    status = pj_mutex_create_simple(pool, NULL, &stream->jb_mutex);
-    if (status != PJ_SUCCESS)
-        goto err_cleanup;
 
-    /* Create mutex for RTCP purposes */
-    status = pj_mutex_create_simple(pool, NULL, &stream->rtcp_mutex);
+    status = pj_mutex_create_simple(pool, NULL, &stream->jb_mutex);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
 
@@ -3072,9 +3068,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_destroy( pjmedia_stream *stream )
     PJ_ASSERT_RETURN(stream != NULL, PJ_EINVAL);
 
     /* Send RTCP BYE (also SDES & XR) */
-    if (stream->transport && stream->rtcp_mutex &&
-        !stream->rtcp_sdes_bye_disabled)
-    {
+    if (stream->transport && !stream->rtcp_sdes_bye_disabled) {
 #if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
         send_rtcp(stream, PJ_TRUE, PJ_TRUE, stream->rtcp.xr_enabled, PJ_FALSE);
 #else
@@ -3158,11 +3152,6 @@ PJ_DEF(pj_status_t) pjmedia_stream_destroy( pjmedia_stream *stream )
         pj_mutex_unlock(stream->jb_mutex);
         pj_mutex_destroy(stream->jb_mutex);
         stream->jb_mutex = NULL;
-    }
-
-    if (stream->rtcp_mutex) {
-        pj_mutex_destroy(stream->rtcp_mutex);
-        stream->rtcp_mutex = NULL;
     }
 
     /* Destroy jitter buffer */

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -588,7 +588,8 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
     /* To avoid deadlock with media transport, we use the transport's
      * group lock.
      */
-    pj_grp_lock_acquire( stream->transport->grp_lock );
+    if (stream->transport->grp_lock)
+        pj_grp_lock_acquire( stream->transport->grp_lock );
 
     /* Build RTCP RR/SR packet */
     pjmedia_rtcp_build_rtcp(&stream->rtcp, &sr_rr_pkt, &len);
@@ -671,7 +672,8 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
         }
     }
 
-    pj_grp_lock_release( stream->transport->grp_lock );
+    if (stream->transport->grp_lock)
+        pj_grp_lock_release( stream->transport->grp_lock );
 
     return status;
 }

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -107,6 +107,7 @@ struct pjmedia_vid_stream
     pjmedia_vid_codec_mgr   *codec_mgr;     /**< Codec manager.             */
     pjmedia_vid_stream_info  info;          /**< Stream info.               */
     pj_grp_lock_t           *grp_lock;      /**< Stream lock.               */
+    pj_mutex_t              *rtcp_mutex;    /**< RTCP mutex.                */
 
     pjmedia_vid_channel     *enc;           /**< Encoding channel.          */
     pjmedia_vid_channel     *dec;           /**< Decoding channel.          */
@@ -584,7 +585,7 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
     int len, max_len;
     pj_status_t status;
 
-    pj_grp_lock_acquire( stream->grp_lock );
+    pj_mutex_lock(stream->rtcp_mutex);
 
     /* Build RTCP RR/SR packet */
     pjmedia_rtcp_build_rtcp(&stream->rtcp, &sr_rr_pkt, &len);
@@ -667,7 +668,7 @@ static pj_status_t send_rtcp(pjmedia_vid_stream *stream,
         }
     }
 
-    pj_grp_lock_release( stream->grp_lock );
+    pj_mutex_unlock(stream->rtcp_mutex);
 
     return status;
 }
@@ -1843,6 +1844,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
         stream->cname.slen = p - stream->cname.ptr;
     }
 
+    /* Create mutex for RTCP purposes */
+    status = pj_mutex_create_simple(pool, NULL, &stream->rtcp_mutex);
+    if (status != PJ_SUCCESS)
+        goto err_cleanup;
+
     /* Create group lock */
     status = pj_grp_lock_create_w_handler(pool, NULL, stream, 
                                           &on_destroy,
@@ -2191,7 +2197,9 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
     pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream, &stream->rtcp);
 
     /* Send RTCP BYE (also SDES) */
-    if (stream->transport && stream->grp_lock && !stream->rtcp_sdes_bye_disabled) {
+    if (stream->transport && stream->rtcp_mutex &&
+        !stream->rtcp_sdes_bye_disabled)
+    {
         send_rtcp(stream, PJ_TRUE, PJ_TRUE, PJ_FALSE, PJ_FALSE);
     }
 
@@ -2235,6 +2243,10 @@ static void on_destroy( void *arg )
     }
 
     /* Free mutex */
+    if (stream->rtcp_mutex) {
+        pj_mutex_destroy(stream->rtcp_mutex);
+        stream->rtcp_mutex = NULL;
+    }
     stream->grp_lock = NULL;
 
     /* Destroy jitter buffer */


### PR DESCRIPTION
It is reported that a deadlock can occur between stream and ICE:

```
SIPMediaControl!pj_mutex_lock_ex+156 [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 1124]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 1124
SIPMediaControl!on_rx_rtp+411 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 2077]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 2077
SIPMediaControl!srtp_rtp_cb+6d [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_srtp.c @ 1552]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_srtp.c @ 1552
SIPMediaControl!ice_on_rx_data+f2 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_ice.c @ 2572]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_ice.c @ 2572
SIPMediaControl!ice_rx_data+34 [C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 2287]	  C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 2287
SIPMediaControl!pj_ice_sess_on_rx_pkt+1dd [C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_session.c @ 3742]	  C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_session.c @ 3742
SIPMediaControl!stun_on_rx_data+b5 [C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 2369]	  C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 2369
SIPMediaControl!on_data_recvfrom+104 [C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\stun_sock.c @ 1009]	  C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\stun_sock.c @ 1009
SIPMediaControl!ioqueue_on_read_complete+fc [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\activesock.c @ 520 + 23]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\activesock.c @ 520 + 23
SIPMediaControl!ioqueue_dispatch_read_event+21e [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\ioqueue_common_abs.c @ 629]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\ioqueue_common_abs.c @ 629
SIPMediaControl!pj_ioqueue_poll+3ac [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\ioqueue_select.c @ 1128]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\ioqueue_select.c @ 1128
SIPMediaControl!pjsip_endpt_handle_events2+8e [C:\UCS\External\pjsip\pjproject-2.14\pjsip\src\pjsip\sip_endpoint.c @ 746]	  C:\UCS\External\pjsip\pjproject-2.14\pjsip\src\pjsip\sip_endpoint.c @ 746
SIPMediaControl!worker_thread+50 [C:\UCS\External\pjsip\pjproject-2.14\pjsip\src\pjsua-lib\pjsua_core.c @ 807 + 30]	  C:\UCS\External\pjsip\pjproject-2.14\pjsip\src\pjsua-lib\pjsua_core.c @ 807 + 30
SIPMediaControl!thread_main+4a [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 538 + 7]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 538 + 7
```

```
SIPMediaControl!pj_mutex_lock_ex+156 [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 1124]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 1124
SIPMediaControl!grp_lock_acquire+36 [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\lock.c @ 300]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\lock.c @ 300
SIPMediaControl!send_data+b2 [C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 1837]	  C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 1837
SIPMediaControl!pj_ice_strans_sendto2+35 [C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 1988]	  C:\UCS\External\pjsip\pjproject-2.14\pjnath\src\pjnath\ice_strans.c @ 1988
SIPMediaControl!transport_send_rtcp2+7d [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_ice.c @ 2512]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_ice.c @ 2512
SIPMediaControl!transport_send_rtcp+32 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_srtp.c @ 1417]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\transport_srtp.c @ 1417
SIPMediaControl!send_rtcp+26c [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1211 + 15]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1211 + 15
SIPMediaControl!check_tx_rtcp+46 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1270]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1270
SIPMediaControl!put_frame_imp+3a0 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1556]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1556
SIPMediaControl!put_frame+16b [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1725]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\stream.c @ 1725
SIPMediaControl!write_port+1dd [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\conference.c @ 1862 + 1c]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\conference.c @ 1862 + 1c
SIPMediaControl!get_frame+5f8 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\conference.c @ 2230]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\conference.c @ 2230
SIPMediaControl!clock_callback+9d [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\master_port.c @ 195]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\master_port.c @ 195
SIPMediaControl!clock_thread+c5 [C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\clock_thread.c @ 395]	  C:\UCS\External\pjsip\pjproject-2.14\pjmedia\src\pjmedia\clock_thread.c @ 395
SIPMediaControl!thread_main+4a [C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 538 + 7]	  C:\UCS\External\pjsip\pjproject-2.14\pjlib\src\pj\os_core_win32.c @ 538 + 7
```

The issue occurs because of the added locking when sending RTCP in #3528 .
