### PR TITLE
Fixed incorrect SDP buffer length calculation

### DIFF
--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -898,7 +898,8 @@ static int print_session(const pjmedia_sdp_session *ses,
     if (len < 5 + 2 + ses->origin.user.slen +
               20 + 20 + 3 + /* max digits of origin.id and version +
                              * whitespaces */
-              ses->origin.net_type.slen+ses->origin.addr.slen + 4)
+              ses->origin.net_type.slen + ses->origin.addr_type.slen +
+              ses->origin.addr.slen + 2 + 2)
     {
         return -1;
     }

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -895,9 +895,10 @@ static int print_session(const pjmedia_sdp_session *ses,
     int printed;
 
     /* Check length for v= and o= lines. */
-    if (len < 5+ 
-              2+ses->origin.user.slen+18+
-              ses->origin.net_type.slen+ses->origin.addr.slen + 2)
+    if (len < 5 + 2 + ses->origin.user.slen +
+              20 + 20 + 3 + /* max digits of origin.id and version +
+                             * whitespaces */
+              ses->origin.net_type.slen+ses->origin.addr.slen + 4)
     {
         return -1;
     }
@@ -959,7 +960,7 @@ static int print_session(const pjmedia_sdp_session *ses,
     }
 
     /* Time */
-    if ((end-p) < 24) {
+    if ((end-p) < 2+20+1+20+2) {
         return -1;
     }
     *p++ = 't';


### PR DESCRIPTION
Since #3565, we can use 64-bit integer for the fields in o= and t= lines, but we didn't update the required buffer length to accommodate the fields.
