### PR TITLE
Prevent race condition in DTLS media stop

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -1890,8 +1890,10 @@ static pj_status_t dtls_media_stop(pjmedia_transport *tp)
     PJ_LOG(2,(ds->base.name, "dtls_media_stop()"));
 #endif
 
+    DTLS_LOCK(ds);
     dtls_media_stop_channel(ds, RTP_CHANNEL);
     dtls_media_stop_channel(ds, RTCP_CHANNEL);
+    DTLS_UNLOCK(ds);
 
     ds->setup = DTLS_SETUP_UNKNOWN;
     ds->use_ice = PJ_FALSE;


### PR DESCRIPTION
To fix #3898.

If two threads call `pjmedia_transport_media_stop()` at the same time, it will potentially cause the issue.

We already have similar mechanism during destruction of DTLS media.
