### PR TITLE
Fixed SDP media transport protocol info parsing

### DIFF
--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -1770,7 +1770,7 @@ PJ_DEF(pj_uint32_t) pjmedia_sdp_transport_get_proto(const pj_str_t *tp)
     PJ_ASSERT_RETURN(tp, PJMEDIA_TP_PROTO_NONE);
 
     idx = pj_strtok2(tp, "/", &token, 0);
-    if (idx != tp->slen)
+    if ((idx != tp->slen) && (tp->slen != token.slen))
         pj_strset(&rest, tp->ptr + token.slen + 1, tp->slen - token.slen - 1);
 
     if (pj_stricmp2(&token, "RTP") == 0) {


### PR DESCRIPTION
To fix #3800.

Summary of the report:
In `pjmedia_sdp_transport_get_proto()`:
```
idx = pj_strtok2(tp, "/", &token, 0);
if (idx != tp->slen)
        pj_strset(&rest, tp->ptr + token.slen + 1, tp->slen - token.slen - 1);
```

`rest.slen` will be set to -1 if delimiter `/` is not found within the string, such as if the transport is plain `udp`.

This causes the subsequent check within the function to not work properly:
```
    } else if (pj_stricmp2(&token, "UDP") == 0) {
        /* Starts with "UDP" */

        /* Plain UDP */
        if (rest.slen == 0)
            return PJMEDIA_TP_PROTO_UDP;
```

Thank you to @miguelpenades for the report and the patch.
