### PR TITLE
Potential issues when IPv6 is disabled

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1376,7 +1376,8 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     }
 
     acc->cfg.nat64_opt = cfg->nat64_opt;
-    acc->cfg.ipv6_media_use = cfg->ipv6_media_use;
+    acc->cfg.ipv6_media_use = PJ_HAS_IPV6? cfg->ipv6_media_use :
+                                           PJSUA_IPV6_DISABLED;
     acc->cfg.enable_rtcp_mux = cfg->enable_rtcp_mux;
     acc->cfg.lock_codec = cfg->lock_codec;
     acc->cfg.enable_rtcp_xr = cfg->enable_rtcp_xr;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2756,10 +2756,9 @@ pj_bool_t pjsua_sip_acc_is_using_ipv6(pjsua_acc_id acc_id)
 #if PJ_HAS_IPV6
     pjsua_acc *acc = &pjsua_var.acc[acc_id];
 
-    return (PJ_HAS_IPV6 &&
-            ((acc->tp_type & PJSIP_TRANSPORT_IPV6) == PJSIP_TRANSPORT_IPV6 ||
-             pjsua_var.acc[acc_id].cfg.ipv6_sip_use ==
-             PJSUA_IPV6_ENABLED_USE_IPV6_ONLY));
+    return ((acc->tp_type & PJSIP_TRANSPORT_IPV6) == PJSIP_TRANSPORT_IPV6 ||
+            pjsua_var.acc[acc_id].cfg.ipv6_sip_use ==
+            PJSUA_IPV6_ENABLED_USE_IPV6_ONLY);
 #else
     PJ_UNUSED_ARG(acc_id);
     return PJ_FALSE;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -462,6 +462,12 @@ PJ_DEF(pj_status_t) pjsua_acc_add( const pjsua_acc_config *cfg,
     PJ_ASSERT_RETURN(pjsua_var.acc_cnt < PJ_ARRAY_SIZE(pjsua_var.acc),
                      PJ_ETOOMANY);
 
+#if !PJ_HAS_IPV6
+    PJ_ASSERT_RETURN(cfg->ipv6_sip_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg->ipv6_media_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg->nat64_opt == PJSUA_IPV6_DISABLED, PJ_EINVAL);
+#endif
+
     /* Must have a transport */
     PJ_ASSERT_RETURN(pjsua_var.tpdata[0].data.ptr != NULL, PJ_EINVALIDOP);
 
@@ -845,6 +851,12 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     PJ_ASSERT_RETURN(acc_id>=0 && acc_id<(int)PJ_ARRAY_SIZE(pjsua_var.acc),
                      PJ_EINVAL);
 
+#if !PJ_HAS_IPV6
+    PJ_ASSERT_RETURN(cfg->ipv6_sip_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg->ipv6_media_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg->nat64_opt == PJSUA_IPV6_DISABLED, PJ_EINVAL);
+#endif
+
     PJ_LOG(4,(THIS_FILE, "Modifying account %d", acc_id));
     pj_log_push_indent();
 
@@ -1005,6 +1017,13 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         pj_strdup_with_null(acc->pool, &acc->srv_domain, &id_sip_uri->host);
         acc->srv_port = 0;
         acc->is_sips = PJSIP_URI_SCHEME_IS_SIPS(id_name_addr);
+        update_reg = PJ_TRUE;
+        unreg_first = PJ_TRUE;
+    }
+
+    /* SIP IP version preference */
+    if (acc->cfg.ipv6_sip_use != cfg->ipv6_sip_use) {
+        acc->cfg.ipv6_sip_use = cfg->ipv6_sip_use;
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
     }
@@ -1375,7 +1394,8 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         acc->cfg.rtp_cfg.bound_addr = b_addr;
     }
 
-    acc->cfg.nat64_opt = cfg->nat64_opt;
+    acc->cfg.nat64_opt = PJ_HAS_IPV6? cfg->nat64_opt :
+                                      PJSUA_NAT64_DISABLED;
     acc->cfg.ipv6_media_use = PJ_HAS_IPV6? cfg->ipv6_media_use :
                                            PJSUA_IPV6_DISABLED;
     acc->cfg.enable_rtcp_mux = cfg->enable_rtcp_mux;
@@ -2733,15 +2753,22 @@ static pj_status_t pjsua_regc_init(int acc_id)
 
 pj_bool_t pjsua_sip_acc_is_using_ipv6(pjsua_acc_id acc_id)
 {
+#if PJ_HAS_IPV6
     pjsua_acc *acc = &pjsua_var.acc[acc_id];
 
-    return ((acc->tp_type & PJSIP_TRANSPORT_IPV6) == PJSIP_TRANSPORT_IPV6 ||
-            pjsua_var.acc[acc_id].cfg.ipv6_sip_use ==
-            PJSUA_IPV6_ENABLED_USE_IPV6_ONLY);
+    return (PJ_HAS_IPV6 &&
+            ((acc->tp_type & PJSIP_TRANSPORT_IPV6) == PJSIP_TRANSPORT_IPV6 ||
+             pjsua_var.acc[acc_id].cfg.ipv6_sip_use ==
+             PJSUA_IPV6_ENABLED_USE_IPV6_ONLY));
+#else
+    PJ_UNUSED_ARG(acc_id);
+    return PJ_FALSE;
+#endif
 }
 
 static int sip_acc_get_pref_ip_ver(pjsua_acc_id acc_id)
 {
+#if PJ_HAS_IPV6
     pjsua_acc *acc = &pjsua_var.acc[acc_id];
 
     if ((acc->tp_type & PJSIP_TRANSPORT_IPV6) == PJSIP_TRANSPORT_IPV6 ||
@@ -2766,6 +2793,10 @@ static int sip_acc_get_pref_ip_ver(pjsua_acc_id acc_id)
          */
         return 0;
     }
+#else
+    PJ_UNUSED_ARG(acc_id);
+    return 4;
+#endif
 }
 
 pj_bool_t pjsua_sip_acc_is_using_stun(pjsua_acc_id acc_id)
@@ -3552,10 +3583,10 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
             goto on_return;
         }
 
-        if (ip_addr_ver == 6 || sip_pref_ip == 6) {
+        if (PJ_HAS_IPV6 && (ip_addr_ver == 6 || sip_pref_ip == 6)) {
             /* Get IPv6 address if dest host is IPv6 or we prefer IPv6. */
             af = pj_AF_INET6();
-        } else if (ip_addr_ver == 4 || sip_pref_ip == 4) {
+        } else if (!PJ_HAS_IPV6 || ip_addr_ver == 4 || sip_pref_ip == 4) {
             /* Get IPv4 address if dest host is IPv4 or we prefer IPv4. */
             af = pj_AF_INET();
         } else {
@@ -3575,7 +3606,9 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
         /* Get fallback address, only if the host is not IP address and
          * account is not bound to a certain transport.
          */
-        if (ip_addr_ver == 0 && acc->tp_type == PJSIP_TRANSPORT_UNSPECIFIED) {
+        if (PJ_HAS_IPV6 && ip_addr_ver == 0 &&
+            acc->tp_type == PJSIP_TRANSPORT_UNSPECIFIED)
+        {
             unsigned cnt = 1;
 
             /* If first address is IPv4, fallback to IPv6, and vice versa. */
@@ -3871,7 +3904,7 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uas_contact( pj_pool_t *pool,
         pjsua_sip_acc_is_using_ipv6(acc_id) ||
         (rdata->tp_info.transport->key.type & PJSIP_TRANSPORT_IPV6))
     {
-        if (acc->cfg.ipv6_sip_use == PJSUA_IPV6_DISABLED)
+        if (!PJ_HAS_IPV6 || acc->cfg.ipv6_sip_use == PJSUA_IPV6_DISABLED)
             return PJSIP_EUNSUPTRANSPORT;
         tp_type = (pjsip_transport_type_e)
                   (((int)tp_type) | PJSIP_TRANSPORT_IPV6);

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -373,8 +373,10 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
     cfg->register_on_acc_add = PJ_TRUE;
     cfg->mwi_expires = PJSIP_MWI_DEFAULT_EXPIRES;
 
-    cfg->ipv6_sip_use = PJSUA_IPV6_ENABLED_NO_PREFERENCE;
-    cfg->ipv6_media_use = PJSUA_IPV6_ENABLED_PREFER_IPV4;
+    cfg->ipv6_sip_use   = PJ_HAS_IPV6? PJSUA_IPV6_ENABLED_NO_PREFERENCE :
+                                       PJSUA_IPV6_DISABLED;
+    cfg->ipv6_media_use = PJ_HAS_IPV6? PJSUA_IPV6_ENABLED_PREFER_IPV4 :
+                                       PJSUA_IPV6_DISABLED;
 
     cfg->media_stun_use = PJSUA_STUN_RETRY_ON_FAILURE;
     cfg->ip_change_cfg.shutdown_tp = PJ_TRUE;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1217,6 +1217,10 @@ PJ_DEF(pj_status_t) pjsua_init( const pjsua_config *ua_cfg,
         }
     }
 
+#if !PJ_HAS_IPV6
+    pjsua_var.ua_cfg.stun_try_ipv6 = PJ_FALSE;
+#endif
+
     /* Start resolving STUN server */
     status = resolve_stun_server(PJ_FALSE, PJ_FALSE, 0);
     if (status != PJ_SUCCESS && status != PJ_EPENDING) {

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -310,7 +310,7 @@ static pj_status_t create_rtp_rtcp_sock(pjsua_call_media *call_med,
     pj_sock_t sock[2];
 
     use_ipv6 = (get_media_ip_version(call_med, rem_sdp) == 6);
-    use_nat64 = (acc->cfg.nat64_opt != PJSUA_NAT64_DISABLED);
+    use_nat64 = PJ_HAS_IPV6 && (acc->cfg.nat64_opt != PJSUA_NAT64_DISABLED);
     af = (use_ipv6 || use_nat64) ? pj_AF_INET6() : pj_AF_INET();
 
     /* Make sure STUN server resolution has completed */
@@ -763,7 +763,7 @@ static pj_status_t create_loop_media_transport(
     pjsua_acc *acc = &pjsua_var.acc[call_med->call->acc_id];
 
     use_ipv6 = (get_media_ip_version(call_med, rem_sdp) == 6);
-    use_nat64 = (acc->cfg.nat64_opt != PJSUA_NAT64_DISABLED);
+    use_nat64 = PJ_HAS_IPV6 && (acc->cfg.nat64_opt != PJSUA_NAT64_DISABLED);
     af = (use_ipv6 || use_nat64) ? pj_AF_INET6() : pj_AF_INET();
 
     pjmedia_loop_tp_setting_default(&opt);
@@ -1021,7 +1021,7 @@ static pj_status_t create_ice_media_transport(
 
     acc_cfg = &pjsua_var.acc[call_med->call->acc_id].cfg;
     use_ipv6 = (get_media_ip_version(call_med, remote_sdp) == 6);
-    use_nat64 = (acc_cfg->nat64_opt != PJSUA_NAT64_DISABLED);
+    use_nat64 = PJ_HAS_IPV6 && (acc_cfg->nat64_opt != PJSUA_NAT64_DISABLED);
 
     /* Make sure STUN server resolution has completed */
     if (pjsua_media_acc_is_using_stun(call_med->call->acc_id)) {
@@ -2820,7 +2820,8 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
                 use_ipv6 = PJ_HAS_IPV6 &&
                            (pjsua_var.acc[call->acc_id].cfg.ipv6_media_use !=
                             PJSUA_IPV6_DISABLED);
-                use_nat64 = (pjsua_var.acc[call->acc_id].cfg.nat64_opt !=
+                use_nat64 = PJ_HAS_IPV6 &&
+                            (pjsua_var.acc[call->acc_id].cfg.nat64_opt !=
                              PJSUA_NAT64_DISABLED);
 
                 m->conn = PJ_POOL_ZALLOC_T(pool, pjmedia_sdp_conn);

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -249,6 +249,8 @@ pj_status_t pjsua_media_subsys_destroy(unsigned flags)
 static int get_media_ip_version(pjsua_call_media *call_med,
                                 const pjmedia_sdp_session *rem_sdp)
 {
+#if PJ_HAS_IPV6
+
     pjsua_ipv6_use ipv6_use;
 
     ipv6_use = pjsua_var.acc[call_med->call->acc_id].cfg.ipv6_media_use;
@@ -276,6 +278,10 @@ static int get_media_ip_version(pjsua_call_media *call_med,
             return 6;
         }
     }
+#else
+    PJ_UNUSED_ARG(call_med);
+    PJ_UNUSED_ARG(rem_sdp);
+#endif
 
     /* Use IPv4. */
     return 4;
@@ -2811,7 +2817,8 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
                 pj_bool_t use_ipv6;
                 pj_bool_t use_nat64;
 
-                use_ipv6 = (pjsua_var.acc[call->acc_id].cfg.ipv6_media_use !=
+                use_ipv6 = PJ_HAS_IPV6 &&
+                           (pjsua_var.acc[call->acc_id].cfg.ipv6_media_use !=
                             PJSUA_IPV6_DISABLED);
                 use_nat64 = (pjsua_var.acc[call->acc_id].cfg.nat64_opt !=
                              PJSUA_NAT64_DISABLED);


### PR DESCRIPTION
When `PJ_HAS_IPV6` is set to zero, there can be issues, e.g:
- disabled video line may use IPv6 address in SDP c= line.

Thanks Justin Maggard for the report.