### PR TITLE
PJ_LOG_HAS_FILENAME

### DIFF
--- a/pjlib/include/pj/log.h
+++ b/pjlib/include/pj/log.h
@@ -82,7 +82,8 @@ enum pj_log_decoration
     PJ_LOG_HAS_LEVEL_TEXT = 2048, /**< Include level text string [no]         */
     PJ_LOG_HAS_THREAD_ID  = 4096, /**< Include thread identification [no]     */
     PJ_LOG_HAS_THREAD_SWC = 8192, /**< Add mark when thread has switched [yes]*/
-    PJ_LOG_HAS_INDENT     =16384  /**< Indentation. Say yes! [yes]            */
+    PJ_LOG_HAS_INDENT     =16384, /**< Indentation. Say yes! [yes]            */
+    PJ_LOG_HAS_FILENAME   =32768, /**< Like HAS_SENDER but truncated left     */
 };
 
 /**

--- a/pjlib/src/pj/log.c
+++ b/pjlib/src/pj/log.c
@@ -416,6 +416,24 @@ PJ_DEF(void) pj_log( const char *sender, int level,
                 *pre++ = *sender++;
         }
     }
+    if (log_decor & PJ_LOG_HAS_FILENAME) {
+        enum { SENDER_WIDTH = PJ_LOG_SENDER_WIDTH };
+        pj_size_t sender_len = strlen(sender);
+        if (pre!=log_buffer) *pre++ = ' ';
+        if (sender_len <= SENDER_WIDTH) {
+            while (sender_len < SENDER_WIDTH)
+                *pre++ = ' ', ++sender_len;
+            while (*sender)
+                *pre++ = *sender++;
+        } else {
+            int i;
+            for (i=0; i<3; ++i)
+                *pre++ = '.';
+            char *truncated_begin = sender + sender_len - SENDER_WIDTH + 3;
+            for (i=0; i<SENDER_WIDTH -3; ++i)
+                *pre++ = *truncated_begin++;
+        }
+    }
     if (log_decor & PJ_LOG_HAS_THREAD_ID) {
         enum { THREAD_WIDTH = PJ_LOG_THREAD_WIDTH };
         const char *thread_name = pj_thread_get_name(pj_thread_this());


### PR DESCRIPTION
When using the filename inside the project as the sender for the pj_log function it get's truncated from the left adding '...' at the beginning to indicate.