### PR TITLE
Enable Late Offer Answer Mode (LOAM) feature in the pjsua

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1998,6 +1998,9 @@ static pj_status_t app_init(void)
     pjsua_call_setting_default(&call_opt);
     call_opt.aud_cnt = app_config.aud_cnt;
     call_opt.vid_cnt = app_config.vid.vid_cnt;
+    if (app_config.enable_loam) {
+        call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
+    }
 
 #if defined(PJSIP_HAS_TLS_TRANSPORT) && PJSIP_HAS_TLS_TRANSPORT!=0
     /* Wipe out TLS key settings in transport configs */

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -3245,7 +3245,7 @@ static pj_status_t add_other_command(pj_cli_t *c)
 
     char* toggle_sdp_offer_command =
         "<CMD name='toggle_sdp_offer' sc='o' id='140' "
-        "desc='Toggle SDP offer use on susequent calls and UPDATEs' />";
+        "desc='Toggle SDP offer use on subsequent calls and UPDATEs' />";
 
     pj_status_t status;
     pj_str_t sleep_xml = pj_str(sleep_command);

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -78,6 +78,7 @@ typedef struct pjsua_app_config
     pj_bool_t               ipv6;
     pj_bool_t               enable_qos;
     pj_bool_t               no_mci;
+    pj_bool_t               enable_loam;
     pj_bool_t               no_tcp;
     pj_bool_t               no_udp;
     pj_bool_t               use_tls;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -95,6 +95,7 @@ static void usage(void)
 #endif
     puts  ("  --set-qos           Enable QoS tagging for SIP and media.");
     puts  ("  --no-mci            Disable message composition indication (RFC 3994)");
+    puts  ("  --set-loam          Enable Late offer answer model");
     puts  ("  --local-port=port   Set TCP/UDP port. This implicitly enables both ");
     puts  ("                      TCP and UDP transports on the specified port, unless");
     puts  ("                      if TCP or UDP is disabled.");
@@ -393,7 +394,8 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_TLS_NEG_TIMEOUT, OPT_TLS_CIPHER,
            OPT_CAPTURE_DEV, OPT_PLAYBACK_DEV,
            OPT_CAPTURE_LAT, OPT_PLAYBACK_LAT, OPT_NO_TONES, OPT_JB_MAX_SIZE,
-           OPT_STDOUT_REFRESH, OPT_STDOUT_REFRESH_TEXT, OPT_IPV6, OPT_QOS, OPT_MCI,
+           OPT_STDOUT_REFRESH, OPT_STDOUT_REFRESH_TEXT, OPT_IPV6, OPT_QOS,
+           OPT_MCI, OPT_LOAM,
 #ifdef _IONBF
            OPT_STDOUT_NO_BUF,
 #endif
@@ -535,6 +537,7 @@ static pj_status_t parse_args(int argc, char *argv[],
 #endif
         { "set-qos",     0, 0, OPT_QOS},
         { "no-mci",     0, 0, OPT_MCI},
+        { "set-loam",   0, 0, OPT_LOAM},
         { "use-timer",  1, 0, OPT_TIMER},
         { "timer-se",   1, 0, OPT_TIMER_SE},
         { "timer-min-se", 1, 0, OPT_TIMER_MIN_SE},
@@ -1471,6 +1474,9 @@ static pj_status_t parse_args(int argc, char *argv[],
         case OPT_MCI:
             cfg->no_mci = PJ_TRUE;
             break;
+        case OPT_LOAM:
+            cfg->enable_loam = PJ_TRUE;
+            break;
         case OPT_VIDEO:
             cfg->vid.vid_cnt = 1;
             cfg->vid.in_auto_show = PJ_TRUE;
@@ -1988,6 +1994,12 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
     if (config->no_mci) {
         pj_strcat2(&cfg, "--no-mci\n");
     }
+
+    /* Late Offer Answer Model */
+    if (config->enable_loam) {
+        pj_strcat2(&cfg, "--set-loam\n");
+    }
+
     /* UDP Transport. */
     pj_ansi_snprintf(line, sizeof(line), "--local-port %d\n",
                      config->udp_cfg.port);

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -95,7 +95,6 @@ static void usage(void)
 #endif
     puts  ("  --set-qos           Enable QoS tagging for SIP and media.");
     puts  ("  --no-mci            Disable message composition indication (RFC 3994)");
-    puts  ("  --set-loam          Enable Late offer answer model");
     puts  ("  --local-port=port   Set TCP/UDP port. This implicitly enables both ");
     puts  ("                      TCP and UDP transports on the specified port, unless");
     puts  ("                      if TCP or UDP is disabled.");
@@ -394,8 +393,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_TLS_NEG_TIMEOUT, OPT_TLS_CIPHER,
            OPT_CAPTURE_DEV, OPT_PLAYBACK_DEV,
            OPT_CAPTURE_LAT, OPT_PLAYBACK_LAT, OPT_NO_TONES, OPT_JB_MAX_SIZE,
-           OPT_STDOUT_REFRESH, OPT_STDOUT_REFRESH_TEXT, OPT_IPV6, OPT_QOS,
-           OPT_MCI, OPT_LOAM,
+           OPT_STDOUT_REFRESH, OPT_STDOUT_REFRESH_TEXT, OPT_IPV6, OPT_QOS, OPT_MCI,
 #ifdef _IONBF
            OPT_STDOUT_NO_BUF,
 #endif
@@ -537,7 +535,6 @@ static pj_status_t parse_args(int argc, char *argv[],
 #endif
         { "set-qos",     0, 0, OPT_QOS},
         { "no-mci",     0, 0, OPT_MCI},
-        { "set-loam",   0, 0, OPT_LOAM},
         { "use-timer",  1, 0, OPT_TIMER},
         { "timer-se",   1, 0, OPT_TIMER_SE},
         { "timer-min-se", 1, 0, OPT_TIMER_MIN_SE},
@@ -1474,9 +1471,6 @@ static pj_status_t parse_args(int argc, char *argv[],
         case OPT_MCI:
             cfg->no_mci = PJ_TRUE;
             break;
-        case OPT_LOAM:
-            cfg->enable_loam = PJ_TRUE;
-            break;
         case OPT_VIDEO:
             cfg->vid.vid_cnt = 1;
             cfg->vid.in_auto_show = PJ_TRUE;
@@ -1993,11 +1987,6 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
     /* Message Composition Indication */
     if (config->no_mci) {
         pj_strcat2(&cfg, "--no-mci\n");
-    }
-
-    /* Late Offer Answer Model */
-    if (config->enable_loam) {
-        pj_strcat2(&cfg, "--set-loam\n");
     }
 
     /* UDP Transport. */

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1462,10 +1462,11 @@ static void ui_toggle_call_sdp_offer()
 {
     app_config.enable_loam = !app_config.enable_loam;
 
+    printf("Subsequent calls and UPDATEs will contain SDP offer: ");
     if (app_config.enable_loam) {
-        printf("Subsequent calls and UPDATEs will NOT contain SDP offer.\n");
+        printf("YES.\n");
     } else {
-        printf("Subsequent calls and UPDATEs will contain SDP offer.\n");
+      printf("NO.\n");
     }
 }
 

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -734,6 +734,9 @@ static void ui_make_new_call()
 
         pjsua_msg_data_init(&msg_data_);
         TEST_MULTIPART(&msg_data_);
+        if (app_config.enable_loam) {
+            call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
+        }
         pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
                              &msg_data_, &current_call);
 
@@ -771,6 +774,10 @@ static void ui_make_multi_call()
         pj_strncpy(&tmp, &binfo.uri, sizeof(buf));
     } else {
         tmp = pj_str(result.uri_result);
+    }
+
+    if (app_config.enable_loam) {
+        call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
     }
 
     for (i=0; i<my_atoi(menuin); ++i) {
@@ -1099,6 +1106,9 @@ static void ui_call_reinvite()
 static void ui_send_update()
 {
     if (current_call != -1) {
+        if (app_config.enable_loam) {
+            call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
+        }
         pjsua_call_update2(current_call, &call_opt, NULL);
     } else {
         PJ_LOG(3,(THIS_FILE, "No current call"));

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1464,9 +1464,9 @@ static void ui_toggle_call_sdp_offer()
 
     printf("Subsequent calls and UPDATEs will contain SDP offer: ");
     if (app_config.enable_loam) {
-        printf("YES.\n");
-    } else {
         printf("NO.\n");
+    } else {
+        printf("YES.\n");
     }
 }
 

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1460,7 +1460,17 @@ static void ui_send_arbitrary_request()
 
 static void ui_toggle_call_sdp_offer()
 {
-    app_config.enable_loam = !app_config.enable_loam;
+    char input[32];
+
+    printf("Subsequent calls and UPDATEs will contain SDP offer [yes/no]:");
+    if (fgets(input, sizeof(input), stdin) == NULL)
+        return;
+
+    if (pj_ansi_strnicmp(input, "y", 1) == 0) {
+        app_config.enable_loam = 0;
+    } else {
+        app_config.enable_loam = 1;
+    }
 }
 
 static void ui_echo(char menuin[])

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1460,16 +1460,12 @@ static void ui_send_arbitrary_request()
 
 static void ui_toggle_call_sdp_offer()
 {
-    char input[32];
+    app_config.enable_loam = !app_config.enable_loam;
 
-    printf("Subsequent calls and UPDATEs will contain SDP offer [yes/no]:");
-    if (fgets(input, sizeof(input), stdin) == NULL)
-        return;
-
-    if (pj_ansi_strnicmp(input, "y", 1) == 0) {
-        app_config.enable_loam = 0;
+    if (app_config.enable_loam) {
+        printf("Subsequent calls and UPDATEs will NOT contain SDP offer.\n");
     } else {
-        app_config.enable_loam = 1;
+        printf("Subsequent calls and UPDATEs will contain SDP offer.\n");
     }
 }
 

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1466,7 +1466,7 @@ static void ui_toggle_call_sdp_offer()
     if (app_config.enable_loam) {
         printf("YES.\n");
     } else {
-      printf("NO.\n");
+        printf("NO.\n");
     }
 }
 

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -248,6 +248,8 @@ static void keystroke_help()
     puts("| dq  Dump curr. call quality  | cd  Disconnect port      | dc  Dump config   |");
     puts("|                              |  V  Adjust audio Volume  |  f  Save config   |");
     puts("|  S  Send arbitrary REQUEST   | Cp  Codec priorities     |                   |");
+    puts("| +l Set Late Offer Answer Mode   |                       |                   |");
+    puts("| -l Unset Late Offer Answer Mode |                       |                   |");
     puts("+-----------------------------------------------------------------------------+");
 #if PJSUA_HAS_VIDEO
     puts("| Video: \"vid help\" for more info                                             |");
@@ -1088,6 +1090,11 @@ static void ui_delete_account()
     }
 }
 
+static void ui_unset_loam_mode()
+{
+    app_config.enable_loam = PJ_FALSE;
+}
+
 static void ui_call_hold()
 {
     if (current_call != -1) {
@@ -1451,6 +1458,11 @@ static void ui_send_arbitrary_request()
         pj_str_t method = pj_str(text);
         pjsua_call_send_request(current_call, &method, NULL);
     }
+}
+
+static void ui_set_loam_mode()
+{
+    app_config.enable_loam = PJ_TRUE;
 }
 
 static void ui_echo(char menuin[])
@@ -1930,6 +1942,8 @@ void legacy_main(void)
                 ui_add_buddy();
             } else if (menuin[1] == 'a') {
                 ui_add_account(&app_config.rtp_cfg);
+            } else if (menuin[1] == 'l') {
+                ui_set_loam_mode();
             } else {
                 printf("Invalid input %s\n", menuin);
             }
@@ -1940,6 +1954,8 @@ void legacy_main(void)
                 ui_delete_buddy();
             } else if (menuin[1] == 'a') {
                 ui_delete_account();
+            } else if (menuin[1] == 'l') {
+                ui_unset_loam_mode();
             } else {
                 printf("Invalid input %s\n", menuin);
             }

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -236,7 +236,7 @@ static void keystroke_help()
     puts("|  a  Answer call              |  i  Send IM              | !a  Modify accnt. |");
     puts("|  h  Hangup call  (ha=all)    |  s  Subscribe presence   | rr  (Re-)register |");
     puts("|  H  Hold call                |  u  Unsubscribe presence | ru  Unregister    |");
-    puts("|                              |  D  Subscribe dlg event  |                   |");
+    puts("|  o Toggle call SDP offer     |  D  Subscribe dlg event  |                   |");
     puts("|                              |  Du Unsub dlg event      |                   |");
     puts("|  v  re-inVite (release hold) |  t  Toggle online status |  >  Cycle next ac.|");
     puts("|  U  send UPDATE              |  T  Set online status    |  <  Cycle prev ac.|");
@@ -248,8 +248,6 @@ static void keystroke_help()
     puts("| dq  Dump curr. call quality  | cd  Disconnect port      | dc  Dump config   |");
     puts("|                              |  V  Adjust audio Volume  |  f  Save config   |");
     puts("|  S  Send arbitrary REQUEST   | Cp  Codec priorities     |                   |");
-    puts("| +l Set Late Offer Answer Mode   |                       |                   |");
-    puts("| -l Unset Late Offer Answer Mode |                       |                   |");
     puts("+-----------------------------------------------------------------------------+");
 #if PJSUA_HAS_VIDEO
     puts("| Video: \"vid help\" for more info                                             |");
@@ -1460,9 +1458,9 @@ static void ui_send_arbitrary_request()
     }
 }
 
-static void ui_set_loam_mode()
+static void ui_toggle_call_sdp_offer()
 {
-    app_config.enable_loam = PJ_TRUE;
+    app_config.enable_loam = !app_config.enable_loam;
 }
 
 static void ui_echo(char menuin[])
@@ -1942,8 +1940,6 @@ void legacy_main(void)
                 ui_add_buddy();
             } else if (menuin[1] == 'a') {
                 ui_add_account(&app_config.rtp_cfg);
-            } else if (menuin[1] == 'l') {
-                ui_set_loam_mode();
             } else {
                 printf("Invalid input %s\n", menuin);
             }
@@ -1954,8 +1950,6 @@ void legacy_main(void)
                 ui_delete_buddy();
             } else if (menuin[1] == 'a') {
                 ui_delete_account();
-            } else if (menuin[1] == 'l') {
-                ui_unset_loam_mode();
             } else {
                 printf("Invalid input %s\n", menuin);
             }
@@ -1966,6 +1960,13 @@ void legacy_main(void)
              * Hold call.
              */
             ui_call_hold();
+            break;
+
+        case 'o':
+            /*
+             * Toggle call SDP offer
+             */
+            ui_toggle_call_sdp_offer();
             break;
 
         case 'v':


### PR DESCRIPTION
This feature enables empty SDP in the INVITE request. The messages exchanged between the caller (user agent client) and the called party (user agent server) are identical, but the responsibility for choosing the media shifts from one to the other.

See some description at this page https://andrewjprokop.wordpress.com/2014/04/16/sip-media-management-early-offer-vs-late-offer/.

