### PR TITLE
Fixed crash when making call if call setting is not supplied

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -881,6 +881,8 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Failed to apply call setting", status);
         goto on_error;
+    } else if (!opt) {
+        opt = &call->opt;
     }
     
     /* Create sound port if none is instantiated, to check if sound device
@@ -959,7 +961,7 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
      * to using a randomly generated Call-ID
      */
 
-    if (opt && opt->custom_call_id.slen > 0) {
+    if( opt->custom_call_id.slen > 0 ){
         pj_strdup(dlg->pool, &dlg->call_id->id, &opt->custom_call_id);
         PJ_LOG(4,(THIS_FILE, "Set user defined "
                              "Call-ID (%.*s)",

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -959,7 +959,7 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
      * to using a randomly generated Call-ID
      */
 
-    if( opt->custom_call_id.slen > 0 ){
+    if (opt && opt->custom_call_id.slen > 0) {
         pj_strdup(dlg->pool, &dlg->call_id->id, &opt->custom_call_id);
         PJ_LOG(4,(THIS_FILE, "Set user defined "
                              "Call-ID (%.*s)",


### PR DESCRIPTION
To fix #4073, due to the change in #4052.

Call setting is optional, so if not supplied it will cause a crash.
