### PR TITLE
Get thread locale in pj strerror

### DIFF
--- a/pjlib/include/pj/errno.h
+++ b/pjlib/include/pj/errno.h
@@ -82,7 +82,7 @@ PJ_BEGIN_DECL
  * Guidelines on error message length.
  */
 #ifndef PJ_ERR_MSG_SIZE
-#define PJ_ERR_MSG_SIZE  80
+#   define PJ_ERR_MSG_SIZE  80
 #endif
 
 /**
@@ -92,13 +92,15 @@ PJ_BEGIN_DECL
 #   define PJ_PERROR_TITLE_BUF_SIZE     120
 #endif
 
- /**
-  * On Windows XP and later, force the use of GetThreadLocale() in pj_strerror()
-  * to obtain the required locale and corresponding language for the platform error message string.
-  * Default value is set to "no" for compatibility reason, which means use "User default language".
-  *
-  * Default: 0 (no!)
-  */
+/**
+ * On Windows XP and later, force the use of GetThreadLocale() in pj_strerror()
+ * to obtain the required locale and corresponding language for the platform
+ * error message string.
+ * Default value is set to "no" for compatibility reason, which means use
+ * "User default language".
+ *
+ * Default: 0 (no)
+ */
 #ifndef PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE
 #   define PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE      0
 #endif

--- a/pjlib/include/pj/errno.h
+++ b/pjlib/include/pj/errno.h
@@ -81,41 +81,53 @@ PJ_BEGIN_DECL
 /**
  * Guidelines on error message length.
  */
-#define PJ_ERR_MSG_SIZE  80
+#ifndef PJ_ERR_MSG_SIZE
+#   define PJ_ERR_MSG_SIZE	80
+#endif
 
 /**
  * Buffer for title string of #PJ_PERROR().
  */
 #ifndef PJ_PERROR_TITLE_BUF_SIZE
-#   define PJ_PERROR_TITLE_BUF_SIZE     120
+#   define PJ_PERROR_TITLE_BUF_SIZE	120
 #endif
 
+ /**
+  * On Windows XP and later, force the use of GetThreadLocale() in pj_strerror()
+  * to obtain the required locale and corresponding language for the platform error message string.
+  * Default value is set to "no" for compatibility reason, which means use "User default language".
+  *
+  * Default: 0 (no!)
+  */
+#ifndef PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE
+#   define PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE      0
+#endif
 
 /**
  * Get the last platform error/status, folded into pj_status_t.
- * @return      OS dependent error code, folded into pj_status_t.
- * @remark      This function gets errno, or calls GetLastError() function and
- *              convert the code into pj_status_t with PJ_STATUS_FROM_OS. Do
- *              not call this for socket functions!
- * @see pj_get_netos_error()
+ * @return	OS dependent error code, folded into pj_status_t.
+ * @remark	This function gets errno, or calls GetLastError() function and
+ *		convert the code into pj_status_t with PJ_STATUS_FROM_OS. Do
+ *		not call this for socket functions!
+ * @see	pj_get_netos_error()
  */
 PJ_DECL(pj_status_t) pj_get_os_error(void);
 
 /**
  * Set last error.
- * @param code  pj_status_t
+ * @param code	pj_status_t
  */
 PJ_DECL(void) pj_set_os_error(pj_status_t code);
 
 /**
  * Get the last error from socket operations.
- * @return      Last socket error, folded into pj_status_t.
+ * @return	Last socket error, folded into pj_status_t.
  */
 PJ_DECL(pj_status_t) pj_get_netos_error(void);
 
 /**
  * Set error code.
- * @param code  pj_status_t.
+ * @param code	pj_status_t.
  */
 PJ_DECL(void) pj_set_netos_error(pj_status_t code);
 
@@ -125,14 +137,14 @@ PJ_DECL(void) pj_set_netos_error(pj_status_t code);
  * string will be NULL terminated.
  *
  * @param statcode  The error code.
- * @param buf       Buffer to hold the error message string.
+ * @param buf	    Buffer to hold the error message string.
  * @param bufsize   Size of the buffer.
  *
- * @return          The error message as NULL terminated string,
+ * @return	    The error message as NULL terminated string,
  *                  wrapped with pj_str_t.
  */
 PJ_DECL(pj_str_t) pj_strerror( pj_status_t statcode, 
-                               char *buf, pj_size_t bufsize);
+			       char *buf, pj_size_t bufsize);
 
 /**
  * A utility macro to print error message pertaining to the specified error 
@@ -154,17 +166,17 @@ PJ_DECL(pj_str_t) pj_strerror( pj_status_t statcode,
  *
  * @see pj_perror()
  *
- * @param level     The logging verbosity level, valid values are 0-6. Lower
- *                  number indicates higher importance, with level zero 
- *                  indicates fatal error. Only numeral argument is 
- *                  permitted (e.g. not variable).
- * @param arg       Enclosed 'printf' like arguments, with the following
- *                  arguments:
- *                   - the sender (NULL terminated string),
- *                   - the error code (pj_status_t)
- *                   - the format string (title_fmt), and 
- *                   - optional variable number of arguments suitable for the 
- *                     format string.
+ * @param level	    The logging verbosity level, valid values are 0-6. Lower
+ *		    number indicates higher importance, with level zero 
+ *		    indicates fatal error. Only numeral argument is 
+ *		    permitted (e.g. not variable).
+ * @param arg	    Enclosed 'printf' like arguments, with the following
+ *		    arguments:
+ *		     - the sender (NULL terminated string),
+ *		     - the error code (pj_status_t)
+ *		     - the format string (title_fmt), and 
+ *		     - optional variable number of arguments suitable for the 
+ *		       format string.
  *
  * Sample:
  * \verbatim
@@ -172,9 +184,9 @@ PJ_DECL(pj_str_t) pj_strerror( pj_status_t statcode,
    \endverbatim
  * @hideinitializer
  */
-#define PJ_PERROR(level,arg)    do { \
-                                    pj_perror_wrapper_##level(arg); \
-                                } while (0)
+#define PJ_PERROR(level,arg)	do { \
+				    pj_perror_wrapper_##level(arg); \
+				} while (0)
 
 /**
  * A utility function to print error message pertaining to the specified error 
@@ -206,11 +218,11 @@ PJ_DECL(void) pj_perror(int log_level, const char *sender, pj_status_t status,
 /**
  * Type of callback to be specified in #pj_register_strerror()
  *
- * @param e         The error code to lookup.
- * @param msg       Buffer to store the error message.
- * @param max       Length of the buffer.
+ * @param e	    The error code to lookup.
+ * @param msg	    Buffer to store the error message.
+ * @param max	    Length of the buffer.
  *
- * @return          The error string.
+ * @return	    The error string.
  */
 typedef pj_str_t (*pj_error_callback)(pj_status_t e, char *msg, pj_size_t max);
 
@@ -221,22 +233,22 @@ typedef pj_str_t (*pj_error_callback)(pj_status_t e, char *msg, pj_size_t max);
  * for the specified error code range. This handler will be called
  * by #pj_strerror().
  *
- * @param start_code    The starting error code where the handler should
- *                      be called to retrieve the error message.
- * @param err_space     The size of error space. The error code range then
- *                      will fall in start_code to start_code+err_space-1
- *                      range.
- * @param f             The handler to be called when #pj_strerror() is
- *                      supplied with error code that falls into this range.
+ * @param start_code	The starting error code where the handler should
+ *			be called to retrieve the error message.
+ * @param err_space	The size of error space. The error code range then
+ *			will fall in start_code to start_code+err_space-1
+ *			range.
+ * @param f		The handler to be called when #pj_strerror() is
+ *			supplied with error code that falls into this range.
  *
- * @return              PJ_SUCCESS or the specified error code. The 
- *                      registration may fail when the error space has been
- *                      occupied by other handler, or when there are too many
- *                      handlers registered to PJLIB.
+ * @return		PJ_SUCCESS or the specified error code. The 
+ *			registration may fail when the error space has been
+ *			occupied by other handler, or when there are too many
+ *			handlers registered to PJLIB.
  */
 PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
-                                          pj_status_t err_space,
-                                          pj_error_callback f);
+					  pj_status_t err_space,
+					  pj_error_callback f);
 
 /**
  * @hideinitializer
@@ -252,12 +264,12 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  *  the operating system doesn't report error codes properly.
  *
  * @param os_code   Platform OS error code. This value may be evaluated
- *                  more than once.
- * @return          The platform os error code folded into pj_status_t.
+ *		    more than once.
+ * @return	    The platform os error code folded into pj_status_t.
  */
 #ifndef PJ_RETURN_OS_ERROR
 #   define PJ_RETURN_OS_ERROR(os_code)   (os_code ? \
-                                            PJ_STATUS_FROM_OS(os_code) : -1)
+					    PJ_STATUS_FROM_OS(os_code) : -1)
 #endif
 
 
@@ -265,10 +277,10 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * Fold a platform specific error into an pj_status_t code.
  *
- * @param e     The platform os error code.
- * @return      pj_status_t
- * @warning     Macro implementation; the syserr argument may be evaluated
- *              multiple times.
+ * @param e	The platform os error code.
+ * @return	pj_status_t
+ * @warning	Macro implementation; the syserr argument may be evaluated
+ *		multiple times.
  */
 #if PJ_NATIVE_ERR_POSITIVE
 #   define PJ_STATUS_FROM_OS(e) (e == 0 ? PJ_SUCCESS : e + PJ_ERRNO_START_SYS)
@@ -280,11 +292,11 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * Fold an pj_status_t code back to the native platform defined error.
  *
- * @param e     The pj_status_t folded platform os error code.
- * @return      pj_os_err_type
- * @warning     macro implementation; the statcode argument may be evaluated
- *              multiple times.  If the statcode was not created by 
- *              pj_get_os_error or PJ_STATUS_FROM_OS, the results are undefined.
+ * @param e	The pj_status_t folded platform os error code.
+ * @return	pj_os_err_type
+ * @warning	macro implementation; the statcode argument may be evaluated
+ *		multiple times.  If the statcode was not created by 
+ *		pj_get_os_error or PJ_STATUS_FROM_OS, the results are undefined.
  */
 #if PJ_NATIVE_ERR_POSITIVE
 #   define PJ_STATUS_TO_OS(e) (e == 0 ? PJ_SUCCESS : e - PJ_ERRNO_START_SYS)
@@ -303,8 +315,8 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * Use this macro to generate error message text for your error code,
  * so that they look uniformly as the rest of the libraries.
  *
- * @param code  The error code
- * @param msg   The error test.
+ * @param code	The error code
+ * @param msg	The error test.
  */
 #ifndef PJ_BUILD_ERR
 #   define PJ_BUILD_ERR(code,msg) { code, msg " (" #code ")" }
@@ -315,47 +327,47 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * Unknown error has been reported.
  */
-#define PJ_EUNKNOWN         (PJ_ERRNO_START_STATUS + 1) /* 70001 */
+#define PJ_EUNKNOWN	    (PJ_ERRNO_START_STATUS + 1)	/* 70001 */
 /**
  * @hideinitializer
  * The operation is pending and will be completed later.
  */
-#define PJ_EPENDING         (PJ_ERRNO_START_STATUS + 2) /* 70002 */
+#define PJ_EPENDING	    (PJ_ERRNO_START_STATUS + 2)	/* 70002 */
 /**
  * @hideinitializer
  * Too many connecting sockets.
  */
-#define PJ_ETOOMANYCONN     (PJ_ERRNO_START_STATUS + 3) /* 70003 */
+#define PJ_ETOOMANYCONN	    (PJ_ERRNO_START_STATUS + 3)	/* 70003 */
 /**
  * @hideinitializer
  * Invalid argument.
  */
-#define PJ_EINVAL           (PJ_ERRNO_START_STATUS + 4) /* 70004 */
+#define PJ_EINVAL	    (PJ_ERRNO_START_STATUS + 4)	/* 70004 */
 /**
  * @hideinitializer
  * Name too long (eg. hostname too long).
  */
-#define PJ_ENAMETOOLONG     (PJ_ERRNO_START_STATUS + 5) /* 70005 */
+#define PJ_ENAMETOOLONG	    (PJ_ERRNO_START_STATUS + 5)	/* 70005 */
 /**
  * @hideinitializer
  * Not found.
  */
-#define PJ_ENOTFOUND        (PJ_ERRNO_START_STATUS + 6) /* 70006 */
+#define PJ_ENOTFOUND	    (PJ_ERRNO_START_STATUS + 6)	/* 70006 */
 /**
  * @hideinitializer
  * Not enough memory.
  */
-#define PJ_ENOMEM           (PJ_ERRNO_START_STATUS + 7) /* 70007 */
+#define PJ_ENOMEM	    (PJ_ERRNO_START_STATUS + 7)	/* 70007 */
 /**
  * @hideinitializer
  * Bug detected!
  */
-#define PJ_EBUG             (PJ_ERRNO_START_STATUS + 8) /* 70008 */
+#define PJ_EBUG             (PJ_ERRNO_START_STATUS + 8)	/* 70008 */
 /**
  * @hideinitializer
  * Operation timed out.
  */
-#define PJ_ETIMEDOUT        (PJ_ERRNO_START_STATUS + 9) /* 70009 */
+#define PJ_ETIMEDOUT        (PJ_ERRNO_START_STATUS + 9)	/* 70009 */
 /**
  * @hideinitializer
  * Too many objects.
@@ -370,17 +382,17 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * The specified option is not supported.
  */
-#define PJ_ENOTSUP          (PJ_ERRNO_START_STATUS + 12)/* 70012 */
+#define PJ_ENOTSUP	    (PJ_ERRNO_START_STATUS + 12)/* 70012 */
 /**
  * @hideinitializer
  * Invalid operation.
  */
-#define PJ_EINVALIDOP       (PJ_ERRNO_START_STATUS + 13)/* 70013 */
+#define PJ_EINVALIDOP	    (PJ_ERRNO_START_STATUS + 13)/* 70013 */
 /**
  * @hideinitializer
  * Operation is cancelled.
  */
-#define PJ_ECANCELLED       (PJ_ERRNO_START_STATUS + 14)/* 70014 */
+#define PJ_ECANCELLED	    (PJ_ERRNO_START_STATUS + 14)/* 70014 */
 /**
  * @hideinitializer
  * Object already exists.
@@ -390,48 +402,48 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * End of file.
  */
-#define PJ_EEOF             (PJ_ERRNO_START_STATUS + 16)/* 70016 */
+#define PJ_EEOF		    (PJ_ERRNO_START_STATUS + 16)/* 70016 */
 /**
  * @hideinitializer
  * Size is too big.
  */
-#define PJ_ETOOBIG          (PJ_ERRNO_START_STATUS + 17)/* 70017 */
+#define PJ_ETOOBIG	    (PJ_ERRNO_START_STATUS + 17)/* 70017 */
 /**
  * @hideinitializer
  * Error in gethostbyname(). This is a generic error returned when
  * gethostbyname() has returned an error.
  */
-#define PJ_ERESOLVE         (PJ_ERRNO_START_STATUS + 18)/* 70018 */
+#define PJ_ERESOLVE	    (PJ_ERRNO_START_STATUS + 18)/* 70018 */
 /**
  * @hideinitializer
  * Size is too small.
  */
-#define PJ_ETOOSMALL        (PJ_ERRNO_START_STATUS + 19)/* 70019 */
+#define PJ_ETOOSMALL	    (PJ_ERRNO_START_STATUS + 19)/* 70019 */
 /**
  * @hideinitializer
  * Ignored
  */
-#define PJ_EIGNORED         (PJ_ERRNO_START_STATUS + 20)/* 70020 */
+#define PJ_EIGNORED	    (PJ_ERRNO_START_STATUS + 20)/* 70020 */
 /**
  * @hideinitializer
  * IPv6 is not supported
  */
-#define PJ_EIPV6NOTSUP      (PJ_ERRNO_START_STATUS + 21)/* 70021 */
+#define PJ_EIPV6NOTSUP	    (PJ_ERRNO_START_STATUS + 21)/* 70021 */
 /**
  * @hideinitializer
  * Unsupported address family
  */
-#define PJ_EAFNOTSUP        (PJ_ERRNO_START_STATUS + 22)/* 70022 */
+#define PJ_EAFNOTSUP	    (PJ_ERRNO_START_STATUS + 22)/* 70022 */
 /**
  * @hideinitializer
  * Object no longer exists
  */
-#define PJ_EGONE            (PJ_ERRNO_START_STATUS + 23)/* 70023 */
+#define PJ_EGONE	    (PJ_ERRNO_START_STATUS + 23)/* 70023 */
 /**
  * @hideinitializer
  * Socket is stopped
  */
-#define PJ_ESOCKETSTOP      (PJ_ERRNO_START_STATUS + 24)/* 70024 */
+#define PJ_ESOCKETSTOP	    (PJ_ERRNO_START_STATUS + 24)/* 70024 */
 
 /** @} */   /* pj_errnum */
 
@@ -441,44 +453,44 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
 /**
  * PJ_ERRNO_START is where PJLIB specific error values start.
  */
-#define PJ_ERRNO_START          20000
+#define PJ_ERRNO_START		20000
 
 /**
  * PJ_ERRNO_SPACE_SIZE is the maximum number of errors in one of 
  * the error/status range below.
  */
-#define PJ_ERRNO_SPACE_SIZE     50000
+#define PJ_ERRNO_SPACE_SIZE	50000
 
 /**
  * PJ_ERRNO_START_STATUS is where PJLIB specific status codes start.
  * Effectively the error in this class would be 70000 - 119000.
  */
-#define PJ_ERRNO_START_STATUS   (PJ_ERRNO_START + PJ_ERRNO_SPACE_SIZE)
+#define PJ_ERRNO_START_STATUS	(PJ_ERRNO_START + PJ_ERRNO_SPACE_SIZE)
 
 /**
  * PJ_ERRNO_START_SYS converts platform specific error codes into
  * pj_status_t values.
  * Effectively the error in this class would be 120000 - 169000.
  */
-#define PJ_ERRNO_START_SYS      (PJ_ERRNO_START_STATUS + PJ_ERRNO_SPACE_SIZE)
+#define PJ_ERRNO_START_SYS	(PJ_ERRNO_START_STATUS + PJ_ERRNO_SPACE_SIZE)
 
 /**
  * PJ_ERRNO_START_USER are reserved for applications that use error
  * codes along with PJLIB codes.
  * Effectively the error in this class would be 170000 - 219000.
  */
-#define PJ_ERRNO_START_USER     (PJ_ERRNO_START_SYS + PJ_ERRNO_SPACE_SIZE)
+#define PJ_ERRNO_START_USER	(PJ_ERRNO_START_SYS + PJ_ERRNO_SPACE_SIZE)
 
 
 /*
  * Below are list of error spaces that have been taken so far:
- *  - PJSIP_ERRNO_START         (PJ_ERRNO_START_USER)
- *  - PJMEDIA_ERRNO_START       (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE)
- *  - PJSIP_SIMPLE_ERRNO_START  (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*2)
- *  - PJLIB_UTIL_ERRNO_START    (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*3)
- *  - PJNATH_ERRNO_START        (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*4)
+ *  - PJSIP_ERRNO_START		(PJ_ERRNO_START_USER)
+ *  - PJMEDIA_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE)
+ *  - PJSIP_SIMPLE_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*2)
+ *  - PJLIB_UTIL_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*3)
+ *  - PJNATH_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*4)
  *  - PJMEDIA_AUDIODEV_ERRNO_START (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*5)
- *  - PJ_SSL_ERRNO_START           (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*6)
+ *  - PJ_SSL_ERRNO_START	   (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*6)
  *  - PJMEDIA_VIDEODEV_ERRNO_START (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*7)
  */
 
@@ -495,7 +507,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 1
-    #define pj_perror_wrapper_1(arg)    pj_perror_1 arg
+    #define pj_perror_wrapper_1(arg)	pj_perror_1 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_1(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -511,7 +523,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 2
-    #define pj_perror_wrapper_2(arg)    pj_perror_2 arg
+    #define pj_perror_wrapper_2(arg)	pj_perror_2 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_2(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -527,7 +539,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 3
-    #define pj_perror_wrapper_3(arg)    pj_perror_3 arg
+    #define pj_perror_wrapper_3(arg)	pj_perror_3 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_3(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -543,7 +555,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 4
-    #define pj_perror_wrapper_4(arg)    pj_perror_4 arg
+    #define pj_perror_wrapper_4(arg)	pj_perror_4 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_4(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -559,7 +571,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 5
-    #define pj_perror_wrapper_5(arg)    pj_perror_5 arg
+    #define pj_perror_wrapper_5(arg)	pj_perror_5 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_5(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -575,7 +587,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 6
-    #define pj_perror_wrapper_6(arg)    pj_perror_6 arg
+    #define pj_perror_wrapper_6(arg)	pj_perror_6 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_6(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -589,5 +601,5 @@ void pj_errno_clear_handlers(void);
 
 PJ_END_DECL
 
-#endif  /* __PJ_ERRNO_H__ */
+#endif	/* __PJ_ERRNO_H__ */
 

--- a/pjlib/include/pj/errno.h
+++ b/pjlib/include/pj/errno.h
@@ -82,14 +82,14 @@ PJ_BEGIN_DECL
  * Guidelines on error message length.
  */
 #ifndef PJ_ERR_MSG_SIZE
-#   define PJ_ERR_MSG_SIZE	80
+#define PJ_ERR_MSG_SIZE  80
 #endif
 
 /**
  * Buffer for title string of #PJ_PERROR().
  */
 #ifndef PJ_PERROR_TITLE_BUF_SIZE
-#   define PJ_PERROR_TITLE_BUF_SIZE	120
+#   define PJ_PERROR_TITLE_BUF_SIZE     120
 #endif
 
  /**
@@ -105,29 +105,29 @@ PJ_BEGIN_DECL
 
 /**
  * Get the last platform error/status, folded into pj_status_t.
- * @return	OS dependent error code, folded into pj_status_t.
- * @remark	This function gets errno, or calls GetLastError() function and
- *		convert the code into pj_status_t with PJ_STATUS_FROM_OS. Do
- *		not call this for socket functions!
- * @see	pj_get_netos_error()
+ * @return      OS dependent error code, folded into pj_status_t.
+ * @remark      This function gets errno, or calls GetLastError() function and
+ *              convert the code into pj_status_t with PJ_STATUS_FROM_OS. Do
+ *              not call this for socket functions!
+ * @see pj_get_netos_error()
  */
 PJ_DECL(pj_status_t) pj_get_os_error(void);
 
 /**
  * Set last error.
- * @param code	pj_status_t
+ * @param code  pj_status_t
  */
 PJ_DECL(void) pj_set_os_error(pj_status_t code);
 
 /**
  * Get the last error from socket operations.
- * @return	Last socket error, folded into pj_status_t.
+ * @return      Last socket error, folded into pj_status_t.
  */
 PJ_DECL(pj_status_t) pj_get_netos_error(void);
 
 /**
  * Set error code.
- * @param code	pj_status_t.
+ * @param code  pj_status_t.
  */
 PJ_DECL(void) pj_set_netos_error(pj_status_t code);
 
@@ -137,14 +137,14 @@ PJ_DECL(void) pj_set_netos_error(pj_status_t code);
  * string will be NULL terminated.
  *
  * @param statcode  The error code.
- * @param buf	    Buffer to hold the error message string.
+ * @param buf       Buffer to hold the error message string.
  * @param bufsize   Size of the buffer.
  *
- * @return	    The error message as NULL terminated string,
+ * @return          The error message as NULL terminated string,
  *                  wrapped with pj_str_t.
  */
 PJ_DECL(pj_str_t) pj_strerror( pj_status_t statcode, 
-			       char *buf, pj_size_t bufsize);
+                               char *buf, pj_size_t bufsize);
 
 /**
  * A utility macro to print error message pertaining to the specified error 
@@ -166,17 +166,17 @@ PJ_DECL(pj_str_t) pj_strerror( pj_status_t statcode,
  *
  * @see pj_perror()
  *
- * @param level	    The logging verbosity level, valid values are 0-6. Lower
- *		    number indicates higher importance, with level zero 
- *		    indicates fatal error. Only numeral argument is 
- *		    permitted (e.g. not variable).
- * @param arg	    Enclosed 'printf' like arguments, with the following
- *		    arguments:
- *		     - the sender (NULL terminated string),
- *		     - the error code (pj_status_t)
- *		     - the format string (title_fmt), and 
- *		     - optional variable number of arguments suitable for the 
- *		       format string.
+ * @param level     The logging verbosity level, valid values are 0-6. Lower
+ *                  number indicates higher importance, with level zero 
+ *                  indicates fatal error. Only numeral argument is 
+ *                  permitted (e.g. not variable).
+ * @param arg       Enclosed 'printf' like arguments, with the following
+ *                  arguments:
+ *                   - the sender (NULL terminated string),
+ *                   - the error code (pj_status_t)
+ *                   - the format string (title_fmt), and 
+ *                   - optional variable number of arguments suitable for the 
+ *                     format string.
  *
  * Sample:
  * \verbatim
@@ -184,9 +184,9 @@ PJ_DECL(pj_str_t) pj_strerror( pj_status_t statcode,
    \endverbatim
  * @hideinitializer
  */
-#define PJ_PERROR(level,arg)	do { \
-				    pj_perror_wrapper_##level(arg); \
-				} while (0)
+#define PJ_PERROR(level,arg)    do { \
+                                    pj_perror_wrapper_##level(arg); \
+                                } while (0)
 
 /**
  * A utility function to print error message pertaining to the specified error 
@@ -218,11 +218,11 @@ PJ_DECL(void) pj_perror(int log_level, const char *sender, pj_status_t status,
 /**
  * Type of callback to be specified in #pj_register_strerror()
  *
- * @param e	    The error code to lookup.
- * @param msg	    Buffer to store the error message.
- * @param max	    Length of the buffer.
+ * @param e         The error code to lookup.
+ * @param msg       Buffer to store the error message.
+ * @param max       Length of the buffer.
  *
- * @return	    The error string.
+ * @return          The error string.
  */
 typedef pj_str_t (*pj_error_callback)(pj_status_t e, char *msg, pj_size_t max);
 
@@ -233,22 +233,22 @@ typedef pj_str_t (*pj_error_callback)(pj_status_t e, char *msg, pj_size_t max);
  * for the specified error code range. This handler will be called
  * by #pj_strerror().
  *
- * @param start_code	The starting error code where the handler should
- *			be called to retrieve the error message.
- * @param err_space	The size of error space. The error code range then
- *			will fall in start_code to start_code+err_space-1
- *			range.
- * @param f		The handler to be called when #pj_strerror() is
- *			supplied with error code that falls into this range.
+ * @param start_code    The starting error code where the handler should
+ *                      be called to retrieve the error message.
+ * @param err_space     The size of error space. The error code range then
+ *                      will fall in start_code to start_code+err_space-1
+ *                      range.
+ * @param f             The handler to be called when #pj_strerror() is
+ *                      supplied with error code that falls into this range.
  *
- * @return		PJ_SUCCESS or the specified error code. The 
- *			registration may fail when the error space has been
- *			occupied by other handler, or when there are too many
- *			handlers registered to PJLIB.
+ * @return              PJ_SUCCESS or the specified error code. The 
+ *                      registration may fail when the error space has been
+ *                      occupied by other handler, or when there are too many
+ *                      handlers registered to PJLIB.
  */
 PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
-					  pj_status_t err_space,
-					  pj_error_callback f);
+                                          pj_status_t err_space,
+                                          pj_error_callback f);
 
 /**
  * @hideinitializer
@@ -264,12 +264,12 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  *  the operating system doesn't report error codes properly.
  *
  * @param os_code   Platform OS error code. This value may be evaluated
- *		    more than once.
- * @return	    The platform os error code folded into pj_status_t.
+ *                  more than once.
+ * @return          The platform os error code folded into pj_status_t.
  */
 #ifndef PJ_RETURN_OS_ERROR
 #   define PJ_RETURN_OS_ERROR(os_code)   (os_code ? \
-					    PJ_STATUS_FROM_OS(os_code) : -1)
+                                            PJ_STATUS_FROM_OS(os_code) : -1)
 #endif
 
 
@@ -277,10 +277,10 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * Fold a platform specific error into an pj_status_t code.
  *
- * @param e	The platform os error code.
- * @return	pj_status_t
- * @warning	Macro implementation; the syserr argument may be evaluated
- *		multiple times.
+ * @param e     The platform os error code.
+ * @return      pj_status_t
+ * @warning     Macro implementation; the syserr argument may be evaluated
+ *              multiple times.
  */
 #if PJ_NATIVE_ERR_POSITIVE
 #   define PJ_STATUS_FROM_OS(e) (e == 0 ? PJ_SUCCESS : e + PJ_ERRNO_START_SYS)
@@ -292,11 +292,11 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * Fold an pj_status_t code back to the native platform defined error.
  *
- * @param e	The pj_status_t folded platform os error code.
- * @return	pj_os_err_type
- * @warning	macro implementation; the statcode argument may be evaluated
- *		multiple times.  If the statcode was not created by 
- *		pj_get_os_error or PJ_STATUS_FROM_OS, the results are undefined.
+ * @param e     The pj_status_t folded platform os error code.
+ * @return      pj_os_err_type
+ * @warning     macro implementation; the statcode argument may be evaluated
+ *              multiple times.  If the statcode was not created by 
+ *              pj_get_os_error or PJ_STATUS_FROM_OS, the results are undefined.
  */
 #if PJ_NATIVE_ERR_POSITIVE
 #   define PJ_STATUS_TO_OS(e) (e == 0 ? PJ_SUCCESS : e - PJ_ERRNO_START_SYS)
@@ -315,8 +315,8 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * Use this macro to generate error message text for your error code,
  * so that they look uniformly as the rest of the libraries.
  *
- * @param code	The error code
- * @param msg	The error test.
+ * @param code  The error code
+ * @param msg   The error test.
  */
 #ifndef PJ_BUILD_ERR
 #   define PJ_BUILD_ERR(code,msg) { code, msg " (" #code ")" }
@@ -327,47 +327,47 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * Unknown error has been reported.
  */
-#define PJ_EUNKNOWN	    (PJ_ERRNO_START_STATUS + 1)	/* 70001 */
+#define PJ_EUNKNOWN         (PJ_ERRNO_START_STATUS + 1) /* 70001 */
 /**
  * @hideinitializer
  * The operation is pending and will be completed later.
  */
-#define PJ_EPENDING	    (PJ_ERRNO_START_STATUS + 2)	/* 70002 */
+#define PJ_EPENDING         (PJ_ERRNO_START_STATUS + 2) /* 70002 */
 /**
  * @hideinitializer
  * Too many connecting sockets.
  */
-#define PJ_ETOOMANYCONN	    (PJ_ERRNO_START_STATUS + 3)	/* 70003 */
+#define PJ_ETOOMANYCONN     (PJ_ERRNO_START_STATUS + 3) /* 70003 */
 /**
  * @hideinitializer
  * Invalid argument.
  */
-#define PJ_EINVAL	    (PJ_ERRNO_START_STATUS + 4)	/* 70004 */
+#define PJ_EINVAL           (PJ_ERRNO_START_STATUS + 4) /* 70004 */
 /**
  * @hideinitializer
  * Name too long (eg. hostname too long).
  */
-#define PJ_ENAMETOOLONG	    (PJ_ERRNO_START_STATUS + 5)	/* 70005 */
+#define PJ_ENAMETOOLONG     (PJ_ERRNO_START_STATUS + 5) /* 70005 */
 /**
  * @hideinitializer
  * Not found.
  */
-#define PJ_ENOTFOUND	    (PJ_ERRNO_START_STATUS + 6)	/* 70006 */
+#define PJ_ENOTFOUND        (PJ_ERRNO_START_STATUS + 6) /* 70006 */
 /**
  * @hideinitializer
  * Not enough memory.
  */
-#define PJ_ENOMEM	    (PJ_ERRNO_START_STATUS + 7)	/* 70007 */
+#define PJ_ENOMEM           (PJ_ERRNO_START_STATUS + 7) /* 70007 */
 /**
  * @hideinitializer
  * Bug detected!
  */
-#define PJ_EBUG             (PJ_ERRNO_START_STATUS + 8)	/* 70008 */
+#define PJ_EBUG             (PJ_ERRNO_START_STATUS + 8) /* 70008 */
 /**
  * @hideinitializer
  * Operation timed out.
  */
-#define PJ_ETIMEDOUT        (PJ_ERRNO_START_STATUS + 9)	/* 70009 */
+#define PJ_ETIMEDOUT        (PJ_ERRNO_START_STATUS + 9) /* 70009 */
 /**
  * @hideinitializer
  * Too many objects.
@@ -382,17 +382,17 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * The specified option is not supported.
  */
-#define PJ_ENOTSUP	    (PJ_ERRNO_START_STATUS + 12)/* 70012 */
+#define PJ_ENOTSUP          (PJ_ERRNO_START_STATUS + 12)/* 70012 */
 /**
  * @hideinitializer
  * Invalid operation.
  */
-#define PJ_EINVALIDOP	    (PJ_ERRNO_START_STATUS + 13)/* 70013 */
+#define PJ_EINVALIDOP       (PJ_ERRNO_START_STATUS + 13)/* 70013 */
 /**
  * @hideinitializer
  * Operation is cancelled.
  */
-#define PJ_ECANCELLED	    (PJ_ERRNO_START_STATUS + 14)/* 70014 */
+#define PJ_ECANCELLED       (PJ_ERRNO_START_STATUS + 14)/* 70014 */
 /**
  * @hideinitializer
  * Object already exists.
@@ -402,48 +402,48 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
  * @hideinitializer
  * End of file.
  */
-#define PJ_EEOF		    (PJ_ERRNO_START_STATUS + 16)/* 70016 */
+#define PJ_EEOF             (PJ_ERRNO_START_STATUS + 16)/* 70016 */
 /**
  * @hideinitializer
  * Size is too big.
  */
-#define PJ_ETOOBIG	    (PJ_ERRNO_START_STATUS + 17)/* 70017 */
+#define PJ_ETOOBIG          (PJ_ERRNO_START_STATUS + 17)/* 70017 */
 /**
  * @hideinitializer
  * Error in gethostbyname(). This is a generic error returned when
  * gethostbyname() has returned an error.
  */
-#define PJ_ERESOLVE	    (PJ_ERRNO_START_STATUS + 18)/* 70018 */
+#define PJ_ERESOLVE         (PJ_ERRNO_START_STATUS + 18)/* 70018 */
 /**
  * @hideinitializer
  * Size is too small.
  */
-#define PJ_ETOOSMALL	    (PJ_ERRNO_START_STATUS + 19)/* 70019 */
+#define PJ_ETOOSMALL        (PJ_ERRNO_START_STATUS + 19)/* 70019 */
 /**
  * @hideinitializer
  * Ignored
  */
-#define PJ_EIGNORED	    (PJ_ERRNO_START_STATUS + 20)/* 70020 */
+#define PJ_EIGNORED         (PJ_ERRNO_START_STATUS + 20)/* 70020 */
 /**
  * @hideinitializer
  * IPv6 is not supported
  */
-#define PJ_EIPV6NOTSUP	    (PJ_ERRNO_START_STATUS + 21)/* 70021 */
+#define PJ_EIPV6NOTSUP      (PJ_ERRNO_START_STATUS + 21)/* 70021 */
 /**
  * @hideinitializer
  * Unsupported address family
  */
-#define PJ_EAFNOTSUP	    (PJ_ERRNO_START_STATUS + 22)/* 70022 */
+#define PJ_EAFNOTSUP        (PJ_ERRNO_START_STATUS + 22)/* 70022 */
 /**
  * @hideinitializer
  * Object no longer exists
  */
-#define PJ_EGONE	    (PJ_ERRNO_START_STATUS + 23)/* 70023 */
+#define PJ_EGONE            (PJ_ERRNO_START_STATUS + 23)/* 70023 */
 /**
  * @hideinitializer
  * Socket is stopped
  */
-#define PJ_ESOCKETSTOP	    (PJ_ERRNO_START_STATUS + 24)/* 70024 */
+#define PJ_ESOCKETSTOP      (PJ_ERRNO_START_STATUS + 24)/* 70024 */
 
 /** @} */   /* pj_errnum */
 
@@ -453,44 +453,44 @@ PJ_DECL(pj_status_t) pj_register_strerror(pj_status_t start_code,
 /**
  * PJ_ERRNO_START is where PJLIB specific error values start.
  */
-#define PJ_ERRNO_START		20000
+#define PJ_ERRNO_START          20000
 
 /**
  * PJ_ERRNO_SPACE_SIZE is the maximum number of errors in one of 
  * the error/status range below.
  */
-#define PJ_ERRNO_SPACE_SIZE	50000
+#define PJ_ERRNO_SPACE_SIZE     50000
 
 /**
  * PJ_ERRNO_START_STATUS is where PJLIB specific status codes start.
  * Effectively the error in this class would be 70000 - 119000.
  */
-#define PJ_ERRNO_START_STATUS	(PJ_ERRNO_START + PJ_ERRNO_SPACE_SIZE)
+#define PJ_ERRNO_START_STATUS   (PJ_ERRNO_START + PJ_ERRNO_SPACE_SIZE)
 
 /**
  * PJ_ERRNO_START_SYS converts platform specific error codes into
  * pj_status_t values.
  * Effectively the error in this class would be 120000 - 169000.
  */
-#define PJ_ERRNO_START_SYS	(PJ_ERRNO_START_STATUS + PJ_ERRNO_SPACE_SIZE)
+#define PJ_ERRNO_START_SYS      (PJ_ERRNO_START_STATUS + PJ_ERRNO_SPACE_SIZE)
 
 /**
  * PJ_ERRNO_START_USER are reserved for applications that use error
  * codes along with PJLIB codes.
  * Effectively the error in this class would be 170000 - 219000.
  */
-#define PJ_ERRNO_START_USER	(PJ_ERRNO_START_SYS + PJ_ERRNO_SPACE_SIZE)
+#define PJ_ERRNO_START_USER     (PJ_ERRNO_START_SYS + PJ_ERRNO_SPACE_SIZE)
 
 
 /*
  * Below are list of error spaces that have been taken so far:
- *  - PJSIP_ERRNO_START		(PJ_ERRNO_START_USER)
- *  - PJMEDIA_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE)
- *  - PJSIP_SIMPLE_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*2)
- *  - PJLIB_UTIL_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*3)
- *  - PJNATH_ERRNO_START	(PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*4)
+ *  - PJSIP_ERRNO_START         (PJ_ERRNO_START_USER)
+ *  - PJMEDIA_ERRNO_START       (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE)
+ *  - PJSIP_SIMPLE_ERRNO_START  (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*2)
+ *  - PJLIB_UTIL_ERRNO_START    (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*3)
+ *  - PJNATH_ERRNO_START        (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*4)
  *  - PJMEDIA_AUDIODEV_ERRNO_START (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*5)
- *  - PJ_SSL_ERRNO_START	   (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*6)
+ *  - PJ_SSL_ERRNO_START           (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*6)
  *  - PJMEDIA_VIDEODEV_ERRNO_START (PJ_ERRNO_START_USER + PJ_ERRNO_SPACE_SIZE*7)
  */
 
@@ -507,7 +507,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 1
-    #define pj_perror_wrapper_1(arg)	pj_perror_1 arg
+    #define pj_perror_wrapper_1(arg)    pj_perror_1 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_1(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -523,7 +523,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 2
-    #define pj_perror_wrapper_2(arg)	pj_perror_2 arg
+    #define pj_perror_wrapper_2(arg)    pj_perror_2 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_2(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -539,7 +539,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 3
-    #define pj_perror_wrapper_3(arg)	pj_perror_3 arg
+    #define pj_perror_wrapper_3(arg)    pj_perror_3 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_3(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -555,7 +555,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 4
-    #define pj_perror_wrapper_4(arg)	pj_perror_4 arg
+    #define pj_perror_wrapper_4(arg)    pj_perror_4 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_4(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -571,7 +571,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 5
-    #define pj_perror_wrapper_5(arg)	pj_perror_5 arg
+    #define pj_perror_wrapper_5(arg)    pj_perror_5 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_5(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -587,7 +587,7 @@ void pj_errno_clear_handlers(void);
  * @param arg       Log expression.
  */
 #if PJ_LOG_MAX_LEVEL >= 6
-    #define pj_perror_wrapper_6(arg)	pj_perror_6 arg
+    #define pj_perror_wrapper_6(arg)    pj_perror_6 arg
     /** Internal function. */
     PJ_DECL(void) pj_perror_6(const char *sender, pj_status_t status, 
                               const char *title_fmt, ...)
@@ -601,5 +601,5 @@ void pj_errno_clear_handlers(void);
 
 PJ_END_DECL
 
-#endif	/* __PJ_ERRNO_H__ */
+#endif  /* __PJ_ERRNO_H__ */
 

--- a/pjlib/src/pj/os_error_win32.c
+++ b/pjlib/src/pj/os_error_win32.c
@@ -174,10 +174,13 @@ int platform_strerror( pj_os_err_type os_errcode,
 
     if (!len) {
         DWORD   dwLanguageId;
-#if defined(PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE) && (PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE==1) && (WINVER >= 0x0500)
-        dwLanguageId = LANGIDFROMLCID(GetThreadLocale());        /* current thread language */
+#if defined(PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE) && \
+    (PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE==1) && (WINVER >= 0x0500)
+        /* current thread language */
+        dwLanguageId = LANGIDFROMLCID(GetThreadLocale());
 #else
-        dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);/* LANG_USER_DEFAULT - User default language */
+        /* LANG_USER_DEFAULT - User default language */
+        dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
 #endif
 #if PJ_NATIVE_STRING_IS_UNICODE
         len = FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM 

--- a/pjlib/src/pj/os_error_win32.c
+++ b/pjlib/src/pj/os_error_win32.c
@@ -173,12 +173,18 @@ int platform_strerror( pj_os_err_type os_errcode,
 
 
     if (!len) {
+        DWORD   dwLanguageId;
+#if defined(PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE) && (PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE==1) && (WINVER >= 0x0500)
+        dwLanguageId = LANGIDFROMLCID(GetThreadLocale());        /* current thread language */
+#else
+        dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);/* LANG_USER_DEFAULT - User default language */
+#endif
 #if PJ_NATIVE_STRING_IS_UNICODE
         len = FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM 
                              | FORMAT_MESSAGE_IGNORE_INSERTS,
                              NULL,
                              os_errcode,
-                             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
+                             dwLanguageId,
                              wbuf,
                              PJ_ARRAY_SIZE(wbuf),
                              NULL);
@@ -190,7 +196,7 @@ int platform_strerror( pj_os_err_type os_errcode,
                              | FORMAT_MESSAGE_IGNORE_INSERTS,
                              NULL,
                              os_errcode,
-                             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
+                             dwLanguageId,
                              buf,
                              (int)bufsize,
                              NULL);

--- a/pjlib/src/pjlib-test/errno.c
+++ b/pjlib/src/pjlib-test/errno.c
@@ -86,7 +86,17 @@ int errno_test(void)
     pj_set_os_error(rc);
 
     /* Whole */
+#if defined(PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE) && (PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE==1) && (WINVER >= 0x0500)
+    LCID lcid = GetThreadLocale();
+    /* set en_US thread locale to obtain "invalid" in errbuff */
+    BOOL res = SetThreadLocale(MAKELCID(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), SORT_DEFAULT));
+    PJ_UNUSED_ARG(res);
+#endif
     pj_strerror(rc, errbuf, sizeof(errbuf));
+#if defined(PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE) && (PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE==1) && (WINVER >= 0x0500)
+    /* restore thread locale now */
+    SetThreadLocale(lcid);
+#endif
     trim_newlines(errbuf);
     PJ_LOG(3,(THIS_FILE, "...msg for rc=ERROR_INVALID_DATA: '%s'", errbuf));
     if (my_stristr(errbuf, "invalid") == NULL) {


### PR DESCRIPTION
This changes are for users who use pjsip under non english Windows redactions.

1) PJ_ERR_MSG_SIZE 
For example russian language is not so laconic as English. Windows FormatMessage function often requires more than 80 character for message buffer. Thats why I need to increase PJ_ERR_MSG_SIZE value (in fact I use 160 - twice more!), but I preffere to declare PJ_ERR_MSG_SIZE in my config_site.h file. The only change I need for this purpose is to surrond #define PJ_ERR_MSG_SIZE by #ifndef

2) PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE
pj_strerror() calls Windows FormatMessage function with the value of languageId parameter meaning "User default language" which is language configured for user session. This is not always comfortable. For example pjlib_project errno_test() failes for non English user language because FormatMessage return national language string (for examle cyrillic string) not containing the word "invalid" which is test criteria.   
But starting from Windows XP application can set locale (and language) information on application and thread basis. It's logically to expect the program will reflect to current thread locale. My idea is to use current thread language to obtain OS error description.
To support this I have modified platform_strerror() (for Windows platform) so that it calls FormatMessage with current thread language instead of user default language. 
For compatibility reason I have introduced  PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE macro wich may be set in config_site.h file. By default behaviour is not changed, but if user define PJ_STRERROR_USE_WIN_GET_THREAD_LOCALE platform_strerror() will call GetThreadLocale() to get current locale (and language).
As an usage example: if that macro is defined, error_test() fors English thread locale before calling pj_strerror() and now test is succeeded under non English Windows redactions.