### PR TITLE
Fixed dialog event Coverity warnings

### DIFF
--- a/pjsip/src/pjsip-simple/dlg_event.c
+++ b/pjsip/src/pjsip-simple/dlg_event.c
@@ -564,9 +564,11 @@ static void dlg_event_on_evsub_rx_notify(pjsip_evsub *sub,
 
     } else {
         unsigned i;
+        pj_mutex_lock(dlgev->mutex);
         for (i=0; i<dlgev->status.info_cnt; ++i) {
             dlgev->status.info[i].dialog_node = NULL;
         }
+        pj_mutex_unlock(dlgev->mutex);
     }
 
     /* Notify application. */

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -349,7 +349,9 @@ pjsua_buddy_get_dlg_event_info( pjsua_buddy_id buddy_id,
     pj_strncpy(&info->uri, &buddy->uri, sizeof(info->buf_)-total);
     total += info->uri.slen;
 
-    if (buddy->dlg_ev_status.info[0].dialog_info_state.slen > 0) {
+    if (buddy->dlg_ev_status.info[0].dialog_info_state.slen > 0 &&
+        total < sizeof(info->buf_))
+    {
         info->dialog_info_state.ptr = info->buf_ + total;
         pj_strncpy(&info->dialog_info_state,
             &buddy->dlg_ev_status.info[0].dialog_info_state,
@@ -357,119 +359,131 @@ pjsua_buddy_get_dlg_event_info( pjsua_buddy_id buddy_id,
         total += info->dialog_info_state.slen;
     }
 
-    if (buddy->dlg_ev_status.info[0].dialog_info_entity.slen > 0) {
+    if (buddy->dlg_ev_status.info[0].dialog_info_entity.slen > 0 &&
+        total < sizeof(info->buf_))
+    {
         info->dialog_info_entity.ptr = info->buf_ + total;
         pj_strncpy(&info->dialog_info_entity,
             &buddy->dlg_ev_status.info[0].dialog_info_entity,
             buddy->dlg_ev_status.info[0].dialog_info_entity.slen);
         total += info->dialog_info_entity.slen;
     }
-    if (buddy->dlg_ev_status.info[0].dialog_state.slen == 0) {
-        info->dialog_state.ptr = info->buf_ + total;
-        info->dialog_state = pj_str("NULL");
-        total += info->dialog_state.slen;
-    }
+
     if (buddy->dlg_ev_status.info[0].dialog_node) {
-        info->dialog_id.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_id, &buddy->dlg_ev_status.info[0].dialog_id,
-                   sizeof(info->buf_)-total);
-        total += info->dialog_id.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_id.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_id,
+                       &buddy->dlg_ev_status.info[0].dialog_id,
+                       sizeof(info->buf_)-total);
+            total += info->dialog_id.slen;
+        }
 
-        info->dialog_call_id.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_call_id,
-                   &buddy->dlg_ev_status.info[0].dialog_call_id,
-                   sizeof(info->buf_)-total);
-        total += info->dialog_call_id.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_call_id.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_call_id,
+                       &buddy->dlg_ev_status.info[0].dialog_call_id,
+                       sizeof(info->buf_)-total);
+            total += info->dialog_call_id.slen;
+        }
 
-        info->dialog_remote_tag.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_remote_tag,
-                   &buddy->dlg_ev_status.info[0].dialog_remote_tag,
-                   sizeof(info->buf_)-total);
-        total += info->dialog_remote_tag.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_remote_tag.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_remote_tag,
+                       &buddy->dlg_ev_status.info[0].dialog_remote_tag,
+                       sizeof(info->buf_)-total);
+            total += info->dialog_remote_tag.slen;
+        }
 
-        info->dialog_local_tag.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_local_tag,
-                   &buddy->dlg_ev_status.info[0].dialog_local_tag,
-                   sizeof(info->buf_)-total);
-        total += info->dialog_local_tag.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_local_tag.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_local_tag,
+                       &buddy->dlg_ev_status.info[0].dialog_local_tag,
+                       sizeof(info->buf_)-total);
+            total += info->dialog_local_tag.slen;
+        }
 
-        info->dialog_direction.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_direction,
-                   &buddy->dlg_ev_status.info[0].dialog_direction,
-                   sizeof(info->buf_)-total);
-        total += info->dialog_direction.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_direction.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_direction,
+                       &buddy->dlg_ev_status.info[0].dialog_direction,
+                       sizeof(info->buf_)-total);
+            total += info->dialog_direction.slen;
+        }
 
-        info->dialog_state.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_state,
-                   &buddy->dlg_ev_status.info[0].dialog_state,
-                   buddy->dlg_ev_status.info[0].dialog_state.slen);
-        total += info->dialog_state.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_state.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_state,
+                       &buddy->dlg_ev_status.info[0].dialog_state,
+                       buddy->dlg_ev_status.info[0].dialog_state.slen);
+            total += info->dialog_state.slen;
+        }
 
-        info->dialog_duration.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_duration,
-                   &buddy->dlg_ev_status.info[0].dialog_duration,
-                   buddy->dlg_ev_status.info[0].dialog_duration.slen);
-        total += info->dialog_duration.slen;
+        if (total < sizeof(info->buf_)) {
+            info->dialog_duration.ptr = info->buf_ + total;
+            pj_strncpy(&info->dialog_duration,
+                       &buddy->dlg_ev_status.info[0].dialog_duration,
+                       buddy->dlg_ev_status.info[0].dialog_duration.slen);
+            total += info->dialog_duration.slen;
+        }
 
-        if (buddy->dlg_ev_status.info[0].local_identity.ptr) {
+        if (buddy->dlg_ev_status.info[0].local_identity.slen > 0 &&
+            total < sizeof(info->buf_))
+        {
             info->local_identity.ptr = info->buf_ + total;
             pj_strncpy(&info->local_identity,
                        &buddy->dlg_ev_status.info[0].local_identity,
                        buddy->dlg_ev_status.info[0].local_identity.slen);
             total += info->local_identity.slen;
-        } else {
-            info->local_identity = pj_str("NULL");
         }
 
-        if (buddy->dlg_ev_status.info[0].local_identity_display.ptr) {
+        if (buddy->dlg_ev_status.info[0].local_identity_display.slen > 0 &&
+            total < sizeof(info->buf_))
+        {
             info->local_identity_display.ptr = info->buf_ + total;
             pj_strncpy(&info->local_identity_display,
                 &buddy->dlg_ev_status.info[0].local_identity_display,
                 buddy->dlg_ev_status.info[0].local_identity_display.slen);
             total += info->local_identity_display.slen;
-        } else {
-            info->local_identity_display = pj_str("NULL");
         }
 
-        if (buddy->dlg_ev_status.info[0].local_target_uri.ptr) {
+        if (buddy->dlg_ev_status.info[0].local_target_uri.slen > 0 &&
+            total < sizeof(info->buf_))
+        {
             info->local_target_uri.ptr = info->buf_ + total;
             pj_strncpy(&info->local_target_uri,
                        &buddy->dlg_ev_status.info[0].local_target_uri,
                        buddy->dlg_ev_status.info[0].local_target_uri.slen);
             total += info->local_target_uri.slen;
-        } else {
-            info->local_target_uri = pj_str("NULL");
         }
 
-        if (buddy->dlg_ev_status.info[0].remote_identity.ptr) {
+        if (buddy->dlg_ev_status.info[0].remote_identity.slen > 0 &&
+            total < sizeof(info->buf_))
+        {
             info->remote_identity.ptr = info->buf_ + total;
             pj_strncpy(&info->remote_identity,
                        &buddy->dlg_ev_status.info[0].remote_identity,
                        buddy->dlg_ev_status.info[0].remote_identity.slen);
             total += info->remote_identity.slen;
-        } else {
-            info->remote_identity = pj_str("NULL");
         }
 
-        if (buddy->dlg_ev_status.info[0].remote_identity_display.ptr) {
+        if (buddy->dlg_ev_status.info[0].remote_identity_display.slen > 0 &&
+            total < sizeof(info->buf_))
+        {
             info->remote_identity_display.ptr = info->buf_ + total;
             pj_strncpy(&info->remote_identity_display,
                 &buddy->dlg_ev_status.info[0].remote_identity_display,
                 buddy->dlg_ev_status.info[0].remote_identity_display.slen);
             total += info->remote_identity_display.slen;
-        } else {
-            info->remote_identity_display = pj_str("NULL");
         }
 
-        if (buddy->dlg_ev_status.info[0].remote_target_uri.ptr) {
+        if (buddy->dlg_ev_status.info[0].remote_target_uri.slen > 0 &&
+            total < sizeof(info->buf_))
+        {
             info->remote_target_uri.ptr = info->buf_ + total;
             pj_strncpy(&info->remote_target_uri,
                        &buddy->dlg_ev_status.info[0].remote_target_uri,       
                        buddy->dlg_ev_status.info[0].remote_target_uri.slen);
             total += info->remote_target_uri.slen;
-        }
-        else {
-            info->remote_target_uri = pj_str("NULL");
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -329,6 +329,18 @@ pjsua_buddy_get_dlg_event_info( pjsua_buddy_id buddy_id,
     pjsua_buddy *buddy;
     pj_status_t status;
 
+#define COPY_TO_BUF(status, field) \
+    if (status.field.slen > 0) { \
+        if (total + status.field.slen < sizeof(info->buf_)) { \
+            info->field.ptr = info->buf_ + total; \
+            pj_strncpy(&info->field, &status.field, status.field.slen); \
+            total += info->field.slen; \
+        } else { \
+            PJ_LOG(4, (THIS_FILE, "Insufficient buffer when copying %s", \
+                                  #field)); \
+        } \
+    }
+
     PJ_ASSERT_RETURN(pjsua_buddy_is_valid(buddy_id),  PJ_EINVAL);
 
     pj_bzero(info, sizeof(pjsua_buddy_dlg_event_info));
@@ -349,142 +361,24 @@ pjsua_buddy_get_dlg_event_info( pjsua_buddy_id buddy_id,
     pj_strncpy(&info->uri, &buddy->uri, sizeof(info->buf_)-total);
     total += info->uri.slen;
 
-    if (buddy->dlg_ev_status.info[0].dialog_info_state.slen > 0 &&
-        total < sizeof(info->buf_))
-    {
-        info->dialog_info_state.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_info_state,
-            &buddy->dlg_ev_status.info[0].dialog_info_state,
-            buddy->dlg_ev_status.info[0].dialog_info_state.slen);
-        total += info->dialog_info_state.slen;
-    }
-
-    if (buddy->dlg_ev_status.info[0].dialog_info_entity.slen > 0 &&
-        total < sizeof(info->buf_))
-    {
-        info->dialog_info_entity.ptr = info->buf_ + total;
-        pj_strncpy(&info->dialog_info_entity,
-            &buddy->dlg_ev_status.info[0].dialog_info_entity,
-            buddy->dlg_ev_status.info[0].dialog_info_entity.slen);
-        total += info->dialog_info_entity.slen;
-    }
+    COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_info_state);
+    COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_info_entity);
 
     if (buddy->dlg_ev_status.info[0].dialog_node) {
-        if (total < sizeof(info->buf_)) {
-            info->dialog_id.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_id,
-                       &buddy->dlg_ev_status.info[0].dialog_id,
-                       sizeof(info->buf_)-total);
-            total += info->dialog_id.slen;
-        }
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_id);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_call_id);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_remote_tag);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_local_tag);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_direction);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_state);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], dialog_duration);
 
-        if (total < sizeof(info->buf_)) {
-            info->dialog_call_id.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_call_id,
-                       &buddy->dlg_ev_status.info[0].dialog_call_id,
-                       sizeof(info->buf_)-total);
-            total += info->dialog_call_id.slen;
-        }
-
-        if (total < sizeof(info->buf_)) {
-            info->dialog_remote_tag.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_remote_tag,
-                       &buddy->dlg_ev_status.info[0].dialog_remote_tag,
-                       sizeof(info->buf_)-total);
-            total += info->dialog_remote_tag.slen;
-        }
-
-        if (total < sizeof(info->buf_)) {
-            info->dialog_local_tag.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_local_tag,
-                       &buddy->dlg_ev_status.info[0].dialog_local_tag,
-                       sizeof(info->buf_)-total);
-            total += info->dialog_local_tag.slen;
-        }
-
-        if (total < sizeof(info->buf_)) {
-            info->dialog_direction.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_direction,
-                       &buddy->dlg_ev_status.info[0].dialog_direction,
-                       sizeof(info->buf_)-total);
-            total += info->dialog_direction.slen;
-        }
-
-        if (total < sizeof(info->buf_)) {
-            info->dialog_state.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_state,
-                       &buddy->dlg_ev_status.info[0].dialog_state,
-                       buddy->dlg_ev_status.info[0].dialog_state.slen);
-            total += info->dialog_state.slen;
-        }
-
-        if (total < sizeof(info->buf_)) {
-            info->dialog_duration.ptr = info->buf_ + total;
-            pj_strncpy(&info->dialog_duration,
-                       &buddy->dlg_ev_status.info[0].dialog_duration,
-                       buddy->dlg_ev_status.info[0].dialog_duration.slen);
-            total += info->dialog_duration.slen;
-        }
-
-        if (buddy->dlg_ev_status.info[0].local_identity.slen > 0 &&
-            total < sizeof(info->buf_))
-        {
-            info->local_identity.ptr = info->buf_ + total;
-            pj_strncpy(&info->local_identity,
-                       &buddy->dlg_ev_status.info[0].local_identity,
-                       buddy->dlg_ev_status.info[0].local_identity.slen);
-            total += info->local_identity.slen;
-        }
-
-        if (buddy->dlg_ev_status.info[0].local_identity_display.slen > 0 &&
-            total < sizeof(info->buf_))
-        {
-            info->local_identity_display.ptr = info->buf_ + total;
-            pj_strncpy(&info->local_identity_display,
-                &buddy->dlg_ev_status.info[0].local_identity_display,
-                buddy->dlg_ev_status.info[0].local_identity_display.slen);
-            total += info->local_identity_display.slen;
-        }
-
-        if (buddy->dlg_ev_status.info[0].local_target_uri.slen > 0 &&
-            total < sizeof(info->buf_))
-        {
-            info->local_target_uri.ptr = info->buf_ + total;
-            pj_strncpy(&info->local_target_uri,
-                       &buddy->dlg_ev_status.info[0].local_target_uri,
-                       buddy->dlg_ev_status.info[0].local_target_uri.slen);
-            total += info->local_target_uri.slen;
-        }
-
-        if (buddy->dlg_ev_status.info[0].remote_identity.slen > 0 &&
-            total < sizeof(info->buf_))
-        {
-            info->remote_identity.ptr = info->buf_ + total;
-            pj_strncpy(&info->remote_identity,
-                       &buddy->dlg_ev_status.info[0].remote_identity,
-                       buddy->dlg_ev_status.info[0].remote_identity.slen);
-            total += info->remote_identity.slen;
-        }
-
-        if (buddy->dlg_ev_status.info[0].remote_identity_display.slen > 0 &&
-            total < sizeof(info->buf_))
-        {
-            info->remote_identity_display.ptr = info->buf_ + total;
-            pj_strncpy(&info->remote_identity_display,
-                &buddy->dlg_ev_status.info[0].remote_identity_display,
-                buddy->dlg_ev_status.info[0].remote_identity_display.slen);
-            total += info->remote_identity_display.slen;
-        }
-
-        if (buddy->dlg_ev_status.info[0].remote_target_uri.slen > 0 &&
-            total < sizeof(info->buf_))
-        {
-            info->remote_target_uri.ptr = info->buf_ + total;
-            pj_strncpy(&info->remote_target_uri,
-                       &buddy->dlg_ev_status.info[0].remote_target_uri,       
-                       buddy->dlg_ev_status.info[0].remote_target_uri.slen);
-            total += info->remote_target_uri.slen;
-        }
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], local_identity);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], local_identity_display);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], local_target_uri);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], remote_identity);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], remote_identity_display);
+        COPY_TO_BUF(buddy->dlg_ev_status.info[0], remote_target_uri);
     }
 
     /* subscription state and termination reason */


### PR DESCRIPTION
Re #3754 , Coverity yields a couple of warnings:
```
>>>     CID 1533986:  Concurrent data access violations  (MISSING_LOCK)
>>>     Accessing "dlgev->status" without holding lock "pj_mutex_t.mutex". Elsewhere, "pjsip_dlg_event.status" is written to with "pj_mutex_t.mutex" held 1 out of 1 times.
567             for (i=0; i<dlgev->status.info_cnt; ++i) {
568                 dlgev->[status.info](http://status.info/)[i].dialog_node = NULL;
```

```
353             info->dialog_info_state.ptr = info->buf_ + total;
>>>     CID 1533985:    (OVERRUN)
>>>     Overrunning array of 1024 bytes at byte offset 1024 by dereferencing pointer "info->dialog_info_state.ptr".
```
