### PR TITLE
Fixed deprecation warnings on Mac and iOS

### DIFF
--- a/configure-iphone
+++ b/configure-iphone
@@ -20,8 +20,8 @@ if test "$*" = "--help" -o "$*" = "-h"; then
   echo "  ARCH       Optional flags to specify target architecture, e.g."
   echo "             ARCH=\"-arch armv7\". Default is arm64."
   echo "  MIN_IOS    Optional flags to specify minimum supported iOS"
-  echo "             versions, e.g. MIN_IOS=\"-miphoneos-version-min=10.0\". "
-  echo "             Default is 7.0."
+  echo "             versions, e.g. MIN_IOS=\"-miphoneos-version-min=11.0\". "
+  echo "             Default is 11.0."
   echo ""
   exit 0
 fi
@@ -123,7 +123,7 @@ if test "${ARCH_VAL}" = "arm64e"; then
 fi 
 
 if test "${MIN_IOS}" = ""; then
-  MIN_IOS_VER="7.0"
+  MIN_IOS_VER="11.0"
   echo "$F: MIN_IOS is not specified, choosing ${MIN_IOS_VER}"
   MIN_IOS="-miphoneos-version-min=${MIN_IOS_VER}"
 fi

--- a/pjlib/src/pj/activesock.c
+++ b/pjlib/src/pj/activesock.c
@@ -143,6 +143,9 @@ static void activesock_destroy_iphone_os_stream(pj_activesock_t *asock)
 
 static void activesock_create_iphone_os_stream(pj_activesock_t *asock)
 {
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && \
+     __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
+
     if (ios_bg_support && asock->bg_setting && asock->stream_oriented) {
         activesock_destroy_iphone_os_stream(asock);
 
@@ -164,6 +167,8 @@ static void activesock_create_iphone_os_stream(pj_activesock_t *asock)
             activesock_destroy_iphone_os_stream(asock);
         }
     }
+
+#endif
 }
 
 

--- a/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
+++ b/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
@@ -29,6 +29,12 @@
     #define COREAUDIO_MAC 1
 #endif
 
+#if (TARGET_OS_OSX && defined(__MAC_12_0))
+    #define AUDIO_OBJECT_ELEMENT_MAIN kAudioObjectPropertyElementMain;
+#else
+    #define AUDIO_OBJECT_ELEMENT_MAIN kAudioObjectPropertyElementMaster;
+#endif
+
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioConverter.h>
 #if COREAUDIO_MAC
@@ -447,7 +453,7 @@ static pj_status_t ca_factory_refresh(pjmedia_aud_dev_factory *f)
     /* Find out how many audio devices there are */
     addr.mSelector = kAudioHardwarePropertyDevices;
     addr.mScope = kAudioObjectPropertyScopeGlobal;
-    addr.mElement = kAudioObjectPropertyElementMaster;
+    addr.mElement = AUDIO_OBJECT_ELEMENT_MAIN;
     ostatus = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &addr,
                                              0, NULL, &dev_size);
     if (ostatus != noErr) {
@@ -492,7 +498,7 @@ static pj_status_t ca_factory_refresh(pjmedia_aud_dev_factory *f)
         /* Find default audio input device */
         addr.mSelector = kAudioHardwarePropertyDefaultInputDevice;
         addr.mScope = kAudioObjectPropertyScopeGlobal;
-        addr.mElement = kAudioObjectPropertyElementMaster;
+        addr.mElement = AUDIO_OBJECT_ELEMENT_MAIN;
         size = sizeof(dev_id);
         
         ostatus = AudioObjectGetPropertyData(kAudioObjectSystemObject,
@@ -544,7 +550,7 @@ static pj_status_t ca_factory_refresh(pjmedia_aud_dev_factory *f)
         /* Get device name */
         addr.mSelector = kAudioDevicePropertyDeviceName;
         addr.mScope = kAudioObjectPropertyScopeGlobal;
-        addr.mElement = kAudioObjectPropertyElementMaster;
+        addr.mElement = AUDIO_OBJECT_ELEMENT_MAIN;
         size = sizeof(cdi->info.name);
         AudioObjectGetPropertyData(cdi->dev_id, &addr,
                                    0, NULL,

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -326,7 +326,8 @@ static pj_status_t darwin_factory_refresh(pjmedia_vid_dev_factory *f)
                   , AVCaptureDeviceTypeExternalUnknown
 #endif
 #if TARGET_OS_IPHONE && defined(__IPHONE_10_0)
-                  , AVCaptureDeviceTypeBuiltInDuoCamera
+                  // Deprecated in iOS 10.2
+                  // , AVCaptureDeviceTypeBuiltInDuoCamera
                   , AVCaptureDeviceTypeBuiltInTelephotoCamera
 #endif
                   ];
@@ -338,7 +339,10 @@ static pj_status_t darwin_factory_refresh(pjmedia_vid_dev_factory *f)
 
             dev_list = [dds devices];
         } else {
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_15
+#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+     __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_15) || \
+    (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && \
+     __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)
             dev_list = [AVCaptureDevice devices];
 #endif
         }


### PR DESCRIPTION
Increase default minimum iOS version to 11 as XCode 14 doesn't support deployment to releases older than iOS 11 (note that latest XCode is now XCode 15).
https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
`Building for deployment to OS releases older than macOS 10.13, iOS 11, tvOS 11, and watchOS 4 is no longer supported. (92834476)`

Also fixed various deprecation warnings on Mac and iOS:
```
../src/pjmedia-audiodev/coreaudio_dev.m:557:25: warning: 'kAudioObjectPropertyElementMaster' is
 deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
        addr.mElement = kAudioObjectPropertyElementMaster;
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                        kAudioObjectPropertyElementMain
```

```
../src/pjmedia-videodev/darwin_dev.m:329:21: warning: 'AVCaptureDeviceTypeBuiltInDuoCamera' is
 deprecated: first deprecated in iOS 10.2 - Use AVCaptureDeviceTypeBuiltInDualCamera instead. [-Wdeprecated-declarations]
                  , AVCaptureDeviceTypeBuiltInDuoCamera
```

```
../src/pjmedia-videodev/darwin_dev.m:342:41: warning: 'devices' is deprecated: first deprecated in
 iOS 10.0 - Use AVCaptureDeviceDiscoverySession instead. [-Wdeprecated-declarations]
            dev_list = [AVCaptureDevice devices];
```

```
../src/pj/activesock.c:155:37: warning: 'kCFStreamNetworkServiceTypeVoIP' is deprecated: first 
deprecated in iOS 9.0 - use PushKit for VoIP control purposes [-Wdeprecated-declarations]
                                    kCFStreamNetworkServiceTypeVoIP)
```
