### PR TITLE
Print log after sending SIP message successfully

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -877,6 +877,12 @@ static void transport_send_callback(pjsip_transport *transport,
 
     PJ_UNUSED_ARG(transport);
 
+    /* Print log on successful sending */
+    if (size > 0) {
+        PJ_LOG(5,(transport->obj_name,
+                  "%s sent successfully", pjsip_tx_data_get_info(tdata)));
+    }
+
     /* Mark pending off so that app can resend/reuse txdata from inside
      * the callback.
      */
@@ -965,6 +971,13 @@ PJ_DEF(pj_status_t) pjsip_transport_send(  pjsip_transport *tr,
 
     if (status != PJ_EPENDING) {
         tdata->is_pending = 0;
+
+        /* Print log on successful sending */
+        if (status == PJ_SUCCESS) {
+            PJ_LOG(5,(tr->obj_name,
+                      "%s sent successfully", pjsip_tx_data_get_info(tdata)));
+        }
+
         pjsip_tx_data_dec_ref(tdata);
     }
 


### PR DESCRIPTION
Sending a SIP message is done asynchronously, so when the log says "TX n bytes Request msg.." actually the message may not be on the wire yet. Even for TCP/TLS the transport, the connection may not be established yet. Having a log line printed for a successful send can be useful for debugging purpose.