### PR TITLE
Adjust disabled media IP version according to offer

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2823,9 +2823,13 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
                 pj_bool_t use_ipv6;
                 pj_bool_t use_nat64;
 
-                use_ipv6 = PJ_HAS_IPV6 &&
-                           (pjsua_var.acc[call->acc_id].cfg.ipv6_media_use !=
-                            PJSUA_IPV6_DISABLED);
+                if (rem_sdp) {
+                    use_ipv6 = (get_media_ip_version(call_med, rem_sdp) == 6);
+                } else {
+                    use_ipv6 = PJ_HAS_IPV6 &&
+                        (pjsua_var.acc[call->acc_id].cfg.ipv6_media_use !=
+                         PJSUA_IPV6_DISABLED);
+                }
                 use_nat64 = PJ_HAS_IPV6 &&
                             (pjsua_var.acc[call->acc_id].cfg.nat64_opt !=
                              PJSUA_NAT64_DISABLED);


### PR DESCRIPTION
To fix #4020.

If we reject a media offer, currently we only take into account the local setting, so even if the offer is IPv4, such as:
```
m=audio 31002 RTP/SAVP 0 8 96 97 9 18 101
c=IN IP4 10.207.114.11
```
 the answer can be:
```
m=audio 0 RTP/SAVP 0 8 96 97 9 18 101
c=IN IP6 ::1
```

In this patch, we will try to check the remote SDP IP version instead.
