### PR TITLE
Fix data race reported by ThreadSanitizer in caching pool

### DIFF
--- a/pjlib/include/pj/pool.h
+++ b/pjlib/include/pj/pool.h
@@ -849,12 +849,16 @@ struct pj_caching_pool
 
     /**
      * Total size of memory currently used by application.
+     *
+     * This field is deprecated.
      */
     pj_size_t       used_size;
 
     /**
      * The maximum size of memory used by application throughout the life
      * of the caching pool.
+     *
+     * This field is deprecated.
      */
     pj_size_t       peak_used_size;
 

--- a/pjlib/src/pj/pool_caching.c
+++ b/pjlib/src/pj/pool_caching.c
@@ -75,8 +75,12 @@ PJ_DEF(void) pj_caching_pool_init( pj_caching_pool *cp,
     cp->factory.create_pool = &cpool_create_pool;
     cp->factory.release_pool = &cpool_release_pool;
     cp->factory.dump_status = &cpool_dump_status;
-    cp->factory.on_block_alloc = &cpool_on_block_alloc;
-    cp->factory.on_block_free = &cpool_on_block_free;
+
+    /* Deprecated, these callbacks are only used for updating cp.used_size &
+     * cp.peak_used_size which are no longer used.
+     */
+    //cp->factory.on_block_alloc = &cpool_on_block_alloc;
+    //cp->factory.on_block_free = &cpool_on_block_free;
 
     pool = pj_pool_create_on_buf("cachingpool", cp->pool_buf, sizeof(cp->pool_buf));
     status = pj_lock_create_simple_mutex(pool, "cachingpool", &cp->lock);

--- a/pjnath/src/pjturn-srv/main.c
+++ b/pjnath/src/pjturn-srv/main.c
@@ -49,8 +49,9 @@ static void dump_status(pj_turn_srv *srv)
     }
 
     printf("Worker threads : %d\n", srv->core.thread_cnt);
-    printf("Total mem usage: %u.%03uMB\n", (unsigned)(g_cp.used_size / 1000000), 
-           (unsigned)((g_cp.used_size % 1000000)/1000));
+    /* Field used_size is deprecated by #3897 */
+    //printf("Total mem usage: %u.%03uMB\n", (unsigned)(g_cp.used_size / 1000000),
+    //       (unsigned)((g_cp.used_size % 1000000)/1000));
     printf("UDP port range : %u %u %u (next/min/max)\n", srv->ports.next_udp,
            srv->ports.min_udp, srv->ports.max_udp);
     printf("TCP port range : %u %u %u (next/min/max)\n", srv->ports.next_tcp,

--- a/pjsip-apps/src/samples/pjsip-perf.c
+++ b/pjsip-apps/src/samples/pjsip-perf.c
@@ -900,8 +900,9 @@ static void destroy_app()
     if (app.pool) {
         pj_pool_release(app.pool);
         app.pool = NULL;
-        PJ_LOG(3,(THIS_FILE, "Peak memory size: %luMB",
-                             app.cp.peak_used_size / 1000000));
+        /* Field peak_used_size is deprecated by #3897 */
+        //PJ_LOG(3,(THIS_FILE, "Peak memory size: %luMB",
+        //                     app.cp.peak_used_size / 1000000));
         pj_caching_pool_destroy(&app.cp);
     }
 

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -502,9 +502,10 @@ on_return:
     pj_log_set_level(4);
 
     /* Dumping memory pool usage */
-    PJ_LOG(3,(THIS_FILE, "Peak memory size=%lu MB",
-                         (unsigned long)
-                         (caching_pool.peak_used_size / 1000000)));
+    /* Field peak_used_size is deprecated by #3897 */
+    //PJ_LOG(3,(THIS_FILE, "Peak memory size=%lu MB",
+    //                     (unsigned long)
+    //                     (caching_pool.peak_used_size / 1000000)));
 
     pjsip_endpt_destroy(endpt);
     pj_caching_pool_destroy(&caching_pool);


### PR DESCRIPTION
There is a report of data race:
```
 WARNING: ThreadSanitizer: data race (pid=13933)
  Write of size 8 at 0x726800000680 by main thread (mutexes: read M0):
    #0 cpool_on_block_alloc
    #1 default_block_alloc
    #2 pj_pool_create_block
    #3 pj_pool_allocate_find

  Previous write of size 8 at 0x726800000680 by thread T4 (mutexes: write M1, write M2):
    #0 cpool_on_block_free
    #1 default_block_free
    #2 reset_pool
    #3 pj_pool_destroy_int
```

After investigation, `cpool_on_block_alloc() & cpool_on_block_free()` are only used for updating fields `cp.used_size` & `cp.peak_used_size` which are for informational/logging purpose only. While updated without mutex protection, the information is potentially inaccurate. So I think deprecating those fields & the caching pool callbacks is safe and is able to fix the data race issue.

Thanks to Taisto Qvist for the report.