### PR TITLE
Fixed Opus decoder PLC setting

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -641,6 +641,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     struct opus_data *opus_data = (struct opus_data *)codec->codec_data;
     int idx, err;
     pj_bool_t auto_bit_rate = PJ_TRUE;
+    pj_bool_t enc_use_plc = PJ_FALSE;
 
     PJ_ASSERT_RETURN(codec && attr && opus_data, PJ_EINVAL);
 
@@ -697,7 +698,10 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     if (idx >= 0) {
         unsigned plc;
         plc = (unsigned) pj_strtoul(&attr->setting.enc_fmtp.param[idx].val);
-        attr->setting.plc = plc > 0? PJ_TRUE: PJ_FALSE;
+        if (plc > 0)
+            enc_use_plc = PJ_TRUE;
+        /* Do not modify local PLC setting as it's used for decoding. */
+        // attr->setting.plc = plc > 0? PJ_TRUE: PJ_FALSE
     }
 
     /* Check vad */
@@ -750,7 +754,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     opus_encoder_ctl(opus_data->enc, OPUS_SET_DTX(attr->setting.vad ? 1 : 0));
     /* Set PLC */
     opus_encoder_ctl(opus_data->enc,
-                     OPUS_SET_INBAND_FEC(attr->setting.plc ? 1 : 0));
+                     OPUS_SET_INBAND_FEC(enc_use_plc));
     /* Set bandwidth */
     opus_encoder_ctl(opus_data->enc,
                      OPUS_SET_MAX_BANDWIDTH(get_opus_bw_constant(


### PR DESCRIPTION
According to [RFC 7587](https://datatracker.ietf.org/doc/html/rfc7587):
```
The "useinbandfec" parameter is a unidirectional receive-only
      parameter.
useinbandfec:  specifies that the decoder has the capability to take
      advantage of the Opus in-band FEC.
```
So if remote FMTP signals that it doesn't wish to use FEC, it should have no impact to our local/decoding PLC setting, `attr->setting.plc`, which will be used by stream to decide whether to recover a frame.
