### PR TITLE
Fix assertion in testing SIP resolve with loop-dgram tp_selector

### DIFF
--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -440,6 +440,8 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
             query->naptr[0].res_type = pj_str("_sip._tcp.");
         else if (type == PJSIP_TRANSPORT_UDP || type == PJSIP_TRANSPORT_UDP6)
             query->naptr[0].res_type = pj_str("_sip._udp.");
+        else if (type == PJSIP_TRANSPORT_LOOP_DGRAM)
+            query->naptr[0].res_type = pj_str("_sip._loopdgram.");
         else {
             pj_assert(!"Unknown transport type");
             query->naptr[0].res_type = pj_str("_sip._udp.");

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -441,7 +441,7 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
         else if (type == PJSIP_TRANSPORT_UDP || type == PJSIP_TRANSPORT_UDP6)
             query->naptr[0].res_type = pj_str("_sip._udp.");
         else if (type == PJSIP_TRANSPORT_LOOP_DGRAM)
-            query->naptr[0].res_type = pj_str("_sip._loopdgram.");
+            query->naptr[0].res_type = pj_str("_sip._udp.");
         else {
             pj_assert(!"Unknown transport type");
             query->naptr[0].res_type = pj_str("_sip._udp.");

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -441,6 +441,12 @@ int test_main(char *testlist)
     }
 #endif
 
+#if INCLUDE_LOOP_TEST
+    /* repeat again after resolver is configured in resolve_test() */
+    if (SHOULD_RUN_TEST(include_loop_test)) {
+        DO_TEST(transport_loop_test());
+    }
+#endif
 
 #if INCLUDE_TSX_TEST
     if (SHOULD_RUN_TEST(include_tsx_test)) {

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -441,7 +441,7 @@ int test_main(char *testlist)
     }
 #endif
 
-#if INCLUDE_LOOP_TEST
+#if INCLUDE_LOOP_TEST   
     /* repeat again after resolver is configured in resolve_test() */
     if (SHOULD_RUN_TEST(include_loop_test)) {
         DO_TEST(transport_loop_test());

--- a/pjsip/src/test/transport_loop_test.c
+++ b/pjsip/src/test/transport_loop_test.c
@@ -23,6 +23,90 @@
 
 #define THIS_FILE   "transport_loop_test.c"
 
+static void send_cb(pjsip_send_state *st, pj_ssize_t sent, pj_bool_t *cont)
+{
+    int *loop_resolve_status = (int*)st->token;
+    if (sent < 0) {
+        /* Success! */
+        *loop_resolve_status = (int)-sent;
+    } else {
+        PJ_LOG(3,(THIS_FILE,
+                  "   error: expecting error in send_cb() but got sent=%ld",
+                 sent));
+        *loop_resolve_status = 0;
+    }
+}
+
+static int loop_resolve_error()
+{
+    pjsip_transport *loop = NULL;
+    pj_sockaddr_in addr;
+    pj_str_t url;
+    pjsip_tx_data *tdata;
+    pjsip_tpselector tp_sel;
+    int i, loop_resolve_status;
+    pj_status_t status;
+
+    loop_resolve_status = 0;
+    pj_bzero(&addr, sizeof(addr));
+
+    status = pjsip_endpt_acquire_transport( endpt, PJSIP_TRANSPORT_LOOP_DGRAM,
+                                            &addr, sizeof(addr), NULL, &loop);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: loop transport is not configured", status);
+        return -210;
+    }
+
+    url = pj_str("sip:bob@unresolved-host");
+
+    for (i=0; i<2; ++i) {
+        /* variant a: without tp_selector */
+        status = pjsip_endpt_create_request( endpt, &pjsip_options_method,
+                                            &url, &url, &url, NULL, NULL, -1, 
+                                            NULL, &tdata);
+        if (status != PJ_SUCCESS) {
+            app_perror("   Error: unable to create request", status);
+            loop_resolve_status = -220;
+            goto on_return;
+        }
+
+        if (i==1) {
+            /* variant b: with tp_selector */
+            pj_bzero(&tp_sel, sizeof(tp_sel));
+            tp_sel.type = PJSIP_TPSELECTOR_TRANSPORT;
+            tp_sel.u.transport = loop;
+
+            pjsip_tx_data_set_transport(tdata, &tp_sel);
+        }
+        loop_resolve_status = PJ_EPENDING;
+        status = pjsip_endpt_send_request_stateless(endpt, tdata, 
+                                                    &loop_resolve_status,
+                                                    &send_cb);
+        if (status!=PJ_EPENDING && status!=PJ_SUCCESS) {
+            /* Success! (we're expecting error and got immediate error)*/
+            loop_resolve_status = 0;
+        } else {
+            flush_events(500);
+            if (loop_resolve_status!=PJ_EPENDING && loop_resolve_status!=PJ_SUCCESS) {
+                /* Success! (we're expecting error in callback)*/
+                //PJ_PERROR(3, (THIS_FILE, loop_resolve_status, 
+                //              "   correctly got error"));
+                loop_resolve_status = 0;
+            } else {
+                PJ_LOG(3,(THIS_FILE, "   error: expecting error but status=%d", status));
+                loop_resolve_status = -240;
+                goto on_return;
+            }
+        }
+    }
+
+on_return:
+    if (loop)
+        pjsip_transport_dec_ref(loop);
+    return loop_resolve_status;
+
+}
+
 static int datagram_loop_test()
 {
     enum { LOOP = 8 };
@@ -60,6 +144,11 @@ static int datagram_loop_test()
         if (status != 0)
             return status;
     }
+
+    /* Resolve error */
+    status = loop_resolve_error();
+    if (status)
+        return status;
 
     min_rtt = 0xFFFFFFF;
     for (i=0; i<LOOP; ++i)


### PR DESCRIPTION
Assertion:
```
pjsip/sip_resolve.c:444: pjsip_resolve: Assertion `!"Unknown transport type"' failed.
```
when `tdata` is configured with `tp_selector` with loop-dgram transport. This scenario should only happen during testing.

Also add testing for this scenario as part of `transport_loop_test()`.