### PR TITLE
Add function to initialize MediaFormat audio & video

### DIFF
--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -205,11 +205,7 @@ void MyCall::onCallMediaState(OnCallMediaStateParam &prm)
         med_port = new MyAudioMediaPort();
 
         MediaFormatAudio fmt;
-        fmt.type = PJMEDIA_TYPE_AUDIO;
-        fmt.clockRate = 16000;
-        fmt.channelCount = 1;
-        fmt.bitsPerSample = 16;
-        fmt.frameTimeUsec = 20000;
+        fmt.init(PJMEDIA_FORMAT_PCM, 16000, 1, 20000, 16);
 
         med_port->createPort("med_port", fmt);
 

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -96,6 +96,13 @@ public:
     MediaFormatAudio() : clockRate(0), channelCount(0), frameTimeUsec(0),
                          bitsPerSample(0), avgBps(0), maxBps(0)
     {}
+
+    /**
+     * Initialization
+     */
+    void init(pj_uint32_t formatId, unsigned clockRate, unsigned channelCount,
+              int frameTimeUsec, int bitsPerSample,
+              pj_uint32_t avgBps=0, pj_uint32_t maxBps=0);
 };
 
 /**
@@ -119,6 +126,21 @@ struct MediaFormatVideo : public MediaFormat
      * Export to pjmedia_format.
      */
     pjmedia_format toPj() const;
+
+public:
+    /**
+     * Default constructor
+     */
+    MediaFormatVideo() : width(0), height(0), fpsNum(0),
+                         fpsDenum(1), avgBps(0), maxBps(0)
+    {}
+
+    /**
+     * Initialization
+     */
+    void init(pj_uint32_t formatId, unsigned width, unsigned height,
+              int fpsNum, int fpsDenum=1,
+              pj_uint32_t avgBps=0, pj_uint32_t maxBps=0);
 };
 
 /** Array of MediaFormatAudio */
@@ -2026,12 +2048,16 @@ struct VideoPreviewOpParam {
     unsigned                windowFlags;
 
     /**
-     * Media format video. If left uninitialized, this parameter will not be used and 
-     * the capture device will be opened using PJMEDIA wrapper default format, 
-     * e.g: 
+     * Media format video. By default, this parameter is uninitialized
+     * and will not be used.
+     *
+     * To initialize it, use MediaFormatVideo::init().
+     * If left uninitialized, the capture device will be opened using
+     * PJMEDIA wrapper default format, e.g:
      * - Android : PJMEDIA_FORMAT_I420 using the first supported size and 15fps
      * - iOS : PJMEDIA_FORMAT_BGRA using size 352x288 and 15fps
-     * Note that when the preview is already opened, this setting will be ignored.
+     * Note that when the preview is already opened, this setting will be
+     * ignored.
      */
     MediaFormatVideo        format;
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -70,6 +70,22 @@ pjmedia_format MediaFormatAudio::toPj() const
     return pj_format;
 }
 
+void MediaFormatAudio::init(pj_uint32_t formatId,
+                            unsigned clockRate, unsigned channelCount,
+                            int frameTimeUsec, int bitsPerSample,
+                            pj_uint32_t avgBps, pj_uint32_t maxBps)
+{
+    type = PJMEDIA_TYPE_AUDIO;
+    id = formatId;
+
+    this->clockRate = clockRate;
+    this->channelCount = channelCount;
+    this->frameTimeUsec = frameTimeUsec;
+    this->bitsPerSample = bitsPerSample;
+    this->avgBps = avgBps;
+    this->maxBps = maxBps;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 /* Audio Media operations. */
 void ConfPortInfo::fromPj(const pjsua_conf_port_info &port_info)
@@ -1558,6 +1574,27 @@ pjmedia_format MediaFormatVideo::toPj() const
 #endif
     return pj_format;
 }
+
+void MediaFormatVideo::init(pj_uint32_t formatId,
+                            unsigned width, unsigned height,
+                            int fpsNum, int fpsDenum,
+                            pj_uint32_t avgBps, pj_uint32_t maxBps)
+{
+#if PJSUA_HAS_VIDEO
+    type = PJMEDIA_TYPE_VIDEO;
+    id = formatId;
+
+    this->width = width;
+    this->height = height;
+    this->fpsNum = fpsNum;
+    this->fpsDenum = fpsDenum;
+    this->avgBps = avgBps;
+    this->maxBps = maxBps;
+#else
+    type = PJMEDIA_TYPE_UNKNOWN;
+#endif
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 void VideoDevInfo::fromPj(const pjmedia_vid_dev_info &dev_info)


### PR DESCRIPTION
Currently, the object `MediaFormatAudio/Video` will be uninitalised upon creation (i.e. `type == PJMEDIA_TYPE_NONE`).

To initialise it, user needs to explicitly set its parent's `type` to `PJMEDIA_TYPE_AUDIO/VIDEO`, otherwise the object will still considered to be uninitialised.

For example:
```
VideoPreview prev(videoDevIdx);
VideoPreviewOpParam param = VideoPreviewOpParam();
param.format.id = PJMEDIA_FORMAT_I420;
param.format.width = 1080;
param.format.height = 1920;
param.format.fpsNum = 15;
param.format.fpsDenum = 1;
/* Despite all the above initialisations, param.format.type is still PJMEDIA_TYPE_NONE and hence, will just be ignored. */
prev.start(param);
```
