### PR TITLE
Fix coverity warning

### DIFF
--- a/pjlib/src/pjlib-test/ioq_tcp.c
+++ b/pjlib/src/pjlib-test/ioq_tcp.c
@@ -887,7 +887,7 @@ on_error:
         if (client[i].key != NULL) {
             pj_ioqueue_unregister(client[i].key);
             client[i].key = NULL;
-            server[i].sock = PJ_INVALID_SOCKET;
+            client[i].sock = PJ_INVALID_SOCKET;
         } else if (client[i].sock != PJ_INVALID_SOCKET) {
             pj_sock_close(client[i].sock);
             client[i].sock = PJ_INVALID_SOCKET;

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -803,8 +803,10 @@ pjmedia_endpt_create_video_sdp(pjmedia_endpt *endpt,
             continue;
         }
 
-        pjmedia_vid_codec_mgr_get_default_param(NULL, &codec_info[i],
-                                                &codec_param);
+        status = pjmedia_vid_codec_mgr_get_default_param(NULL, &codec_info[i],
+                                                         &codec_param);
+        if (status != PJ_SUCCESS)
+            return status;
 
         fmt = &m->desc.fmt[m->desc.fmt_count++];
         fmt->ptr = (char*) pj_pool_alloc(pool, 8);

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2895,7 +2895,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
     pj_sockaddr_cp(&stream->rem_rtp_addr, &info->rem_addr);
     if (stream->si.rtcp_mux) {
         pj_sockaddr_cp(&att_param.rem_rtcp, &info->rem_addr);
-    } else if (pj_sockaddr_has_addr(&info->rem_rtcp.addr)) {
+    } else if (pj_sockaddr_has_addr(&info->rem_rtcp)) {
         pj_sockaddr_cp(&att_param.rem_rtcp, &info->rem_rtcp);
     }
     att_param.addr_len = pj_sockaddr_get_len(&info->rem_addr);

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -2044,7 +2044,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
     pj_sockaddr_cp(&stream->rem_rtp_addr, &info->rem_addr);
     if (info->rtcp_mux) {
         pj_sockaddr_cp(&att_param.rem_rtcp, &info->rem_addr);
-    } else if (pj_sockaddr_has_addr(&info->rem_rtcp.addr)) {
+    } else if (pj_sockaddr_has_addr(&info->rem_rtcp)) {
         pj_sockaddr_cp(&att_param.rem_rtcp, &info->rem_rtcp);
     }
     att_param.addr_len = pj_sockaddr_get_len(&info->rem_addr);

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -272,7 +272,7 @@ PJ_DEF(pj_status_t) pjsip_100rel_create_prack( pjsip_inv_session *inv,
     if (rseq < 1) {
         PJ_LOG(4, (dd->inv->dlg->obj_name,
                    "Ignoring 100rel response RSeq header value less than 1"));
-        return PJSIP_EINVALIDMSG;
+        return PJ_EIGNORED;
     }
 
     /* Find UAC state for the specified call leg */

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -269,6 +269,12 @@ PJ_DEF(pj_status_t) pjsip_100rel_create_prack( pjsip_inv_session *inv,
     }
     rseq = (pj_uint32_t) pj_strtoul(&rseq_hdr->hvalue);
 
+    if (rseq < 1) {
+        PJ_LOG(4, (dd->inv->dlg->obj_name,
+                   "Ignoring 100rel response RSeq header value less than 1"));
+        return PJSIP_EINVALIDMSG;
+    }
+
     /* Find UAC state for the specified call leg */
     uac_state = dd->uac_state_list;
     while (uac_state) {


### PR DESCRIPTION
Warnings from coverity:
```
*** CID 1547500:  Integer handling issues  (INTEGER_OVERFLOW)
/pjsip/src/pjsip-ua/sip_100rel.c: 293 in pjsip_100rel_create_prack()
287             dd->uac_state_list = uac_state;
288         }
289     
290         /* If this is from new INVITE transaction, reset UAC state. */
291         if (rdata->msg_info.cseq->cseq != uac_state->cseq) {
292             uac_state->cseq = rdata->msg_info.cseq->cseq;
>>>     CID 1547500:  Integer handling issues  (INTEGER_OVERFLOW)
>>>     Expression "rseq - 1U", which is equal to 4294967295, where "rseq" is known to be equal to 0, underflows the type that receives it, an unsigned integer 32 bits wide.
293             uac_state->rseq = rseq - 1;
294         }
295     
296         /* Ignore provisional response retransmission */
297         if (rseq <= uac_state->rseq) {
298             /* This should have been handled before */
```
From [ref](https://datatracker.ietf.org/doc/html/rfc3262#section-7.1), the RSeq value must be set to 1 to 2**32 -1.
The patch will check for the RSeq value and make sure it is greater than 1.

```
*** CID 1547498:  Error handling issues  (CHECKED_RETURN)
/pjmedia/src/pjmedia/endpoint.c: 806 in pjmedia_endpt_create_video_sdp()
800             /* Must support RTP packetization */
801             if ((codec_info[i].packings & PJMEDIA_VID_PACKING_PACKETS) == 0)
802             {
803                 continue;
804             }
805     
>>>     CID 1547498:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "pjmedia_vid_codec_mgr_get_default_param" without checking return value (as is done elsewhere 8 out of 10 times).
806             pjmedia_vid_codec_mgr_get_default_param(NULL, &codec_info[i],
807                                                     &codec_param);
808     
809             fmt = &m->desc.fmt[m->desc.fmt_count++];
810             fmt->ptr = (char*) pj_pool_alloc(pool, 8);
811             fmt->slen = pj_utoa(codec_info[i].pt, fmt->ptr);
```
Fix by adding check to the return value from `pjmedia_vid_codec_mgr_get_default_param()`.

```
*** CID 1547497:  Incorrect expression  (COPY_PASTE_ERROR)
/pjlib/src/pjlib-test/ioq_tcp.c: 890 in compliance_test_2()
884                 server[i].sock = PJ_INVALID_SOCKET;
885             }
886     
887             if (client[i].key != NULL) {
888                 pj_ioqueue_unregister(client[i].key);
889                 client[i].key = NULL;
>>>     CID 1547497:  Incorrect expression  (COPY_PASTE_ERROR)
>>>     "server" in "server[i].sock" looks like a copy-paste error.
890                 server[i].sock = PJ_INVALID_SOCKET;
891             } else if (client[i].sock != PJ_INVALID_SOCKET) {
892                 pj_sock_close(client[i].sock);
893                 client[i].sock = PJ_INVALID_SOCKET;
894             }
895         }
```
It should be client sock.

