### PR TITLE
Avoid dialog destroy while waiting for dialog lock

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -948,6 +948,11 @@ PJ_DEF(pj_status_t) pjsip_dlg_inc_session( pjsip_dialog *dlg,
  */
 PJ_DEF(void) pjsip_dlg_inc_lock(pjsip_dialog *dlg)
 {
+    /* Add ref temporarily to avoid possible dialog destroy while waiting
+     * the lock.
+     */
+    pj_grp_lock_add_ref(dlg->grp_lock_);
+
     PJ_LOG(6,(dlg->obj_name, "Entering pjsip_dlg_inc_lock(), sess_count=%d",
               dlg->sess_count));
 
@@ -956,6 +961,9 @@ PJ_DEF(void) pjsip_dlg_inc_lock(pjsip_dialog *dlg)
 
     PJ_LOG(6,(dlg->obj_name, "Leaving pjsip_dlg_inc_lock(), sess_count=%d",
               dlg->sess_count));
+
+    /* Lock has been acquired, dec ref */
+    pj_grp_lock_dec_ref(dlg->grp_lock_);
 }
 
 /* Try to acquire dialog's group lock, but bail out if group lock can not be


### PR DESCRIPTION
A dialog may be destroyed while other thread is waiting for dialog lock. For example when caller & callee trying to disconnect the call simultaneously:
1. Thread 1 is about to sending a BYE, but gets context-switched when waiting for dialog lock, which may happen in `pjsip_dlg_create_request(), `pjsip_inv_send_msg()`, or `pjsip_dlg_send_request()`.
2. Thread 2 receives BYE, sends 200/BYE response. The BYE transaction termination leads to call disconnection and both dialog & invite-session get destroyed.
3. Back to thread 1, the dialog lock being waited for has just been destroyed (may lead to undefined behavior).

This PR patch offers best effort to avoid the premature dialog destroy by:
- incrementing the dialog lock reference before waiting for the dialog lock in `pjsip_dlg_inc_lock()`,
- using invite-session reference when dialog lock is not used, note that dialog won't be destroyed when there is still an invite session using it.

This approach won't work if the context switch happens before the reference counter (of dialog or invite-session) is incremented, however that should be able to be handled in the app layer (see the PJSUA approach below).

Note that PJSUA uses `acquire_call()` to acquire the dialog lock before accessing the call's dialog. The `acquire_call()` calls `pjsip_dlg_try_inc_lock()` instead of `pjsip_dlg_inc_lock()` so it won't block when the dialog lock is not available (and perhaps safer when the lock is destroyed). The pattern is like:
```
pj_status_t pjsua_call_hangup(..)
{
  // try to lock dialog
  status = acquire_call(..., &dlg);
  if (status != PJ_SUCCESS) {
    // failed to lock dialog
    return status;
  }

  // create & send BYE
  pjsip_inv_end_session(..);
  pjsip_inv_send_msg(..);

  // release dialog
  pjsip_dlg_dec_lock(dlg);
}
```