### PR TITLE
Add an option to disable Message Composition Indication feature (MCI)

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -77,6 +77,7 @@ typedef struct pjsua_app_config
     pj_bool_t               no_refersub;
     pj_bool_t               ipv6;
     pj_bool_t               enable_qos;
+    pj_bool_t               enable_mci;
     pj_bool_t               no_tcp;
     pj_bool_t               no_udp;
     pj_bool_t               use_tls;

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -77,7 +77,7 @@ typedef struct pjsua_app_config
     pj_bool_t               no_refersub;
     pj_bool_t               ipv6;
     pj_bool_t               enable_qos;
-    pj_bool_t               enable_mci;
+    pj_bool_t               no_mci;
     pj_bool_t               no_tcp;
     pj_bool_t               no_udp;
     pj_bool_t               use_tls;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -94,6 +94,7 @@ static void usage(void)
     puts  ("  --ipv6              Create SIP IPv6 transports.");
 #endif
     puts  ("  --set-qos           Enable QoS tagging for SIP and media.");
+    puts  ("  --no-mci            Disable message composition indication (RFC 3994)");
     puts  ("  --local-port=port   Set TCP/UDP port. This implicitly enables both ");
     puts  ("                      TCP and UDP transports on the specified port, unless");
     puts  ("                      if TCP or UDP is disabled.");
@@ -226,7 +227,6 @@ static void usage(void)
     puts  ("  --accept-redirect=N Specify how to handle call redirect (3xx) response.");
     puts  ("                      0: reject, 1: follow automatically,");
     puts  ("                      2: follow + replace To header (default), 3: ask");
-    puts  ("  --set-mci           Use message composition indication RFC 3994");
 
     puts  ("");
     puts  ("CLI options:");
@@ -534,7 +534,7 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "ipv6",        0, 0, OPT_IPV6},
 #endif
         { "set-qos",     0, 0, OPT_QOS},
-        { "set-mci",     0, 0, OPT_MCI},
+        { "no-mci",     0, 0, OPT_MCI},
         { "use-timer",  1, 0, OPT_TIMER},
         { "timer-se",   1, 0, OPT_TIMER_SE},
         { "timer-min-se", 1, 0, OPT_TIMER_MIN_SE},
@@ -1469,7 +1469,7 @@ static pj_status_t parse_args(int argc, char *argv[],
             cfg->udp_cfg.qos_params.dscp_val = 0x18;
             break;
         case OPT_MCI:
-            cfg->enable_mci = PJ_TRUE;
+            cfg->no_mci = PJ_TRUE;
             break;
         case OPT_VIDEO:
             cfg->vid.vid_cnt = 1;
@@ -1985,8 +1985,8 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
     }
 
     /* Message Composition Indication */
-    if (config->enable_mci) {
-        pj_strcat2(&cfg, "--set-mci\n");
+    if (config->no_mci) {
+        pj_strcat2(&cfg, "--no-mci\n");
     }
     /* UDP Transport. */
     pj_ansi_snprintf(line, sizeof(line), "--local-port %d\n",

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -226,6 +226,7 @@ static void usage(void)
     puts  ("  --accept-redirect=N Specify how to handle call redirect (3xx) response.");
     puts  ("                      0: reject, 1: follow automatically,");
     puts  ("                      2: follow + replace To header (default), 3: ask");
+    puts  ("  --set-mci           Use message composition indication RFC 3994");
 
     puts  ("");
     puts  ("CLI options:");
@@ -392,7 +393,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_TLS_NEG_TIMEOUT, OPT_TLS_CIPHER,
            OPT_CAPTURE_DEV, OPT_PLAYBACK_DEV,
            OPT_CAPTURE_LAT, OPT_PLAYBACK_LAT, OPT_NO_TONES, OPT_JB_MAX_SIZE,
-           OPT_STDOUT_REFRESH, OPT_STDOUT_REFRESH_TEXT, OPT_IPV6, OPT_QOS,
+           OPT_STDOUT_REFRESH, OPT_STDOUT_REFRESH_TEXT, OPT_IPV6, OPT_QOS, OPT_MCI,
 #ifdef _IONBF
            OPT_STDOUT_NO_BUF,
 #endif
@@ -533,6 +534,7 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "ipv6",        0, 0, OPT_IPV6},
 #endif
         { "set-qos",     0, 0, OPT_QOS},
+        { "set-mci",     0, 0, OPT_MCI},
         { "use-timer",  1, 0, OPT_TIMER},
         { "timer-se",   1, 0, OPT_TIMER_SE},
         { "timer-min-se", 1, 0, OPT_TIMER_MIN_SE},
@@ -1466,6 +1468,9 @@ static pj_status_t parse_args(int argc, char *argv[],
             cfg->udp_cfg.qos_params.flags = PJ_QOS_PARAM_HAS_DSCP;
             cfg->udp_cfg.qos_params.dscp_val = 0x18;
             break;
+        case OPT_MCI:
+            cfg->enable_mci = PJ_TRUE;
+            break;
         case OPT_VIDEO:
             cfg->vid.vid_cnt = 1;
             cfg->vid.in_auto_show = PJ_TRUE;
@@ -1979,6 +1984,10 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
         pj_strcat2(&cfg, "--set-qos\n");
     }
 
+    /* Message Composition Indication */
+    if (config->enable_mci) {
+        pj_strcat2(&cfg, "--set-mci\n");
+    }
     /* UDP Transport. */
     pj_ansi_snprintf(line, sizeof(line), "--local-port %d\n",
                      config->udp_cfg.port);

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -824,7 +824,7 @@ static void ui_send_instant_message()
 
 
     /* Send typing indication. */
-    if (app_config.enable_mci) {
+    if (!app_config.no_mci) {
         if (i != -1)
             pjsua_call_send_typing_ind(i, PJ_TRUE, NULL);
         else {
@@ -835,7 +835,7 @@ static void ui_send_instant_message()
 
     /* Input the IM . */
     if (!simple_input("Message", text, sizeof(text))) {
-        if (app_config.enable_mci) {
+        if (!app_config.no_mci) {
             /*
             * Cancelled.
             * Send typing notification too, saying we're not typing.

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -824,26 +824,30 @@ static void ui_send_instant_message()
 
 
     /* Send typing indication. */
-    if (i != -1)
-        pjsua_call_send_typing_ind(i, PJ_TRUE, NULL);
-    else {
-        pj_str_t tmp_uri = pj_str(uri);
-        pjsua_im_typing(current_acc, &tmp_uri, PJ_TRUE, NULL);
+    if (app_config.enable_mci) {
+        if (i != -1)
+            pjsua_call_send_typing_ind(i, PJ_TRUE, NULL);
+        else {
+            pj_str_t tmp_uri = pj_str(uri);
+            pjsua_im_typing(current_acc, &tmp_uri, PJ_TRUE, NULL);
+        }
     }
 
     /* Input the IM . */
     if (!simple_input("Message", text, sizeof(text))) {
-        /*
-        * Cancelled.
-        * Send typing notification too, saying we're not typing.
-        */
-        if (i != -1)
-            pjsua_call_send_typing_ind(i, PJ_FALSE, NULL);
-        else {
-            pj_str_t tmp_uri = pj_str(uri);
-            pjsua_im_typing(current_acc, &tmp_uri, PJ_FALSE, NULL);
+        if (app_config.enable_mci) {
+            /*
+            * Cancelled.
+            * Send typing notification too, saying we're not typing.
+            */
+            if (i != -1)
+                pjsua_call_send_typing_ind(i, PJ_FALSE, NULL);
+            else {
+                pj_str_t tmp_uri = pj_str(uri);
+                pjsua_im_typing(current_acc, &tmp_uri, PJ_FALSE, NULL);
+            }
+            return;
         }
-        return;
     }
 
     tmp = pj_str(text);


### PR DESCRIPTION
The Message Composition Indication feature (RFC-3994) is always enabled currently. And it leads to sending massive messages while typing.
The PR switches off the feature by default and adds an option to a configuration file to enable the feature
```
--set-mci
```
