### PR TITLE
Prevent recreating TLS transport when answering a call after network change

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1633,7 +1633,7 @@ PJ_DEF(pj_status_t) pjsip_dlg_send_response( pjsip_dialog *dlg,
     /* Copy the initial destination host to tdata. This information can be
      * used later by transport for transport selection.
      */
-    if (dlg->initial_dest.slen) {
+    if (!tdata->dest_info.name.slen && dlg->initial_dest.slen) {
         pj_strdup(tdata->pool, &tdata->dest_info.name, &dlg->initial_dest);
         PJ_LOG(5, (THIS_FILE, "Setting initial dest %.*s",
             (int)dlg->initial_dest.slen, dlg->initial_dest.ptr));

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1630,6 +1630,15 @@ PJ_DEF(pj_status_t) pjsip_dlg_send_response( pjsip_dialog *dlg,
         pj_assert(status == PJ_SUCCESS);
     }
 
+    /* Copy the initial destination host to tdata. This information can be
+     * used later by transport for transport selection.
+     */
+    if (dlg->initial_dest.slen) {
+        pj_strdup(tdata->pool, &tdata->dest_info.name, &dlg->initial_dest);
+        PJ_LOG(5, (THIS_FILE, "Setting initial dest %.*s",
+            (int)dlg->initial_dest.slen, dlg->initial_dest.ptr));
+    }
+
     /* Ask transaction to send the response */
     status = pjsip_tsx_send_msg(tsx, tdata);
 


### PR DESCRIPTION
When acquiring transport for `TLS`, the library tries to match the transport remote host with `tdata` destination host (67e46c1ac45ad784db5b9080f5ed8b133c122872).

When `tdata` destination host is not set to the remote hostname, no matching transport will be found and a new transport 
will be forced to be created and leads to verification failure of the new transport/`PJSIP_TLS_ECERTVERIF`.

This is the case when sending `RESPONSE` message after a network change on `TLS`.
This patch will set the `tdata` destination host using the dialog's `initial_dest`.

Notes: on the above scenario, app requires to update the `Contact` header by sending an `UPDATE` message before answering the call. ([ref](https://docs.pjsip.org/en/2.14/specific-guides/network_nat/ip_change.html#notes-and-limitations))
