### PR TITLE
Fixed issues when adding new media and deinitializing media

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -772,6 +772,7 @@ void pjsua_ice_check_start_trickling(pjsua_call *call,
 pj_bool_t   pjsua_call_media_is_changing(pjsua_call *call);
 pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
                                   pjmedia_type type,
+                                  const pjmedia_sdp_session *rem_sdp,
                                   const pjsua_transport_config *tcfg,
                                   int security_level,
                                   int *sip_err_code,

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5587,6 +5587,7 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
             goto on_return;
         }
 
+        opt.vid_cnt = 1;
         call->opt = opt;
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5587,7 +5587,6 @@ static void pjsua_call_on_rx_offer(pjsip_inv_session *inv,
             goto on_return;
         }
 
-        opt.vid_cnt = 1;
         call->opt = opt;
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1929,14 +1929,14 @@ PJ_DEF(pj_status_t) pjsua_destroy2(unsigned flags)
         /* Terminate all calls. */
         if ((flags & PJSUA_DESTROY_NO_TX_MSG) == 0) {
             pjsua_call_hangup_all();
-        }
-
-        /* Deinit media channel of all calls (see #1717) */
-        for (i=0; i<(int)pjsua_var.ua_cfg.max_calls; ++i) {
-            /* TODO: check if we're not allowed to send to network in the
-             *       "flags", and if so do not do TURN allocation...
-             */
-            pjsua_media_channel_deinit(i);
+        } else {
+            /* Deinit media channel of all calls (see #1717) */
+            for (i=0; i<(int)pjsua_var.ua_cfg.max_calls; ++i) {
+                /* TODO: check if we're not allowed to send to network in the
+                 *       "flags", and if so do not do TURN allocation...
+                 */
+                pjsua_media_channel_deinit(i);
+            }
         }
 
         /* Set all accounts to offline */

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -246,9 +246,9 @@ pj_status_t pjsua_media_subsys_destroy(unsigned flags)
     return PJ_SUCCESS;
 }
 
-static int get_media_ip_version(pjsua_call_media *call_med)
+static int get_media_ip_version(pjsua_call_media *call_med,
+                                const pjmedia_sdp_session *rem_sdp)
 {
-    pjmedia_sdp_session *rem_sdp = call_med->call->async_call.rem_sdp;
     pjsua_ipv6_use ipv6_use;
 
     ipv6_use = pjsua_var.acc[call_med->call->acc_id].cfg.ipv6_media_use;
@@ -287,7 +287,8 @@ static int get_media_ip_version(pjsua_call_media *call_med)
  */
 static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
                                         const pjsua_transport_config *cfg,
-                                        pjmedia_sock_info *skinfo)
+                                        pjmedia_sock_info *skinfo,
+                                        const pjmedia_sdp_session *rem_sdp)
 {
     enum {
         RTP_RETRY = 100
@@ -302,7 +303,7 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
     pjsua_acc *acc = &pjsua_var.acc[call_med->call->acc_id];
     pj_sock_t sock[2];
 
-    use_ipv6 = (get_media_ip_version(call_med) == 6);
+    use_ipv6 = (get_media_ip_version(call_med, rem_sdp) == 6);
     use_nat64 = (acc->cfg.nat64_opt != PJSUA_NAT64_DISABLED);
     af = (use_ipv6 || use_nat64) ? pj_AF_INET6() : pj_AF_INET();
 
@@ -705,12 +706,13 @@ on_error:
 
 /* Create normal UDP media transports */
 static pj_status_t create_udp_media_transport(const pjsua_transport_config *cfg,
-                                              pjsua_call_media *call_med)
+                                              pjsua_call_media *call_med,
+                                              const pjmedia_sdp_session *rem_sdp)
 {
     pjmedia_sock_info skinfo;
     pj_status_t status;
 
-    status = create_rtp_rtcp_sock(call_med, cfg, &skinfo);
+    status = create_rtp_rtcp_sock(call_med, cfg, &skinfo, rem_sdp);
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Unable to create RTP/RTCP socket",
                      status);
@@ -745,7 +747,8 @@ on_error:
 /* Create loop media transport */
 static pj_status_t create_loop_media_transport(
                        const pjsua_transport_config *cfg,
-                       pjsua_call_media *call_med)
+                       pjsua_call_media *call_med,
+                       const pjmedia_sdp_session *rem_sdp)
 {
     pj_status_t status;
     pjmedia_loop_tp_setting opt;
@@ -753,7 +756,7 @@ static pj_status_t create_loop_media_transport(
     int af;
     pjsua_acc *acc = &pjsua_var.acc[call_med->call->acc_id];
 
-    use_ipv6 = (get_media_ip_version(call_med) == 6);
+    use_ipv6 = (get_media_ip_version(call_med, rem_sdp) == 6);
     use_nat64 = (acc->cfg.nat64_opt != PJSUA_NAT64_DISABLED);
     af = (use_ipv6 || use_nat64) ? pj_AF_INET6() : pj_AF_INET();
 
@@ -996,6 +999,7 @@ static void on_ice_complete(pjmedia_transport *tp,
 static pj_status_t create_ice_media_transport(
                                 const pjsua_transport_config *cfg,
                                 pjsua_call_media *call_med,
+                                const pjmedia_sdp_session *remote_sdp,
                                 pj_bool_t async)
 {
     char stunip[PJ_INET6_ADDRSTRLEN];
@@ -1010,7 +1014,7 @@ static pj_status_t create_ice_media_transport(
     pjmedia_sdp_session *rem_sdp;
 
     acc_cfg = &pjsua_var.acc[call_med->call->acc_id].cfg;
-    use_ipv6 = (get_media_ip_version(call_med) == 6);
+    use_ipv6 = (get_media_ip_version(call_med, remote_sdp) == 6);
     use_nat64 = (acc_cfg->nat64_opt != PJSUA_NAT64_DISABLED);
 
     /* Make sure STUN server resolution has completed */
@@ -1984,6 +1988,7 @@ pj_bool_t  pjsua_call_media_is_changing(pjsua_call *call)
 /* Initialize the media line */
 pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
                                   pjmedia_type type,
+                                  const pjmedia_sdp_session *rem_sdp,
                                   const pjsua_transport_config *tcfg,
                                   int security_level,
                                   int *sip_err_code,
@@ -2027,9 +2032,10 @@ pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
         pjsua_set_media_tp_state(call_med, PJSUA_MED_TP_CREATING);
 
         if (acc->cfg.use_loop_med_tp) {
-            status = create_loop_media_transport(tcfg, call_med);
+            status = create_loop_media_transport(tcfg, call_med, rem_sdp);
         } else if (acc->cfg.ice_cfg.enable_ice) {
-            status = create_ice_media_transport(tcfg, call_med, async);
+            status = create_ice_media_transport(tcfg, call_med, rem_sdp,
+                                                async);
             if (async && status == PJ_EPENDING) {
                 /* We will resume call media initialization in the
                  * on_ice_complete() callback.
@@ -2040,7 +2046,7 @@ pj_status_t pjsua_call_media_init(pjsua_call_media *call_med,
                 return PJ_EPENDING;
             }
         } else {
-            status = create_udp_media_transport(tcfg, call_med);
+            status = create_udp_media_transport(tcfg, call_med, rem_sdp);
         }
 
         if (status != PJ_SUCCESS) {
@@ -2516,15 +2522,17 @@ pj_status_t pjsua_media_channel_init(pjsua_call_id call_id,
             PJ_LOG(4,(THIS_FILE, "Call %d: setting media direction "
                                  "#%d to %d.", call_id, mi,
                                  call_med->def_dir));
-        } else if (!reinit) {
-            /* Initialize default initial media direction as bidirectional */
+        } else if (!reinit || mi >= call->med_cnt) {
+            /* Initialize default media direction as bidirectional,
+             * for initial media or newly added media.
+             */
             call_med->def_dir = PJMEDIA_DIR_ENCODING_DECODING;
         }
 
         if (enabled) {
             call_med->enable_rtcp_mux = acc->cfg.enable_rtcp_mux;
 
-            status = pjsua_call_media_init(call_med, media_type,
+            status = pjsua_call_media_init(call_med, media_type, rem_sdp,
                                            &acc->cfg.rtp_cfg,
                                            security_level, sip_err_code,
                                            async,

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -2088,7 +2088,7 @@ static pj_status_t call_add_video(pjsua_call *call,
 
     /* Initialize call media */
     call_med = &call->media_prov[call->med_prov_cnt++];
-    status = pjsua_call_media_init(call_med, PJMEDIA_TYPE_VIDEO,
+    status = pjsua_call_media_init(call_med, PJMEDIA_TYPE_VIDEO, NULL,
                                    &acc_cfg->rtp_cfg, call->secure_level,
                                    NULL, PJ_FALSE, NULL);
     if (status != PJ_SUCCESS)
@@ -2237,7 +2237,7 @@ static pj_status_t call_modify_video(pjsua_call *call,
                 call->opt.vid_cnt++;
         }
 
-        status = pjsua_call_media_init(call_med, PJMEDIA_TYPE_VIDEO,
+        status = pjsua_call_media_init(call_med, PJMEDIA_TYPE_VIDEO, NULL,
                                        &acc_cfg->rtp_cfg, call->secure_level,
                                        NULL, PJ_FALSE, NULL);
         if (status != PJ_SUCCESS)

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -2134,6 +2134,7 @@ static pj_status_t call_add_video(pjsua_call *call,
 
         pjmedia_sdp_media_add_attr(sdp_m, a);
     }
+    call_med->def_dir = dir;
 
     /* Update SDP media line by media transport */
     status = pjmedia_transport_encode_sdp(call_med->tp, pool,


### PR DESCRIPTION
There are several issues when adding new media, which need to be fixed:
- Default new added media is initialised as `inactive`.
  This is because we currently don't set media direction for media reinitialization.
```
    if (!reinit) {
            /* Initialize default initial media direction as bidirectional. */
            call_med->def_dir = PJMEDIA_DIR_ENCODING_DECODING;
    }
```
- Currently, the IP version detection is only done from initial offer.
```
static int get_media_ip_version(pjsua_call_media *call_med)
{
    pjmedia_sdp_session *rem_sdp = call_med->call->async_call.rem_sdp;
```

- Set the default direction to the specified `param->dir` when adding video using `pjsua_call_set_vid_strm(call_id, PJSUA_CALL_VID_STRM_ADD, param)`.

There's also another issue with double media deinitialization:
```
==60122==ERROR: AddressSanitizer: heap-use-after-free on address 0x00010ea8e938 at pc 0x0001064b4ee0 bp 0x00016b9eca30 sp 0x00016b9ec1f0
READ of size 2048 at 0x00010ea8e938 thread T4
    #1 0x104a66804 in pj_memcpy string.h:854
    #2 0x104a77d54 in pjmedia_stream_get_info stream.c:3250
    #3 0x104784d94 in pjsua_aud_stop_stream pjsua_aud.c:563
    #4 0x1047571a0 in stop_media_stream pjsua_media.c:3122
    #5 0x104750924 in stop_media_session pjsua_media.c:3179
    #6 0x10474f664 in pjsua_media_channel_deinit pjsua_media.c:3262
    #7 0x10471dc20 in pjsua_destroy2 pjsua_core.c:1939

0x00010ea8e938 is located 56 bytes inside of 8000-byte region [0x00010ea8e900,0x00010ea90840)
freed by thread T4 here:
    #5 0x104ea9228 in pj_pool_release pool_i.h:102
    #6 0x104ea92ec in pj_pool_safe_release pool_i.h:111
    #7 0x104a751b8 in pjmedia_stream_destroy stream.c:3170
    #8 0x104785564 in pjsua_aud_stop_stream pjsua_aud.c:612
    #9 0x1047571a0 in stop_media_stream pjsua_media.c:3122
    #10 0x104750924 in stop_media_session pjsua_media.c:3179
    #11 0x10474f664 in pjsua_media_channel_deinit pjsua_media.c:3262
    #12 0x1046ed130 in pjsua_call_hangup pjsua_call.c:3123
    #13 0x1047039c4 in pjsua_call_hangup_all pjsua_call.c:4002
    #14 0x10471db9c in pjsua_destroy2 pjsua_core.c:1931
```
`pjsua_call_hangup_all()` and `pjsua_media_channel_deinit()` will deinitialise the media twice.
