### PR TITLE
Modified DTLS cert signature algorithm used

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -464,7 +464,7 @@ static pj_status_t ssl_generate_cert(X509 **p_cert, EVP_PKEY **p_priv_key)
     if (!X509_set_pubkey(cert, priv_key)) goto on_error;
 
     /* Sign with the private key */
-    if (!X509_sign(cert, priv_key, EVP_sha1())) goto on_error;
+    if (!X509_sign(cert, priv_key, EVP_sha256())) goto on_error;
 
     /* Free big number */
     BN_free(bne);


### PR DESCRIPTION
To fix #3844 .

As per RFC 4572 section 5 (https://datatracker.ietf.org/doc/html/rfc4572#section-5):
`A certificate fingerprint MUST be computed using the same one-way
   hash function as is used in the certificate's signature algorithm.`

Currently we sign our local certificate using SHA-1, but compute the fingerprint using SHA-256.

Patch provided by @trengginas .
