### PR TITLE
Prevent race condition within DNS callbacks in pjsip resolver

### DIFF
--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -51,6 +51,7 @@ struct query
     pjsip_resolver_callback *cb;
     pj_dns_async_query      *object;
     pj_dns_async_query      *object6;
+    pj_grp_lock_t           *grp_lock;
     pj_status_t              last_error;
 
     /* Original request: */
@@ -71,6 +72,7 @@ struct query
 struct pjsip_resolver_t
 {
     pj_dns_resolver *res;
+    pj_grp_lock_t   *grp_lock;
     pjsip_ext_resolver *ext_res;
 };
 
@@ -93,9 +95,18 @@ PJ_DEF(pj_status_t) pjsip_resolver_create( pj_pool_t *pool,
                                            pjsip_resolver_t **p_res)
 {
     pjsip_resolver_t *resolver;
+    pj_status_t status;
 
     PJ_ASSERT_RETURN(pool && p_res, PJ_EINVAL);
     resolver = PJ_POOL_ZALLOC_T(pool, pjsip_resolver_t);
+
+    /* Create group lock */
+    status = pj_grp_lock_create(pool, NULL, &resolver->grp_lock);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    pj_grp_lock_add_ref(resolver->grp_lock);
+
     *p_res = resolver;
 
     return PJ_SUCCESS;
@@ -159,6 +170,11 @@ PJ_DEF(void) pjsip_resolver_destroy(pjsip_resolver_t *resolver)
         pj_dns_resolver_destroy(resolver->res, PJ_FALSE);
 #endif
         resolver->res = NULL;
+    }
+
+    if (resolver->grp_lock) {
+        pj_grp_lock_dec_ref(resolver->grp_lock);
+        resolver->grp_lock = NULL;
     }
 }
 
@@ -393,6 +409,7 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
     query->objname = THIS_FILE;
     query->token = token;
     query->cb = cb;
+    query->grp_lock = resolver->grp_lock;
     query->req.target = *target;
     pj_strdup(pool, &query->req.target.addr.host, &target->addr.host);
 
@@ -532,6 +549,8 @@ static void dns_a_callback(void *user_data,
     struct query *query = (struct query*) user_data;
     pjsip_server_addresses *srv = &query->server;
 
+    pj_grp_lock_acquire(query->grp_lock);
+
     /* Reset outstanding job */
     query->object = NULL;
 
@@ -577,6 +596,8 @@ static void dns_a_callback(void *user_data,
         else
             (*query->cb)(query->last_error, query->token, NULL);
     }
+
+    pj_grp_lock_release(query->grp_lock);
 }
 
 
@@ -589,6 +610,8 @@ static void dns_aaaa_callback(void *user_data,
 {
     struct query *query = (struct query*) user_data;
     pjsip_server_addresses *srv = &query->server;
+
+    pj_grp_lock_acquire(query->grp_lock);
 
     /* Reset outstanding job */
     query->object6 = NULL;
@@ -636,6 +659,8 @@ static void dns_aaaa_callback(void *user_data,
         else
             (*query->cb)(query->last_error, query->token, NULL);
     }
+
+    pj_grp_lock_release(query->grp_lock);
 }
 
 


### PR DESCRIPTION
In our DNS resolver, in order to avoid deadlock, we utilize a workaround in #1108 by releasing the lock before calling the callback.

However, this means that there can be a race condition. In sip_resolve, it is reported that the callback can be called twice when DNS A and AAAA responses are processed at the same time:

```
06-15 01:36:26.024   597   597 D SipTelecomPJ: 01:36:26.024     resolver.c  ...Transmitting 32 bytes to NS 0 ([...:53](http://...:53/)): DNS A query for [domain.net](http://domain.net/): Success
06-15 01:36:26.026   597   923 D SipTelecomPJ: 01:36:26.026   pjsua_core.c  TX 745 bytes Request msg SUBSCRIBE/cseq=1832 (tdta0x9061e068) to TLS [...:5061](http://...:5061/):
06-15 01:36:26.026   597   923 D SipTelecomPJ: SUBSCRIBE  ...
...

06-15 01:36:26.027   597   597 D SipTelecomPJ: 01:36:26.024  sip_resolve.c  ...DNS AAAA record resolution failed: No answer record in the DNS response (PJLIB_UTIL_EDNSNOANSWERREC)
06-15 01:36:26.027   597   597 D SipTelecomPJ: 01:36:26.027   pjsua_core.c !...TX 745 bytes Request msg SUBSCRIBE/cseq=1832 (tdta0x9061e068) to TLS [...:5061](http://...:5061/):
06-15 01:36:26.027   597   597 D SipTelecomPJ: SUBSCRIBE ...
...
06-15 01:36:26.028   597   597 D SipTelecomPJ: 01:36:26.028 evsub0x9060c86  .....Subscription state changed NULL --> SENT cause
```
