### PR TITLE
Fix warnings for 32-bit compiler and misc fixes.

### DIFF
--- a/pjmedia/src/pjmedia-codec/speex_codec.c
+++ b/pjmedia/src/pjmedia-codec/speex_codec.c
@@ -22,7 +22,6 @@
 #include <pjmedia/errno.h>
 #include <pjmedia/endpoint.h>
 #include <pjmedia/port.h>
-#include <speex/speex.h>
 #include <pj/assert.h>
 #include <pj/log.h>
 #include <pj/pool.h>
@@ -34,6 +33,7 @@
  */
 #if defined(PJMEDIA_HAS_SPEEX_CODEC) && PJMEDIA_HAS_SPEEX_CODEC!=0
 
+#include <speex/speex.h>
 
 #define THIS_FILE   "speex_codec.c"
 

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -79,7 +79,8 @@ pjmedia_clock_src_get_time_msec( const pjmedia_clock_src *clocksrc )
 {
     pj_timestamp ts;
 
-    pjmedia_clock_src_get_current_timestamp(clocksrc, &ts);
+    if (pjmedia_clock_src_get_current_timestamp(clocksrc, &ts) != PJ_SUCCESS)
+        return 0;
 
 #if PJ_HAS_INT64
     if (ts.u64 > PJ_UINT64(0x3FFFFFFFFFFFFF))

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -1677,8 +1677,8 @@ static pj_bool_t on_check_complete(pj_ice_sess *ice,
             }
         }
 
-        LOG5((ice->obj_name, "Check %ld is successful%s",
-             GET_CHECK_ID(&ice->clist, check),
+        LOG5((ice->obj_name, "Check %d is successful%s",
+             (int)GET_CHECK_ID(&ice->clist, check),
              (check->nominated ? " and nominated" : "")));
 
         /* On the first valid pair, we call the callback, if present */

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -485,10 +485,10 @@ static pj_status_t logging_on_tx_msg(pjsip_tx_data *tdata)
      *  transport layer. So don't try to access tp_info when the module
      *  has lower priority than transport layer.
      */
-    PJ_LOG(4,(THIS_FILE, "TX %ld bytes %s to %s %s:\n"
+    PJ_LOG(4,(THIS_FILE, "TX %d bytes %s to %s %s:\n"
                          "%.*s\n"
                          "--end msg--",
-                         (tdata->buf.cur - tdata->buf.start),
+                         (int)(tdata->buf.cur - tdata->buf.start),
                          pjsip_tx_data_get_info(tdata),
                          tdata->tp_info.transport->type_name,
                          pj_addr_str_print(&input_str, 


### PR DESCRIPTION
- speex_codec: Include speex/speex.h when codec is enabled.
- clock_thread: Fix for ‘ts.u64’ may be used uninitialized in this function.
- ice_session: Fix for format '%ld' expects argument of type 'long int', but argument 3 has type 'int'.
- pjsua_core: Fix for format '%ld' expects argument of type 'long int', but argument 3 has type 'int'.