### PR TITLE
pjsip_find_msg: Log warning if Content-Length field not found

### DIFF
--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -937,6 +937,8 @@ PJ_DEF(pj_status_t) pjsip_find_msg( const char *buf, pj_size_t size,
 
     /* Found Content-Length? */
     if (content_length == -1) {
+        /* As per RFC3261 7.4.2, 7.5, 20.14, Content-Length is mandatory over TCP. */
+        PJ_LOG(2, (THIS_FILE, "Field Content-Length not found!"));
         return status;
     }
 


### PR DESCRIPTION
The pjsip_find_msg() is used when in TCP to find the message boundaries in the stream. For that, it uses the Content-Length field, which is only mandatory in SIP TCP according to spec. Since this function is used only in TCP transport, that's totally fine.
However, a SIP test written in TTCN-3 was recently sending a message without Content-Length field (because there was no body at all in the message). That made Asterisk discard the message without any kind of feedback, as if it was a black hole.
Write down some log line explaining the user that a Content-Length value is expected.