### PR TITLE
Fix bug when writing empty string to log

### DIFF
--- a/pjlib/src/pj/log.c
+++ b/pjlib/src/pj/log.c
@@ -468,11 +468,11 @@ PJ_DEF(void) pj_log( const char *sender, int level,
         print_len = pj_ansi_snprintf(pre, sizeof(log_buffer)-len, 
                                      "<logging error: msg too long>");
     }
-    if (print_len < 1 || print_len >= (int)(sizeof(log_buffer)-len)) {
+    if (print_len < 0 || print_len >= (int)(sizeof(log_buffer)-len)) {
         print_len = sizeof(log_buffer) - len - 1;
     }
     len = len + print_len;
-    if (len > 0 && len < (int)sizeof(log_buffer)-2) {
+    if (len >= 0 && len < (int)sizeof(log_buffer)-2) {
         if (log_decor & PJ_LOG_HAS_CR) {
             log_buffer[len++] = '\r';
         }

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -89,6 +89,7 @@ int test_inner(void)
 #endif
 
 #if INCLUDE_OS_TEST
+    DO_TEST( log_test() );
     DO_TEST( os_test() );
 #endif
 

--- a/pjlib/src/pjlib-test/test.h
+++ b/pjlib/src/pjlib-test/test.h
@@ -87,6 +87,7 @@ extern int exception_test(void);
 extern int rand_test(void);
 extern int list_test(void);
 extern int hash_test(void);
+extern int log_test(void);
 extern int os_test(void);
 extern int pool_test(void);
 extern int pool_perf_test(void);


### PR DESCRIPTION
Writing empty string to log, i.e. `PJ_LOG(3,(THIS_FILE, "%s", ""))` will cause log writer (`pj_log_write()`) to be called with maximum buffer length.

Also added `log_test()` in `pjlib-test` to test this and other scenarios.