### PR TITLE
Save the original user and password part when parsing URI

### DIFF
--- a/pjsip/include/pjsip/sip_uri.h
+++ b/pjsip/include/pjsip/sip_uri.h
@@ -337,6 +337,7 @@ PJ_INLINE(void*) pjsip_uri_clone( pj_pool_t *pool, const void *uri )
 typedef struct pjsip_sip_uri
 {
     pjsip_uri_vptr *vptr;               /**< Pointer to virtual function table.*/
+    pj_str_t        original;           /**< Optional pointer to original user and password. */
     pj_str_t        user;               /**< Optional user part. */
     pj_str_t        passwd;             /**< Optional password part. */
     pj_str_t        host;               /**< Host part, always exists. */

--- a/pjsip/include/pjsip/sip_uri.h
+++ b/pjsip/include/pjsip/sip_uri.h
@@ -337,9 +337,9 @@ PJ_INLINE(void*) pjsip_uri_clone( pj_pool_t *pool, const void *uri )
 typedef struct pjsip_sip_uri
 {
     pjsip_uri_vptr *vptr;               /**< Pointer to virtual function table.*/
-    pj_str_t        original;           /**< Optional pointer to original user and password. */
     pj_str_t        user;               /**< Optional user part. */
     pj_str_t        passwd;             /**< Optional password part. */
+    pj_str_t        orig_userpass;      /**< Optional original user&pass. */
     pj_str_t        host;               /**< Host part, always exists. */
     int             port;               /**< Optional port number, or zero. */
     pj_str_t        user_param;         /**< Optional user parameter */

--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1508,6 +1508,8 @@ static void* int_parse_sip_url( pj_scanner *scanner,
     int colon;
     int skip_ws = scanner->skip_ws;
     scanner->skip_ws = 0;
+    char *start, *end;
+    pj_str_t orig;
 
     pj_scan_get(scanner, &pconst.pjsip_TOKEN_SPEC, &scheme);
     colon = pj_scan_get_char(scanner);
@@ -1530,9 +1532,15 @@ static void* int_parse_sip_url( pj_scanner *scanner,
         })
     }
 
+    start = scanner->curptr;
+
     if (int_is_next_user(scanner)) {
         int_parse_user_pass(scanner, pool, &url->user, &url->passwd);
     }
+
+    end = scanner->curptr;
+    pj_strset3(&orig, start, end);
+    pj_strdup(pool, &url->original, &orig);
 
     /* Get host:port */
     int_parse_uri_host_port(scanner, &url->host, &url->port);

--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1508,8 +1508,6 @@ static void* int_parse_sip_url( pj_scanner *scanner,
     int colon;
     int skip_ws = scanner->skip_ws;
     scanner->skip_ws = 0;
-    char *start, *end;
-    pj_str_t orig;
 
     pj_scan_get(scanner, &pconst.pjsip_TOKEN_SPEC, &scheme);
     colon = pj_scan_get_char(scanner);
@@ -1532,15 +1530,16 @@ static void* int_parse_sip_url( pj_scanner *scanner,
         })
     }
 
-    start = scanner->curptr;
-
     if (int_is_next_user(scanner)) {
-        int_parse_user_pass(scanner, pool, &url->user, &url->passwd);
-    }
+        char *start = scanner->curptr;
+        pj_str_t orig;
 
-    end = scanner->curptr;
-    pj_strset3(&orig, start, end);
-    pj_strdup(pool, &url->original, &orig);
+        start = scanner->curptr;
+        int_parse_user_pass(scanner, pool, &url->user, &url->passwd);
+
+        pj_strset3(&orig, start, scanner->curptr - 1);
+        pj_strdup(pool, &url->orig_userpass, &orig);
+    }
 
     /* Get host:port */
     int_parse_uri_host_port(scanner, &url->host, &url->port);

--- a/pjsip/src/pjsip/sip_uri.c
+++ b/pjsip/src/pjsip/sip_uri.c
@@ -267,6 +267,10 @@ static pj_ssize_t pjsip_url_print(  pjsip_uri_context_e context,
     copy_advance_check(buf, *scheme);
     copy_advance_char_check(buf, ':');
 
+    if (url->original.slen) {
+        copy_advance_check(buf, url->original);
+    } else {
+
     /* Print "user:password@", if any. */
     if (url->user.slen) {
         const pj_cis_t *spec = pjsip_cfg()->endpt.allow_tx_hash_in_uri ?
@@ -279,6 +283,7 @@ static pj_ssize_t pjsip_url_print(  pjsip_uri_context_e context,
         }
 
         copy_advance_char_check(buf, '@');
+    }
     }
 
     /* Print host. */
@@ -506,6 +511,7 @@ static pj_status_t pjsip_url_compare( pjsip_uri_context_e context,
 PJ_DEF(void) pjsip_sip_uri_assign(pj_pool_t *pool, pjsip_sip_uri *url, 
                                   const pjsip_sip_uri *rhs)
 {
+    pj_strdup( pool, &url->original, &rhs->original);
     pj_strdup( pool, &url->user, &rhs->user);
     pj_strdup( pool, &url->passwd, &rhs->passwd);
     pj_strdup( pool, &url->host, &rhs->host);

--- a/pjsip/src/pjsip/sip_uri.c
+++ b/pjsip/src/pjsip/sip_uri.c
@@ -267,23 +267,23 @@ static pj_ssize_t pjsip_url_print(  pjsip_uri_context_e context,
     copy_advance_check(buf, *scheme);
     copy_advance_char_check(buf, ':');
 
-    if (url->original.slen) {
-        copy_advance_check(buf, url->original);
-    } else {
-
     /* Print "user:password@", if any. */
     if (url->user.slen) {
-        const pj_cis_t *spec = pjsip_cfg()->endpt.allow_tx_hash_in_uri ?
-                                &pc->pjsip_USER_SPEC_LENIENT :
-                                &pc->pjsip_USER_SPEC;
-        copy_advance_escape(buf, url->user, *spec);
-        if (url->passwd.slen) {
-            copy_advance_char_check(buf, ':');
-            copy_advance_escape(buf, url->passwd, pc->pjsip_PASSWD_SPEC);
+        /* Use the URI's original username and password, if any. */
+        if (url->orig_userpass.slen) {
+            copy_advance_check(buf, url->orig_userpass);
+        } else {
+            const pj_cis_t *spec = pjsip_cfg()->endpt.allow_tx_hash_in_uri ?
+                                    &pc->pjsip_USER_SPEC_LENIENT :
+                                    &pc->pjsip_USER_SPEC;
+            copy_advance_escape(buf, url->user, *spec);
+            if (url->passwd.slen) {
+                copy_advance_char_check(buf, ':');
+                copy_advance_escape(buf, url->passwd, pc->pjsip_PASSWD_SPEC);
+            }
         }
 
         copy_advance_char_check(buf, '@');
-    }
     }
 
     /* Print host. */
@@ -511,9 +511,9 @@ static pj_status_t pjsip_url_compare( pjsip_uri_context_e context,
 PJ_DEF(void) pjsip_sip_uri_assign(pj_pool_t *pool, pjsip_sip_uri *url, 
                                   const pjsip_sip_uri *rhs)
 {
-    pj_strdup( pool, &url->original, &rhs->original);
     pj_strdup( pool, &url->user, &rhs->user);
     pj_strdup( pool, &url->passwd, &rhs->passwd);
+    pj_strdup( pool, &url->orig_userpass, &rhs->orig_userpass);
     pj_strdup( pool, &url->host, &rhs->host);
     url->port = rhs->port;
     pj_strdup( pool, &url->user_param, &rhs->user_param);

--- a/pjsip/src/test/uri_test.c
+++ b/pjsip/src/test/uri_test.c
@@ -908,6 +908,8 @@ static pj_status_t do_uri_test(pj_pool_t *pool, struct uri_test *entry)
     pj_add_timestamp(&var.cmp_time, &t2);
 
     /* Compare text. */
+    /* Printing results may differ, but the comparison above must match. */
+#if 0
     if (entry->printed) {
         if (pj_strcmp2(&s1, entry->printed) != 0) {
             /* Not equal. */
@@ -927,6 +929,7 @@ static pj_status_t do_uri_test(pj_pool_t *pool, struct uri_test *entry)
             status = -70;
         }
     }
+#endif
 
 on_return:
     return status;

--- a/pjsip/src/test/uri_test.c
+++ b/pjsip/src/test/uri_test.c
@@ -571,6 +571,7 @@ static pjsip_uri *create_uri14(pj_pool_t *pool)
     pj_strdup2(pool, &name_addr->display, "This is -. !% *_+`'~ me");
     pj_strdup2(pool, &url->user, "a19A&=+$,;?/,");
     pj_strdup2(pool, &url->passwd, "@a&Zz=+$,");
+    pj_strdup2(pool, &url->orig_userpass, "a19A&=+$,;?/%2c:%40a&Zz=+$,");
     pj_strdup2(pool, &url->host, "my_proxy09.MY-domain.com");
     url->port = 9801;
     return (pjsip_uri*)name_addr;
@@ -908,8 +909,6 @@ static pj_status_t do_uri_test(pj_pool_t *pool, struct uri_test *entry)
     pj_add_timestamp(&var.cmp_time, &t2);
 
     /* Compare text. */
-    /* Printing results may differ, but the comparison above must match. */
-#if 0
     if (entry->printed) {
         if (pj_strcmp2(&s1, entry->printed) != 0) {
             /* Not equal. */
@@ -929,7 +928,6 @@ static pj_status_t do_uri_test(pj_pool_t *pool, struct uri_test *entry)
             status = -70;
         }
     }
-#endif
 
 on_return:
     return status;


### PR DESCRIPTION
We have received the following report:
- Remote sends a URI that escapes an unreserved character, which is actually allowed by [RFC 2396: Uniform Resource Identifiers (URI)](https://datatracker.ietf.org/doc/html/rfc2396#section-2.4.2) (as well as the newer [RFC 3896](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4)):
```
In some cases, data that could be represented by an unreserved
   character may appear escaped; for example, some of the unreserved
   "mark" characters are automatically escaped by some systems.
```
For example: `sip:%2auser@host.com` (which is decoded as `sip:*user@host.com`).

- PJSIP will parse the URI, unescape it, and then store and use it in its unescaped form.
- But the remote will reject this URI when unescaped.

Although both URIs should be identical according to the RFC, it may be preferable if we use the URI in its original encoding.
