### PR TITLE
Secure random number generator for SRTP key when using PJ_SSL_SOCK_IMP_APPLE

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -34,7 +34,7 @@
 #  endif
 #endif
 
-#ifdef PJ_SSL_SOCK_IMP_APPLE
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
     #include <Security/SecRandom.h>
 #endif
 
@@ -138,12 +138,14 @@ static pj_status_t generate_crypto_attr_value(pj_pool_t *pool,
                 return PJMEDIA_ERRNO_FROM_LIBSRTP(1);
             }
 #elif defined(PJ_HAS_SSL_SOCK) && (PJ_HAS_SSL_SOCK != 0) && \
-    (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_APPLE)
-            int status = SecRandomCopyBytes(kSecRandomDefault, crypto_suites[cs_idx].cipher_key_len, &key);
-            if (status != errSecSuccess) {
-                    PJ_LOG(4,(THIS_FILE, "Failed generating random key "
-                            "(native err=%d)", status));
-                    return PJMEDIA_ERRNO_FROM_LIBSRTP(1);
+      (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_APPLE)
+            int err = SecRandomCopyBytes(kSecRandomDefault,
+                                         crypto_suites[cs_idx].cipher_key_len,
+                                         &key);
+            if (err != errSecSuccess) {
+                PJ_LOG(4,(THIS_FILE, "Failed generating random key "
+                          "(native err=%d)", err));
+                return PJMEDIA_ERRNO_FROM_LIBSRTP(1);
             }
 #else
             PJ_LOG(3,(THIS_FILE, "Warning: simple random generator is used "

--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -34,6 +34,9 @@
 #  endif
 #endif
 
+#ifdef PJ_SSL_SOCK_IMP_APPLE
+    #include <Security/SecRandom.h>
+#endif
 
 #include <pj/rand.h>
 
@@ -133,6 +136,14 @@ static pj_status_t generate_crypto_attr_value(pj_pool_t *pool,
                 PJ_LOG(4,(THIS_FILE, "Failed generating random key "
                           "(native err=%d)", err));
                 return PJMEDIA_ERRNO_FROM_LIBSRTP(1);
+            }
+#elif defined(PJ_HAS_SSL_SOCK) && (PJ_HAS_SSL_SOCK != 0) && \
+    (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_APPLE)
+            int status = SecRandomCopyBytes(kSecRandomDefault, crypto_suites[cs_idx].cipher_key_len, &key);
+            if (status != errSecSuccess) {
+                    PJ_LOG(4,(THIS_FILE, "Failed generating random key "
+                            "(native err=%d)", status));
+                    return PJMEDIA_ERRNO_FROM_LIBSRTP(1);
             }
 #else
             PJ_LOG(3,(THIS_FILE, "Warning: simple random generator is used "

--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -34,7 +34,7 @@
 #  endif
 #endif
 
-#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_APPLE)
     #include <Security/SecRandom.h>
 #endif
 


### PR DESCRIPTION
I noticed in the logs that PJSIP is using an insecure random number generator (RNG) when PJ_SSL_SOCK_IMP_APPLE is used: 

> transport_srtp.c  Warning: simple random generator is used for generating SRTP key

This seems to be because if any implementation other than PJ_SSL_SOCK_IMP_OPENSSL is used the non-secure RNG is used. A secure RNG does exist in Apple's Security framework (https://developer.apple.com/documentation/security/1399291-secrandomcopybytes) against which PJSIP should be linked when PJ_SSL_SOCK_IMP_APPLE is used. 

This PR checks if PJ_SSL_SOCK_IMP_APPLE is defined and uses Apple's secure RNG if this is the case. 