### PR TITLE
Replace Trac links in the doc

### DIFF
--- a/pjlib/include/pj/lock.h
+++ b/pjlib/include/pj/lock.h
@@ -177,7 +177,9 @@ PJ_DECL(pj_status_t) pj_lock_destroy( pj_lock_t *lock );
  *    - must be able to synchronize with external lock (for example, a dialog
  *      lock must be able to sync itself with PJSUA lock)
  *
- * Please see https://trac.pjsip.org/repos/wiki/Group_Lock for more info.
+ * Please see 
+ * https://docs.pjsip.org/en/latest/specific-guides/develop/group_lock.html
+ * for more info.
  */
 
 /**

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -975,8 +975,8 @@
 
 /**
  * Specify the tone generator algorithm to be used. Please see 
- * http://trac.pjsip.org/repos/wiki/Tone_Generator for the performance
- * analysis results of the various tone generator algorithms.
+ * https://docs.pjsip.org/en/latest/specific-guides/media/tonegen.html for
+ * the performance analysis results of the various tone generator algorithms.
  *
  * Default value:
  *  - PJMEDIA_TONEGEN_FLOATING_POINT when PJ_HAS_FLOATING_POINT is set


### PR DESCRIPTION
This PR will replace obsolete Trac links in the code documentation.

Thank you to @jtojnar for the original patch in #3981. This PR will replace #3981.

Note that after further search, the following links are being intentionally left unchanged:
* http://trac.pjsip.org/repos/wiki/Audio_Dev_API
because it contains info about deprecated APIs that are not available in the newer docs.
* http://trac.pjsip.org/repos/wiki/Intel_IPP_Codecs
no corresponding entry in docs.pjsip.org and also, almost obsolete (?)
* http://trac.pjsip.org/repos/wiki/Nokia_APS_VAS_Direct
obsolete
