### PR TITLE
Possible race between media deinitialization and media initialization

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1843,6 +1843,12 @@ static pj_status_t call_media_init_cb(pjsua_call_media *call_med,
         goto on_return;
     }
 
+    /* Check if media is deinitializing */
+    if (call_med->call->async_call.med_ch_deinit || !call_med->tp) {
+        status = PJ_ECANCELLED;
+        goto on_return;
+    }
+
     pjmedia_transport_simulate_lost(call_med->tp, PJMEDIA_DIR_ENCODING,
                                     pjsua_var.media_cfg.tx_drop_pct);
 


### PR DESCRIPTION
A crash has been reported in destroying PJSUA with several concurrent calls, call stack trace is:
```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x0000000000000028
Triggered by Thread:  0

Thread 0 Crashed:
0   (pjmedia_transport_simulate_lost + 28)
1   (call_media_init_cb + 168)
2   (call_media_init_cb + 168)
3   (ice_init_complete_cb + 252)
4   (timer_cb + 108)
5   (pj_timer_heap_poll + 616)
6   (pjsip_endpt_handle_events2 + 96)
7   (pjsua_handle_events + 84)
8   (busy_sleep + 88)
9   (pjsua_destroy2 + 1620)
```

Asynchronous ICE initialization callback seems to be invoked after the ICE transport is destroyed. As the ICE initialization callback is called by `pjsua_destroy2()` context (as shown in the stack trace above), simply adding media deinitialization check should be sufficient for this issue.