### PR TITLE
Enable PendingJob use on Python

### DIFF
--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -121,7 +121,13 @@ using namespace pj;
 %feature("director") FindBuddyMatch;
 %feature("director") AudioMediaPlayer;
 %feature("director") AudioMediaPort;
-%feature("director") PendingJob;
+// PendingJob is only used on Python
+#ifdef SWIGPYTHON
+    %feature("director") PendingJob;
+#else
+    %ignore pj::PendingJob;
+    %ignore pj::Endpoint::utilAddPendingJob;
+#endif
 
 //
 // STL stuff.

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -121,6 +121,7 @@ using namespace pj;
 %feature("director") FindBuddyMatch;
 %feature("director") AudioMediaPlayer;
 %feature("director") AudioMediaPort;
+%feature("director") PendingJob;
 
 //
 // STL stuff.
@@ -234,6 +235,13 @@ using namespace pj;
 	Runtime.getRuntime().gc();
 	libDestroy_();
   }
+%}
+#endif
+
+#ifdef SWIGPYTHON
+%pythonprepend pj::Endpoint::utilAddPendingJob(PendingJob *job) %{
+    # print('disowning job')
+    job.__disown__()
 %}
 #endif
 

--- a/pjsip-apps/src/swig/python/test.py
+++ b/pjsip-apps/src/swig/python/test.py
@@ -230,10 +230,10 @@ class TestJob(pj.PendingJob):
         print("Job deleted id:", id(self), "value:", self.val.value)
 
 def add_new_job1(ep):
-	print("Creating job 1")
-	job = TestJob()
-	print("Adding job 1")
-	ep.utilAddPendingJob(job)
+    print("Creating job 1")
+    job = TestJob()
+    print("Adding job 1")
+    ep.utilAddPendingJob(job)
 
 # Function to be executed in a separate thread
 def add_new_job2(ep):

--- a/pjsip-apps/src/swig/python/test.py
+++ b/pjsip-apps/src/swig/python/test.py
@@ -3,6 +3,9 @@ import sys
 import time
 from collections import deque
 import struct
+import gc
+from random import randint
+import threading
 
 write=sys.stdout.write
 
@@ -210,6 +213,69 @@ def ua_tonegen_test():
 
     ep.libDestroy()
 
+class RandomIntVal():
+    def __init__(self):
+        self.value = randint(0, 100000)
+
+class TestJob(pj.PendingJob):
+    def __init__(self):
+        super().__init__()
+        self.val = RandomIntVal()
+        print("Job created id:", id(self), "value:", self.val.value)
+
+    def execute(self, is_pending):
+        print("Executing job value:", self.val.value, is_pending)
+
+    def __del__(self):
+        print("Job deleted id:", id(self), "value:", self.val.value)
+
+def add_new_job1(ep):
+	print("Creating job 1")
+	job = TestJob()
+	print("Adding job 1")
+	ep.utilAddPendingJob(job)
+
+# Function to be executed in a separate thread
+def add_new_job2(ep):
+    ep.libRegisterThread("thread")
+    print("Creating job 2")
+    job = TestJob()
+    print("Adding job 2")
+    ep.utilAddPendingJob(job)
+
+def ua_pending_job_test():
+    write("PendingJob test.." + "\r\n")
+    ep_cfg = pj.EpConfig()
+    ep_cfg.uaConfig.threadCnt = 0
+    ep_cfg.uaConfig.mainThreadOnly = True
+
+    ep = pj.Endpoint()
+    ep.libCreate()
+    ep.libInit(ep_cfg)
+    ep.libStart()
+
+    # test 1
+    # adding job from a separate function
+    add_new_job1(ep)
+
+    # test 2
+    # adding job from a different thread
+    my_thread = threading.Thread(target=add_new_job2, args=(ep,))
+    my_thread.start()
+
+    time.sleep(1)
+    print("Collecting gc 1")
+    gc.collect()
+
+    print("Handling events")
+    for _ in range(100):
+        ep.libHandleEvents(10)
+
+    print("Collecting gc 2")
+    gc.collect()
+
+    ep.libDestroy()
+
 #
 # main()
 #
@@ -219,6 +285,7 @@ if __name__ == "__main__":
     ua_run_log_test()
     ua_run_ua_test()
     ua_tonegen_test()
+    ua_pending_job_test()
     sys.exit(0)
 
 


### PR DESCRIPTION
Continuing #3774.

First of all, using `PendingJob` is only useful on Python.

`Endpoint::utilAddPendingJob()` will *always* execute the pending job directly unless `mainThreadOnly` is set to `true` (the default is false) (and thread count 0).
```
     * Utility to register a pending job to be executed by main thread.
     * If EpConfig::UaConfig::mainThreadOnly is false, the job will be
     * executed immediately.
    void utilAddPendingJob(PendingJob *job);
```
```
    /**
     * When this flag is non-zero, all callbacks that come from thread
     * other than main thread will be posted to the main thread and
     * to be executed by Endpoint::libHandleEvents() function. This
     * includes the logging callback. Note that this will only work if
     * threadCnt is set to zero and Endpoint::libHandleEvents() is
     * performed by main thread. By default, the main thread is set
     * from the thread that invoke Endpoint::libCreate()
     *
     * Default: false
     */
    bool                mainThreadOnly;
```
```
    /* See if we can execute immediately */
    if (!mainThreadOnly || pj_thread_this()==mainThread) {
        job->execute(false);
        delete job;
        return;
    }
```

This makes the problem much less complicated since `mainThreadOnly` typically won't be enabled on Java nor C# (and enabling this on Android is definitely a no no due to the main thread being the GUI thread).
Therefore, the simplest solution has been provided by @nanangizz in (https://github.com/pjsip/pjproject/pull/3774#issuecomment-1803227688) using `__disown__()`.

This turns out to be a classical "elements within a container" problem, where we want the container to own the elements. And just for future reference, in case that we also encounter similar issues for Java and C#, the solutions are readily available in the docs:
- https://www.swig.org/Doc4.1/Java.html#Java_memory_management_objects (Memory management for objects passed to the C++ layer)
- https://www.swig.org/Doc4.1/CSharp.html#CSharp_memory_management_objects (Memory management for objects passed to the C++ layer)

For Python, the solution can be found here:
- https://www.swig.org/Doc4.1/Python.html#Python_nn35 (Ownership and object destruction)
- https://stackoverflow.com/questions/50259152/adding-swig-pythoncode-to-set-thisown-flag-on-python-object
