### PR TITLE
Fixed thread leak in Mac OS

### DIFF
--- a/pjlib/src/pj/os_core_darwin.m
+++ b/pjlib/src/pj/os_core_darwin.m
@@ -91,6 +91,7 @@ PJ_DEF(int) pj_run_app(pj_main_func_ptr main_func, int argc, char *argv[],
     param.main_func = main_func;
     if (pthread_create(&thread, NULL, &main_thread, &param) == 0) {
         CFRunLoopRun();
+        pthread_join(thread, NULL);
     }
     
     PJ_UNUSED_ARG(pool);


### PR DESCRIPTION
As reported by `Thread Sanitizer`:
```
WARNING: ThreadSanitizer: thread leak (pid=43999)
  Thread T4 (tid=13541807, finished) created by main thread at:
    #0 pthread_create <null>:112207392 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x2fd88) (BuildId: 981013a59ee23029b2ed90b76951327532000000200000000100000000000b00)
    #1 pj_run_app os_core_darwin.m:92 (pjsua-arm-apple-darwin22.5.0:arm64+0x1002d16a0) (BuildId: 6ea65fbc18bf32ec86bb9612d863d97532000000200000000100000000000d00)
    #2 main main.c:158 (pjsua-arm-apple-darwin22.5.0:arm64+0x100003560) (BuildId: 6ea65fbc18bf32ec86bb9612d863d97532000000200000000100000000000d00)

SUMMARY: ThreadSanitizer: thread leak os_core_darwin.m:92 in pj_run_app
```
