### PR TITLE
Fix assertion in quitting pjsua app when AVI feature is disabled

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1718,6 +1718,11 @@ static pj_status_t app_init(void)
             }
         }
 #else
+        for (i=0; i<app_config.avi_cnt; ++i) {
+            app_config.avi[i].dev_id = PJMEDIA_VID_INVALID_DEV;
+            app_config.avi[i].slot = PJSUA_INVALID_ID;
+        }
+
         PJ_LOG(2,(THIS_FILE,
                   "Warning: --play-avi is ignored because AVI is disabled"));
 #endif  /* PJMEDIA_VIDEO_DEV_HAS_AVI */


### PR DESCRIPTION
Steps to reproduce:
1. Build PJSIP with AVI feature disabled, e.g: undefine or set to 0 `PJMEDIA_VIDEO_DEV_HAS_AVI`.
2. Start pjsua app with AVI, e.g: add param `--play-avi some.avi`.
3. Quit pjsua, assertion is raised.

Call stack:
```
pjmedia_port_destroy(pjmedia_port * port=0x00000000) Line 126 + 0x24 bytes	C
pjmedia_conf_remove_port(pjmedia_conf * conf=0x026a19f4, unsigned int port=0) Line 1278 + 0xc bytes	C
pjsua_conf_remove_port(int id=0) Line 974 + 0x10 bytes	C
app_destroy() Line 2137 + 0x12 bytes	C
pjsua_app_destroy() Line 2221 + 0x5 bytes	C
```

Assertion happens because the conference port ID & device ID for AVI are initialized to 0 instead of invalid.