### PR TITLE
Add support for Android flexible page sizes

### DIFF
--- a/pjsip-apps/src/samples/android_sample/jni/Application.mk
+++ b/pjsip-apps/src/samples/android_sample/jni/Application.mk
@@ -3,4 +3,3 @@ APP_CPPFLAGS := -fexceptions -frtti
 APP_STL := c++_shared
 
 APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
-

--- a/pjsip-apps/src/samples/android_sample/jni/Application.mk
+++ b/pjsip-apps/src/samples/android_sample/jni/Application.mk
@@ -1,3 +1,6 @@
 APP_ABI := all
 APP_CPPFLAGS := -fexceptions -frtti
 APP_STL := c++_shared
+
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
+


### PR DESCRIPTION
As specified in Android official doc: https://developer.android.com/guide/practices/page-sizes#ndk-build, Android now supports 16 KB page sizes.

`
Historically, Android has only supported 4 KB memory page sizes, which has optimized system memory performance for the average amount of total memory that Android devices have typically had. Beginning with Android 15, AOSP supports devices that are configured to use a page size of 16 KB (16 KB devices). If your app uses any [NDK](https://developer.android.com/ndk) libraries, either directly or indirectly through an SDK, then you will need to rebuild your app for it to work on these 16 KB devices.
`

Note that as described in the doc above, the patch in this PR requires NDK r27 and higher. For r26 or below, you can supply the flags `CFLAGS="-D__BIONIC_NO_PAGE_SIZE_MACRO" LDFLAGS="-Wl,-z,max-page-size=16384"` to `configure-android`.