### PR TITLE
Fixed CI build failure due to Python setup

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -30,14 +30,14 @@ jobs:
       run: CFLAGS="-g -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib" CXXFLAGS="-g -fPIC" ./configure
     - name: make
       run: make
+    - name: set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: swig bindings
       run: cd pjsip-apps/src/swig && make
     - name: disable firewall
       run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: set up Python 3.10 for pjsua test
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
     - name: unit tests
       run: make pjlib-test-ci pjmedia-test pjlib-util-test pjsua-test
 
@@ -91,6 +91,10 @@ jobs:
       run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl@1.1/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib" CXXFLAGS="-fPIC" ./configure
     - name: make
       run: make
+    - name: set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: swig bindings
       run: cd pjsip-apps/src/swig && make
 
@@ -105,6 +109,10 @@ jobs:
       run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=/usr/local/
     - name: make
       run: make
+    - name: set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: swig bindings
       run: cd pjsip-apps/src/swig && make
 
@@ -122,14 +130,14 @@ jobs:
       run: CFLAGS="-g -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -DHAS_VID_CODEC_TEST=0 -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib" CXXFLAGS="-g -fPIC" ./configure
     - name: make
       run: make
+    - name: set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: swig bindings
       run: cd pjsip-apps/src/swig && make
     - name: disable firewall
       run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: set up Python 3.10 for pjsua test
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
     - name: unit tests
       run: make pjlib-test-ci pjmedia-test pjlib-util-test pjsua-test
 
@@ -188,6 +196,10 @@ jobs:
       run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl@1.1/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib" CXXFLAGS="-fPIC" ./configure
     - name: make
       run: make
+    - name: set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: swig bindings
       run: cd pjsip-apps/src/swig && make
 
@@ -204,5 +216,9 @@ jobs:
       run: CFLAGS="-I/usr/local/include -I/usr/local/opt/openssl@1.1/include -fPIC" LDFLAGS="-L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib" CXXFLAGS="-fPIC" ./configure
     - name: make
       run: make
+    - name: set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: swig bindings
       run: cd pjsip-apps/src/swig && make


### PR DESCRIPTION
To fix the following error:
```
Run cd pjsip-apps/src/swig && make
/Applications/Xcode_14.2.app/Contents/Developer/usr/bin/make  --no-print-directory -C python 
swig -I../../../../pjlib/include -I../../../../pjlib-util/include -I../../../../pjmedia/include -I../../../../pjsip/include -I../../../../pjnath/include -c++  -w312 -threads -DSWIG_NO_EXPORT_ITERATOR_METHODS -python -o pjsua2_wrap.cpp ../pjsua2.i
python3 setup.py build 
Traceback (most recent call last):
  File "/Users/runner/work/pjproject/pjproject/pjsip-apps/src/swig/python/setup.py", line 20, in <module>
    from distutils.core import setup, Extension
ModuleNotFoundError: No module named 'distutils'
make[1]: *** [_pjsua2.so] Error 1
make: *** [python] Error 2
Error: Process completed with exit code 2.
```
