### PR TITLE
Assertion due to deleted account during incoming call in PJSUA2

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2167,7 +2167,12 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
          * otherwise hangup the call with 480
          */
         if (pjsua_var.ua_cfg.cb.on_incoming_call) {
-            pjsua_var.ua_cfg.cb.on_incoming_call(acc_id, call_id, rdata);
+            /* For PJSUA2, avoid invoking this callback again when it has been
+             * invoked from on_media_transport_created().
+             */
+            if (call->incoming_data) {
+                pjsua_var.ua_cfg.cb.on_incoming_call(acc_id, call_id, rdata);
+            }
 
             /* Notes:
              * - the call might be reset when it's rejected or hangup
@@ -2178,6 +2183,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
              * answer/hangup should have been delayed (see #1923), 
              * so let's process the answer/hangup now.
              */
+
             if (call->async_call.call_var.inc_call.hangup) {
                 process_pending_call_hangup(call);
             } else if (call->med_ch_cb == NULL && call->inv) {

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2141,7 +2141,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
      */
     if (dlg->mod_data[pjsua_var.mod.id] == NULL) {
         /* In PJSUA2, on_incoming_call() may be called from 
-         * on_media_transport_created() hence this might already set
+         * on_create_media_transport() hence this might already set
          * to allow notification about fail events via on_call_state() and
          * on_call_tsx_state().
          */
@@ -2168,7 +2168,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
          */
         if (pjsua_var.ua_cfg.cb.on_incoming_call) {
             /* For PJSUA2, avoid invoking this callback again when it has been
-             * invoked from on_media_transport_created().
+             * invoked from on_create_media_transport().
              */
             if (call->incoming_data) {
                 pjsua_var.ua_cfg.cb.on_incoming_call(acc_id, call_id, rdata);


### PR DESCRIPTION
Reported that assertion occurs in incoming call callback due to the selected account is being deleted:
```
../src/pjsua-lib/pjsua_acc.c:650: void *pjsua_acc_get_user_data(pjsua_acc_id): assertion "pjsua_var.acc[acc_id].valid" failed

pjsua_acc_get_user_data+280
pj::Account::lookup(int)+20
pj::Endpoint::lookupAcc(int, char const*)+24
pj::Endpoint::on_incoming_call(int, int, pjsip_rx_data*)+60)
pjsua_call_on_incoming+6336
```
Initially this sounds strange as `pjsua_call_on_incoming()` and `pjsua_acc_del()` seem to be mutually exclusive, i.e: protected by PJSUA lock. However, after investigation, it is possible because `pjsua_call_on_state_changed()` may temporarily release the PJSUA lock. In PJSUA2 (not the case in PJSUA), the `pjsua_call_on_state_changed()` will be called when a 100/Trying response is sent **and** the incoming call callback is called early (before media transport creation callback and before sending 100 response).

The assertion seems to occur when PJSUA invokes incoming call callback (after sending 100 response or `pjsua_call_on_state_changed()`) which eventually will be ignored by PJSUA2 as such callback has been called earlier, so the proposed solution here is to avoid invoking the PJSUA callback when PJSUA2 has invoke the incoming call callback earlier.

Thanks to Valery Kolesnikov for the report.