### PR TITLE
Add check in siprtp sample app for disabled audio media

### DIFF
--- a/pjsip-apps/src/samples/siprtp.c
+++ b/pjsip-apps/src/samples/siprtp.c
@@ -1420,6 +1420,11 @@ static void call_on_media_update( pjsip_inv_session *inv,
     pjmedia_sdp_neg_get_active_local(inv->neg, &local_sdp);
     pjmedia_sdp_neg_get_active_remote(inv->neg, &remote_sdp);
 
+    if (local_sdp->media[0]->desc.port == 0) {
+        PJ_LOG(3, (THIS_FILE, "Audio media inactive"));
+        return;
+    }
+
     status = pjmedia_stream_info_from_sdp(&audio->si, inv->pool, app.med_endpt,
                                           local_sdp, remote_sdp, 0);
     if (status != PJ_SUCCESS) {


### PR DESCRIPTION
If siprtp sample app rejects the media by setting the port to 0, it should not proceed to create media transport and media thread (the latter can cause division by zero since `strm->clock_rate == 0`).
