### PR TITLE
Avoid creating a TCP/TLS listener when listener is not preferred in IP change scenario

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -2787,6 +2787,9 @@ typedef struct pjsua_ip_change_param
 {
     /**
      * If set to PJ_TRUE, this will restart the transport listener.
+     * Note that if restarting listener is enabled and the listener is
+     * configured with a bound address, the address will be reset
+     * so it will bind to any address (e.g: IPv4 "0.0.0.0" or IPv6 "::").
      * 
      * Default : PJ_TRUE
      */

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -756,6 +756,22 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart(pjsip_tpfactory *factory,
     pj_status_t status = PJ_SUCCESS;
     struct tls_listener *listener = (struct tls_listener *)factory;
 
+    /* Just update the published address if currently no listener */
+    if (!listener->ssock) {
+        PJ_LOG(3,(factory->obj_name,
+                      "TLS restart requested while no listener created, "
+                      "update the published address only"));
+
+        status = update_factory_addr(listener, a_name);
+        if (status != PJ_SUCCESS)
+            return status;
+
+        /* Set transport info. */
+       update_transport_info(listener);
+
+       return PJ_SUCCESS;
+    }
+
     lis_close(listener);
 
     status = pjsip_tls_transport_lis_start(factory, local, a_name);


### PR DESCRIPTION
This PR fixes a bug that IP change may create a TCP/TLS listener when currently no listener is created (e.g: due to `PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER`). Also updates PJSUA docs that specifies bound address setting will be reset (assuming IP has just changed, so the bound address is no longer valid).

Thanks to Marcus Froeschl for the report.