### PR TITLE
removed a bashism that prevented configuration

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -10362,7 +10362,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 		     *)
 			;;
 		  esac
-		  ac_webrtc_aec3_cflags+=" -DWEBRTC_APM_DEBUG_DUMP=0 -DWEBRTC_POSIX=1"
+      if [ -n "${ac_webrtc_aec3_cflags}" ]; then
+        ac_webrtc_aec3_cflags="${ac_webrtc_aec3_cflags} -DWEBRTC_APM_DEBUG_DUMP=0 -DWEBRTC_POSIX=1"
+      else
+        ac_webrtc_aec3_cflags="-DWEBRTC_APM_DEBUG_DUMP=0 -DWEBRTC_POSIX=1"
+      fi
            	else
            	  ac_no_webrtc_aec3=1
            	  printf "%s\n" "#define PJMEDIA_HAS_LIBWEBRTC_AEC3 0" >>confdefs.h


### PR DESCRIPTION
To my understanding `+=` is a bashism that a real `sh` does not understand. In order to successfully configure with `--enable-libwebrtc-aec3` on FreeBSD I needed this.

P.S.: There are more bashisms in the aconfigure script, but this made the script fail, because the variable was empty.

P.P.S.: In order to build with `--enable-libwebrtc-aec3` on FreeBSD there are more things to do. Some types need to be corrected. `pid_t` is 4 bytes on FreeBSD, for example.