### PR TITLE
Terminate client transaction upon transport error

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2187,11 +2187,12 @@ static void send_msg_callback( pjsip_send_state *send_state,
             else
                 sc = PJSIP_SC_TSX_TRANSPORT_ERROR;
 
-            /* We terminate the transaction for 502 error. For 503,
-             * we will retry it.
+            /* For client transaction, we terminate the transaction.
+             * Otherwise, we terminate the transaction for 502 error.
+             * For 503, we will retry it.
              * See https://github.com/pjsip/pjproject/pull/3805
              */
-            if (sc == PJSIP_SC_BAD_GATEWAY &&
+            if ((tsx->role == PJSIP_ROLE_UAC || sc == PJSIP_SC_BAD_GATEWAY) &&
                 tsx->state != PJSIP_TSX_STATE_TERMINATED &&
                 tsx->state != PJSIP_TSX_STATE_DESTROYED)
             {

--- a/pjsip/src/test/tsx_bench.c
+++ b/pjsip/src/test/tsx_bench.c
@@ -138,7 +138,7 @@ static int uas_tsx_bench(unsigned working_set, pj_timestamp *p_elapsed)
     rdata.msg_info.from = (pjsip_from_hdr*) pjsip_msg_find_hdr(request->msg, PJSIP_H_FROM, NULL);
     rdata.msg_info.to = (pjsip_to_hdr*) pjsip_msg_find_hdr(request->msg, PJSIP_H_TO, NULL);
     rdata.msg_info.cseq = (pjsip_cseq_hdr*) pjsip_msg_find_hdr(request->msg, PJSIP_H_CSEQ, NULL);
-    rdata.msg_info.cid = (pjsip_cid_hdr*) pjsip_msg_find_hdr(request->msg, PJSIP_H_FROM, NULL);
+    rdata.msg_info.cid = (pjsip_cid_hdr*) pjsip_msg_find_hdr(request->msg, PJSIP_H_CALL_ID, NULL);
     rdata.msg_info.via = via;
     
     pj_sockaddr_in_init(&remote, 0, 0);

--- a/pjsip/src/test/tsx_uas_test.c
+++ b/pjsip/src/test/tsx_uas_test.c
@@ -1532,7 +1532,7 @@ int tsx_transport_failure_test(void)
         PJ_LOG(5,(THIS_FILE, "   transport loop fail mode set"));
 
         end_test = now;
-        end_test.sec += 5;
+        end_test.sec += 50;
 
         do {
             pj_time_val interval = { 0, 1 };

--- a/pjsip/src/test/tsx_uas_test.c
+++ b/pjsip/src/test/tsx_uas_test.c
@@ -710,10 +710,11 @@ static void tsx_user_on_tsx_state(pjsip_transaction *tsx, pjsip_event *e)
             if (!test_complete)
                 test_complete = 1;
 
-            if (tsx->status_code != PJSIP_SC_TSX_TRANSPORT_ERROR) {
+            if (tsx->status_code != PJSIP_SC_REQUEST_TIMEOUT) {
                 PJ_LOG(3,(THIS_FILE,"    error: incorrect status code"
                           " (expecting %d, got %d)",
-                          PJSIP_SC_TSX_TRANSPORT_ERROR,
+                          PJSIP_SC_REQUEST_TIMEOUT,
+                          // PJSIP_SC_TSX_TRANSPORT_ERROR,
                           tsx->status_code));
                 test_complete = -170;
             }
@@ -726,12 +727,13 @@ static void tsx_user_on_tsx_state(pjsip_transaction *tsx, pjsip_event *e)
             if (!test_complete)
                 test_complete = 1;
 
-            if (tsx->status_code != PJSIP_SC_TSX_TRANSPORT_ERROR &&
+            if (tsx->status_code != PJSIP_SC_REQUEST_TIMEOUT &&
                 tsx->status_code != PJSIP_SC_OK)
             {
                 PJ_LOG(3,(THIS_FILE,"    error: incorrect status code"
                           " (expecting %d, got %d)",
-                          PJSIP_SC_TSX_TRANSPORT_ERROR,
+                          PJSIP_SC_REQUEST_TIMEOUT,
+                          // PJSIP_SC_TSX_TRANSPORT_ERROR,
                           tsx->status_code));
                 test_complete = -170;
             }
@@ -1199,9 +1201,11 @@ static int perform_test( char *target_uri, char *from_uri,
     int sent_cnt;
     pj_status_t status;
 
-    PJ_LOG(3,(THIS_FILE,
-              "   please standby, this will take at most %d seconds..",
-              test_time));
+    if (test_time > 0) {
+        PJ_LOG(3,(THIS_FILE,
+                  "   please standby, this will take at most %d seconds..",
+                  test_time));
+    }
 
     /* Reset test. */
     recv_count = 0;
@@ -1481,24 +1485,29 @@ int tsx_transport_failure_test(void)
 {
     struct test_desc
     {
+        int result;
         int transport_delay;
         int fail_delay;
         char *branch_id;
         char *title;
     } tests[] =
     {
-        { 0,  10,   TEST10_BRANCH_ID, "test10: failed transport in TRYING state (no delay)" },
-        { 50, 10,   TEST10_BRANCH_ID, "test10: failed transport in TRYING state (50 ms delay)" },
-        { 0,  1500, TEST11_BRANCH_ID, "test11: failed transport in PROCEEDING state (no delay)" },
-        // After ticket #2076, transport error will be ignored if tsx is in COMPLETED state, note that
-        // tsx state will be shifted to COMPLETED state once 200 response is sent due to transport delay.
-        //{ 50, 1500, TEST11_BRANCH_ID, "test11: failed transport in PROCEEDING state (50 ms delay)" },
-        { 0,  2500, TEST12_BRANCH_ID, "test12: failed transport in COMPLETED state (no delay)" },
-        //Not applicable (maybe)
-        //This test may expect transport failure notification in COMPLETED state. This may not be
-        //possible because the loop transport can only notify failure when it has something to send,
-        //while in this case, there is nothing to send because UAS already sends 200/OK
-        //{ 50, 2500, TEST12_BRANCH_ID, "test12: failed transport in COMPLETED state (50 ms delay)" },
+        // After #3805 and #3806, transport error will be ignored and
+        // the tests will time out.
+        // All tests are valid, but it will take too long to complete,
+        // so we disable some of the similar ones.
+        { 0, 0,  10,   TEST10_BRANCH_ID,
+          "test10: failed transport in TRYING state (no delay)" },
+        //{ 0, 50, 10,   TEST10_BRANCH_ID,
+        //  "test10: failed transport in TRYING state (50 ms delay)" },
+        //{ 1, 0,  1500, TEST11_BRANCH_ID,
+        //  "test11: failed transport in PROCEEDING state (no delay)" },
+        { 1, 50, 1500, TEST11_BRANCH_ID,
+          "test11: failed transport in PROCEEDING state (50 ms delay)" },
+        { 1, 0,  2500, TEST12_BRANCH_ID,
+          "test12: failed transport in COMPLETED state (no delay)" },
+        //{ 1, 50, 2500, TEST12_BRANCH_ID,
+        //  "test12: failed transport in COMPLETED state (50 ms delay)" },
     };
     int i, status;
 
@@ -1532,7 +1541,7 @@ int tsx_transport_failure_test(void)
         PJ_LOG(5,(THIS_FILE, "   transport loop fail mode set"));
 
         end_test = now;
-        end_test.sec += 50;
+        end_test.sec += 33;
 
         do {
             pj_time_val interval = { 0, 1 };
@@ -1540,13 +1549,10 @@ int tsx_transport_failure_test(void)
             pjsip_endpt_handle_events(endpt, &interval);
         } while (!test_complete && PJ_TIME_VAL_LT(now, end_test));
 
-        if (test_complete == 0) {
-            PJ_LOG(3,(THIS_FILE, "   error: test has timed out"));
+        if (test_complete != tests[i].result) {
+            PJ_LOG(3,(THIS_FILE, "   error: expecting timeout"));
             return -41;
         }
-
-        if (test_complete != 1)
-            return test_complete;
     }
 
     return 0;


### PR DESCRIPTION
#3805 will prevent immediate transaction termination upon transport error.
This will introduce new behavioral change which is an issue.

**Provided an outgoing INVITE  without patch**
```
22:27:26.194    inv05253D64  .UAC invite session created for dialog dlg05253D64
22:27:26.194     sip_util.c  .Request msg INVITE/cseq=8155 (tdta05262D64) created.
22:27:26.194    inv05253D64  ..Sending Request msg INVITE/cseq=8155 (tdta05262D64)
22:27:26.194    dlg05253D64  ...Sending Request msg INVITE/cseq=8155 (tdta05262D64)
22:27:26.194    tsx0530BEE4  ....Transaction created for Request msg INVITE/cseq=8155 (tdta05262D64)
22:27:26.194    tsx0530BEE4  ...Sending Request msg INVITE/cseq=8155 (tdta05262D64) in state Null
22:27:26.194  sip_resolve.c  ....Target '192.168.1.114:0' type=TCP resolved to '192.168.1.114:5060' type=TCP (TCP transport)
22:27:26.194   tcpc06C06114  ....TCP client transport created
22:27:26.194   tcpc06C06114  ....TCP transport 192.168.100.51:63251 is connecting to 192.168.1.114:5060...
22:27:26.194   pjsua_core.c  ....TX 955 bytes Request msg INVITE/cseq=8155 (tdta05262D64) to TCP 192.168.1.114:5060:
22:27:26.198    tsx0530BEE4  ....State changed from Null to Calling, event=TX_MSG
22:27:26.198    dlg05253D64  .....Transaction tsx0530BEE4 state changed to Calling
22:27:26.198    inv05253D64  ......State changed from NULL to CALLING, event=TSX_STATE
22:27:26.198    pjsua_app.c  .......Call 0 state changed to CALLING
22:27:26.198    pjsua_app.c  .......Tsx tsx0530BEE4 state changed: Calling code: 0
22:27:31.204   sound_port.c !EC suspended because of inactivity
22:27:47.244   tcpc06C06114  TCP connect() error: [code=130060]: Connection timed out (WSAETIMEDOUT)
22:27:47.244    tsx0530BEE4  Failed to send Request msg INVITE/cseq=8155 (tdta05262D64)! err=130060 (Connection timed out (WSAETIMEDOUT))
22:27:47.244    tsx0530BEE4  State changed from Calling to Terminated, event=TRANSPORT_ERROR
22:27:47.244    dlg05253D64  .Transaction tsx0530BEE4 state changed to Terminated
22:27:47.244    inv05253D64  ..State changed from CALLING to DISCONNECTED, event=TSX_STATE
22:27:47.244  pjsua_media.c  ...Call 0: deinitializing media..
```

**With patch**
```
22:33:35.824    inv05451564  .UAC invite session created for dialog dlg05451564
22:33:35.824     sip_util.c  .Request msg INVITE/cseq=7217 (tdta05460564) created.
22:33:35.824    inv05451564  ..Sending Request msg INVITE/cseq=7217 (tdta05460564)
22:33:35.824    dlg05451564  ...Sending Request msg INVITE/cseq=7217 (tdta05460564)
22:33:35.824    tsx0550BEE4  ....Transaction created for Request msg INVITE/cseq=7217 (tdta05460564)
22:33:35.824    tsx0550BEE4  ...Sending Request msg INVITE/cseq=7217 (tdta05460564) in state Null
22:33:35.824  sip_resolve.c  ....Target '192.168.1.114:0' type=TCP resolved to '192.168.1.114:5060' type=TCP (TCP transport)
22:33:35.824   tcpc06E06114  ....TCP client transport created
22:33:35.824   tcpc06E06114  ....TCP transport 192.168.100.51:63302 is connecting to 192.168.1.114:5060...
22:33:35.824   pjsua_core.c  ....TX 955 bytes Request msg INVITE/cseq=7217 (tdta05460564) to TCP 192.168.1.114:5060:
22:33:35.837    tsx0550BEE4  ....State changed from Null to Calling, event=TX_MSG
22:33:35.837    dlg05451564  .....Transaction tsx0550BEE4 state changed to Calling
22:33:35.837    inv05451564  ......State changed from NULL to CALLING, event=TSX_STATE
22:33:35.837    pjsua_app.c  .......Call 0 state changed to CALLING
22:33:35.837    pjsua_app.c  .......Tsx tsx0550BEE4 state changed: Calling code: 0
22:33:56.871   tcpc06E06114  TCP connect() error: [code=130060]: Connection timed out (WSAETIMEDOUT)
22:33:56.871    tsx0550BEE4  Failed to send Request msg INVITE/cseq=7217 (tdta05460564)! err=130060 (Connection timed out (WSAETIMEDOUT))
22:33:56.871   tcpc06E06114  TCP send() error, sent=-130060
22:33:56.872    pjsua_app.c  SIP TCP transport is disconnected from 192.168.1.114:5060: Connection timed out (WSAETIMEDOUT) [status=130060]
22:33:56.872    pjsua_acc.c  Disconnected notification for transport tcpc06E06114
22:33:56.872 sip_transport.  .Transport tcpc06E06114 shutting down, force=0
22:33:56.873 sip_transport.  Transport tcpc06E06114 is being destroyed due to timeout in idle timer
22:33:56.873   tcpc06E06114  TCP transport destroyed with reason 130060: Connection timed out (WSAETIMEDOUT)
22:34:07.848    tsx0550BEE4  Timeout timer event
22:34:07.848    tsx0550BEE4  .State changed from Calling to Terminated, event=TIMER
22:34:07.848    dlg05451564  ..Transaction tsx0550BEE4 state changed to Terminated
22:34:07.848    inv05451564  ...State changed from CALLING to DISCONNECTED, event=TSX_STATE
22:34:07.848  pjsua_media.c  ....Call 0: deinitializing media..
```

The outgoing INVITE transaction will be terminated by timeout timer and the call disconnected notification will require additional time.

As stated in RFC 6026 (https://www.rfc-editor.org/rfc/rfc6026.html), section 7.1:
```
A server transaction MUST NOT discard transaction state based only on
   encountering a non-recoverable transport error when sending a
   response.  Instead, the associated INVITE server transaction state
   machine MUST remain in its current state.  (Timers will eventually
   cause it to transition to the "Terminated" state).  This allows
   retransmissions of the INVITE to be absorbed instead of being
   processed as a new request.
```

And section 7.2:
```
Note that it is not necessary to preserve client transaction state
   upon the detection of unrecoverable transport errors.  Existing
   requirements ensure the TU has been notified, and the new
   requirements in this document ensure that any received retransmitted
   response will be dropped since there will no longer be any matching
   transaction state.
```

Upon transport error, only server transaction that must not be discarded/terminated.

This PR will terminate client transaction upon transport error.