### PR TITLE
pj_dns_srv_resolve() returns query object when it shouldn't

### DIFF
--- a/pjlib-util/include/pjlib-util/resolver.h
+++ b/pjlib-util/include/pjlib-util/resolver.h
@@ -406,7 +406,7 @@ PJ_DECL(pj_status_t) pj_dns_resolver_destroy(pj_dns_resolver *resolver,
  * @param user_data Arbitrary user data to be associated with the query,
  *                  and which will be given back in the callback.
  * @param p_query   Optional pointer to receive the query object, if one
- *                  was started. If this pointer is specified, a NULL may
+ *                  was started. If this pointer is specified, a NULL will
  *                  be returned if response cache is available immediately.
  *
  * @return          PJ_SUCCESS if either an asynchronous query has been 

--- a/pjlib-util/include/pjlib-util/srv_resolver.h
+++ b/pjlib-util/include/pjlib-util/srv_resolver.h
@@ -181,7 +181,7 @@ typedef void pj_dns_srv_resolver_cb(void *user_data,
  * @param cb            Pointer to callback function to receive the
  *                      notification when the resolution process completes.
  * @param p_query       Optional pointer to receive the query object, if one
- *                      was started. If this pointer is specified, a NULL may
+ *                      was started. If this pointer is specified, a NULL will
  *                      be returned if response cache is available immediately.
  *
  * @return              PJ_SUCCESS on success, or the appropriate error code.

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -107,7 +107,7 @@ PJ_DEF(pj_status_t) pj_dns_srv_resolve( const pj_str_t *domain_name,
 {
     pj_size_t len;
     pj_str_t target_name;
-    pj_dns_srv_async_query *query_job;
+    pj_dns_srv_async_query *query_job, *p_q = NULL;
     pj_status_t status;
 
     PJ_ASSERT_RETURN(domain_name && domain_name->slen &&
@@ -156,8 +156,11 @@ PJ_DEF(pj_status_t) pj_dns_srv_resolve( const pj_str_t *domain_name,
                                          query_job->dns_state, 0, 
                                          &dns_callback,
                                          query_job, &query_job->q_srv);
-    if (status==PJ_SUCCESS && p_query && query_job->q_srv)
-        *p_query = query_job;
+    if (query_job->q_srv)
+        p_q = query_job;
+
+    if (status==PJ_SUCCESS && p_query)
+        *p_query = p_q;
 
     return status;
 }

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -156,7 +156,7 @@ PJ_DEF(pj_status_t) pj_dns_srv_resolve( const pj_str_t *domain_name,
                                          query_job->dns_state, 0, 
                                          &dns_callback,
                                          query_job, &query_job->q_srv);
-    if (status==PJ_SUCCESS && p_query)
+    if (status==PJ_SUCCESS && p_query && query_job->q_srv)
         *p_query = query_job;
 
     return status;


### PR DESCRIPTION
According to the documentation of [pj_dns_srv_resolve()](https://github.com/pjsip/pjproject/blob/28c54a42f6978e6c5b8d051bb9ae984a3a6130d7/pjlib-util/include/pjlib-util/srv_resolver.h#L183) the optional parameter _p_query_ \
can be used to retrieve the query object _if one was started_.

It's supposed to return NULL when the response is available from the cache. \
I noticed that the function **always** returns the internal query object, no matter if the response is in the cache or not
which makes it weird to deal with the case where the response is available immediately \
(because the callback will be called before the function returns). \
This PR adds an additional check to see whether a query was actually started and returns the object only in that case (if any).