### PR TITLE
Fixed length check for RTCP FB SLI and RPSI parsing

### DIFF
--- a/pjmedia/src/pjmedia/rtcp_fb.c
+++ b/pjmedia/src/pjmedia/rtcp_fb.c
@@ -704,7 +704,8 @@ PJ_DEF(pj_status_t) pjmedia_rtcp_fb_parse_sli(
         return PJ_ETOOSMALL;
     }
 
-    cnt = pj_ntohs((pj_uint16_t)hdr->rtcp_common.length) - 2;
+    cnt = pj_ntohs((pj_uint16_t)hdr->rtcp_common.length);
+    if (cnt > 2) cnt -= 2; else cnt = 0;
     if (length < (cnt+3)*4)
         return PJ_ETOOSMALL;
 
@@ -755,7 +756,9 @@ PJ_DEF(pj_status_t) pjmedia_rtcp_fb_parse_rpsi(
         return PJ_ETOOSMALL;
     }
 
-    rpsi_len = (pj_ntohs((pj_uint16_t)hdr->rtcp_common.length)-2) * 4;
+    rpsi_len = pj_ntohs((pj_uint16_t)hdr->rtcp_common.length);
+    if (rpsi_len > 2) rpsi_len -= 2; else rpsi_len = 0;
+    rpsi_len *= 4;
     if (length < rpsi_len + 12)
         return PJ_ETOOSMALL;
 


### PR DESCRIPTION
The length check for RTCP FB NACK parsing has been fixed here: https://github.com/pjsip/pjproject/commit/22af44e68a0c7d190ac1e25075e1382f77e9397a

So we do the same for SLI and RPSI. Note that the library currently doesn't parse SLI and RPSI, so there is no issue affecting PJSIP users.

