### PR TITLE
Prevent immediate tsx termination upon transport error

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2182,13 +2182,15 @@ static void send_msg_callback( pjsip_send_state *send_state,
              * since with 503 normally client should try again.
              * See https://github.com/pjsip/pjproject/issues/870
              */
-            if (-sent==PJ_ERESOLVE || -sent==PJLIB_UTIL_EDNS_NXDOMAIN) {
+            if (-sent==PJ_ERESOLVE || -sent==PJLIB_UTIL_EDNS_NXDOMAIN)
                 sc = PJSIP_SC_BAD_GATEWAY;
-            } else {
+            else
                 sc = PJSIP_SC_TSX_TRANSPORT_ERROR;
-            }
 
-            /* Terminate transaction, if it's not already terminated. */
+            /* We terminate the transaction for 502 error. For 503,
+             * we will retry it.
+             * See https://github.com/pjsip/pjproject/pull/3805
+             */
             if (sc == PJSIP_SC_BAD_GATEWAY &&
                 tsx->state != PJSIP_TSX_STATE_TERMINATED &&
                 tsx->state != PJSIP_TSX_STATE_DESTROYED)


### PR DESCRIPTION
It is reported that we will immediately terminate the transaction and the INVITE session upon transport error:
```
11:09:45.912         inv0x10953d5a8  ..Sending Response msg 200/INVITE/cseq=24793 (tdta0x109535da8)
11:09:45.912         dlg0x10953d5a8  ...Sending Response msg 200/INVITE/cseq=24793 (tdta0x109535da8)
11:09:45.912         tsx0x1099a0b28  ...Sending Response msg 200/INVITE/cseq=24793 (tdta0x109535da8) in state Proceeding
11:09:45.913         tsx0x1099a0b28  ....Failed to send Response msg 200/INVITE/cseq=24793 (tdta0x109535da8)! err=120111 (Connection refused)
11:09:45.913         tsx0x1099a0b28  ....State changed from Proceeding to Terminated, event=TRANSPORT_ERROR
11:09:45.913         dlg0x10953d5a8  .....Transaction tsx0x1099a0b28 state changed to Terminated
11:09:45.913         inv0x10953d5a8  ......State changed from INCOMING to DISCONNECTED, event=TSX_STATE
```

However, according to RFC 3261 (https://www.rfc-editor.org/rfc/rfc3261), section 13.3.1.4, we are supposed to periodically retry the 2xx:
```
The UAS core generates a 2xx response.
...
   Once the response has been constructed, it is passed to the INVITE
   server transaction.  Note, however, that the INVITE server
   transaction will be destroyed as soon as it receives this final
   response and passes it to the transport.  Therefore, it is necessary
   to periodically pass the response directly to the transport until the
   ACK arrives.  The 2xx response is passed to the transport with an
   interval that starts at T1 seconds and doubles for each
   retransmission until it reaches T2 seconds (T1 and T2 are defined in
   [Section 17](https://www.rfc-editor.org/rfc/rfc3261.html#section-17)).  Response retransmissions cease when an ACK request for
   the response is received.  This is independent of whatever transport
   protocols are used to send the response.
```

Which is in line with section 8.1.3.1:
```
8.1.3.1 Transaction Layer Errors
If a fatal transport error is reported by the transport layer
(generally, due to fatal ICMP errors in UDP or connection failures in
TCP), the condition MUST be treated as a 503 (Service Unavailable)
status code.
```

And our own comment in https://github.com/pjsip/pjproject/blob/master/pjsip/src/pjsip/sip_transaction.c#L2181
```
            /* Server resolution error is now mapped to 502 instead of 503,
             * since with 503 normally client should try again.
             * See https://github.com/pjsip/pjproject/issues/870
```

This is further emphasised in RFC 6026 (https://www.rfc-editor.org/rfc/rfc6026.html), section 7.1:
```
A server transaction MUST NOT discard transaction state based only on
   encountering a non-recoverable transport error when sending a
   response.  Instead, the associated INVITE server transaction state
   machine MUST remain in its current state.  (Timers will eventually
   cause it to transition to the "Terminated" state).  This allows
   retransmissions of the INVITE to be absorbed instead of being
   processed as a new request.
```

With the patch, transport error (503) will not cause immediate tsx termination:
Case 1: if retry/retransmit succeeds
```
11:20:30.785         inv0x10743d5a8  ..Sending Response msg 200/INVITE/cseq=5365 (tdta0x107435da8)
11:20:30.786         dlg0x10743d5a8  ...Sending Response msg 200/INVITE/cseq=5365 (tdta0x107435da8)
11:20:30.786         tsx0x10789cf28  ...Sending Response msg 200/INVITE/cseq=5365 (tdta0x107435da8) in state Proceeding
11:20:30.786        tdta0x1074461a8  ....Destroying txdata Response msg 100/INVITE/cseq=5365 (tdta0x1074461a8)
11:20:30.786         tsx0x10789cf28  ....Failed to send Response msg 200/INVITE/cseq=5365 (tdta0x107435da8)! err=120111 (Connection refused)
11:20:31.287         tsx0x10789cf28 !Retransmit timer event
11:20:31.287         tsx0x10789cf28  .Retransmiting Response msg 200/INVITE/cseq=5365 (tdta0x107435da8), count=0, restart?=1
11:20:31.287           pjsua_core.c  .TX 991 bytes Response msg 200/INVITE/cseq=5365 (tdta0x107435da8) to TCP 192.168.1.80:62848:
11:20:31.292         sip_endpoint.c  Processing incoming message: Request msg ACK/cseq=5365 (rdata0x107217010)
11:20:31.292           pjsua_core.c  .RX 370 bytes Request msg ACK/cseq=5365 (rdata0x107217010) from TCP 192.168.1.80:62848:
11:20:31.292         dlg0x10743d5a8  .Received Request msg ACK/cseq=5365 (rdata0x107217010)
11:20:31.292         tsx0x10789cf28  ..Request to terminate transaction
11:20:31.292         tsx0x10789cf28  ...State changed from Completed to Terminated, event=USER
11:20:31.292         dlg0x10743d5a8  ....Transaction tsx0x10789cf28 state changed to Terminated
11:20:31.292         inv0x10743d5a8  ..State changed from CONNECTING to CONFIRMED, event=RX_MSG
11:20:31.292            pjsua_app.c  ...Call 0 state changed to CONFIRMED
```

Case 2: if retransmissions fail
```
11:22:06.729         inv0x107f3d5a8  ..Sending Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8)
11:22:06.729         dlg0x107f3d5a8  ...Sending Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8)
11:22:06.729         tsx0x1083a0b28  ...Sending Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8) in state Proceeding
11:22:06.729        tdta0x107f461a8  ....Destroying txdata Response msg 100/INVITE/cseq=32010 (tdta0x107f461a8)
11:22:06.730         tsx0x1083a0b28  ....Failed to send Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8)! err=120111 (Connection refused)
11:22:07.230         tsx0x1083a0b28 !Retransmit timer event
11:22:07.230         tsx0x1083a0b28  .Retransmiting Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8), count=0, restart?=1
11:22:07.230         tsx0x1083a0b28  .Failed to send Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8)! err=120111 (Connection refused)
...
11:22:38.243         tsx0x1083a0b28 !Retransmit timer event
11:22:38.243         tsx0x1083a0b28  .Retransmiting Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8), count=9, restart?=1
11:22:38.243         tsx0x1083a0b28  .Failed to send Response msg 200/INVITE/cseq=32010 (tdta0x107f35da8)! err=120111 (Connection refused)
11:22:38.730         tsx0x1083a0b28 !Timeout timer event
11:22:38.731         tsx0x1083a0b28  .State changed from Completed to Terminated, event=TIMER
11:22:38.731         dlg0x107f3d5a8  ..Transaction tsx0x1083a0b28 state changed to Terminated
11:22:38.731             sip_util.c  ...Request msg BYE/cseq=18615 (tdta0x107f961a8) created.
11:22:38.731         inv0x107f3d5a8  ....Sending Request msg BYE/cseq=18615 (tdta0x107f961a8)
11:22:38.731         dlg0x107f3d5a8  .....Sending Request msg BYE/cseq=18615 (tdta0x107f961a8)
11:22:38.731         tsx0x10f551528  ......Transaction created for Request msg BYE/cseq=18615 (tdta0x107f961a8)
11:22:38.731         tsx0x10f551528  .....Sending Request msg BYE/cseq=18615 (tdta0x107f961a8) in state Null
```

