### PR TITLE
Fix bad address length check in pj_ioqueue_sendto()

### DIFF
--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -1056,7 +1056,7 @@ retry_on_restart:
     /*
      * Check that address storage can hold the address parameter.
      */
-    PJ_ASSERT_RETURN(addrlen <= (int)sizeof(pj_sockaddr_in), PJ_EBUG);
+    PJ_ASSERT_RETURN(addrlen <= (int)sizeof(pj_sockaddr), PJ_EBUG);
 
     /*
      * Schedule asynchronous send.

--- a/pjlib/src/pj/ioqueue_common_abs.h
+++ b/pjlib/src/pj/ioqueue_common_abs.h
@@ -63,7 +63,7 @@ struct write_operation
     pj_size_t               size;
     pj_ssize_t              written;
     unsigned                flags;
-    pj_sockaddr_in          rmt_addr;
+    pj_sockaddr             rmt_addr;
     int                     rmt_addrlen;
 };
 


### PR DESCRIPTION
Fix issue #3938:

> Assertion when checking address length in pj_ioqueue_sendto in ioqueue_common_abs.c of an IPv6 address. Looks like the `PJ_ASSERT_RETURN(addrlen <= (int)sizeof(pj_sockaddr_in), PJ_EBUG)` is old code that has not been updated to account for IPv6 addresses.

Thanks to @rickdialpad for the detailed report and the proposed patch.

PS: I don't think verifying the address family is necessary here as the check seems to concern about the storage capacity only. Btw, also updated the storage type (`write_operation.rmt_addr`) to `pj_sockaddr`.