### PR TITLE
Fixed SWIG Python build failure on Mac

### DIFF
--- a/pjsip-apps/src/swig/python/Makefile
+++ b/pjsip-apps/src/swig/python/Makefile
@@ -26,7 +26,9 @@ SWIG_FLAGS=-I../../../../pjlib/include \
 SRC_DIR=../../../../pjsip/include
 SRCS=$(SRC_DIR)/pjsua2/endpoint.hpp $(SRC_DIR)/pjsua2/types.hpp
 
-USE_THREADS = -threads -DSWIG_NO_EXPORT_ITERATOR_METHODS
+USE_THREADS = -threads
+# In SWIG 4.2 the build will fail if we use this flag
+#-DSWIG_NO_EXPORT_ITERATOR_METHODS
 SWIG_FLAGS += -w312 $(USE_THREADS)
 
 .PHONY: all install uninstall


### PR DESCRIPTION
I can't find the reason why we need to use this flag `SWIG_NO_EXPORT_ITERATOR_METHODS`.

But this will cause SWIG Python build to fail on Mac.
```
pjsua2_wrap.cpp:6275:34: error: no template named 'SwigPyIteratorClosed_T'
    struct SwigPyMapIterator_T : SwigPyIteratorClosed_T<OutIterator, ValueType, FromOper>
                                 ^
pjsua2_wrap.cpp:6278:4: error: no template named 'SwigPyIteratorClosed_T'
        : SwigPyIteratorClosed_T<OutIterator,ValueType,FromOper>(curr, first, last, seq)
   ```

Note:
- Only known to happen on SWIG 4.2 (4.1.1 and before seems to build just fine).
- Reproducible on CI machine and my local Mac.
