### PR TITLE
Update cifuzz.yml: upload-artifact@v1 is deprecated

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -25,7 +25,7 @@ jobs:
         fuzz-seconds: 300
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: ${{ matrix.sanitizer }}-artifacts


### PR DESCRIPTION
CI fuzz currently fails:
`
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`.
`
Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
