### PR TITLE
Suppress warning of uninitialized value in fuzz-crypto

### DIFF
--- a/tests/fuzz/fuzz-crypto.c
+++ b/tests/fuzz/fuzz-crypto.c
@@ -45,7 +45,7 @@ void encode_base64_differential(const uint8_t *Data, size_t Size) {
 
     //OPENSSL
     BIO *bio, *bio_mem;
-    char *ssl_output;
+    char *ssl_output = NULL;
     int  ssl_output_len;
 
     bio = BIO_new(BIO_f_base64());
@@ -58,6 +58,9 @@ void encode_base64_differential(const uint8_t *Data, size_t Size) {
     BIO_flush(bio);
 
     ssl_output_len = BIO_get_mem_data(bio_mem, &ssl_output);
+    if (ssl_output_len <= 0) {
+        abort();
+    }
 
     //Differential
     int result = memcmp(pj_output, ssl_output, ssl_output_len);


### PR DESCRIPTION
```
==211664==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5a0bf6b3d930 in encode_base64_differential [pjsip/tests/fuzz/fuzz-crypto.c:63](https://github.com/pjsip/pjproject/blob/f38d781a82a2b51b51a9996d4d76bdd8e69304d4/tests/fuzz/fuzz-crypto.c#L63):18

Uninitialized value was created by an allocation of 'ssl_output' in the stack frame
    #0 0x5a0bf6b3d70b in encode_base64_differential [pjsip/tests/fuzz/fuzz-crypto.c:48](https://github.com/pjsip/pjproject/blob/f38d781a82a2b51b51a9996d4d76bdd8e69304d4/tests/fuzz/fuzz-crypto.c#L48):5
```

Note that I am unable to reproduce it locally and I believe the issue should not happen if the test data is within the minimum and maximum size.

But for robustness, it's better to initialize `ssl_output` and check the return value of `BIO_get_mem_data().`

`BIO_get_mem_data() returns the total number of bytes available on success, 0 if b is NULL, or a negative value in case of other errors.`
