### PR TITLE
Video CI test on iOS device

### DIFF
--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/project.pbxproj
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		3AF9B5342B7B454D0043987D /* ipjsua-swiftVidTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ipjsua-swiftVidTest.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AF9B5362B7B454D0043987D /* ipjsua_swiftVidTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ipjsua_swiftVidTest.swift; sourceTree = "<group>"; };
 		3AF9B5382B7B454D0043987D /* ipjsua_swiftVidTestLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ipjsua_swiftVidTestLaunchTests.swift; sourceTree = "<group>"; };
+		3AF9B53F2B7B583C0043987D /* ipjsua-swift.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ipjsua-swift.xctestplan"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +182,7 @@
 		3A6FC60F25CBD4540065F472 = {
 			isa = PBXGroup;
 			children = (
+				3AF9B53F2B7B583C0043987D /* ipjsua-swift.xctestplan */,
 				3AF9B5352B7B454D0043987D /* ipjsua-swiftVidTest */,
 				3A6FC75A25CBD6CF0065F472 /* Frameworks */,
 				3A6FC6AF25CBD5790065F472 /* Libraries */,
@@ -637,7 +639,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teluu.ipjsua-swiftVidTest";
@@ -665,7 +667,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teluu.ipjsua-swiftVidTest";

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/project.pbxproj
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3A4E3B582B62025C0016735C /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4E3B562B62025B0016735C /* MetalKit.framework */; };
 		3A4E3B592B62025C0016735C /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4E3B572B62025B0016735C /* Metal.framework */; };
+		3A4E3BA52B734E9A0016735C /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4E3BA42B734E9A0016735C /* Network.framework */; };
 		3A6FC61C25CBD4540065F472 /* ipjsua_swiftApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6FC61B25CBD4540065F472 /* ipjsua_swiftApp.swift */; };
 		3A6FC61E25CBD4540065F472 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6FC61D25CBD4540065F472 /* ContentView.swift */; };
 		3A6FC62025CBD4550065F472 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3A6FC61F25CBD4550065F472 /* Assets.xcassets */; };
@@ -51,11 +52,24 @@
 		3A6FC7F225CD1A3E0065F472 /* libwebrtc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6FC7DE25CD1A3D0065F472 /* libwebrtc.a */; };
 		3A6FC7F325CD1A3E0065F472 /* libpjmedia-codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6FC7DF25CD1A3D0065F472 /* libpjmedia-codec.a */; };
 		3A6FC7F425CD1A3E0065F472 /* libpjmedia-audiodev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6FC7E025CD1A3D0065F472 /* libpjmedia-audiodev.a */; };
+		3AF9B5372B7B454D0043987D /* ipjsua_swiftVidTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF9B5362B7B454D0043987D /* ipjsua_swiftVidTest.swift */; };
+		3AF9B5392B7B454D0043987D /* ipjsua_swiftVidTestLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF9B5382B7B454D0043987D /* ipjsua_swiftVidTestLaunchTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3AF9B53A2B7B454D0043987D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A6FC61025CBD4540065F472 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A6FC61725CBD4540065F472;
+			remoteInfo = "ipjsua-swift";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		3A4E3B562B62025B0016735C /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		3A4E3B572B62025B0016735C /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		3A4E3BA42B734E9A0016735C /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		3A6FC61825CBD4540065F472 /* ipjsua-swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ipjsua-swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A6FC61B25CBD4540065F472 /* ipjsua_swiftApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ipjsua_swiftApp.swift; sourceTree = "<group>"; };
 		3A6FC61D25CBD4540065F472 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -101,6 +115,9 @@
 		3A6FC7DE25CD1A3D0065F472 /* libwebrtc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwebrtc.a; sourceTree = "<group>"; };
 		3A6FC7DF25CD1A3D0065F472 /* libpjmedia-codec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjmedia-codec.a"; sourceTree = "<group>"; };
 		3A6FC7E025CD1A3D0065F472 /* libpjmedia-audiodev.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libpjmedia-audiodev.a"; sourceTree = "<group>"; };
+		3AF9B5342B7B454D0043987D /* ipjsua-swiftVidTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ipjsua-swiftVidTest.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AF9B5362B7B454D0043987D /* ipjsua_swiftVidTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ipjsua_swiftVidTest.swift; sourceTree = "<group>"; };
+		3AF9B5382B7B454D0043987D /* ipjsua_swiftVidTestLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ipjsua_swiftVidTestLaunchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +164,14 @@
 				3A6FC7F325CD1A3E0065F472 /* libpjmedia-codec.a in Frameworks */,
 				3A6FC78525CBE3700065F472 /* UIKit.framework in Frameworks */,
 				3A6FC78625CBE3700065F472 /* VideoToolbox.framework in Frameworks */,
+				3A4E3BA52B734E9A0016735C /* Network.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AF9B5312B7B454D0043987D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,6 +181,7 @@
 		3A6FC60F25CBD4540065F472 = {
 			isa = PBXGroup;
 			children = (
+				3AF9B5352B7B454D0043987D /* ipjsua-swiftVidTest */,
 				3A6FC75A25CBD6CF0065F472 /* Frameworks */,
 				3A6FC6AF25CBD5790065F472 /* Libraries */,
 				3A6FC61A25CBD4540065F472 /* ipjsua-swift */,
@@ -167,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				3A6FC61825CBD4540065F472 /* ipjsua-swift.app */,
+				3AF9B5342B7B454D0043987D /* ipjsua-swiftVidTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -223,6 +250,7 @@
 		3A6FC75A25CBD6CF0065F472 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3A4E3BA42B734E9A0016735C /* Network.framework */,
 				3A4E3B572B62025B0016735C /* Metal.framework */,
 				3A4E3B562B62025B0016735C /* MetalKit.framework */,
 				3A6FC75B25CBD6E10065F472 /* AudioToolbox.framework */,
@@ -246,6 +274,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		3AF9B5352B7B454D0043987D /* ipjsua-swiftVidTest */ = {
+			isa = PBXGroup;
+			children = (
+				3AF9B5362B7B454D0043987D /* ipjsua_swiftVidTest.swift */,
+				3AF9B5382B7B454D0043987D /* ipjsua_swiftVidTestLaunchTests.swift */,
+			);
+			path = "ipjsua-swiftVidTest";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -266,18 +303,40 @@
 			productReference = 3A6FC61825CBD4540065F472 /* ipjsua-swift.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3AF9B5332B7B454D0043987D /* ipjsua-swiftVidTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AF9B53E2B7B454D0043987D /* Build configuration list for PBXNativeTarget "ipjsua-swiftVidTest" */;
+			buildPhases = (
+				3AF9B5302B7B454D0043987D /* Sources */,
+				3AF9B5312B7B454D0043987D /* Frameworks */,
+				3AF9B5322B7B454D0043987D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3AF9B53B2B7B454D0043987D /* PBXTargetDependency */,
+			);
+			name = "ipjsua-swiftVidTest";
+			productName = "ipjsua-swiftVidTest";
+			productReference = 3AF9B5342B7B454D0043987D /* ipjsua-swiftVidTest.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		3A6FC61025CBD4540065F472 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1520;
 				LastUpgradeCheck = 1240;
 				TargetAttributes = {
 					3A6FC61725CBD4540065F472 = {
 						CreatedOnToolsVersion = 12.4;
 						LastSwiftMigration = 1240;
+					};
+					3AF9B5332B7B454D0043987D = {
+						CreatedOnToolsVersion = 15.2;
+						TestTargetID = 3A6FC61725CBD4540065F472;
 					};
 				};
 			};
@@ -295,6 +354,7 @@
 			projectRoot = "";
 			targets = (
 				3A6FC61725CBD4540065F472 /* ipjsua-swift */,
+				3AF9B5332B7B454D0043987D /* ipjsua-swiftVidTest */,
 			);
 		};
 /* End PBXProject section */
@@ -306,6 +366,13 @@
 			files = (
 				3A6FC62325CBD4550065F472 /* Preview Assets.xcassets in Resources */,
 				3A6FC62025CBD4550065F472 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AF9B5322B7B454D0043987D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -322,7 +389,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3AF9B5302B7B454D0043987D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3AF9B5392B7B454D0043987D /* ipjsua_swiftVidTestLaunchTests.swift in Sources */,
+				3AF9B5372B7B454D0043987D /* ipjsua_swiftVidTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3AF9B53B2B7B454D0043987D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3A6FC61725CBD4540065F472 /* ipjsua-swift */;
+			targetProxy = 3AF9B53A2B7B454D0043987D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3A6FC62525CBD4550065F472 /* Debug */ = {
@@ -463,9 +547,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"ipjsua-swift/Preview Content\"";
-				DEVELOPMENT_TEAM = 93NHJQ455P;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 93NHJQ455P;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "ipjsua-swift/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -488,6 +574,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teluu.ipjsua-swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Teluu Profile";
 				SWIFT_OBJC_BRIDGING_HEADER = "ipjsua-swift/ipjsua-swift-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -501,9 +589,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"ipjsua-swift/Preview Content\"";
-				DEVELOPMENT_TEAM = 93NHJQ455P;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 93NHJQ455P;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "ipjsua-swift/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -526,9 +616,66 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teluu.ipjsua-swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Teluu Profile";
 				SWIFT_OBJC_BRIDGING_HEADER = "ipjsua-swift/ipjsua-swift-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3AF9B53C2B7B454D0043987D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 93NHJQ455P;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.teluu.ipjsua-swiftVidTest";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Teluu Profile";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "ipjsua-swift";
+			};
+			name = Debug;
+		};
+		3AF9B53D2B7B454D0043987D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 93NHJQ455P;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.teluu.ipjsua-swiftVidTest";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Teluu Profile";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "ipjsua-swift";
 			};
 			name = Release;
 		};
@@ -549,6 +696,15 @@
 			buildConfigurations = (
 				3A6FC62825CBD4550065F472 /* Debug */,
 				3A6FC62925CBD4550065F472 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AF9B53E2B7B454D0043987D /* Build configuration list for PBXNativeTarget "ipjsua-swiftVidTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AF9B53C2B7B454D0043987D /* Debug */,
+				3AF9B53D2B7B454D0043987D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/xcshareddata/xcschemes/ipjsua-swift.xcscheme
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/xcshareddata/xcschemes/ipjsua-swift.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1420"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ipjsua-swift.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/xcshareddata/xcschemes/ipjsua-swift.xcscheme
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xcodeproj/xcshareddata/xcschemes/ipjsua-swift.xcscheme
@@ -28,6 +28,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AF9B5332B7B454D0043987D"
+               BuildableName = "ipjsua-swiftVidTest.xctest"
+               BlueprintName = "ipjsua-swiftVidTest"
+               ReferencedContainer = "container:ipjsua-swift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xctestplan
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "A0480BD1-665B-4D82-9F04-A4890A775321",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:ipjsua-swift.xcodeproj",
+      "identifier" : "3A6FC61725CBD4540065F472",
+      "name" : "ipjsua-swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:ipjsua-swift.xcodeproj",
+        "identifier" : "3AF9B5332B7B454D0043987D",
+        "name" : "ipjsua-swiftVidTest"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ContentView.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ContentView.swift
@@ -75,12 +75,11 @@ struct ContentView: View {
     var body: some View {
         VStack(alignment: .center) {
             HStack(alignment: .center) {
+                Text(pjsip_vars.calling == true ? "Destination:" :
+                     pjsip_vars.vid_win != nil ? "Video" : "")
                 if (!pjsip_vars.calling) {
-                    Text("Destination:")
                     TextField(pjsip_vars.dest, text: $pjsip_vars.dest)
                         .frame(minWidth:0, maxWidth:200)
-                } else if (pjsip_vars.vid_win != nil) {
-                    Text("Video")
                 }
             }
 

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ContentView.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ContentView.swift
@@ -75,7 +75,7 @@ struct ContentView: View {
     var body: some View {
         VStack(alignment: .center) {
             HStack(alignment: .center) {
-                Text(pjsip_vars.calling == true ? "Destination:" :
+                Text(pjsip_vars.calling != true ? "Destination:" :
                      pjsip_vars.vid_win != nil ? "Video" : "")
                 if (!pjsip_vars.calling) {
                     TextField(pjsip_vars.dest, text: $pjsip_vars.dest)

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ContentView.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ContentView.swift
@@ -79,6 +79,8 @@ struct ContentView: View {
                     Text("Destination:")
                     TextField(pjsip_vars.dest, text: $pjsip_vars.dest)
                         .frame(minWidth:0, maxWidth:200)
+                } else if (pjsip_vars.vid_win != nil) {
+                    Text("Video")
                 }
             }
 

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/Info.plist
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/Info.plist
@@ -6,6 +6,8 @@
 	<string>Audio call permission</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Video call permission</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Local network permission</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ipjsua_swiftApp.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ipjsua_swiftApp.swift
@@ -24,7 +24,7 @@ import SwiftUI
 
 class PjsipVars: ObservableObject {
     @Published var calling = false
-    var dest: String = "sip:test@sip.pjsip.org"
+    var dest: String = "sip:localhost:5080"
     var call_id: pjsua_call_id = PJSUA_INVALID_ID.rawValue
     /* Video window */
     @Published var vid_win:UIView? = nil
@@ -54,6 +54,7 @@ struct ipjsua_swiftApp: App {
         pjsua_media_config_default(&media_cfg);
 
         /* Initialize application callbacks */
+        cfg.cb.on_incoming_call = on_incoming_call;
         cfg.cb.on_call_state = on_call_state;
         cfg.cb.on_call_media_state = on_call_media_state;
 
@@ -64,9 +65,36 @@ struct ipjsua_swiftApp: App {
         var transport_id = pjsua_transport_id();
         var tcp_cfg = pjsua_transport_config();
         pjsua_transport_config_default(&tcp_cfg);
-        tcp_cfg.port = 5060;
+        tcp_cfg.port = 5080;
         status = pjsua_transport_create(PJSIP_TRANSPORT_TCP,
                                         &tcp_cfg, &transport_id);
+
+        /* Add local account */
+        var aid = pjsua_acc_id();
+        status = pjsua_acc_add_local(transport_id, pj_bool_t(PJ_TRUE.rawValue), &aid);
+
+        /* Use colorbar for local account and enable incoming video */
+        var acc_cfg = pjsua_acc_config();
+        var tmp_pool:UnsafeMutablePointer<pj_pool_t>? = nil;
+        var info : [pjmedia_vid_dev_info] =
+            Array(repeating: pjmedia_vid_dev_info(), count: 16);
+        var count:UInt32 = UInt32(info.capacity);
+
+        tmp_pool = pjsua_pool_create("tmp-ipjsua", 1000, 1000);
+        pjsua_acc_get_config(aid, tmp_pool, &acc_cfg);
+        acc_cfg.vid_in_auto_show = pj_bool_t(PJ_TRUE.rawValue);
+
+        pjsua_vid_enum_devs(&info, &count);
+        for i in 0..<count {
+            let name: [CChar] = tupleToArray(tuple: info[Int(i)].name);
+            if let dev_name = String(validatingUTF8: name) {
+                if (dev_name == "Colorbar generator") {
+                    acc_cfg.vid_cap_dev = pjmedia_vid_dev_index(i);
+                    break;
+                }
+            }
+        }
+        pjsua_acc_modify(aid, &acc_cfg);
 
         /* Init account config */
         let id = strdup("Test<sip:test@sip.pjsip.org>");
@@ -76,7 +104,6 @@ struct ipjsua_swiftApp: App {
         let registrar = strdup("sip:sip.pjsip.org");
         let proxy = strdup("sip:sip.pjsip.org;transport=tcp");
 
-        var acc_cfg = pjsua_acc_config();
         pjsua_acc_config_default(&acc_cfg);
         acc_cfg.id = pj_str(id);
         acc_cfg.cred_count = 1;
@@ -95,7 +122,9 @@ struct ipjsua_swiftApp: App {
         /* Free strings */
         free(id); free(username); free(passwd); free(realm);
         free(registrar); free(proxy);
-        
+
+        pj_pool_release(tmp_pool);
+
         /* Start pjsua */
         status = pjsua_start();
     }
@@ -107,6 +136,19 @@ struct ipjsua_swiftApp: App {
                 .preferredColorScheme(.light)
         }
     }
+}
+
+private func on_incoming_call(acc_id: pjsua_acc_id, call_id: pjsua_call_id,
+                              rdata: UnsafeMutablePointer<pjsip_rx_data>?)
+{
+    var opt = pjsua_call_setting();
+
+    pjsua_call_setting_default(&opt);
+    opt.aud_cnt = 1;
+    opt.vid_cnt = 1;
+
+    /* Automatically answer call with 200 */
+    pjsua_call_answer2(call_id, &opt, 200, nil, nil);
 }
 
 private func on_call_state(call_id: pjsua_call_id,
@@ -157,9 +199,25 @@ private func on_call_media_state(call_id: pjsua_call_id)
                     let vid_win:UIView =
                         Unmanaged<UIView>.fromOpaque(wi.hwnd.info.ios.window).takeUnretainedValue();
 
-                    /* UIView update must be done in the main thread */
-                    DispatchQueue.main.sync {
-                        AppDelegate.Shared.pjsip_vars.vid_win = vid_win;
+                    /* For local loopback test, one acts as a transmitter,
+                       the other as a receiver.
+                     */
+                    if (AppDelegate.Shared.pjsip_vars.vid_win == nil) {
+                        /* UIView update must be done in the main thread */
+                        DispatchQueue.main.sync {
+                            AppDelegate.Shared.pjsip_vars.vid_win = vid_win;
+                        }
+                    } else {
+                        if (AppDelegate.Shared.pjsip_vars.vid_win != vid_win) {
+                            /* Transmitter */
+                            var param = pjsua_call_vid_strm_op_param ();
+
+                            pjsua_call_vid_strm_op_param_default(&param);
+                            param.med_idx = 1;
+                            pjsua_call_set_vid_strm(call_id,
+                                                    PJSUA_CALL_VID_STRM_START_TRANSMIT,
+                                                    &param);
+                        }
                     }
                 }
                 break;

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ipjsua_swiftApp.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swift/ipjsua_swiftApp.swift
@@ -24,7 +24,7 @@ import SwiftUI
 
 class PjsipVars: ObservableObject {
     @Published var calling = false
-    var dest: String = "sip:localhost:5080"
+    var dest: String = "sip:test@sip.pjsip.org"
     var call_id: pjsua_call_id = PJSUA_INVALID_ID.rawValue
     /* Video window */
     @Published var vid_win:UIView? = nil

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -73,7 +73,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
         saveScreenshot(image: fullScreenshot)
     }
 
-    // Helper method to wait for an element to have a certain text
+    // Helper method to wait for an element to appear/exist
     func waitForElement(_ element: XCUIElement, timeout: TimeInterval)
     {
         let predicate = NSPredicate(format: "exists == 1")
@@ -87,10 +87,8 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
     func saveScreenshot(image: XCUIScreenshot) {
         let pngData = image.pngRepresentation
-        let documentsDirectory = FileManager.default.urls(
-                                 for: .documentDirectory,
-                                 in: .userDomainMask).first!
-        let fileURL = documentsDirectory.appendingPathComponent("screenshot.png")
+        let resultPath = URL(fileURLWithPath: ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"]!)
+        let fileURL = resultPath.appendingPathComponent("screenshot.png")
 
         do {
             try pngData.write(to: fileURL)

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -26,7 +26,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
         app.launch()
 
         // Access the Destination text field
-        let textField = app.textFields["Destination:"]
+        let textField = app.textFields["sip:test@sip.pjsip.org"]
 
         // Type localhost into the text field
         textField.tap() // Ensure the text field is focused

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -10,6 +10,15 @@ final class ipjsua_swiftVidTest: XCTestCase {
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
+        // Add an interruption monitor to handle system alerts
+        addUIInterruptionMonitor(withDescription: "Allow network permission") { (alert) -> Bool in
+            if alert.buttons["Allow"].exists {
+                alert.buttons["Allow"].tap()
+                return true
+            }
+            return false
+        }
+
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -87,8 +87,10 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
     func saveScreenshot(image: XCUIScreenshot) {
         let pngData = image.pngRepresentation
-        let resultPath = URL(fileURLWithPath: ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"]!)
-        let fileURL = resultPath.appendingPathComponent("screenshot.png")
+        let documentsDirectory = FileManager.default.urls(
+                                 for: .documentDirectory,
+                                 in: .userDomainMask).first!
+        let fileURL = documentsDirectory.appendingPathComponent("screenshot.png")
 
         do {
             try pngData.write(to: fileURL)

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -46,6 +46,8 @@ final class ipjsua_swiftVidTest: XCTestCase {
         let expectedText = "Video"
         waitForElement(label, toHaveText: expectedText, timeout: 6)
 
+        expectation.fulfill()
+
         // Capture a screenshot of the entire screen
         let fullScreenshot = app.windows.firstMatch.screenshot()
         // Save the screenshot to a file
@@ -62,7 +64,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
         XCTAssertEqual(result, .completed, "Element didn't contain expected" +
-                                           " \text within \(timeout) seconds")
+                       " \(text) within \(timeout) seconds")
     }
 
     func saveScreenshot(image: XCUIScreenshot) {

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -12,7 +12,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
         // Add an interruption monitor to handle system alerts
         addUIInterruptionMonitor(withDescription: "Allow network permission") { (alert) -> Bool in
-            print("UI alert: ", alert.staticTexts.element.label)
+            print("UI alert: ", alert.description)
             if alert.buttons["Allow"].exists {
                 alert.buttons["Allow"].tap()
                 return true
@@ -34,13 +34,12 @@ final class ipjsua_swiftVidTest: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
+    func testVideo() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
 
         // Access the Destination text field
-        let label = app.staticTexts["Destination:"]
         let textField = app.textFields["sip:test@sip.pjsip.org"]
 
         // Type localhost into the text field
@@ -58,11 +57,16 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
         // Wait for video to appear
         let expectation = XCTestExpectation(description: "Wait for video")
-        let expectedText = "Video"
-        waitForElement(label, toHaveText: expectedText, timeout: 6)
+        let label = app.staticTexts["Video"]
+        waitForElement(label, timeout: 6)
 
         expectation.fulfill()
 
+        // This is necessary to invoke UI interruption monitor above
+        app.staticTexts["Video"].tap()
+
+        sleep(1)
+        
         // Capture a screenshot of the entire screen
         let fullScreenshot = app.windows.firstMatch.screenshot()
         // Save the screenshot to a file
@@ -70,16 +74,15 @@ final class ipjsua_swiftVidTest: XCTestCase {
     }
 
     // Helper method to wait for an element to have a certain text
-    func waitForElement(_ element: XCUIElement, toHaveText text: String,
-                        timeout: TimeInterval)
+    func waitForElement(_ element: XCUIElement, timeout: TimeInterval)
     {
-        let predicate = NSPredicate(format: "label CONTAINS[c] %@", text)
+        let predicate = NSPredicate(format: "exists == 1")
         let expectation = XCTNSPredicateExpectation(predicate: predicate,
                                                     object: element)
 
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
-        XCTAssertEqual(result, .completed, "Element didn't contain expected" +
-                       " \(text) within \(timeout) seconds")
+        XCTAssertEqual(result, .completed, "Element not found within " +
+                                           "\(timeout) seconds")
     }
 
     func saveScreenshot(image: XCUIScreenshot) {

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -12,6 +12,11 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
         // Add an interruption monitor to handle system alerts
         addUIInterruptionMonitor(withDescription: "Allow network permission") { (alert) -> Bool in
+            print("UI alert: ", alert.staticTexts.element.label)
+            if alert.buttons["Allow"].exists {
+                alert.buttons["Allow"].tap()
+                return true
+            }
             if alert.buttons["OK"].exists {
                 alert.buttons["OK"].tap()
                 return true
@@ -48,6 +53,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
         XCTAssertEqual(textField.value as? String, dest)
 
         // Click "Make call" button
+        print("Making video call")
         app.buttons["Make call"].tap()
 
         // Wait for video to appear

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -26,6 +26,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
         app.launch()
 
         // Access the Destination text field
+        let label = app.staticTexts["Destination:"]
         let textField = app.textFields["sip:test@sip.pjsip.org"]
 
         // Type localhost into the text field
@@ -34,17 +35,34 @@ final class ipjsua_swiftVidTest: XCTestCase {
         let dest = "sip:localhost:5080"
         textField.typeText(dest)
 
+        // Use XCTAssert to verify the text is correct
+        XCTAssertEqual(textField.value as? String, dest)
+
         // Click "Make call" button
         app.buttons["Make call"].tap()
 
-        // Use XCTAssert and related functions to verify your tests produce
-        // the correct results.
-        XCTAssertEqual(textField.value as? String, dest)
+        // Wait for video to appear
+        let expectation = XCTestExpectation(description: "Wait for video")
+        let expectedText = "Video"
+        waitForElement(label, toHaveText: expectedText, timeout: 6)
 
         // Capture a screenshot of the entire screen
         let fullScreenshot = app.windows.firstMatch.screenshot()
         // Save the screenshot to a file
         saveScreenshot(image: fullScreenshot)
+    }
+
+    // Helper method to wait for an element to have a certain text
+    func waitForElement(_ element: XCUIElement, toHaveText text: String,
+                        timeout: TimeInterval)
+    {
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", text)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate,
+                                                    object: element)
+
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(result, .completed, "Element didn't contain expected" +
+                                           " \text within \(timeout) seconds")
     }
 
     func saveScreenshot(image: XCUIScreenshot) {
@@ -61,7 +79,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
             XCTFail("Failed to save screenshot: \(error)")
         }
     }
-
+/*
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.
@@ -70,4 +88,5 @@ final class ipjsua_swiftVidTest: XCTestCase {
             }
         }
     }
+*/
 }

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -29,8 +29,9 @@ final class ipjsua_swiftVidTest: XCTestCase {
         let textField = app.textFields["sip:test@sip.pjsip.org"]
 
         // Type localhost into the text field
-        textField.tap() // Ensure the text field is focused
-        let dest = "sip:localhost:5080";
+        textField.tap()
+        textField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
+        let dest = "sip:localhost:5080"
         textField.typeText(dest)
 
         // Click "Make call" button

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -26,7 +26,7 @@ final class ipjsua_swiftVidTest: XCTestCase {
         app.launch()
 
         // Access the Destination text field
-        let textField = app.textFields["Destination"]
+        let textField = app.textFields["Destination:"]
 
         // Type localhost into the text field
         textField.tap() // Ensure the text field is focused

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -1,0 +1,72 @@
+//
+//  ipjsua_swiftVidTest.swift
+//  ipjsua-swiftVidTest
+//
+
+import XCTest
+
+final class ipjsua_swiftVidTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Access the Destination text field
+        let textField = app.textFields["Destination"]
+
+        // Type localhost into the text field
+        textField.tap() // Ensure the text field is focused
+        let dest = "sip:localhost:5080";
+        textField.typeText(dest)
+
+        // Click "Make call" button
+        app.buttons["Make call"].tap()
+
+        // Use XCTAssert and related functions to verify your tests produce
+        // the correct results.
+        XCTAssertEqual(textField.value as? String, dest)
+
+        // Capture a screenshot of the entire screen
+        let fullScreenshot = app.windows.firstMatch.screenshot()
+        // Save the screenshot to a file
+        saveScreenshot(image: fullScreenshot)
+    }
+
+    func saveScreenshot(image: XCUIScreenshot) {
+        let pngData = image.pngRepresentation
+        let documentsDirectory = FileManager.default.urls(
+                                 for: .documentDirectory,
+                                 in: .userDomainMask).first!
+        let fileURL = documentsDirectory.appendingPathComponent("screenshot.png")
+
+        do {
+            try pngData.write(to: fileURL)
+            print("Screenshot saved to:", fileURL)
+        } catch {
+            XCTFail("Failed to save screenshot: \(error)")
+        }
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTest.swift
@@ -12,8 +12,8 @@ final class ipjsua_swiftVidTest: XCTestCase {
 
         // Add an interruption monitor to handle system alerts
         addUIInterruptionMonitor(withDescription: "Allow network permission") { (alert) -> Bool in
-            if alert.buttons["Allow"].exists {
-                alert.buttons["Allow"].tap()
+            if alert.buttons["OK"].exists {
+                alert.buttons["OK"].tap()
                 return true
             }
             return false

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTestLaunchTests.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTestLaunchTests.swift
@@ -14,7 +14,7 @@ final class ipjsua_swiftVidTestLaunchTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
     }
-
+/*
     func testLaunch() throws {
         let app = XCUIApplication()
         app.launch()
@@ -27,4 +27,5 @@ final class ipjsua_swiftVidTestLaunchTests: XCTestCase {
         attachment.lifetime = .keepAlways
         add(attachment)
     }
+*/
 }

--- a/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTestLaunchTests.swift
+++ b/pjsip-apps/src/pjsua/ios-swift/ipjsua-swiftVidTest/ipjsua_swiftVidTestLaunchTests.swift
@@ -1,0 +1,30 @@
+//
+//  ipjsua_swiftVidTestLaunchTests.swift
+//  ipjsua-swiftVidTest
+//
+
+import XCTest
+
+final class ipjsua_swiftVidTestLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Video test on iOS device using Bitrise and Firebase.
`Device testing with Firebase` https://devcenter.bitrise.io/en/testing/device-testing-with-firebase.html

Test setup:
- Using `ipjsua-swift` sample app.
- Video capture: colorbar. Video renderer: Metal

Test scenario:
- Local video call utilising a single iOS device only (video call initiated to local account `sip:localhost:5080`).
   **UI test (Automated)**: Simulate triple tap on `Destination:` text field, type in the text `sip:localhost:5080`. Verify using `XCTAssert` that the text is correct. If yes, click the button `Make call`.
- The device will only display one video, so only one party will transmit the video, while the other one will receive and show the video.
   **Verification**: Make sure that the incoming video view is not `nil` (i.e. check if `pjsua_vid_win_info.hwnd.info.ios.window != NULL`).
