### PR TITLE
Update dialog remote info in target refresh

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1818,6 +1818,9 @@ void pjsip_dlg_on_rx_request( pjsip_dialog *dlg, pjsip_rx_data *rdata )
             enum { TMP_LEN=PJSIP_MAX_URL_SIZE };
             pj_ssize_t len;
 
+            PJ_LOG(4, (dlg->obj_name, "Updating remote contact in "
+                                      "target refresh"));
+
             dlg->remote.contact = (pjsip_contact_hdr*)
                                   pjsip_hdr_clone(dlg->pool, contact);
             dlg->target = dlg->remote.contact->uri;
@@ -1828,6 +1831,7 @@ void pjsip_dlg_on_rx_request( pjsip_dialog *dlg, pjsip_rx_data *rdata )
             pjsip_fromto_hdr_set_to(dlg->remote.info);
         
             /* Print the remote info. */
+            tmp.ptr = (char*) pj_pool_alloc(rdata->tp_info.pool, TMP_LEN);
             len = pjsip_uri_print(PJSIP_URI_IN_FROMTO_HDR,
                                   dlg->remote.info->uri, tmp.ptr, TMP_LEN);
             if (len < 1) {

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1814,9 +1814,31 @@ void pjsip_dlg_on_rx_request( pjsip_dialog *dlg, pjsip_rx_data *rdata )
                            dlg->remote.contact->uri,
                            contact->uri)))
         {
+            pj_str_t tmp;
+            enum { TMP_LEN=PJSIP_MAX_URL_SIZE };
+            pj_ssize_t len;
+
             dlg->remote.contact = (pjsip_contact_hdr*)
                                   pjsip_hdr_clone(dlg->pool, contact);
             dlg->target = dlg->remote.contact->uri;
+
+            /* Update remote info as well. */
+            dlg->remote.info = (pjsip_fromto_hdr*)
+                               pjsip_hdr_clone(dlg->pool, rdata->msg_info.from);
+            pjsip_fromto_hdr_set_to(dlg->remote.info);
+        
+            /* Print the remote info. */
+            len = pjsip_uri_print(PJSIP_URI_IN_FROMTO_HDR,
+                                  dlg->remote.info->uri, tmp.ptr, TMP_LEN);
+            if (len < 1) {
+                tmp.slen=pj_ansi_strxcpy(tmp.ptr, "<-error: uri too long->", TMP_LEN);
+                if (tmp.slen<0)
+                    tmp.slen = pj_ansi_strlen(tmp.ptr);
+            } else
+                tmp.slen = len;
+        
+            /* Save the remote info. */
+            pj_strdup(dlg->pool, &dlg->remote.info_str, &tmp);
         }
     }
 


### PR DESCRIPTION
For the following scenario:
Bob (3502) transfers a call from Alice (3500) to Carol (3501).

After the transfer completes, Carol receives a re-INVITE and now the From and Contact header's display name is "3500" (Alice). `pjsua_call_info::remote_contact` is updated and contains the new display name ("3500", Alice), but `pjsua_call_info::remote_info` still contains the old display name ("3502", Bob).

