### PR TITLE
Fix build error with Opus and Visual Studio

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -1244,7 +1244,7 @@ static pj_status_t  codec_recover( pjmedia_codec *codec,
 }
 
 #if defined(_MSC_VER)
-#   pragma comment(lib, "libopus.a")
+#   pragma comment(lib, "opus.lib")
 #endif
 
 

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -1244,8 +1244,11 @@ static pj_status_t  codec_recover( pjmedia_codec *codec,
 }
 
 #if defined(_MSC_VER)
-#   pragma comment(lib, "opus.lib")
+#  if 1 /* Change to 0 if Opus lib name is "opus.lib" */
+#    pragma comment(lib, "libopus.a")
+#  else
+#    pragma comment(lib, "opus.lib")
+#  endif
 #endif
-
 
 #endif /* PJMEDIA_HAS_OPUS_CODEC */


### PR DESCRIPTION
I built pjproject with Opus and Visual Studio.  I got error and fix this.

How to repeat
-------------

Install Visual Studio and vcpkg
(I test with VS2017 / VS2019 Community Edition)

note: "Build Instructions"(for Windows)
https://docs.pjsip.org/en/latest/get-started/windows/build_instructions.html

Install vcpkg and run "vcpkg integrate install"

https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-msbuild?pivots=shell-cmd

```cmd
> cd C:\
> git clone https://github.com/microsoft/vcpkg.git
> cd vcpkg && bootstrap-vcpkg.bat
> set VCPKG_ROOT="C:\vcpkg"
> set PATH=%VCPKG_ROOT%;%PATH%
> vcpkg integrate install
```

Start "x86 Native Tools Command Prompt for VS 20xx" from Windows start menu
and run these commands.

```cmd
> tar xzf pjproject-2.14.1.tar.gz
> cd pjproject-2.14.1
> vcpkg new --application
> vcpkg add port opus
> notepad pjlib\include\pj\config_site.h
```
...And add this #define

```C
#define PJMEDIA_HAS_OPUS_CODEC 1
```

Start build.

* Click pjproject-vs14.sln
* Set pjsua as Active or Startup Project.
* Set Win32 as the platform.
* Select Debug or Release build as appropriate.

Open "Property" window of project "pjmedia_codec","pjsua" and "pjsystest" and change configuration.
a. Open "Configuration property >> vcpkg".
b. Set "Use Vcpkg Manifest" to "Yes".

Open "Property" window of project "samples".
a. Open "Configuration property >> VC++ Directory".
b. Add "(path_of_pjproject)\vcpkg_installed\x86-windows\x86-windows\lib"(for "Win32") to "Library directory".

Do "Build >> Build solution".

Got this error.

```text
Error	LNK1104	cannot open file 'libopus.a'.	pjsua
Error	LNK1104	cannot open file 'libopus.a'.	pjsystest
Error	LNK1104	cannot open file 'libopus.a'.	samples
```
