### PR TITLE
Set default ka_data to double-CRLF - so it is a valid SIP message

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -337,7 +337,7 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
     cfg->timer_setting = pjsua_var.ua_cfg.timer_setting;
     cfg->lock_codec = 1;
     cfg->ka_interval = 15;
-    cfg->ka_data = pj_str("\r\n");
+    cfg->ka_data = pj_str("\r\n\r\n");
     cfg->vid_cap_dev = PJMEDIA_VID_DEFAULT_CAPTURE_DEV;
     cfg->vid_rend_dev = PJMEDIA_VID_DEFAULT_RENDER_DEV;
 #if PJMEDIA_HAS_VIDEO


### PR DESCRIPTION
Set the default `.ka_data` field to double-CRLF, i.,e., a valid SIP message.

Users of the default `pjsua_acc_config` have a bogus `.ka_data` field — affects `pjsua` CLI application when the RESPONSE has `Flow-Timer`.

Addresses #3986
