### PR TITLE
Fixed ioqueue backend selection configure script

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -6518,19 +6518,26 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ioqueue backend" >&5
 printf %s "checking ioqueue backend... " >&6; }
 
+ac_os_objs=ioqueue_select.o
+ac_linux_poll=select
+
 case $target in
 	*darwin* | *bsd*)
 		# Check whether --enable-kqueue was given.
 if test ${enable_kqueue+y}
 then :
   enableval=$enable_kqueue;
-				ac_os_objs=ioqueue_kqueue.o
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: kqueue()" >&5
+				if test "$enable_kqueue" = "yes"; then
+					ac_os_objs=ioqueue_kqueue.o
+					{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: kqueue()" >&5
 printf "%s\n" "kqueue()" >&6; }
+				else
+					{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
+printf "%s\n" "select()" >&6; }
+				fi
 
 else $as_nop
 
-				ac_os_objs=ioqueue_select.o
 				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
 printf "%s\n" "select()" >&6; }
 
@@ -6542,19 +6549,22 @@ fi
 if test ${enable_epoll+y}
 then :
   enableval=$enable_epoll;
-				ac_os_objs=ioqueue_epoll.o
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: /dev/epoll" >&5
+				if test "$enable_epoll" = "yes"; then
+					ac_os_objs=ioqueue_epoll.o
+					{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: /dev/epoll" >&5
 printf "%s\n" "/dev/epoll" >&6; }
-				printf "%s\n" "#define PJ_HAS_LINUX_EPOLL 1" >>confdefs.h
+					printf "%s\n" "#define PJ_HAS_LINUX_EPOLL 1" >>confdefs.h
 
-				ac_linux_poll=epoll
+					ac_linux_poll=epoll
+				else
+					{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
+printf "%s\n" "select()" >&6; }
+				fi
 
 else $as_nop
 
-				ac_os_objs=ioqueue_select.o
 				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
 printf "%s\n" "select()" >&6; }
-				ac_linux_poll=select
 
 fi
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -467,17 +467,23 @@ AC_SUBST(ac_os_objs)
 AC_SUBST(ac_linux_poll)
 AC_MSG_CHECKING([ioqueue backend])
 
+ac_os_objs=ioqueue_select.o
+ac_linux_poll=select
+
 case $target in
 	*darwin* | *bsd*)
 		AC_ARG_ENABLE(kqueue,
 				AS_HELP_STRING([--enable-kqueue],
 						[Use kqueue ioqueue on macos/BSD (experimental)]),
 				[
-				ac_os_objs=ioqueue_kqueue.o
-				AC_MSG_RESULT([kqueue()])
+				if test "$enable_kqueue" = "yes"; then
+					ac_os_objs=ioqueue_kqueue.o
+					AC_MSG_RESULT([kqueue()])
+				else
+					AC_MSG_RESULT([select()])
+				fi
 				],
 				[
-				ac_os_objs=ioqueue_select.o
 				AC_MSG_RESULT([select()])
 				])
 		;;
@@ -486,15 +492,17 @@ case $target in
 				AS_HELP_STRING([--enable-epoll],
 						[Use /dev/epoll ioqueue on Linux (experimental)]),
 				[
-				ac_os_objs=ioqueue_epoll.o
-				AC_MSG_RESULT([/dev/epoll])
-				AC_DEFINE(PJ_HAS_LINUX_EPOLL,1)
-				ac_linux_poll=epoll
+				if test "$enable_epoll" = "yes"; then
+					ac_os_objs=ioqueue_epoll.o
+					AC_MSG_RESULT([/dev/epoll])
+					AC_DEFINE(PJ_HAS_LINUX_EPOLL,1)
+					ac_linux_poll=epoll
+				else
+					AC_MSG_RESULT([select()])
+				fi
 				],
 				[
-				ac_os_objs=ioqueue_select.o
 				AC_MSG_RESULT([select()])
-				ac_linux_poll=select
 				])
 		;;
 esac


### PR DESCRIPTION
To fix #3877

https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Package-Options.html
```
AC_ARG_ENABLE (feature, help-string, [action-if-given], [action-if-not-given])
     --enable-feature[=arg]
     --disable-feature
If the user gave configure the option --enable-feature or --disable-feature, run shell commands
action-if-given.
If neither option was given, run shell commands action-if-not-given.

The user can give an argument by following the feature name with ‘=’ and the argument.
Giving an argument of ‘no’  requests that the feature not be made available. If no argument is given,
it defaults to ‘yes’. --disable-feature is equivalent to --enable-feature=no.
```
