### PR TITLE
Fix to ext_fmts accessed out of stack scope.

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -288,6 +288,9 @@ pj_status_t pjsua_aud_subsys_init()
     unsigned opt;
     pjmedia_audio_codec_config codec_cfg;
     pj_status_t status;
+#if PJMEDIA_HAS_PASSTHROUGH_CODECS
+    pjmedia_format ext_fmts[32];
+#endif
 
     /* To suppress warning about unused var when all codecs are disabled */
     PJ_UNUSED_ARG(codec_id);
@@ -305,7 +308,6 @@ pj_status_t pjsua_aud_subsys_init()
     {
         unsigned aud_idx;
         unsigned ext_fmt_cnt = 0;
-        pjmedia_format ext_fmts[32];
 
         /* List extended formats supported by audio devices */
         for (aud_idx = 0; aud_idx < pjmedia_aud_dev_count(); ++aud_idx) {


### PR DESCRIPTION
`pjsua_aud_subsys_init`: The `ext_fmts` array is declared on the stack and assigned to `codec_cfg.passthrough.setting.fmts` to be passed into `pjmedia_codec_register_audio_codecs`.

However, `ext_fmts` goes out of scope on line 343 of `pjsua_aud.c`. The gcc address sanitizer has flagged it as out of scope stack reference, since that stack area can be freely reused by the register function.

This fix moves ext_fmts outside of the block so it remains on the stack.