### PR TITLE
Fix version string in Python setup

### DIFF
--- a/pjsip-apps/src/swig/python/setup.py
+++ b/pjsip-apps/src/swig/python/setup.py
@@ -63,7 +63,7 @@ pj_version = pj_version_major + "." + pj_version_minor
 if pj_version_rev:
     pj_version += "." + pj_version_rev
 if pj_version_suffix:
-    pj_version += "-" + pj_version_suffix
+    pj_version += pj_version_suffix
 
 #print 'PJ_VERSION = "'+ pj_version + '"'
 


### PR DESCRIPTION
To fix #3969.

Our version suffix convention already includes '-' (such as "-svn" back when we still used SVN, or "-dev" for now), so we don't need the extra '-'.
Thanks to @frisky5 for the fix.
