### PR TITLE
Simple command line argument parsing utility in PJLIB

### DIFF
--- a/pjlib/build/pjlib.vcproj
+++ b/pjlib/build/pjlib.vcproj
@@ -12638,6 +12638,10 @@
 			Filter="h;hpp;hxx;hm;inl"
 			>
 			<File
+				RelativePath="..\include\pj\argparse.h"
+				>
+			</File>
+			<File
 				RelativePath="..\include\pj\activesock.h"
 				>
 			</File>

--- a/pjlib/build/pjlib.vcxproj
+++ b/pjlib/build/pjlib.vcxproj
@@ -1036,6 +1036,7 @@
     <ClInclude Include="..\include\pjlib.h" />
     <ClInclude Include="..\include\pj\activesock.h" />
     <ClInclude Include="..\include\pj\addr_resolv.h" />
+    <ClInclude Include="..\include\pj\argparse.h" />
     <ClInclude Include="..\include\pj\array.h" />
     <ClInclude Include="..\include\pj\assert.h" />
     <ClInclude Include="..\include\pj\compat\assert.h" />

--- a/pjlib/build/pjlib.vcxproj.filters
+++ b/pjlib/build/pjlib.vcxproj.filters
@@ -442,5 +442,8 @@
     <ClInclude Include="..\src\pj\ssl_sock_imp_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\pj\argparse.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/pjlib/include/pj/argparse.h
+++ b/pjlib/include/pj/argparse.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2008-2024 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+#ifndef __PJ_ARGPARSE_H__
+#define __PJ_ARGPARSE_H__
+
+/**
+ * @file argparse.h
+ * @brief Command line argument parser
+ */
+#include <pj/ctype.h>
+#include <pj/errno.h>
+#include <pj/string.h>
+
+PJ_BEGIN_DECL
+
+/**
+ * Define function to display parsing error.
+ */
+#ifndef PJ_ARGPARSE_ERROR
+#  include <stdio.h>
+#  define PJ_ARGPARSE_ERROR(fmt, arg) printf(fmt "\n", arg)
+#endif
+
+
+/**
+ * @defgroup PJ_ARGPARSE Command line argument parser
+ * @ingroup PJ_MISC
+ * @{
+ *
+ * This module provides header only utilities to parse command line arguments.
+ * This is mostly used by PJSIP test and sample apps. Note that there is
+ * getopt() implementation in PJLIB-UTIL (but it's in PJLIB-UTIL, so it can't
+ * be used by PJLIB)
+ */
+
+/**
+ * Peek the next possible option from argv. An argument is considered an
+ * option if it starts with "-" and followed by at least another letter that
+ * is not digit or starts with "--" and followed by a letter.
+ *
+ * @param argv      The argv, which must be null terminated.
+ *
+ * @return next option or NULL.
+ */
+static char* pj_argparse_peek_next_option(char *const argv[])
+{
+    while (*argv) {
+        const char *arg = *argv;
+        if ((*arg=='-' && *(arg+1) && !pj_isdigit(*(arg+1))) ||
+            (*arg=='-' && *(arg+1)=='-' && *(arg+2)))
+        {
+            return *argv;
+        }
+        ++argv;
+    }
+    return NULL;
+}
+
+/**
+ * Check that an option exists, without modifying argv.
+ *
+ * @param opt       The option to find, e.g. "-h", "--help"
+ * @param argv      The argv, which must be null terminated.
+ *
+ * @return PJ_TRUE if the option exists, else PJ_FALSE.
+ */
+static pj_bool_t pj_argparse_exists(const char *opt, char *const argv[])
+{
+    int i;
+    for (i=1; argv[i]; ++i) {
+        if (pj_ansi_strcmp(argv[i], opt)==0)
+            return PJ_TRUE;
+    }
+    return PJ_FALSE;
+}
+
+/**
+ * Check for an option and if it exists, returns PJ_TRUE remove that option
+ * from argc/argv.
+ *
+ * @param opt       The option to find, e.g. "-h", "--help"
+ * @param argc      Pointer to argc.
+ * @param argv      Null terminated argv.
+ *
+ * @return PJ_TRUE if the option exists, else PJ_FALSE.
+ */
+static pj_bool_t pj_argparse_get_bool(const char *opt, int *argc, char *argv[])
+{
+    int i;
+    for (i=1; argv[i]; ++i) {
+        if (pj_ansi_strcmp(argv[i], opt)==0) {
+            pj_memmove(&argv[i], &argv[i+1], ((*argc)-i)*sizeof(char*));
+            (*argc)--;
+            return PJ_TRUE;
+        }
+    }
+    return PJ_FALSE;
+}
+
+/**
+ * Check for an option and if it exists, get the value and remove both
+ * the option the the value from argc/argv. Note that the function only
+ * supports whitespace as separator between option and value (i.e. equal
+ * sign is not supported).
+ *
+ * @param opt           The option to find, e.g. "-t", "--type"
+ * @param argc          Pointer to argc.
+ * @param argv          Null terminated argv.
+ * @param ptr_value     Pointer to receive the value.
+ *
+ * @return PJ_SUCCESS if the option exists and value is found or if the
+ *                    option does not exist
+ *         PJ_EINVAL if the option exits but value is not found,
+ */
+static pj_status_t pj_argparse_get_str( const char *opt, int *argc,
+                                        char *argv[], char **ptr_value)
+{
+    int i;
+    for (i=1; argv[i]; ++i) {
+        if (pj_ansi_strcmp(argv[i], opt)==0) {
+            pj_memmove(&argv[i], &argv[i+1], ((*argc)-i)*sizeof(char*));
+            (*argc)--;
+
+            if (argv[i]) {
+                char *val = argv[i];
+                pj_memmove(&argv[i], &argv[i+1], ((*argc)-i)*sizeof(char*));
+                (*argc)--;
+                *ptr_value = val;
+                return PJ_SUCCESS;
+            } else {
+                PJ_ARGPARSE_ERROR("Error: missing value for %s argument",
+                                  opt);
+                return PJ_EINVAL;
+            }
+        }
+    }
+    return PJ_SUCCESS;
+}
+
+/**
+ * Check for an option and if it exists, get the integer value and remove both
+ * the option the the value from argc/argv. Note that the function only
+ * supports whitespace as separator between option and value (i.e. equal
+ * sign is not supported)
+ *
+ * @param opt           The option to find, e.g. "-h", "--help"
+ * @param argc          Pointer to argc.
+ * @param argv          Null terminated argv.
+ * @param ptr_value     Pointer to receive the value.
+ *
+ * @return PJ_SUCCESS if the option exists and value is found or if the
+ *                    option does not exist
+ *         PJ_EINVAL if the option exits but value is not found,
+ */
+static pj_status_t pj_argparse_get_int( char *opt, int *argc, char *argv[],
+                                        int *ptr_value)
+{
+    char *endptr, *sval=NULL;
+    long val;
+    pj_status_t status = pj_argparse_get_str(opt, argc, argv, &sval);
+    if (status!=PJ_SUCCESS || !sval)
+        return status;
+
+    val = strtol(sval, &endptr, 10);
+    if (*endptr) {
+        PJ_ARGPARSE_ERROR("Error: invalid value for %s argument",
+                          opt);
+        return PJ_EINVAL;
+    }
+
+    *ptr_value = (int)val;
+    return PJ_SUCCESS;
+}
+
+/**
+ * @}
+ */
+
+PJ_END_DECL
+
+
+#endif  /* __PJ_ARGPARSE_H__ */
+

--- a/pjlib/include/pj/argparse.h
+++ b/pjlib/include/pj/argparse.h
@@ -45,25 +45,29 @@ PJ_BEGIN_DECL
  * This module provides header only utilities to parse command line arguments.
  * This is mostly used by PJSIP test and sample apps. Note that there is
  * getopt() implementation in PJLIB-UTIL (but it's in PJLIB-UTIL, so it can't
- * be used by PJLIB)
+ * be used by PJLIB).
+ *
+ * Limitations:
+ * - the utility only supports white space(s) as separator between an option
+ *   and its value. Equal sign is not supported.
+ * - the utility does not support double dash (--) as separator between options
+ *   and operands. It will keep treating arguments after -- as possible
+ *   options.
  */
 
 /**
  * Peek the next possible option from argv. An argument is considered an
- * option if it starts with "-" and followed by at least another letter that
- * is not digit or starts with "--" and followed by a letter.
+ * option if it starts with "-".
  *
  * @param argv      The argv, which must be null terminated.
  *
- * @return next option or NULL.
+ * @return          next option or NULL.
  */
 PJ_INLINE(char*) pj_argparse_peek_next_option(char *const argv[])
 {
     while (*argv) {
         const char *arg = *argv;
-        if ((*arg=='-' && *(arg+1) && !pj_isdigit(*(arg+1))) ||
-            (*arg=='-' && *(arg+1)=='-' && *(arg+2)))
-        {
+        if (*arg=='-') {
             return *argv;
         }
         ++argv;
@@ -74,12 +78,12 @@ PJ_INLINE(char*) pj_argparse_peek_next_option(char *const argv[])
 /**
  * Check that an option exists, without modifying argv.
  *
- * @param opt       The option to find, e.g. "-h", "--help"
  * @param argv      The argv, which must be null terminated.
+ * @param opt       The option to find, e.g. "-h", "--help"
  *
- * @return PJ_TRUE if the option exists, else PJ_FALSE.
+ * @return          PJ_TRUE if the option exists, else PJ_FALSE.
  */
-PJ_INLINE(pj_bool_t) pj_argparse_exists(const char *opt, char *const argv[])
+PJ_INLINE(pj_bool_t) pj_argparse_exists(char *const argv[], const char *opt)
 {
     int i;
     for (i=1; argv[i]; ++i) {
@@ -90,16 +94,17 @@ PJ_INLINE(pj_bool_t) pj_argparse_exists(const char *opt, char *const argv[])
 }
 
 /**
- * Check for an option and if it exists, returns PJ_TRUE remove that option
- * from argc/argv.
+ * Check for an option and if it exists remove that option from argc/argv and
+ * returns PJ_TRUE.
  *
- * @param opt       The option to find, e.g. "-h", "--help"
  * @param argc      Pointer to argc.
  * @param argv      Null terminated argv.
+ * @param opt       The option to find, e.g. "-h", "--help"
  *
- * @return PJ_TRUE if the option exists, else PJ_FALSE.
+ * @return          PJ_TRUE if the option exists, else PJ_FALSE.
  */
-PJ_INLINE(pj_bool_t) pj_argparse_get_bool(const char *opt, int *argc, char *argv[])
+PJ_INLINE(pj_bool_t) pj_argparse_get_bool(int *argc, char *argv[],
+                                          const char *opt)
 {
     int i;
     for (i=1; argv[i]; ++i) {
@@ -113,22 +118,23 @@ PJ_INLINE(pj_bool_t) pj_argparse_get_bool(const char *opt, int *argc, char *argv
 }
 
 /**
- * Check for an option and if it exists, get the value and remove both
+ * Check for an option and if it exists get the value and remove both
  * the option the the value from argc/argv. Note that the function only
- * supports whitespace as separator between option and value (i.e. equal
- * sign is not supported).
+ * supports whitespace(s) as separator between option and value (i.e. equal
+ * sign is not supported, e.g. "--server=127.0.0.1" will not be parsed
+ * correctly).
  *
- * @param opt           The option to find, e.g. "-t", "--type"
  * @param argc          Pointer to argc.
  * @param argv          Null terminated argv.
+ * @param opt           The option to find, e.g. "-t", "--type"
  * @param ptr_value     Pointer to receive the value.
  *
- * @return PJ_SUCCESS if the option exists and value is found or if the
- *                    option does not exist
- *         PJ_EINVAL if the option exits but value is not found,
+ * @return              - PJ_SUCCESS if the option exists and value is found
+ *                        or if the option does not exist
+ *                      - PJ_EINVAL if the option exits but value is not found
  */
-PJ_INLINE(pj_status_t) pj_argparse_get_str(const char *opt, int *argc,
-                                           char *argv[], char **ptr_value)
+PJ_INLINE(pj_status_t) pj_argparse_get_str(int *argc, char *argv[],
+                                           const char *opt, char **ptr_value)
 {
     int i;
     for (i=1; argv[i]; ++i) {
@@ -155,24 +161,25 @@ PJ_INLINE(pj_status_t) pj_argparse_get_str(const char *opt, int *argc,
 /**
  * Check for an option and if it exists, get the integer value and remove both
  * the option the the value from argc/argv. Note that the function only
- * supports whitespace as separator between option and value (i.e. equal
- * sign is not supported)
+ * supports whitespace(s) as separator between option and value (i.e. equal
+ * sign is not supported, e.g. "--port=80" will not be parsed correctly).
  *
  * @param opt           The option to find, e.g. "-h", "--help"
  * @param argc          Pointer to argc.
  * @param argv          Null terminated argv.
  * @param ptr_value     Pointer to receive the value.
  *
- * @return PJ_SUCCESS if the option exists and value is found or if the
- *                    option does not exist
- *         PJ_EINVAL if the option exits but value is not found,
+ * @return              - PJ_SUCCESS if the option exists and value is found
+ *                        or if the option does not exist
+ *                      - PJ_EINVAL if the option exits but value is not found,
+ *                        or if the value is not an integer.
  */
-PJ_INLINE(pj_status_t) pj_argparse_get_int(char *opt, int *argc, char *argv[],
-                                           int *ptr_value)
+PJ_INLINE(pj_status_t) pj_argparse_get_int(int *argc, char *argv[],
+                                           const char *opt, int *ptr_value)
 {
     char *endptr, *sval=NULL;
     long val;
-    pj_status_t status = pj_argparse_get_str(opt, argc, argv, &sval);
+    pj_status_t status = pj_argparse_get_str(argc, argv, opt, &sval);
     if (status!=PJ_SUCCESS || !sval)
         return status;
 

--- a/pjlib/include/pj/argparse.h
+++ b/pjlib/include/pj/argparse.h
@@ -119,7 +119,7 @@ PJ_INLINE(pj_bool_t) pj_argparse_get_bool(int *argc, char *argv[],
 
 /**
  * Check for an option and if it exists get the value and remove both
- * the option the the value from argc/argv. Note that the function only
+ * the option and the value from argc/argv. Note that the function only
  * supports whitespace(s) as separator between option and value (i.e. equal
  * sign is not supported, e.g. "--server=127.0.0.1" will not be parsed
  * correctly).
@@ -160,7 +160,7 @@ PJ_INLINE(pj_status_t) pj_argparse_get_str(int *argc, char *argv[],
 
 /**
  * Check for an option and if it exists, get the integer value and remove both
- * the option the the value from argc/argv. Note that the function only
+ * the option and the value from argc/argv. Note that the function only
  * supports whitespace(s) as separator between option and value (i.e. equal
  * sign is not supported, e.g. "--port=80" will not be parsed correctly).
  *

--- a/pjlib/include/pj/argparse.h
+++ b/pjlib/include/pj/argparse.h
@@ -57,7 +57,7 @@ PJ_BEGIN_DECL
  *
  * @return next option or NULL.
  */
-static char* pj_argparse_peek_next_option(char *const argv[])
+PJ_INLINE(char*) pj_argparse_peek_next_option(char *const argv[])
 {
     while (*argv) {
         const char *arg = *argv;
@@ -79,7 +79,7 @@ static char* pj_argparse_peek_next_option(char *const argv[])
  *
  * @return PJ_TRUE if the option exists, else PJ_FALSE.
  */
-static pj_bool_t pj_argparse_exists(const char *opt, char *const argv[])
+PJ_INLINE(pj_bool_t) pj_argparse_exists(const char *opt, char *const argv[])
 {
     int i;
     for (i=1; argv[i]; ++i) {
@@ -99,7 +99,7 @@ static pj_bool_t pj_argparse_exists(const char *opt, char *const argv[])
  *
  * @return PJ_TRUE if the option exists, else PJ_FALSE.
  */
-static pj_bool_t pj_argparse_get_bool(const char *opt, int *argc, char *argv[])
+PJ_INLINE(pj_bool_t) pj_argparse_get_bool(const char *opt, int *argc, char *argv[])
 {
     int i;
     for (i=1; argv[i]; ++i) {
@@ -127,8 +127,8 @@ static pj_bool_t pj_argparse_get_bool(const char *opt, int *argc, char *argv[])
  *                    option does not exist
  *         PJ_EINVAL if the option exits but value is not found,
  */
-static pj_status_t pj_argparse_get_str( const char *opt, int *argc,
-                                        char *argv[], char **ptr_value)
+PJ_INLINE(pj_status_t) pj_argparse_get_str(const char *opt, int *argc,
+                                           char *argv[], char **ptr_value)
 {
     int i;
     for (i=1; argv[i]; ++i) {
@@ -167,8 +167,8 @@ static pj_status_t pj_argparse_get_str( const char *opt, int *argc,
  *                    option does not exist
  *         PJ_EINVAL if the option exits but value is not found,
  */
-static pj_status_t pj_argparse_get_int( char *opt, int *argc, char *argv[],
-                                        int *ptr_value)
+PJ_INLINE(pj_status_t) pj_argparse_get_int(char *opt, int *argc, char *argv[],
+                                           int *ptr_value)
 {
     char *endptr, *sval=NULL;
     long val;

--- a/pjlib/include/pjlib.h
+++ b/pjlib/include/pjlib.h
@@ -25,6 +25,7 @@
  * @brief Include all PJLIB header files.
  */
 
+#include <pj/argparse.h>
 #include <pj/activesock.h>
 #include <pj/addr_resolv.h>
 #include <pj/array.h>

--- a/pjlib/include/pjlib.h
+++ b/pjlib/include/pjlib.h
@@ -25,9 +25,9 @@
  * @brief Include all PJLIB header files.
  */
 
-#include <pj/argparse.h>
 #include <pj/activesock.h>
 #include <pj/addr_resolv.h>
+#include <pj/argparse.h>
 #include <pj/array.h>
 #include <pj/assert.h>
 #include <pj/ctype.h>


### PR DESCRIPTION
The PJSIP suite contains copy of `getopt` implementation, but it is in PJLIB-UTIL and also has different licensing than PJSIP.

This PR implements a simple, header only argument parsing utilities that can be (and will be) used by `pjlib-test` and all unit testing apps to replace current manual parsing. 

## Usage

Argparse provides these few utilities:

- `pj_argparse_exists(..)`: check if argument exists
- `pj_argparse_get_bool(..)`: get an argument and remove it from argc/argv if it exists
- `pj_argparse_get_str(..)`: get an argument and its value and remove the argument-value pair from argc/argv if it exists
- `pj_argparse_get_int(..)`: get an argument and its int value and remove the argument-value pair from argc/argv if it exists
- `pj_argparse_peek_next_option(..)`: get first option (argument with preceeding `-`, or `--`) in argv, to check if there is remaining unrecognized option

### Note

The difference between `pj_argparse_exists(..)` and `pj_argparse_get_bool()` is the latter removes the argument from argc/argv if the argument exists.

There is a different semantic between the return value of `pj_argparse_get_bool()` and `pj_argparse_get_str()` or `pj_argparse_get_int()`. 

`pj_argparse_get_bool()` returns "the value", i.e. TRUE if the the argument exists.

`pj_argparse_get_bool()` and `pj_argparse_get_str()` returns `pj_status_t`, i.e. `PJ_SUCCESS` if everything is okay (an argument has been successfully parsed, or the argument does not exist), or error otherwise. In case of error, the error string would have been printed to the screen.

This design decision is chosen for convenience.

### Sample

For example, to parse these options:

```
Usage:
  pjlib-test [OPTION] [test_to_run] [test_to_run]...

where OPTIONS:
  -h, --help             Show this help screen
  -p, --port PORT        Use port PORT for echo port
  -s, --server SERVER    Use SERVER as echo server

test_to_run is the name of the test, e.g. rand_test, os_test, etc.
```
the following code can be used:

```
int main(int argc, char *argv[])
{
    int i, port = 0;
    char *server = NULL;

    if (pj_argparse_get_bool(&argc, argv, "-h") ||
        pj_argparse_get_bool(&argc, argv, "--help"))
    {
        usage();
        return 0;
    }

    if (pj_argparse_get_int(&argc, argv, "-p", &port) ||
        pj_argparse_get_int(&argc, argv, "--port", &port))
    {
        usage();
        return 1;
    }

    if (pj_argparse_get_str(&argc, argv, "-s", &server) ||
        pj_argparse_get_str(&argc, argv, "--server", &server))
    {
        usage();
        return 1;
    }

    printf("Request to run %d test(s)\n", argc-1);
    for (i=1; i<argc; ++i)
        printf("  - %s", argv[i]);
    puts("");

    ...
}
```

## Limitations

First, the utility only supports white space(s) as separator between an option and its value. Equal sign is not supported:

```
# this will not work
$ ./app --server=127.0.0.1

# this works
$ ./app --server 127.0.0.1
```
Second, the utility does not support double dash (`--`) as separator between options and operands (see [this discussion in stackexchange](https://unix.stackexchange.com/questions/11376/what-does-double-dash-double-hyphen-mean) on the meaning of `--`)
