### PR TITLE
Fixed PJSUA2 API to get/set Opus config

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1779,7 +1779,6 @@ public:
      */
     void resetVideoCodecParam(const string &codec_id) PJSUA2_THROW(Error);
 
-#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
     /**
      * Get codec Opus config.
      *
@@ -1794,7 +1793,6 @@ public:
      */
     void setCodecOpusConfig(const CodecOpusConfig &opus_cfg)
                             PJSUA2_THROW(Error);
-#endif
 
     /**
      * Enumerate all SRTP crypto-suite names.

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -2490,15 +2490,16 @@ void Endpoint::codecSetParam(const string &codec_id,
     PJSUA2_CHECK_EXPR( pjsua_codec_set_param(&codec_str, &pj_param) );
 }
 
-#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
 
 CodecOpusConfig Endpoint::getCodecOpusConfig() const PJSUA2_THROW(Error)
 {
-   pjmedia_codec_opus_config opus_cfg;
    CodecOpusConfig config;
+#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
+   pjmedia_codec_opus_config opus_cfg;
 
    PJSUA2_CHECK_EXPR(pjmedia_codec_opus_get_config(&opus_cfg));
    config.fromPj(opus_cfg);
+#endif
 
    return config;
 }
@@ -2506,6 +2507,7 @@ CodecOpusConfig Endpoint::getCodecOpusConfig() const PJSUA2_THROW(Error)
 void Endpoint::setCodecOpusConfig(const CodecOpusConfig &opus_cfg)
                                   PJSUA2_THROW(Error)
 {
+#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
    const pj_str_t codec_id = {(char *)"opus", 4};
    pjmedia_codec_param param;
    pjmedia_codec_opus_config new_opus_cfg;
@@ -2515,9 +2517,10 @@ void Endpoint::setCodecOpusConfig(const CodecOpusConfig &opus_cfg)
 
    PJSUA2_CHECK_EXPR(pjmedia_codec_opus_set_default_param(&new_opus_cfg,
                                                           &param));
-}
-
+#else
+    PJ_UNUSED_ARG(opus_cfg);
 #endif
+}
 
 void Endpoint::clearCodecInfoList(CodecInfoVector &codec_list)
 {

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -2493,32 +2493,36 @@ void Endpoint::codecSetParam(const string &codec_id,
 
 CodecOpusConfig Endpoint::getCodecOpusConfig() const PJSUA2_THROW(Error)
 {
-   CodecOpusConfig config;
+    CodecOpusConfig config;
 #if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
-   pjmedia_codec_opus_config opus_cfg;
+    pjmedia_codec_opus_config opus_cfg;
 
-   PJSUA2_CHECK_EXPR(pjmedia_codec_opus_get_config(&opus_cfg));
-   config.fromPj(opus_cfg);
+    PJSUA2_CHECK_EXPR(pjmedia_codec_opus_get_config(&opus_cfg));
+    config.fromPj(opus_cfg);
+#else
+    PJSUA2_RAISE_ERROR(PJ_ENOTSUP);
 #endif
 
-   return config;
+    return config;
 }
 
 void Endpoint::setCodecOpusConfig(const CodecOpusConfig &opus_cfg)
                                   PJSUA2_THROW(Error)
 {
 #if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
-   const pj_str_t codec_id = {(char *)"opus", 4};
-   pjmedia_codec_param param;
-   pjmedia_codec_opus_config new_opus_cfg;
-
-   PJSUA2_CHECK_EXPR(pjsua_codec_get_param(&codec_id, &param));
-   new_opus_cfg = opus_cfg.toPj();
-
-   PJSUA2_CHECK_EXPR(pjmedia_codec_opus_set_default_param(&new_opus_cfg,
-                                                          &param));
+    const pj_str_t codec_id = {(char *)"opus", 4};
+    pjmedia_codec_param param;
+    pjmedia_codec_opus_config new_opus_cfg;
+    
+    PJSUA2_CHECK_EXPR(pjsua_codec_get_param(&codec_id, &param));
+    new_opus_cfg = opus_cfg.toPj();
+    
+    PJSUA2_CHECK_EXPR(pjmedia_codec_opus_set_default_param(&new_opus_cfg,
+                                                           &param));
 #else
     PJ_UNUSED_ARG(opus_cfg);
+
+    PJSUA2_RAISE_ERROR(PJ_ENOTSUP);
 #endif
 }
 


### PR DESCRIPTION
To fix #3934.

Checking the macro `PJMEDIA_HAS_OPUS_CODEC` within the PJSUA2 API declaration will complicate the build process, such as for SWIG binding.
We should check the macro in the implementation instead.
