### PR TITLE
Fix bad access in cancelling timer

### DIFF
--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -534,11 +534,14 @@ static int cancel( pj_timer_heap_t *ht,
 
     PJ_CHECK_STACK();
 
-    // Check to see if the timer_id is out of range
+    // Check to see if the timer_id is out of range.
+    // Moved to cancel_timer() as it needs to validate _timer_id earlier
+    /*
     if (entry->_timer_id < 1 || (pj_size_t)entry->_timer_id >= ht->max_size) {
         entry->_timer_id = -1;
         return 0;
     }
+    */
 
     timer_node_slot = ht->timer_ids[entry->_timer_id];
 
@@ -811,6 +814,13 @@ static int cancel_timer(pj_timer_heap_t *ht,
     PJ_ASSERT_RETURN(ht && entry, PJ_EINVAL);
 
     lock_timer_heap(ht);
+
+    // Check to see if the timer_id is out of range
+    if (entry->_timer_id < 1 || (pj_size_t)entry->_timer_id >= ht->max_size) {
+        unlock_timer_heap(ht);
+        return 0;
+    }
+
     timer_copy = GET_TIMER(ht, entry);
     grp_lock = timer_copy->_grp_lock;
 


### PR DESCRIPTION
Reported that in a valgrind test when `PJ_POOL_DEBUG` is set, PJSIP transaction accesses to bad memory in cancelling a timer entry:
```
Invalid read of size 8
    at 0x49BA530: cancel_timer (in /usr/local/lib64/libpj.so.2)
    by 0x48E49B5: tsx_set_state (in /usr/local/lib64/libpjsip.so.2)
```
After investigation, it looks like that when cancelling a timer entry that is never scheduled (i.e: the entry has `_timer_id == -1`), it may cause the timer to access bad location. This does not seem to occur when `PJ_POOL_DEBUG` is not set.

Thanks Taisto Qvist for the report.