### PR TITLE
Fixed account's route set update when modifying account

### DIFF
--- a/pjlib/include/pj/list.h
+++ b/pjlib/include/pj/list.h
@@ -171,6 +171,27 @@ PJ_IDECL(void) pj_list_insert_nodes_after(pj_list_type *lst,
 
 
 /**
+ * Insert the node to the list before the specified element position.
+ *
+ * @param pos   The element to which the node will be inserted before.
+ * @param lst   The list to be inserted.
+ */
+PJ_IDECL(void) pj_list_insert_list_before(pj_list_type *pos,
+                                          pj_list_type *lst);
+
+
+/**
+ * Insert the node to the list after the specified element position.
+ *
+ * @param pos   The element in the list which will precede the inserted
+ *              list.
+ * @param lst   The list to be inserted.
+ */
+PJ_IDECL(void) pj_list_insert_list_after(pj_list_type *pos,
+                                         pj_list_type *lst);
+
+
+/**
  * Remove elements from the source list, and insert them to the destination
  * list. The elements of the source list will occupy the
  * front elements of the target list. Note that the node pointed by \a list2

--- a/pjlib/include/pj/list.h
+++ b/pjlib/include/pj/list.h
@@ -171,7 +171,7 @@ PJ_IDECL(void) pj_list_insert_nodes_after(pj_list_type *lst,
 
 
 /**
- * Insert the node to the list before the specified element position.
+ * Insert a list to another list before the specified element position.
  *
  * @param pos   The element to which the node will be inserted before.
  * @param lst   The list to be inserted.
@@ -181,7 +181,7 @@ PJ_IDECL(void) pj_list_insert_list_before(pj_list_type *pos,
 
 
 /**
- * Insert the node to the list after the specified element position.
+ * Insert a list to another list after the specified element position.
  *
  * @param pos   The element in the list which will precede the inserted
  *              list.

--- a/pjlib/include/pj/list_i.h
+++ b/pjlib/include/pj/list_i.h
@@ -54,6 +54,22 @@ PJ_IDEF(void) pj_list_insert_nodes_before(pj_list_type *pos, pj_list_type *lst)
     pj_list_insert_nodes_after(((pj_list*)pos)->prev, lst);
 }
 
+PJ_IDEF(void) pj_list_insert_list_after(pj_list_type *pos, pj_list_type *lst)
+{
+    if (!pj_list_empty(lst)) {
+        pj_list *lst_last = (pj_list *) ((pj_list*)lst)->prev;
+        pj_list *pos_next = (pj_list *) ((pj_list*)pos)->next;
+
+        pj_link_node(pos, (pj_list *) ((pj_list*)lst)->next);
+        pj_link_node(lst_last, pos_next);
+    }
+}
+
+PJ_IDEF(void) pj_list_insert_list_before(pj_list_type *pos, pj_list_type *lst)
+{
+    pj_list_insert_list_after(((pj_list*)pos)->prev, lst);
+}
+
 PJ_IDEF(void) pj_list_merge_last(pj_list_type *lst1, pj_list_type *lst2)
 {
     if (!pj_list_empty(lst2)) {

--- a/pjlib/include/pj/list_i.h
+++ b/pjlib/include/pj/list_i.h
@@ -62,6 +62,7 @@ PJ_IDEF(void) pj_list_insert_list_after(pj_list_type *pos, pj_list_type *lst)
 
         pj_link_node(pos, (pj_list *) ((pj_list*)lst)->next);
         pj_link_node(lst_last, pos_next);
+        pj_list_init(lst);
     }
 }
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -370,8 +370,6 @@ static pj_status_t initialize_acc(unsigned acc_id)
         }
         pj_list_push_back(&acc->route_set, r);
     }
-       pj_list_push_back(&acc->route_set, pjsip_hdr_shallow_clone(acc->pool, pjsua_var.outbound_proxy.next));
-       pj_list_push_back(&acc->route_set, pjsip_hdr_shallow_clone(acc->pool, pjsua_var.outbound_proxy.prev));
  
     /* Concatenate credentials from account config and global config */
     acc->cred_cnt = 0;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -370,7 +370,7 @@ static pj_status_t initialize_acc(unsigned acc_id)
         }
         pj_list_push_back(&acc->route_set, r);
     }
- 
+
     /* Concatenate credentials from account config and global config */
     acc->cred_cnt = 0;
     for (i=0; i<acc_cfg->cred_count; ++i) {
@@ -824,7 +824,6 @@ static pj_bool_t update_hdr_list(pj_pool_t *pool, pjsip_hdr *dst,
     return changed;
 }
 
-
 /*
  * Modify account information.
  */
@@ -917,7 +916,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
             for (i=pjsua_var.ua_cfg.outbound_proxy_cnt + acc->cfg.proxy_cnt,
                  hr=acc->route_set.prev;
-                 i<rcnt; 
+                 i<rcnt;
                  ++i)
              {
                 pjsip_route_hdr *prev = hr->prev;


### PR DESCRIPTION
There's an issue with account modification via `pjsua_acc_modify()` when updating account's route_set.

Account's route set is a list that consists of:  global proxies + account proxies + service route learnt from `update_service_route()`.
But when modifying account, the learnt service route is never taken into account, causing incorrect list size calculation, and hence incorrect element removal.

The fixes in this PR:
- Learnt route headers is only removed upon registrar change. Account proxy is only modified upon change.
- Remove global outbound proxy modification.
 The current implementation seems to be buggy and not working as intended for the following reasons:
  - there's no API to modify the global proxy,
  - even if app modifies pjsua_var.ua_cfg.outbound_proxy internally (such as by including pjsua_internal.h), the route set is built from the list pjsua_var.outbound_proxy, which actually has different content and is never updated.
- Add new list APIs pj_list_insert_list_before/after().

Thank you to @andreas-wehrmann for the report and fix recommendation.
