### PR TITLE
Make sure pj_dns_resolver_start_query() returns NULL for query object when returning from cache

### DIFF
--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -917,6 +917,12 @@ PJ_DEF(pj_status_t) pj_dns_resolver_start_query( pj_dns_resolver *resolver,
             cache->ref_cnt++;
             pj_grp_lock_release(resolver->grp_lock);
 
+            /* Since we're returning an answer from cache,
+             * there is no query object to return.
+             */
+            if (p_query)
+                *p_query = NULL;
+
             /* This cached response is still valid. Just return this
              * response to caller.
              */


### PR DESCRIPTION
In #3990 I updated the description of [pj_dns_resolver_start_query()](https://github.com/pjsip/pjproject/blob/ed52054c1584c9b2f354d74b2d48b42ad3a9a1cd/pjlib-util/src/pjlib-util/resolver.c#L856) saying that if a pointer for a query object is specified then NULL will be returned if the answer is available from cache.

However, this is not happening because I didn't notice the function returns early when a cached response is available.
This PR corrects this behaviour and sets the pointer to NULL before calling the user callback and then returning from the function.
