### PR TITLE
Final response 2xx not retransmitted when transport is closed

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2221,6 +2221,13 @@ static void send_msg_callback( pjsip_send_state *send_state,
                 tsx_set_state( tsx, PJSIP_TSX_STATE_DESTROYED, 
                                PJSIP_EVENT_TRANSPORT_ERROR,
                                send_state->tdata, 0);
+            } else if (tsx->role == PJSIP_ROLE_UAS && 
+                       tsx->transport_flag & TSX_HAS_PENDING_RESCHED &&
+                       tsx->state != PJSIP_TSX_STATE_TERMINATED &&
+                       tsx->state != PJSIP_TSX_STATE_DESTROYED) 
+            {
+                tsx->transport_flag &= ~(TSX_HAS_PENDING_RESCHED);
+                tsx_resched_retransmission(tsx);
             }
 
         } else {


### PR DESCRIPTION
When transport is closed before sending 2xx final response, the message will fail to be sent. 
However, it is not retransmitted.

```
15:18:01.361       sip_endpoint.c  Processing incoming message: Request msg INVITE/cseq=1 (rdata0xd6da70)
15:18:01.361          tsx0xd75a38  ..Transaction created for Request msg INVITE/cseq=1 (rdata0xd70518)
15:18:01.361          tsx0xd75a38  .Incoming Request msg INVITE/cseq=1 (rdata0xd70518) in state Null
15:18:01.361          tsx0xd75a38  ..State changed from Null to Trying, event=RX_MSG
15:18:01.361          dlg0xd747d8  ...Transaction tsx0xd75a38 state changed to Trying
15:18:01.361          dlg0xd747d8  .UAS dialog created
...
15:18:01.361          tsx0xd75a38  ....State changed from Trying to Proceeding, event=TX_MSG
15:18:01.361          dlg0xd747d8  .....Transaction tsx0xd75a38 state changed to Proceeding
15:18:01.361          inv0xd747d8  ......State changed from NULL to INCOMING, event=TSX_STATE
...
15:18:01.367         tcps0xd6d788 !TCP connection closed
15:18:01.367      sip_transport.c  Transport tcps0xd6d788 shutting down, force=0
15:18:01.368      sip_transport.c  Transport tcps0xd6d788 is being destroyed due to timeout in idle timer
15:18:01.368         tcps0xd6d788  TCP transport destroyed with reason 70016: End of file (PJ_EEOF)
...
15:18:01.368          inv0xd747d8  .Sending Response msg 200/INVITE/cseq=1 (tdta0x7fec84008738)
15:18:01.368      sip_transport.c  .Tx data Response msg 200/INVITE/cseq=1 (tdta0x7fec84001478) cloned
15:18:01.368          dlg0xd747d8  ..Sending Response msg 200/INVITE/cseq=1 (tdta0x7fec84001478)
15:18:01.368          tsx0xd75a38  ..Sending Response msg 200/INVITE/cseq=1 (tdta0x7fec84001478) in state Proceeding
...
15:18:01.378   tcpc0x7fec8400e178 !TCP connect() error: [code=120111]: Connection refused
15:18:01.378          tsx0xd75a38  Failed to send Response msg 200/INVITE/cseq=1 (tdta0x7fec84001478)! err=120111 (Connection refused)
15:18:01.378   tcpc0x7fec8400e178  TCP send() error, sent=-120111
15:18:01.378      sip_transport.c  Transport tcpc0x7fec8400e178 shutting down, force=0
15:18:01.378      sip_transport.c  Transport tcpc0x7fec8400e178 is being destroyed due to timeout in idle timer
15:18:01.378   tcpc0x7fec8400e178  TCP transport destroyed with reason 120111: Connection refused
15:18:33.369          tsx0xd75a38  Timeout timer event
15:18:33.369          tsx0xd75a38  .State changed from Completed to Terminated, event=TIMER
15:18:33.369          dlg0xd747d8  ..Transaction tsx0xd75a38 state changed to Terminated
15:18:33.369           sip_util.c  ...Request msg BYE/cseq=16412 (tdta0xd7a8b8) created.
```
When the transport is closed, the response will be sent using `pjsip_endpt_send_response()` 
https://github.com/pjsip/pjproject/blob/e9771e22030d7d4930042fdd4e25ebba0a369f8f/pjsip/src/pjsip/sip_transaction.c#L2532
with `TSX_HAS_PENDING_TRANSPORT` set and later will prevent the retransmit timer from being scheduled and instead setting `TSX_HAS_PENDING_RESCHED`.
https://github.com/pjsip/pjproject/blob/e9771e22030d7d4930042fdd4e25ebba0a369f8f/pjsip/src/pjsip/sip_transaction.c#L3086

This patch will check if `TSX_HAS_PENDING_RESCHED` is set, and schedule the timer in the case that the send failed.