### PR TITLE
Assertion in restarting listeners in IP change scenario

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -3845,12 +3845,22 @@ static pj_status_t restart_listener(pjsua_transport_id id,
     pj_sockaddr bind_addr;
     pjsua_transport_info tp_info;
     pj_status_t status;
+    pj_bool_t tp_valid = PJ_TRUE;
+    pj_uint16_t saf;
 
-    pjsua_transport_get_info(id, &tp_info);
+    status = pjsua_transport_get_info(id, &tp_info);
+    if (status != PJ_SUCCESS) {
+        /* Transport not valid or already destroyed */
+        tp_valid = PJ_FALSE;
+        goto on_return;
+    }
+
+    saf = tp_info.local_addr.addr.sa_family;
     pj_sockaddr_init(pjsip_transport_type_get_af(tp_info.type),
-                     &bind_addr,
-                     NULL,
-                     pj_sockaddr_get_port(&tp_info.local_addr));
+                        &bind_addr,
+                        NULL,
+                        (saf==PJ_AF_INET || saf==PJ_AF_INET6)?
+                            pj_sockaddr_get_port(&tp_info.local_addr) : 0);
 
     switch (tp_info.type) {
     case PJSIP_TRANSPORT_UDP:
@@ -3899,7 +3909,9 @@ static pj_status_t restart_listener(pjsua_transport_id id,
     PJ_PERROR(3,(THIS_FILE, status, "Listener %.*s restart",
                  (int)tp_info.info.slen, tp_info.info.ptr));
 
-    if (status != PJ_SUCCESS && (restart_lis_delay > 0)) {
+on_return:
+
+    if (tp_valid && status != PJ_SUCCESS && (restart_lis_delay > 0)) {
         /* Try restarting again, with delay. */
         pjsua_schedule_timer2(&restart_listener_cb,
                               (void*)(pj_size_t)id,
@@ -3993,15 +4005,15 @@ PJ_DEF(pj_status_t) pjsua_handle_ip_change(const pjsua_ip_change_param *param)
 
     /* Shutdown all TCP/TLS transports */
     if (param->shutdown_transport) {
-        pjsip_tpmgr_shutdown_param param;
+        pjsip_tpmgr_shutdown_param sd_param;
 
-        pjsip_tpmgr_shutdown_param_default(&param);
-        param.include_udp = PJ_FALSE;
+        pjsip_tpmgr_shutdown_param_default(&sd_param);
+        sd_param.include_udp = PJ_FALSE;
 
         PJ_LOG(4,(THIS_FILE, "IP change shutting down transports.."));
         status = pjsip_tpmgr_shutdown_all(
                                     pjsip_endpt_get_tpmgr(pjsua_var.endpt),
-                                    &param);
+                                    &sd_param);
 
         /* Provide dummy info instead of NULL info to avoid possible crash
          * (if app does not check).


### PR DESCRIPTION
Reported that in some rare case, assertion happens with call stack:
```
Thread 0 Crashed:
0   libsystem_kernel.dylib               0x000000018c14a0dc __pthread_kill + 8
1   libsystem_c.dylib                    0x000000018c08da40 abort + 176
2   libsystem_c.dylib                    0x000000018c08cd30 __assert_rtn + 280
3   libphone.0.dylib                     0x0000000103ff5f74 pj_sockaddr_get_port (sock_common.c:367)
4   libphone.0.dylib                     0x0000000104152cb4 restart_listener (pjsua_core.c:3841)
5   libphone.0.dylib                     0x0000000104152b30 pjsua_handle_ip_change (pjsua_core.c:3998)
```

Unfortunately finding the cause of the issue is not so easy with the available info. This PR attempts to avoid the assertion (not really fix the cause).

Thanks to Oliver Epper for the report.

PS: this PR also contain a fix of a minor issue in shutting down transport in IP change (local var shadowing parameter `param`).