### PR TITLE
Add swig option to include doc for java and python wrapper

### DIFF
--- a/pjsip-apps/src/swig/java/Makefile
+++ b/pjsip-apps/src/swig/java/Makefile
@@ -9,6 +9,9 @@ SWIG_FLAGS=-I../../../../pjlib/include \
 SRC_DIR=../../../../pjsip/include
 SRCS=$(SRC_DIR)/pjsua2/endpoint.hpp $(SRC_DIR)/pjsua2/types.hpp
 
+GEN_DOC = -doxygen
+SWIG_FLAGS += $(GEN_DOC)
+
 ifneq ($(findstring android,$(TARGET_NAME)),)
  OS=android
  ifeq ("$(JAVA_HOME)","")

--- a/pjsip-apps/src/swig/python/Makefile
+++ b/pjsip-apps/src/swig/python/Makefile
@@ -26,10 +26,11 @@ SWIG_FLAGS=-I../../../../pjlib/include \
 SRC_DIR=../../../../pjsip/include
 SRCS=$(SRC_DIR)/pjsua2/endpoint.hpp $(SRC_DIR)/pjsua2/types.hpp
 
+GEN_DOC = -doxygen
 USE_THREADS = -threads
 # In SWIG 4.2 the build will fail if we use this flag
 #-DSWIG_NO_EXPORT_ITERATOR_METHODS
-SWIG_FLAGS += -w312 $(USE_THREADS)
+SWIG_FLAGS += -w312 $(USE_THREADS) $(GEN_DOC)
 
 .PHONY: all install uninstall
 

--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -492,7 +492,7 @@ struct TransportConfig : public PersistentObject
 
     /**
      * This specifies TLS settings for TLS transport. 
-     * It’s only used when creating a SIP TLS transport.
+     * It's only used when creating a SIP TLS transport.
      */
     TlsConfig           tlsConfig;
 


### PR DESCRIPTION
This PR will add the option to include the doc from the `C++` code to the `java` and `python` wrapper.
It is nice to have since on some IDE, the doc will be shown as tooltip information.

Notes:
- Requires `SWIG 4` or later
- Only supports `Java` and `Python`
- On `Python`, the fields doc might get exported as property doc and not shown properly on the tooltip (e.g.: on VS Code). You can use the script in [here](https://github.com/user-attachments/files/16749800/transform_docstrings.txt) to transform the doc further.