### PR TITLE
Prevent pjmedia_codec_param.info.enc_ptime_denum division by zero in stream

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2573,6 +2573,9 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
     if (stream->codec_param.info.frm_ptime_denum < 1)
         stream->codec_param.info.frm_ptime_denum = 1;
 
+    if (stream->codec_param.info.enc_ptime_denum < 1)
+        stream->codec_param.info.enc_ptime_denum = 1;
+
     /* Init the codec. */
     status = pjmedia_codec_init(stream->codec, pool);
     if (status != PJ_SUCCESS)


### PR DESCRIPTION
To fix #3966.

We already have check for `pjmedia_codec_param.info.frm_ptime_denum`, but none for `enc_ptime_denum`.
