### PR TITLE
Fixed bug in pjsua_call_answer()

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2745,7 +2745,7 @@ PJ_DEF(pj_status_t) pjsua_call_answer2(pjsua_call_id call_id,
         goto on_return;
 
     if (!call->inv->invite_tsx ||
-        call->inv->invite_tsx->role != PJSIP_ROLE_UAC ||
+        call->inv->invite_tsx->role != PJSIP_ROLE_UAS ||
         call->inv->invite_tsx->state >= PJSIP_TSX_STATE_COMPLETED)
     {
         PJ_LOG(3,(THIS_FILE, "Unable to answer call (no incoming INVITE or "


### PR DESCRIPTION
There's a fatal bug in the patch of #3770 which caused call answer to not work at all.

The error check: `call->inv->invite_tsx->role != PJSIP_ROLE_UAC` is incorrect, since we should only be able to answer call if the role is UAS.
