### PR TITLE
Fixed Metal renderer memory leak

### DIFF
--- a/pjmedia/src/pjmedia-codec/vid_toolbox.m
+++ b/pjmedia/src/pjmedia-codec/vid_toolbox.m
@@ -554,17 +554,20 @@ static OSStatus create_encoder(vtool_codec_data *vtool_data)
 
     ret = VTSessionCopySupportedPropertyDictionary(vtool_data->enc,
                                                    &supported_prop);
-    if (ret == noErr &&
-        CFDictionaryContainsKey(supported_prop,
+    if (ret == noErr) {
+        if (CFDictionaryContainsKey(supported_prop,
                                 kVTCompressionPropertyKey_MaxH264SliceBytes))
-    {
-        /* kVTCompressionPropertyKey_MaxH264SliceBytes is not yet supported
-         * by Apple. We leave it here for possible future enhancements.
-        SET_PROPERTY(vtool_data->enc,
-                     kVTCompressionPropertyKey_MaxH264SliceBytes,
-                     // param->enc_mtu - NAL_HEADER_ADD_0X30BYTES
-                     (__bridge CFTypeRef)@(param->enc_mtu - 50));
-         */
+        {
+            /* kVTCompressionPropertyKey_MaxH264SliceBytes is not yet supported
+             * by Apple. We leave it here for possible future enhancements.
+            SET_PROPERTY(vtool_data->enc,
+                         kVTCompressionPropertyKey_MaxH264SliceBytes,
+                         // param->enc_mtu - NAL_HEADER_ADD_0X30BYTES
+                         (__bridge CFTypeRef)@(param->enc_mtu - 50));
+             */
+        }
+
+        CFRelease(supported_prop);
     }
 
     VTCompressionSessionPrepareToEncodeFrames(vtool_data->enc);

--- a/pjmedia/src/pjmedia-videodev/metal_dev.m
+++ b/pjmedia/src/pjmedia-videodev/metal_dev.m
@@ -428,6 +428,11 @@ static pj_status_t metal_factory_default_param(pj_pool_t *pool,
         textureCoordBuffer = [device newBufferWithBytes:textureCoordinates
                                      length:sizeof(textureCoordinates)
                                      options:MTLResourceStorageModeShared];
+
+        [pQuadPipelineStateDescriptor release];
+        [fragmentProgram release];
+        [vertexProgram release];
+        [shaderLibrary release];
     }
 
     return self;
@@ -508,6 +513,8 @@ static pj_status_t metal_factory_default_param(pj_pool_t *pool,
      */
     [commandBuffer presentDrawable:drawable];
     [commandBuffer commit];
+
+    [texture release];
 
     stream->is_rendering = PJ_FALSE;
 }


### PR DESCRIPTION
Fixed memory leak due to unreleased Metal texture.

Minor:
- Fixed various small leaks during Metal init.
- Fixed small leak in Video Toolbox.
