### PR TITLE
Use setuptools to replace deprecated distutils

### DIFF
--- a/pjsip-apps/src/swig/python/setup.py
+++ b/pjsip-apps/src/swig/python/setup.py
@@ -17,7 +17,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 #
-from distutils.core import setup, Extension
+try:
+   from setuptools import setup, Extension
+except ImportError:
+   from distutils.core import setup, Extension
+
 import os
 import sys
 import platform


### PR DESCRIPTION
The `distutils` python module has been deprecated ([ref](https://peps.python.org/pep-0632/)) and it is recommended to use `setuptools` instead.

Notes:
When running `"make install"` or `"python setup.py install"` (on Python3.12.5) this error is raised:
```
        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************
```
Using `"python3 -m pip install ."` does work as suggested by [ref](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)