### PR TITLE
Assertion when sending SUBSCRIBE failed synchronously

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -1995,6 +1995,8 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
     pjsip_tpselector tp_sel;
     pj_status_t status;
     const char *sub_str = presence? "presence": "dialog event";
+    pjsip_evsub *sub;
+    pjsip_dialog *dlg;
 
     /* Event subscription callback. */
     pj_bzero(&pres_callback, sizeof(pres_callback));
@@ -2139,14 +2141,23 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
 
     pjsua_process_msg_data(tdata, NULL);
 
+    /* Send request. Note that if the send operation fails sync-ly, e.g:
+     * gethostbyname() error, tsx callback may have been invoked which may
+     * get the subscription terminated and the buddy states reset, we need
+     * to be prepared for such scenario here.
+     */
+    dlg = buddy->dlg;
+    sub = buddy->sub;
+
     if (presence) {
         status = pjsip_pres_send_request(buddy->sub, tdata);
     } else {
         status = pjsip_dlg_event_send_request(buddy->sub, tdata);
     }
     if (status != PJ_SUCCESS) {
-        pjsip_dlg_dec_lock(buddy->dlg);
-        pjsip_pres_terminate(buddy->sub, PJ_FALSE);
+        pjsip_dlg_dec_lock(dlg);
+        if (buddy->sub)
+            pjsip_pres_terminate(buddy->sub, PJ_FALSE);
         buddy->sub = NULL;
         pjsua_perror(THIS_FILE, "Unable to send initial SUBSCRIBE", 
                      status);

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -1995,7 +1995,6 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
     pjsip_tpselector tp_sel;
     pj_status_t status;
     const char *sub_str = presence? "presence": "dialog event";
-    pjsip_evsub *sub;
     pjsip_dialog *dlg;
 
     /* Event subscription callback. */
@@ -2147,7 +2146,6 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
      * to be prepared for such scenario here.
      */
     dlg = buddy->dlg;
-    sub = buddy->sub;
 
     if (presence) {
         status = pjsip_pres_send_request(buddy->sub, tdata);


### PR DESCRIPTION
Reported that assertion happens with this call stack trace:
```
Crashed: Thread: SIGABRT  0x0000000000000000
#00 pc 0x51894 libc.so (BuildId: 058e3ec96fa600fb840a6a6956c6b64e)
#01 pc 0x51864 libc.so (BuildId: 058e3ec96fa600fb840a6a6956c6b64e)
#02 pc 0x51c64 libc.so (BuildId: 058e3ec96fa600fb840a6a6956c6b64e)
#03 pc 0x661c08 libpjsua2.so (pjsip_dlg_dec_lock) (BuildId: 4922aaff88b25fc51d5455bb4471a2161724c7f0)
#04 pc 0x5ea78c libpjsua2.so (subscribe_buddy_presence) (BuildId: 4922aaff88b25fc51d5455bb4471a2161724c7f0)
#05 pc 0x5ea0b8 libpjsua2.so (pjsua_buddy_update_pres) (BuildId: 4922aaff88b25fc51d5455bb4471a2161724c7f0)
```

After investigating the provided log file, the problem seems to be accessing buddy states after getting reset/null-ed. Check `subscribe_buddy()` code here:
https://github.com/pjsip/pjproject/blob/2d5e35182afcb03979451d56ca6e46695975d4e3/pjsip/src/pjsua-lib/pjsua_pres.c#L2142-L2149

When the sending fails synchronously, the callbacks of transaction and event subscription may be invoked. From the callbacks, the event subscription terminates the subscription and PJSUA presence resets the buddy states. So when the send operation returns, the buddy states (e.g: `buddy->dlg` & `buddy->sub`) may have been set to `NULL` and `pjsip_dlg_dec_lock(NULL)` will raise an assertion.

