### PR TITLE
API to get DNS server's bound address to allow specifying zero as port number

### DIFF
--- a/pjlib-util/include/pjlib-util/dns_server.h
+++ b/pjlib-util/include/pjlib-util/dns_server.h
@@ -50,7 +50,8 @@ typedef struct pj_dns_server pj_dns_server;
  *                  registered to.
  * @param af        Address family of the server socket (valid values
  *                  are pj_AF_INET() for IPv4 and pj_AF_INET6() for IPv6).
- * @param port      The UDP port to listen.
+ * @param port      The UDP port to listen. Specify zero to bind to any
+ *                  port.
  * @param flags     Flags, currently must be zero.
  * @param p_srv     Pointer to receive the DNS server instance.
  *
@@ -64,6 +65,17 @@ PJ_DECL(pj_status_t) pj_dns_server_create(pj_pool_factory *pf,
                                           unsigned port,
                                           unsigned flags,
                                           pj_dns_server **p_srv);
+
+/**
+ * Get the DNS server address
+ *
+ * @param srv	    The DNS server instance.
+ * @param addr      It will be filled with the server's bound address.
+ *
+ * @return	    PJ_SUCCESS on success or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pj_dns_server_get_addr(pj_dns_server *srv,
+                                            pj_sockaddr *bound_addr);
 
 /**
  * Destroy DNS server instance.

--- a/pjlib-util/src/pjlib-util/dns_server.c
+++ b/pjlib-util/src/pjlib-util/dns_server.c
@@ -52,6 +52,7 @@ struct pj_dns_server
     pj_pool_t           *pool;
     pj_pool_factory     *pf;
     pj_activesock_t     *asock;
+    pj_sockaddr          bound_addr;
     pj_ioqueue_op_key_t  send_key;
     struct rr            rr_list;
 };
@@ -97,7 +98,8 @@ PJ_DEF(pj_status_t) pj_dns_server_create( pj_pool_factory *pf,
     pj_activesock_cfg_default(&sock_cfg);
 
     status = pj_activesock_create_udp(pool, &sock_addr, &sock_cfg, ioqueue,
-                                      &sock_cb, srv, &srv->asock, NULL);
+                                      &sock_cb, srv, &srv->asock,
+                                      &srv->bound_addr);
     if (status != PJ_SUCCESS)
         goto on_error;
 
@@ -113,6 +115,15 @@ PJ_DEF(pj_status_t) pj_dns_server_create( pj_pool_factory *pf,
 on_error:
     pj_dns_server_destroy(srv);
     return status;
+}
+
+
+PJ_DEF(pj_status_t) pj_dns_server_get_addr(pj_dns_server *srv,
+                                           pj_sockaddr *bound_addr)
+{
+    PJ_ASSERT_RETURN(srv && bound_addr, PJ_EINVAL);
+    pj_memcpy(bound_addr, &srv->bound_addr, sizeof(*bound_addr));
+    return PJ_SUCCESS;
 }
 
 


### PR DESCRIPTION
Specifying zero as port number is syntactically and semantically allowed when creating DNS server, but there was no way to get the bound address. This PR adds such API.

The ability to use zero port is required by pjnath unit tests (currently under development in separate branch) in order to spawn multiple DNS servers simultaneously.