### PR TITLE
Add missing openssl SECLEVEL=0 support

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -483,11 +483,12 @@ static pj_str_t ssl_strerror(pj_status_t status,
 */
 static const struct ssl_ciphers_t ADDITIONAL_CIPHERS[] = {
         {0xFF000000, "DEFAULT"},
-        {0xFF000001, "@SECLEVEL=1"},
-        {0xFF000002, "@SECLEVEL=2"},
-        {0xFF000003, "@SECLEVEL=3"},
-        {0xFF000004, "@SECLEVEL=4"},
-        {0xFF000005, "@SECLEVEL=5"}
+        {0xFF000001, "@SECLEVEL=0"},
+        {0xFF000002, "@SECLEVEL=1"},
+        {0xFF000003, "@SECLEVEL=2"},
+        {0xFF000004, "@SECLEVEL=3"},
+        {0xFF000005, "@SECLEVEL=4"},
+        {0xFF000006, "@SECLEVEL=5"}
 };
 static const unsigned int ADDITIONAL_CIPHER_COUNT = 
     sizeof (ADDITIONAL_CIPHERS) / sizeof (ADDITIONAL_CIPHERS[0]);


### PR DESCRIPTION
Previously added SECLEVEL=n support allowed for only levels 1-5. (see #2596)
However, openssl defines levels 0-5. (see https://www.openssl.org/docs/man3.2/man3/SSL_CTX_set_security_level.html)

Recent openssl versions (3.0+) have moved previous popular ciphers/key lengths (i.e. RSA1024withSHA1) into level 0, so it is now a reasonable choice to use.