### PR TITLE
Branch 2.13 ifs changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ tests/pjsua/logs
 */docs/xml/
 */docs/latex/
 */docs/*.tag
+*.bak

--- a/pjlib/include/pj/assert.h
+++ b/pjlib/include/pj/assert.h
@@ -48,7 +48,11 @@
 #ifndef pj_assert
 #include "pj/log.h"
 #include <string.h>
+#ifdef _WIN32
 #define __FILENAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+#else
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
 #define pj_assert(expr) \
         do { \
                 if (!(expr)) { PJ_LOG(1,(__FILENAME__, "Assert failed: " #expr)); } \
@@ -60,17 +64,18 @@
 #endif
 #endif
 
-  /**
-   * @hideinitializer
-   * for all buils log the message
-   * Check during debug build that an expression is true. If the expression
-   * computes to false during run-time, then the program will stop at the
-   * offending statements.
-   * For release build, this macro only print message on the log.
-   * @param expr	    The expression to be evaluated.
-   * @param ...	    file name,The format string for the log message ("config.c", " PJ_VERSION: %s", PJ_VERSION)
-   */
+/**
+ * @hideinitializer
+ * for all buils log the message
+ * Check during debug build that an expression is true. If the expression
+ * computes to false during run-time, then the program will stop at the
+ * offending statements.
+ * For release build, this macro only print message on the log.
+ * @param expr	    The expression to be evaluated.
+ * @param ...	    file name,The format string for the log message ("config.c", " PJ_VERSION: %s", PJ_VERSION)
+ */
 #ifndef PJ_ASSERT_LOG
+#include "pj/log.h"
 #define PJ_ASSERT_LOG(expr,...)    \
             do { \
                 if (!(expr)) { PJ_LOG(1,(__VA_ARGS__)); assert(expr); } \

--- a/pjlib/include/pj/assert.h
+++ b/pjlib/include/pj/assert.h
@@ -35,20 +35,48 @@
  * Assertion and other helper macros for sanity checking.
  */
 
-/**
- * @hideinitializer
- * Check during debug build that an expression is true. If the expression
- * computes to false during run-time, then the program will stop at the
- * offending statements.
- * For release build, this macro will not do anything.
- *
- * @param expr      The expression to be evaluated.
- */
+ /**
+  * @hideinitializer
+  * Check during debug build that an expression is true. If the expression
+  * computes to false during run-time, then the program will stop at the
+  * offending statements.
+  * For release build, this macro only print assert expression on the log.
+  *
+  * @param expr	    The expression to be evaluated.
+  */
+#ifndef _DEBUG  
+#ifndef pj_assert
+#include "pj/log.h"
+#include <string.h>
+#define __FILENAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+#define pj_assert(expr) \
+        do { \
+                if (!(expr)) { PJ_LOG(1,(__FILENAME__, "Assert failed: " #expr)); } \
+        } while (0)
+#endif
+#else
 #ifndef pj_assert
 #   define pj_assert(expr)   assert(expr)
 #endif
+#endif
 
+  /**
+   * @hideinitializer
+   * for all buils log the message
+   * Check during debug build that an expression is true. If the expression
+   * computes to false during run-time, then the program will stop at the
+   * offending statements.
+   * For release build, this macro only print message on the log.
+   * @param expr	    The expression to be evaluated.
+   * @param ...	    file name,The format string for the log message ("config.c", " PJ_VERSION: %s", PJ_VERSION)
+   */
+#ifndef PJ_ASSERT_LOG
+#define PJ_ASSERT_LOG(expr,...)    \
+            do { \
+                if (!(expr)) { PJ_LOG(1,(__VA_ARGS__)); assert(expr); } \
+            } while (0)
 
+#endif
 /**
  * @hideinitializer
  * If the expression yields false, assertion will be triggered

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -412,7 +412,7 @@
  * Default: 4
  */
 #ifndef PJ_LOG_MAX_LEVEL
-#  define PJ_LOG_MAX_LEVEL   5
+#  define PJ_LOG_MAX_LEVEL   6
 #endif
 
 /**

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -412,7 +412,7 @@
  * Default: 4
  */
 #ifndef PJ_LOG_MAX_LEVEL
-#  define PJ_LOG_MAX_LEVEL   6
+#  define PJ_LOG_MAX_LEVEL   5
 #endif
 
 /**

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -978,6 +978,10 @@ PJ_DEF(void*) pj_thread_local_get(long index)
     //Can't check stack because this function is called
     //by PJ_CHECK_STACK() itself!!!
     //PJ_CHECK_STACK();
+if (index == -1)
+    {
+        return 0;
+    }
 #if defined(PJ_WIN32_WINPHONE8) && PJ_WIN32_WINPHONE8
     return TlsGetValueRT(index);
 #else
@@ -1093,10 +1097,18 @@ PJ_DEF(pj_status_t) pj_mutex_lock(pj_mutex_t *mutex)
         status = PJ_STATUS_FROM_OS(GetLastError());
 
 #endif
+if (status == PJ_SUCCESS)
+    {
     LOG_MUTEX((mutex->obj_name, 
-              (status==PJ_SUCCESS ? "Mutex acquired by thread %s" : "FAILED by %s"),
+            "Mutex acquired by thread %s",
               pj_thread_this()->obj_name));
-
+    }
+    else
+    {
+        LOG_MUTEX_WARN((mutex->obj_name,
+           "FAILED by %s",
+            pj_thread_this()->obj_name));
+    }
 #if PJ_DEBUG
     if (status == PJ_SUCCESS) {
         mutex->owner = pj_thread_this();
@@ -1296,7 +1308,7 @@ static pj_status_t pj_sem_wait_for(pj_sem_t *sem, unsigned timeout)
         LOG_MUTEX((sem->obj_name, "Semaphore acquired by thread %s", 
                                   pj_thread_this()->obj_name));
     } else {
-        LOG_MUTEX((sem->obj_name, "Semaphore: thread %s FAILED to acquire", 
+        LOG_MUTEX_WARN((sem->obj_name, "Semaphore: thread %s FAILED to acquire",
                                   pj_thread_this()->obj_name));
     }
 

--- a/pjmedia/include/pjmedia/circbuf.h
+++ b/pjmedia/include/pjmedia/circbuf.h
@@ -84,9 +84,14 @@ PJ_INLINE(pj_status_t) pjmedia_circ_buf_create(pj_pool_t *pool,
 {
     pjmedia_circ_buf *cbuf;
 
+	*p_cb = NULL;
+
     cbuf = PJ_POOL_ZALLOC_T(pool, pjmedia_circ_buf);
-    cbuf->buf = (pj_int16_t*) pj_pool_calloc(pool, capacity, 
-                                             sizeof(pj_int16_t));
+	if (!cbuf)
+		return PJ_ENOMEM;
+	cbuf->buf = (pj_int16_t*) pj_pool_calloc(pool, capacity, sizeof(pj_int16_t));
+	if (!cbuf->buf)
+		return PJ_ENOMEM;
     cbuf->capacity = capacity;
     cbuf->start = cbuf->buf;
     cbuf->len = 0;

--- a/pjmedia/include/pjmedia/conference.h
+++ b/pjmedia/include/pjmedia/conference.h
@@ -282,8 +282,6 @@ PJ_DECL(pj_status_t) pjmedia_conf_replace_port( pjmedia_conf *conf,
 					    pj_pool_t *pool,
 					    pjmedia_port *strm_port,
 					    unsigned slot );
-
-PJ_DECL(pj_status_t) pjmedia_conf_distroy_port( pjmedia_port* port);
 #if !DEPRECATED_FOR_TICKET_2234
 /**
  * <i><b>Warning:</b> This API has been deprecated since 1.3 and will be

--- a/pjmedia/include/pjmedia/conference.h
+++ b/pjmedia/include/pjmedia/conference.h
@@ -243,6 +243,34 @@ PJ_DECL(pj_status_t) pjmedia_conf_add_port( pjmedia_conf *conf,
                                             const pj_str_t *name,
                                             unsigned *p_slot );
 
+/**
+ * Replace existing media port in the conference bridge (that was
+ * initially added using #pjmedia_conf_add_port()) with a new port
+ * in the same slot whilst maintaining any connections established
+ * by invoking #pjmedia_conf_connect_port().
+ *
+ * By default, the new conference port will have both TX and RX enabled, 
+ * but it is not connected to any other ports. Application SHOULD call 
+ * #pjmedia_conf_connect_port() to  enable audio transmission and receipt 
+ * to/from this port.
+ *
+ * Once the media port is connected to other port(s) in the bridge,
+ * the bridge will continuosly call get_frame() and put_frame() to the
+ * port, allowing media to flow to/from the port.
+ *
+ * @param conf		The conference bridge.
+ * @param pool		Pool to allocate buffers for this port.
+ * @param strm_port	Stream port interface.
+ * @param slot		Slot index of the existing port in
+ *			the conference bridge.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_conf_replace_port( pjmedia_conf *conf,
+					    pj_pool_t *pool,
+					    pjmedia_port *strm_port,
+					    unsigned slot );
+
 
 #if !DEPRECATED_FOR_TICKET_2234
 /**
@@ -433,7 +461,18 @@ PJ_DECL(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
 PJ_DECL(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
                                               unsigned ports[],
                                               unsigned *count );
-
+/**
+ * Get port info.
+ *
+ * @param conf          The conference bridge.
+ * @param slot          Port index.
+ * @param info          Pointer to receive the info.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_conf_get_media_port_info(pjmedia_conf* conf,
+    unsigned slot,
+    pjmedia_port_info* info);
 
 /**
  * Get port info.

--- a/pjmedia/include/pjmedia/conference.h
+++ b/pjmedia/include/pjmedia/conference.h
@@ -213,8 +213,20 @@ PJ_DECL(pjmedia_port*) pjmedia_conf_get_master_port(pjmedia_conf *conf);
 PJ_DECL(pj_status_t) pjmedia_conf_set_port0_name(pjmedia_conf *conf,
                                                  const pj_str_t *name);
 
-
 /**
+ * compare signature of the port with the signature of the port in the conference bridge
+ *
+ * if the conf_slot is not found, return PJ_FALSE
+ *
+ * @param conf          The conference bridge.
+ * @param conf_slot     conference bridge slot
+ * @param signature     signature of the port
+ *
+ * @return              PJ_TRUE if the signature of the port is the same as the signature of the port in the conference bridge
+ */
+ 
+PJ_DECL(pj_bool_t) pjmedia_conf_compare_port_signature(pjmedia_conf* conf, unsigned conf_slot, pj_uint32_t signature);
+/** 
  * Add media port to the conference bridge.
  *
  * By default, the new conference port will have both TX and RX enabled, 
@@ -271,7 +283,7 @@ PJ_DECL(pj_status_t) pjmedia_conf_replace_port( pjmedia_conf *conf,
 					    pjmedia_port *strm_port,
 					    unsigned slot );
 
-
+PJ_DECL(pj_status_t) pjmedia_conf_distroy_port( pjmedia_port* port);
 #if !DEPRECATED_FOR_TICKET_2234
 /**
  * <i><b>Warning:</b> This API has been deprecated since 1.3 and will be

--- a/pjmedia/include/pjmedia/port.h
+++ b/pjmedia/include/pjmedia/port.h
@@ -231,7 +231,14 @@ typedef enum pjmedia_port_op
     /**
      * Enable TX and RX to/from this port.
      */
-    PJMEDIA_PORT_ENABLE
+    PJMEDIA_PORT_ENABLE,
+
+    /**
+     * Enable TX and RX to/from this port and invoke get_frame() and
+     * put_frame() even if there are no connections/listeners or non-
+     * silence audio frames respectively.
+     */
+    PJMEDIA_PORT_ENABLE_ALWAYS
 
 } pjmedia_port_op;
 

--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -413,6 +413,18 @@ PJ_DECL(pj_status_t) pjmedia_stream_resume(pjmedia_stream *stream,
 PJ_DECL(pj_status_t) pjmedia_stream_dial_dtmf(pjmedia_stream *stream,
                                               const pj_str_t *ascii_digit);
 
+/**
+ * Get the number of DTMF digits currently in the RFC 2833 transmit
+ * queue for this stream (valid only for audio streams).
+ *
+ * @param stream	The media stream.
+ * @param digits	Receives the number of queued digits.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_get_queued_dtmf_digits(pjmedia_stream *stream,
+					      unsigned *digits);
+
 
 /**
  * Check if the stream has incoming DTMF digits in the incoming DTMF

--- a/pjmedia/src/pjmedia/conf_switch.c
+++ b/pjmedia/src/pjmedia/conf_switch.c
@@ -1380,7 +1380,8 @@ static pj_status_t get_frame(pjmedia_port *this_port,
 
             while (pj_cmp_timestamp(&cport->ts_clock, &cport->ts_tx) > 0)
             {
-                if (cport->tx_setting == PJMEDIA_PORT_ENABLE) {
+		if ((cport->tx_setting == PJMEDIA_PORT_ENABLE) ||
+			(cport->tx_setting == PJMEDIA_PORT_ENABLE_ALWAYS)) {
                     pjmedia_frame tmp_f;
 
                     tmp_f.timestamp = cport->ts_tx;

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1028,20 +1028,6 @@ on_return:
     }
 	return status;
 }
-PJ_DEF(pj_status_t) pjmedia_conf_distroy_port( pjmedia_port* port)
-{
-
-    PJ_ASSERT_RETURN(port, PJ_EINVAL);
-    pj_status_t status = pjmedia_port_destroy(port);
-    if(status!=PJ_SUCCESS)
-    {
-        pj_perror_2( THIS_FILE,status, "pjmedia_conf_distroy_port::distroy port failed ");
-        return status;
-    }
-    PJ_LOG(4, (THIS_FILE, "pjmedia_conf_distroy_port::distroy port "));
-    return PJ_SUCCESS;
-
-}
 
 #if !DEPRECATED_FOR_TICKET_2234
 /*

--- a/pjmedia/src/pjmedia/null_port.c
+++ b/pjmedia/src/pjmedia/null_port.c
@@ -82,7 +82,11 @@ static pj_status_t null_get_frame(pjmedia_port *this_port,
 {
     frame->type = PJMEDIA_FRAME_TYPE_AUDIO;
     frame->size = PJMEDIA_PIA_AVG_FSZ(&this_port->info);
+#if PJ_HAS_INT64
+	frame->timestamp.u64 += PJMEDIA_PIA_SPF(&this_port->info);
+#else
     frame->timestamp.u32.lo += PJMEDIA_PIA_SPF(&this_port->info);
+#endif
     pjmedia_zero_samples((pj_int16_t*)frame->buf, 
                           PJMEDIA_PIA_SPF(&this_port->info));
 

--- a/pjmedia/src/pjmedia/silencedet.c
+++ b/pjmedia/src/pjmedia/silencedet.c
@@ -235,9 +235,11 @@ PJ_DEF(pj_bool_t) pjmedia_silence_det_apply( pjmedia_silence_det *sd,
                     /* Voiced for long time (>recalc_on_voiced), current 
                      * threshold seems to be too low.
                      */
+			unsigned old = sd->threshold;
                     sd->threshold = (avg_recent_level + sd->threshold) >> 1;
-                    TRACE_((THIS_FILE,"Re-adjust threshold (in talk burst)"
-                            "to %d", sd->threshold));
+			if (sd->threshold != old)
+				TRACE_((THIS_FILE,"%s re-adjust threshold (in talk burst) to %d (was %d)",
+					sd->objname, sd->threshold, old));
 
                     sd->voiced_timer = 0;
 
@@ -248,8 +250,8 @@ PJ_DEF(pj_bool_t) pjmedia_silence_det_apply( pjmedia_silence_det *sd,
                 break;
 
             case STATE_SILENCE:
-                TRACE_((THIS_FILE,"Starting talk burst (level=%d threshold=%d)",
-                        level, sd->threshold));
+		TRACE_((THIS_FILE,"%s starting talk burst (level=%d threshold=%d)",
+			sd->objname, level, sd->threshold));
 
             case STATE_START_SILENCE:
                 sd->state = STATE_VOICED;
@@ -271,9 +273,11 @@ PJ_DEF(pj_bool_t) pjmedia_silence_det_apply( pjmedia_silence_det *sd,
         switch(sd->state) {
             case STATE_SILENCE:
                 if (sd->silence_timer >= sd->recalc_on_silence) {
+			unsigned old = sd->threshold;
                     sd->threshold = avg_recent_level << 1;
-                    TRACE_((THIS_FILE,"Re-adjust threshold (in silence)"
-                            "to %d", sd->threshold));
+			if (sd->threshold != old)
+				TRACE_((THIS_FILE,"%s re-adjust threshold (in silence) to %d (was %d)",
+					sd->objname, sd->threshold, old));
 
                     sd->silence_timer = 0;
 
@@ -294,8 +298,8 @@ PJ_DEF(pj_bool_t) pjmedia_silence_det_apply( pjmedia_silence_det *sd,
                 if (sd->silence_timer >= sd->before_silence) {
                     sd->state = STATE_SILENCE;
                     sd->threshold = avg_recent_level << 1;
-                    TRACE_((THIS_FILE,"Starting silence (level=%d "
-                            "threshold=%d)", level, sd->threshold));
+		    TRACE_((THIS_FILE,"%s starting silence (level=%d threshold=%d)",
+				sd->objname, level, sd->threshold));
 
                     /* Reset sig_level */
                     sd->sum_level = avg_recent_level;
@@ -320,6 +324,9 @@ PJ_DEF(pj_bool_t) pjmedia_silence_det_detect( pjmedia_silence_det *sd,
 {
     pj_uint32_t level;
     
+	if (!p_level && (sd->mode == VAD_MODE_NONE))
+		return PJ_FALSE;
+
     /* Calculate average signal level. */
     level = pjmedia_calc_avg_signal(samples, count);
     

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -1453,11 +1453,6 @@ static pj_status_t put_frame_imp( pjmedia_port *port,
         silence_frame.timestamp.u32.lo = pj_ntohl(stream->enc->rtp.out_hdr.ts);
 
         /* Encode! */
-        if (!stream->codec)
-        {
-            PJ_PERROR(4,(stream->port.info.name.ptr, PJ_EINVAL,"stream codec is null"));
-            return PJ_EINVAL;
-        }
         status = pjmedia_codec_encode( stream->codec, &silence_frame,
                                        channel->out_pkt_size -
                                        sizeof(pjmedia_rtp_hdr),
@@ -1481,11 +1476,6 @@ static pj_status_t put_frame_imp( pjmedia_port *port,
                (frame->type == PJMEDIA_FRAME_TYPE_EXTENDED))
     {
         /* Encode! */
-        if (!stream->codec)
-        {
-            PJ_PERROR(4, (stream->port.info.name.ptr, PJ_EINVAL, "stream codec is null"));
-            return PJ_EINVAL;
-        }
         status = pjmedia_codec_encode( stream->codec, frame,
                                        channel->out_pkt_size -
                                        sizeof(pjmedia_rtp_hdr),

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7466,7 +7466,7 @@ PJ_DECL(pj_status_t) pjsua_enum_conf_ports(pjsua_conf_port_id id[],
 PJ_DECL(pj_status_t) pjsua_conf_get_port_info( pjsua_conf_port_id port_id,
                                                pjsua_conf_port_info *info);
 
-
+PJ_DEF(pj_status_t) pjsua_conf_distroy_port(pjmedia_port* port);
 /**
  * Add arbitrary media port to PJSUA's conference bridge. Application
  * can use this function to add the media port that it creates. For

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -380,7 +380,6 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #   define PJSUA_VID_REQ_KEYFRAME_INTERVAL      3000
 #endif
 
-
  /**
   * Specify whether timer heap events will be polled by a separate worker
   * thread. If this is set/enabled, a worker thread will be dedicated to
@@ -395,6 +394,7 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 #ifndef PJSUA_SEPARATE_WORKER_FOR_TIMER
 #   define PJSUA_SEPARATE_WORKER_FOR_TIMER      0
 #endif
+
 /**
  * Size of internal media port record buffer (in ms)
  */
@@ -2495,7 +2495,6 @@ PJ_DECL(pj_status_t) pjsua_create(void);
  * @return		PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_DECL(pj_status_t) pjsua_create2(const pjsua_logging_config *log_cfg);
- 
 
 /** Forward declaration */
 typedef struct pjsua_media_config pjsua_media_config;

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7465,8 +7465,6 @@ PJ_DECL(pj_status_t) pjsua_enum_conf_ports(pjsua_conf_port_id id[],
  */
 PJ_DECL(pj_status_t) pjsua_conf_get_port_info( pjsua_conf_port_id port_id,
                                                pjsua_conf_port_info *info);
-
-PJ_DEF(pj_status_t) pjsua_conf_distroy_port(pjmedia_port* port);
 /**
  * Add arbitrary media port to PJSUA's conference bridge. Application
  * can use this function to add the media port that it creates. For

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -173,6 +173,8 @@ struct pjsua_call
                                     /**< Is media update successful?        */
     pj_bool_t            hanging_up;/**< Is call in the process of hangup?  */
 
+
+    pjmedia_port* null_port; 
 	pjsua_conf_port_id conf_slot; /**< Slot # in conference bridge.    */
     int			 conf_idx; /**< Index of audio stream that was added to the conference.	    */
     int                  audio_idx; /**< First active audio media.          */

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -148,8 +148,6 @@ struct pjsua_call
     pjsua_call_setting   opt;       /**< Call setting.                      */
     pj_bool_t            opt_inited;/**< Initial call setting has been set,
                                          to avoid different opt in answer.  */
-	pjmedia_sdp_session *offer;		/* Unprocessed remote SDP received in
-									the initial INVITE for inbound calls */
     pjsip_inv_session   *inv;       /**< The invite session.                */
     void                *user_data; /**< User/application data.             */
     pjsip_status_code    last_code; /**< Last status code seen.             */

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -582,7 +582,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
         clear_all_responses(dd);
 
         /* Send 500 response */
-        status = pjsip_inv_end_session(dd->inv, 500, &reason, &tdata);
+        status = pjsip_inv_end_session(dd->inv, 504, &reason, &tdata);
         if (status == PJ_SUCCESS && tdata) {
             pjsip_dlg_send_response(dd->inv->dlg, 
                                     dd->inv->invite_tsx,
@@ -608,7 +608,10 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
             return;
         }
     } else {
+		if (dd->inv->invite_tsx)
         pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
+		else
+			pjsip_tx_data_dec_ref(tdata);
     }
 
     if (final) {

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -965,8 +965,8 @@ PJ_DEF(void) pjsip_dlg_dec_lock(pjsip_dialog *dlg)
 {
     PJ_ASSERT_ON_FAIL(dlg!=NULL, return);
 
-    PJ_LOG(6,(dlg->obj_name, "Entering pjsip_dlg_dec_lock(), sess_count=%d",
-              dlg->sess_count));
+    PJ_LOG(6,(dlg->obj_name, "Entering pjsip_dlg_dec_lock(), sess_count=%d, tsx_count=%d",
+	      dlg->sess_count, dlg->tsx_count));
 
     pj_assert(dlg->sess_count > 0);
     --dlg->sess_count;
@@ -1820,7 +1820,7 @@ static void dlg_update_routeset(pjsip_dialog *dlg, const pjsip_rx_data *rdata)
     //msg_cseq = rdata->msg_info.cseq->cseq;
 
     /* Ignore if route set has been frozen */
-    if (dlg->route_set_frozen)
+     if (dlg->route_set_frozen)
         return;
 
     /* Ignore if the message is an UPDATE response (see ticket #1781) */

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -1952,6 +1952,7 @@ static void send_msg_callback( pjsip_send_state *send_state,
             tsx_update_transport(tsx, send_state->cur_transport);
 
             /* Update remote address. */
+		pj_assert(tdata->dest_info.cur_addr < _countof(tdata->dest_info.addr.entry));
             tsx->addr_len = tdata->dest_info.addr.entry[tdata->dest_info.cur_addr].addr_len;
             pj_memcpy(&tsx->addr, 
                       &tdata->dest_info.addr.entry[tdata->dest_info.cur_addr].addr,
@@ -2378,6 +2379,7 @@ PJ_DEF(pj_status_t) pjsip_tsx_retransmit_no_state(pjsip_transaction *tsx,
 {
     pj_status_t status;
 
+	if (tsx) {
     pj_grp_lock_acquire(tsx->grp_lock);
     if (tdata == NULL) {
         tdata = tsx->last_tx;
@@ -2392,7 +2394,11 @@ PJ_DEF(pj_status_t) pjsip_tsx_retransmit_no_state(pjsip_transaction *tsx,
     if (status == PJ_SUCCESS) {
         pjsip_tx_data_dec_ref(tdata);
     }
-
+	} else {
+		status = PJ_EBUG;
+		if (tdata)
+			pjsip_tx_data_dec_ref(tdata);
+	}
     return status;
 }
 

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -474,7 +474,7 @@ PJ_DEF(pj_status_t) pjsip_tx_data_create( pjsip_tpmgr *mgr,
 
     PJ_ASSERT_RETURN(mgr && p_tdata, PJ_EINVAL);
 
-    pool = pjsip_endpt_create_pool( mgr->endpt, "tdta%Ix",
+    pool = pjsip_endpt_create_pool( mgr->endpt, "tdta%p",
                                     PJSIP_POOL_LEN_TDATA,
                                     PJSIP_POOL_INC_TDATA );
     if (!pool)
@@ -492,8 +492,8 @@ PJ_DEF(pj_status_t) pjsip_tx_data_create( pjsip_tpmgr *mgr,
         return status;
     }
     
-    //status = pj_lock_create_simple_mutex(pool, "tdta%Ix", &tdata->lock);
-    status = pj_lock_create_null_mutex(pool, "tdta%Ix", &tdata->lock);
+    //status = pj_lock_create_simple_mutex(pool, "tdta%p", &tdata->lock);
+    status = pj_lock_create_null_mutex(pool, "tdta%p", &tdata->lock);
     if (status != PJ_SUCCESS) {
         pjsip_endpt_release_pool( mgr->endpt, tdata->pool );
         return status;
@@ -767,7 +767,7 @@ PJ_DEF(char*) pjsip_rx_data_get_info(pjsip_rx_data *rdata)
         return rdata->msg_info.info;
 
     pj_ansi_strcpy(obj_name, "rdata");
-    pj_ansi_snprintf(obj_name+5, sizeof(obj_name)-5, "%Ix", rdata);
+    pj_ansi_snprintf(obj_name+5, sizeof(obj_name)-5, "%p", rdata);
 
     rdata->msg_info.info = get_msg_info(rdata->tp_info.pool, obj_name,
                                         rdata->msg_info.msg);
@@ -786,7 +786,7 @@ PJ_DEF(pj_status_t) pjsip_rx_data_clone( const pjsip_rx_data *src,
     PJ_ASSERT_RETURN(src && flags==0 && p_rdata, PJ_EINVAL);
 
     pool = pj_pool_create(src->tp_info.pool->factory,
-                          "rtd%Ix",
+                          "rtd%p",
                           PJSIP_POOL_RDATA_LEN,
                           PJSIP_POOL_RDATA_INC,
                           NULL);
@@ -1605,7 +1605,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_create( pj_pool_t *pool,
     if (!mgr->table)
         return PJ_ENOMEM;
 
-    status = pj_lock_create_recursive_mutex(pool, "tmgr%Ix", &mgr->lock);
+    status = pj_lock_create_recursive_mutex(pool, "tmgr%p", &mgr->lock);
     if (status != PJ_SUCCESS)
         return status;
 

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1227,7 +1227,8 @@ static void stateless_send_transport_cb( void *token,
 
             if (tdata->via_addr.host.slen > 0 &&
                 (!tdata->via_tp ||
-                 tdata->via_tp == (void *)stateless_data->cur_transport))
+                 tdata->via_tp == (void *)stateless_data->cur_transport||
+		 tdata->msg->line.req.method.id == PJSIP_CANCEL_METHOD))
             {
                 via->sent_by = tdata->via_addr;
 

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1366,7 +1366,6 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
                         (unsigned*)&call_med->strm.a.conf_slot);
                     if (status != PJ_SUCCESS)
                         goto on_return;
-                    PJ_LOG(4, (THIS_FILE, "pjsua_aud_channel_update::pjmedia_conf_add_port [call_med->strm.a.conf_slot:%d]", call_med->strm.a.conf_slot));
                 }
                     if (call->conf_slot == PJSUA_INVALID_ID)
                         call->conf_slot = call_med->strm.a.conf_slot;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1499,11 +1499,6 @@ PJ_DEF(pj_status_t) pjsua_conf_get_port_info( pjsua_conf_port_id id,
 
     return PJ_SUCCESS;
 }
-PJ_DEF(pj_status_t) pjsua_conf_distroy_port( pjmedia_port* port)
-{
-    return pjmedia_conf_distroy_port( port);
-}
-
 /*
  * Add arbitrary media port to PJSUA's conference bridge.
  */

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -23,6 +23,30 @@
 
 #define THIS_FILE               "pjsua_aud.c"
 
+#define SIGNATURE	PJMEDIA_SIG_CLASS_PORT_AUD('A','P')
+
+#define NORMAL_LEVEL		128
+
+ /* These are settings to control the adaptivity of changes in the
+ * signal level of the ports, so that sudden change in signal level
+ * in the port does not cause misaligned signal (which causes noise).
+ */
+#define ATTACK_A			(pjsua_var.media_cfg.clock_rate / pjsua_var.mconf_cfg.samples_per_frame)
+#define ATTACK_B			1
+#define DECAY_A				0
+#define DECAY_B				1
+
+#define SIMPLE_AGC(last, target) \
+	if (target >= last) \
+		target = (ATTACK_A*(last+1)+ATTACK_B*target)/(ATTACK_A+ATTACK_B); \
+	else \
+		target = (DECAY_A*last+DECAY_B*target)/(DECAY_A+DECAY_B)
+
+#define MAX_LEVEL			(32767)
+#define MIN_LEVEL			(-32768)
+
+#define IS_OVERFLOW(s)		(((s) > MAX_LEVEL) || ((s) < MIN_LEVEL))
+
 /*****************************************************************************
  *
  * Prototypes
@@ -40,6 +64,9 @@ static pj_status_t create_aud_param(pjmedia_aud_param *param,
                                     unsigned samples_per_frame,
                                     unsigned bits_per_sample,
                                     pj_bool_t use_default_settings);
+static pj_status_t mport_put_frame(pjmedia_port *this_port, pjmedia_frame *frame);
+static pj_status_t mport_get_frame(pjmedia_port *this_port, pjmedia_frame *frame);
+static pj_status_t mport_on_destroy(pjmedia_port *this_port);
 
 /*****************************************************************************
  *
@@ -77,9 +104,21 @@ PJ_DEF(pjsua_conf_port_id) pjsua_call_get_conf_port(pjsua_call_id call_id)
         goto on_return;
 
     call = &pjsua_var.calls[call_id];
-    if (call->audio_idx >= 0)
-        port_id = call->media[call->audio_idx].strm.a.conf_slot;
-
+	port_id = (call->conf_slot != PJSUA_INVALID_ID) ? call->conf_slot : (call->audio_idx >= 0) ? call->media[call->audio_idx].strm.a.conf_slot : PJSUA_INVALID_ID;
+    if (port_id != PJSUA_INVALID_ID)
+    {
+        goto on_return;
+    }
+    for (int mi = 0;(unsigned) mi < call->med_cnt; ++mi) {
+        pjsua_call_media* call_med = &call->media[mi];
+        if(call_med->strm.a.conf_slot == PJSUA_INVALID_ID || mi== call->audio_idx)
+        {
+            continue;
+        }
+        call->conf_slot = call_med->strm.a.conf_slot;
+        call->audio_idx= mi;
+        port_id = call->conf_slot;
+    }
 on_return:
     PJSUA_UNLOCK();
 
@@ -263,11 +302,435 @@ on_return:
     return status;
 }
 
+PJ_DEF(pj_status_t) pjsua_call_get_queued_dtmf_digits(pjsua_call_id call_id,
+	unsigned *digits)
+{
+	pjsua_call *call;
+	pjsip_dialog *dlg = NULL;
+	pj_status_t status;
+
+	PJ_ASSERT_RETURN(digits, PJ_EINVAL);
+	*digits = 0U;
+	PJ_ASSERT_RETURN(call_id>=0 && call_id<(int)pjsua_var.ua_cfg.max_calls,
+			PJ_EINVAL);
+
+	pj_log_push_indent();
+
+	status = acquire_call("pjsua_call_get_queued_dtmf_digits()", call_id, &call, &dlg);
+	if (status != PJ_SUCCESS)
+		goto on_return;
+
+	if (!pjsua_call_has_media(call_id)) {
+		PJ_LOG(3,(THIS_FILE, "Media is not established yet!"));
+		status = PJ_EINVALIDOP;
+		goto on_return;
+	}
+
+	status = pjmedia_get_queued_dtmf_digits(
+		call->media[call->audio_idx].strm.a.stream, digits);
+
+on_return:
+	if (dlg) pjsip_dlg_dec_lock(dlg);
+	pj_log_pop_indent();
+	return status;
+}
+
 
 /*****************************************************************************
  *
  * Audio media with PJMEDIA backend
  */
+
+static void mport_rec_frame(pjsua_mport_data *data, pjmedia_frame *frame)
+{
+	pj_size_t size, avl, count;
+	pj_bool_t is_silence = PJ_FALSE;
+	pj_size_t silence_samples = 0;
+	pj_int16_t *buf = (pj_int16_t *)frame->buf;
+
+	if (data->record_data.status != PJSUA_REC_RUNNING)
+		return;
+
+	if (frame->type == PJMEDIA_FRAME_TYPE_NONE)
+	{
+		count = size = pjsua_var.mconf_cfg.samples_per_frame;
+		buf = (pj_int16_t *)_alloca(sizeof(*buf) * size);
+		pj_bzero(buf, sizeof(*buf) * size);
+	}
+	else
+	{
+		count = size = (frame->size >> 1);
+	}
+
+	pj_assert(data->record_data.buffer != NULL);
+
+	if (data->record_data.max_samples)
+	{
+		pj_assert(data->record_data.max_samples > data->record_data.samples_recorded);
+		avl = (pj_size_t)((pj_uint64_t)data->record_data.max_samples - data->record_data.samples_recorded);
+		if (count > avl)
+			count = avl;
+	}
+	if (data->record_data.max_duration)
+	{
+		pj_assert(data->record_data.max_duration > data->record_data.samples_seen);
+		avl = data->record_data.max_duration - (pj_size_t)data->record_data.samples_seen;
+		if (count > avl)
+			count = avl;
+	}
+	if ((data->record_data.max_silence || data->record_data.eliminate_silence) && data->record_data.vad)
+	{
+		is_silence = pjmedia_silence_det_detect(data->record_data.vad, (const pj_int16_t *)buf, size, NULL);
+		if (is_silence)
+		{
+			if (!data->record_data.is_silence)
+			{
+				data->record_data.is_silence = PJ_TRUE;
+				data->record_data.vad_timestamp = frame->timestamp;
+			}
+			else
+			{
+				pj_assert(frame->timestamp.u64 > data->record_data.vad_timestamp.u64);
+			}
+			silence_samples = (pj_size_t)(frame->timestamp.u64 - data->record_data.vad_timestamp.u64);
+			if (data->record_data.eliminate_silence)
+			{
+				if ((silence_samples + count) >= data->record_data.eliminate_silence)
+				{
+					count = 0;
+				}
+				else
+				{
+					avl = (data->record_data.eliminate_silence - silence_samples);
+					if (count > avl)
+						count = avl;
+				}
+			}
+			if (data->record_data.max_silence)
+			{
+				pj_assert(data->record_data.max_silence > silence_samples);
+				avl = silence_samples - data->record_data.max_silence;
+				if (count > avl)
+					count = avl;
+			}
+		}
+		else if (data->record_data.is_silence)
+		{
+			data->record_data.is_silence = PJ_FALSE;
+			data->record_data.vad_timestamp = frame->timestamp;
+		}
+	}
+
+	pj_assert(data->record_data.buffer->capacity >= data->record_data.buffer->len);
+	avl = (data->record_data.buffer->capacity - data->record_data.buffer->len);
+	if (count > avl)
+	{
+		if (!data->record_data.overrun)
+		{
+			PJ_LOG(3, (THIS_FILE, "Record buffer overrun for %s: avl=%lu, size=%lu", data->base.info.name.ptr, avl, size));
+			data->record_data.overrun = PJ_TRUE;
+		}
+		if ((data->base.info.fmt.type == PJMEDIA_TYPE_AUDIO) &&
+			(data->base.info.fmt.detail_type == PJMEDIA_FORMAT_DETAIL_AUDIO) &&
+			(data->base.info.fmt.det.aud.channel_count > 1))
+		{
+			// Take account of block size and ensure that only complete blocks are buffered
+			count = avl % data->base.info.fmt.det.aud.channel_count;
+			if (!count)
+				count = avl;
+			else
+				count = avl - count;
+		}
+		else
+		{
+			count = avl;
+		}
+	}
+	if (count)
+	{
+		pjmedia_circ_buf_write(data->record_data.buffer, buf, (unsigned int)count);
+		data->record_data.samples_recorded += count;
+		avl -= count;
+	}
+	data->record_data.samples_seen += size;
+
+	do {
+		if (data->record_data.max_samples && (data->record_data.samples_recorded >= data->record_data.max_samples))
+		{
+			data->record_data.status = PJSUA_REC_STOPPING;
+			data->record_data.er = PJSUA_REC_ER_MAX_SAMPLES;
+			break;
+		}
+		if (data->record_data.max_duration && (data->record_data.samples_seen >= data->record_data.max_duration))
+		{
+			data->record_data.status = PJSUA_REC_STOPPING;
+			data->record_data.er = PJSUA_REC_ER_MAX_DURATION;
+			break;
+		}
+		if (data->record_data.max_silence && ((silence_samples + size) >= data->record_data.max_silence))
+		{
+			data->record_data.status = PJSUA_REC_STOPPING;
+			data->record_data.er = PJSUA_REC_ER_MAX_SILENCE;
+			break;
+		}
+	} while (0);
+
+	// Notify the application to collect the buffered data when the available space
+	// falls below the data threshold or if we've encountered a termination
+	// condition
+	if (!data->record_data.signaled &&
+		((avl < data->record_data.threshold) || (data->record_data.status == PJSUA_REC_STOPPING)))
+	{
+		data->record_data.signaled = PJ_TRUE;
+		pj_event_set(data->record_data.event);
+	}
+
+	if (data->record_data.status == PJSUA_REC_STOPPING)
+	{
+		if (data->record_data.rec_output)
+			pjmedia_conf_configure_port(pjsua_var.mconf, data->slot, PJMEDIA_PORT_NO_CHANGE, PJMEDIA_PORT_ENABLE);
+		else
+			pjmedia_conf_configure_port(pjsua_var.mconf, data->slot, PJMEDIA_PORT_ENABLE, PJMEDIA_PORT_NO_CHANGE);
+	}
+}
+
+static pj_status_t mport_put_frame(pjmedia_port *this_port, pjmedia_frame *frame)
+{
+	PJ_ASSERT_RETURN(this_port->info.signature == SIGNATURE, PJ_EINVALIDOP);
+
+	pjsua_mport_data *data = (pjsua_mport_data*) this_port;
+	if ((data->record_data.status == PJSUA_REC_RUNNING) &&
+		!data->record_data.rec_output)
+	{
+		pj_enter_critical_section();
+		mport_rec_frame(data, frame);
+		pj_leave_critical_section();
+	}
+
+	if ((frame->type == PJMEDIA_FRAME_TYPE_AUDIO) &&
+		(frame->size > 0U) &&
+		(data->listener_cnt > 0U))
+	{
+		const pj_size_t samples = frame->size >> 1;
+		pj_assert(samples == pjsua_var.mconf_cfg.samples_per_frame);
+		pj_enter_critical_section();
+		pj_assert(data->listeners != NULL);
+		for (register pj_uint32_t i = 0; i < data->listener_cnt; ++i)
+		{
+			const pjsua_mport_id id = data->listeners[i];
+			pjsua_mport_data *listener;
+			pj_int32_t *mix_buf;
+			pj_int16_t *buf;
+			pj_size_t j;
+			pj_assert((id >= 0) && (id < (pjsua_mport_id)pjsua_var.media_cfg.max_media_ports));
+			listener = &pjsua_var.mport[id];
+			mix_buf = listener->mix_buf;
+			buf = (pj_int16_t *)frame->buf;
+			if (listener->mix_cnt++ > 0)
+			{
+				for (j = 0; j < samples; ++j)
+				{
+					*mix_buf += *buf++;
+					if (IS_OVERFLOW(*mix_buf))
+					{
+						int tmp_adj = (MAX_LEVEL << 7) / *mix_buf;
+						if (tmp_adj < 0)
+							tmp_adj = -tmp_adj;
+						if (tmp_adj < listener->mix_adj)
+							listener->mix_adj = tmp_adj;
+					}
+					mix_buf++;
+				}
+			}
+			else
+			{
+				for (j = 0; j < samples; ++j)
+				{
+					*mix_buf++ = *buf++;
+				}
+			}
+		}
+		pj_leave_critical_section();
+	}
+
+	return PJ_SUCCESS;
+}
+
+static pj_status_t mport_get_frame(pjmedia_port *this_port, pjmedia_frame *frame)
+{
+	pjsua_mport_data *data;
+	pj_size_t i, size, avl, count;
+
+	PJ_ASSERT_RETURN(this_port->info.signature == SIGNATURE, PJ_EINVALIDOP);
+
+	data = (pjsua_mport_data*) this_port;
+
+	size = pjsua_var.mconf_cfg.samples_per_frame;
+
+	frame->timestamp.u64 = data->play_data.timestamp.u64;
+	data->play_data.timestamp.u64 += size;
+
+	pj_enter_critical_section();
+
+	if (data->play_data.status <= PJSUA_REP_IDLE)
+	{
+		frame->size = 0;
+		frame->type = PJMEDIA_FRAME_TYPE_NONE;
+	}
+	else if (data->play_data.status == PJSUA_REP_CONFERENCING)
+	{
+		if (data->mix_cnt)
+		{
+			pj_int16_t *buf = (pj_int16_t *)frame->buf;
+			SIMPLE_AGC(data->last_mix_adj, data->mix_adj);
+			data->last_mix_adj = data->mix_adj;
+			pj_assert(data->mix_buf != NULL);
+			if (data->mix_adj != NORMAL_LEVEL)
+			{
+				for (i = 0; i < size; ++i)
+				{
+					pj_int32_t s = data->mix_buf[i];
+					s = (s * data->mix_adj) >> 7;
+					if (s > MAX_LEVEL) s = MAX_LEVEL;
+					else if (s < MIN_LEVEL) s = MIN_LEVEL;
+					*buf++ = (pj_int16_t)s;
+				}
+				data->mix_adj = NORMAL_LEVEL;
+			}
+			else
+			{
+				for (i = 0; i < size; ++i)
+				{
+					*buf++ = (pj_int16_t)data->mix_buf[i];
+				}
+			}
+			data->mix_cnt = 0U;
+			frame->size = size << 1;
+			frame->type = PJMEDIA_FRAME_TYPE_AUDIO;
+		}
+		else
+		{
+			frame->size = 0;
+			frame->type = PJMEDIA_FRAME_TYPE_NONE;
+		}
+	}
+	else
+	{
+		pj_assert(data->play_data.buffer != NULL);
+		avl = data->play_data.buffer->len;
+		count = size;
+		if (count > avl)
+		{
+			if (!data->play_data.underrun && (avl || data->play_data.samples_played) && (data->play_data.status == PJSUA_REP_RUNNING))
+			{
+				PJ_LOG(3, (THIS_FILE, "Replay buffer underrun for %s: avl=%lu, size=%lu", this_port->info.name.ptr, avl, size));
+				data->play_data.underrun = PJ_TRUE;
+			}
+			count = avl;
+		}
+		if (count)
+		{
+			pjmedia_circ_buf_read(data->play_data.buffer, (pj_int16_t*)frame->buf, (unsigned int)count);
+			avl -= count;
+			data->play_data.samples_played += count;
+		}
+
+		// Pad with zeroes if necessary
+		if (count < size)
+			pj_bzero((pj_int16_t*)(frame->buf) + count, (size - count) << 1);
+
+		// Notify the application when the remaining data falls below the
+		// threshold or if the replay has completed
+		if (!data->play_data.signaled &&
+			(((data->play_data.status == PJSUA_REP_STOPPING) && !avl) ||
+			((data->play_data.status == PJSUA_REP_RUNNING) && (avl < data->play_data.threshold))))
+		{
+			data->play_data.signaled = PJ_TRUE;
+			pj_event_set(data->play_data.event);
+		}
+
+		frame->size = size << 1;
+		frame->type = PJMEDIA_FRAME_TYPE_AUDIO;
+	}
+
+	if ((data->record_data.status == PJSUA_REC_RUNNING) &&
+		data->record_data.rec_output)
+		mport_rec_frame(data, frame);
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+
+static pj_status_t mport_on_destroy(pjmedia_port *this_port)
+{
+	pjsua_mport_data *data;
+
+	PJ_ASSERT_RETURN(this_port->info.signature == SIGNATURE, PJ_EINVALIDOP);
+
+	data = (pjsua_mport_data*) this_port;
+
+	pj_enter_critical_section();
+
+	if (data->record_data.buffer)
+		pjmedia_circ_buf_reset(data->record_data.buffer);
+	if (data->record_data.status == PJSUA_REC_RUNNING)
+		data->record_data.status = PJSUA_REC_STOPPING;
+	if ((data->record_data.status != PJSUA_REC_IDLE) && !data->record_data.signaled && data->record_data.event)
+	{
+		data->record_data.signaled = PJ_TRUE;
+		pj_event_set(data->record_data.event);
+	}
+
+	if (data->play_data.buffer)
+		pjmedia_circ_buf_reset(data->play_data.buffer);
+	if (data->play_data.status == PJSUA_REP_RUNNING)
+		data->play_data.status = PJSUA_REP_STOPPING;
+	if ((data->play_data.status == PJSUA_REP_STOPPING) && !data->play_data.signaled && data->play_data.event)
+	{
+		data->play_data.signaled = PJ_TRUE;
+		pj_event_set(data->play_data.event);
+	}
+
+	pj_leave_critical_section();
+
+	if (data->play_data.status == PJSUA_REP_CONFERENCING)
+		pjsua_mport_conf_stop((pjsua_mport_id)(data - pjsua_var.mport));
+
+	return PJ_SUCCESS;
+}
+
+static pj_status_t init_mport(pjsua_mport_id id)
+{
+	pj_status_t status;
+	char buf[PJ_MAX_OBJ_NAME];
+	pj_str_t name;
+	register pjsua_mport_data *p = &pjsua_var.mport[id];
+	//pj_bzero(p, sizeof(*p));
+	p->slot = PJSUA_INVALID_ID;
+	_snprintf(buf, sizeof(buf), "mp%d", id);
+	buf[sizeof(buf)-1] = '\0';
+	pj_strdup2_with_null(pjsua_var.pool, &name, buf);
+	status = pjmedia_port_info_init(&p->base.info, &name, SIGNATURE, pjsua_var.media_cfg.clock_rate,
+		pjsua_var.mconf_cfg.channel_count, pjsua_var.mconf_cfg.bits_per_sample, pjsua_var.mconf_cfg.samples_per_frame);
+	if (status == PJ_SUCCESS)
+	{
+		p->base.port_data.ldata = id;
+		p->base.put_frame = &mport_put_frame;
+		p->base.get_frame = &mport_get_frame;
+		p->base.on_destroy = &mport_on_destroy;
+	}
+	return status;
+}
+
+static void deinit_mport(pjsua_mport_id id)
+{
+	pjsua_mport_free(id);
+	register pjsua_mport_data *p = &pjsua_var.mport[id];
+	pjmedia_port_destroy(&p->base);
+	p->base.info.signature = 0;
+}
 
 /* Init pjmedia audio subsystem */
 pj_status_t pjsua_aud_subsys_init()
@@ -411,7 +874,32 @@ pj_status_t pjsua_aud_subsys_init()
                                       pjsua_var.mconf_cfg.samples_per_frame,
                                       pjsua_var.mconf_cfg.bits_per_sample,
                                       &pjsua_var.null_port);
-    PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);
+	if (status != PJ_SUCCESS)
+	{
+		pjsua_perror(THIS_FILE, "Error creating null port", status);
+		goto on_error;
+	}
+
+	/* Initialise the media ports */
+	pjsua_var.mport_cnt = 0U;
+	pjsua_var.mport_id = -1;
+	pjsua_var.mport = (pjsua_mport_data*)pj_pool_zalloc(pjsua_var.pool, sizeof(pjsua_mport_data) * pjsua_var.media_cfg.max_media_ports);
+	if (!pjsua_var.mport)
+	{
+		status = PJ_ENOMEM;
+		pjsua_perror(THIS_FILE, "Error allocating media ports", status);
+		goto on_error;
+	}
+
+	/* Init media port array. */
+	for (unsigned i = 0u; i < pjsua_var.media_cfg.max_media_ports; ++i)
+	{
+		status = init_mport(i);
+		if (status != PJ_SUCCESS) {
+			pjsua_perror(THIS_FILE, "Error initialising media port", status);
+			goto on_error;
+		}
+	}
 
     return status;
 
@@ -507,6 +995,14 @@ pj_status_t pjsua_aud_subsys_destroy()
 {
     unsigned i;
 
+	if (pjsua_var.mport != NULL)
+	{
+		for (i = 0U; i < pjsua_var.media_cfg.max_media_ports; ++i)
+			deinit_mport(i);
+		pjsua_var.mport = NULL;
+	}
+	pjsua_var.mport_cnt = 0U;
+
     close_snd_dev();
 
     /* Destroy file players */
@@ -540,6 +1036,21 @@ pj_status_t pjsua_aud_subsys_destroy()
     return PJ_SUCCESS;
 }
 
+void remove_conf_port(pjsua_conf_port_id* id)
+{
+    if (pjsua_var.mconf) {
+        if (pjsua_conf_remove_port(*id) == PJ_SUCCESS)
+        {
+            PJ_LOG(4, (THIS_FILE, "pjsua_conf_remove_port done id: %d", *id));
+        }
+        else
+        {
+            PJ_LOG(2, (THIS_FILE, "pjsua_conf_remove_port failed"));
+        }
+    }
+    *id = PJSUA_INVALID_ID;
+}
+
 void pjsua_aud_stop_stream(pjsua_call_media *call_med)
 {
     pjmedia_stream *strm = call_med->strm.a.stream;
@@ -552,12 +1063,16 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
         pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med, strm);
 
         pjmedia_stream_send_rtcp_bye(strm);
-
-        if (call_med->strm.a.conf_slot != PJSUA_INVALID_ID) {
-            if (pjsua_var.mconf) {
-                pjsua_conf_remove_port(call_med->strm.a.conf_slot);
-            }
-            call_med->strm.a.conf_slot = PJSUA_INVALID_ID;
+        pjsua_call* call = call_med->call;
+        if(call_med->strm.a.conf_slot != PJSUA_INVALID_ID )
+        {
+            if (call->conf_slot == call_med->strm.a.conf_slot)
+                call->conf_slot = PJSUA_INVALID_ID;
+            remove_conf_port(&call_med->strm.a.conf_slot);
+        }
+        else
+        {
+            PJ_LOG(4, (THIS_FILE, "pjsua_aud_stop_stream::stream is invalid"));
         }
 
         /* Don't check for direction and transmitted packets count as we
@@ -592,7 +1107,6 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
                 pjmedia_port_destroy(call_med->strm.a.media_port);
             call_med->strm.a.media_port = NULL;
         }
-
         pjmedia_stream_destroy(strm);
         call_med->strm.a.stream = NULL;
     }
@@ -662,7 +1176,19 @@ static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
 
     pj_log_pop_indent();
 }
-
+pj_bool_t compare_port_signature(pjsua_conf_port_id conf_slot, pj_uint32_t signature)
+{
+    if (conf_slot == PJSUA_INVALID_ID)
+    {
+        return PJ_FALSE;
+    }
+    pjmedia_port_info port_info;
+    if(pjmedia_conf_get_media_port_info(pjsua_var.mconf, conf_slot, &port_info)!=PJ_SUCCESS)
+    {
+        return PJ_FALSE;
+    }
+    return port_info.signature == signature;
+}
 /* Internal function: update audio channel after SDP negotiation.
  * Warning: do not use temporary/flip-flop pool, e.g: inv->pool_prov,
  *          for creating stream, etc, as after SDP negotiation and when
@@ -683,7 +1209,8 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
     PJ_UNUSED_ARG(local_sdp);
     PJ_UNUSED_ARG(remote_sdp);
 
-    PJ_LOG(4,(THIS_FILE,"Audio channel update.."));
+    PJ_LOG(4,(THIS_FILE,"Audio channel update for index %d for call %d...",
+		call_med->idx, call_med->call->index));
     pj_log_push_indent();
 
     si->rtcp_sdes_bye_disabled = pjsua_var.media_cfg.no_rtcp_sdes_bye;
@@ -802,30 +1329,73 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
                                                   &call_med->strm.a.media_port);
         }
 
-        /*
-         * Add the call to conference bridge.
-         */
-        {
-            char tmp[PJSIP_MAX_URL_SIZE];
-            pj_str_t port_name;
+        if ((call->audio_idx == -1) || ((unsigned)call->audio_idx == strm_idx))
+		{
+			if (call_med->strm.a.conf_slot == PJSUA_INVALID_ID)
+			{
+            /*
+             * Add the stream to conference bridge.
+             */
+                char tmp[PJSIP_MAX_URL_SIZE];
+                pj_str_t port_name;
 
-            port_name.ptr = tmp;
-            port_name.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
-                                             call->inv->dlg->remote.info->uri,
-                                             tmp, sizeof(tmp));
-            if (port_name.slen < 1) {
-                port_name = pj_str("call");
+                port_name.ptr = tmp;
+                port_name.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
+                                                 call->inv->dlg->remote.info->uri,
+                                                 tmp, sizeof(tmp));
+                if (port_name.slen < 1) {
+                    port_name = pj_str("call");
+                }          
+                if (compare_port_signature(call->conf_slot, PJMEDIA_SIG_PORT_NULL))
+                {
+                    status = pjmedia_conf_replace_port(pjsua_var.mconf,
+                        call->inv->pool,
+                        call_med->strm.a.media_port,
+                        (unsigned)call->conf_slot);
+                    if (status != PJ_SUCCESS)
+                        goto on_return;
+                    call_med->strm.a.conf_slot= call->conf_slot;
+                    PJ_LOG(4, (THIS_FILE, "pjsua_aud_channel_update::pjmedia_conf_replace_port [call->conf_slot:%d]", call->conf_slot));
+                }
+                else
+                {
+                    status = pjmedia_conf_add_port(pjsua_var.mconf,
+                        call->inv->pool,
+                        call_med->strm.a.media_port,
+                        &port_name,
+                        (unsigned*)&call_med->strm.a.conf_slot);
+                    if (status != PJ_SUCCESS)
+                        goto on_return;
+                    PJ_LOG(4, (THIS_FILE, "pjsua_aud_channel_update::pjmedia_conf_add_port [call_med->strm.a.conf_slot:%d]", call_med->strm.a.conf_slot));
+                }
+                    if (call->conf_slot == PJSUA_INVALID_ID)
+                        call->conf_slot = call_med->strm.a.conf_slot;
+                
+			}
+			else
+			{
+				/*
+				 * Replace the old/null port in the conference bridge.
+				 */
+				status = pjmedia_conf_replace_port(pjsua_var.mconf,
+					call->inv->pool,
+					call_med->strm.a.media_port,
+					(unsigned)call_med->strm.a.conf_slot);
+				if (status != PJ_SUCCESS)
+					goto on_return;
+                PJ_LOG(4, (THIS_FILE, "pjsua_aud_channel_update::pjmedia_conf_replace_port [call_med->strm.a.conf_slot:%d]", call_med->strm.a.conf_slot));
             }
-            status = pjmedia_conf_add_port(pjsua_var.mconf,
-                                           call->inv->pool,
-                                           call_med->strm.a.media_port,
-                                           &port_name,
-                                           (unsigned*)
-                                           &call_med->strm.a.conf_slot);
-            if (status != PJ_SUCCESS) {
-                goto on_return;
-            }
-        }
+			if (call->audio_idx == -1)
+				call->audio_idx = (int)strm_idx;
+			call->conf_idx = call->audio_idx;
+		}
+		else
+		{
+			PJ_LOG(2, (THIS_FILE, "Ignoring audio channel update for index %d for call %d because the selected index is %d!",
+				call_med->idx, call_med->call->index, call->audio_idx));
+				goto on_return;
+		}
+
 
         /* Subscribe to stream events */
         pjmedia_event_subscribe(NULL, &call_media_on_event, call_med,
@@ -834,6 +1404,8 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
 
 on_return:
     pj_log_pop_indent();
+    if (status != PJ_SUCCESS)
+        PJ_LOG(2, (THIS_FILE, "pjsua_aud_channel_update failed"));
     return status;
 }
 
@@ -864,11 +1436,10 @@ PJ_DEF(unsigned) pjsua_conf_get_max_ports(void)
  */
 PJ_DEF(unsigned) pjsua_conf_get_active_ports(void)
 {
-    unsigned ports[PJSUA_MAX_CONF_PORTS];
-    unsigned count = PJ_ARRAY_SIZE(ports);
+	unsigned count = pjsua_var.media_cfg.max_media_ports;
     pj_status_t status;
 
-    status = pjmedia_conf_enum_ports(pjsua_var.mconf, ports, &count);
+	status = pjmedia_conf_enum_ports(pjsua_var.mconf, NULL, &count);
     if (status != PJ_SUCCESS)
         count = 0;
 
@@ -915,7 +1486,7 @@ PJ_DEF(pj_status_t) pjsua_conf_get_port_info( pjsua_conf_port_id id,
 
     /* Build array of listeners */
     info->listener_cnt = cinfo.listener_cnt;
-    for (i=0; i<cinfo.listener_cnt; ++i) {
+    for (i=0; i<cinfo.listener_cnt && i < PJ_ARRAY_SIZE(info->listeners); ++i) {
         info->listeners[i] = cinfo.listener_slots[i];
     }
 
@@ -1706,6 +2277,1371 @@ PJ_DEF(pj_status_t) pjsua_recorder_destroy(pjsua_recorder_id id)
     return PJ_SUCCESS;
 }
 
+/*****************************************************************************
+ * Media port
+ */
+
+PJ_DEF(pj_status_t) pjsua_mport_alloc(pjmedia_dir dir,
+	pj_bool_t enable_vad, pj_size_t record_buffer_size,
+	pj_size_t record_data_threshold, pj_size_t play_buffer_size,
+	pj_size_t play_data_threshold, pjsua_mport_id *p_id)
+{
+	char name[PJ_MAX_OBJ_NAME];
+
+	if ((dir != PJMEDIA_DIR_CAPTURE) && (dir != PJMEDIA_DIR_PLAYBACK) &&
+		(dir != PJMEDIA_DIR_CAPTURE_PLAYBACK))
+		return PJ_EINVAL;
+
+	PJSUA_LOCK();
+
+	if (pjsua_var.mport_cnt >= pjsua_var.media_cfg.max_media_ports)
+	{
+		PJSUA_UNLOCK();
+		return PJ_ETOOMANY;
+	}
+
+	unsigned int id;
+	for (id = 0; id<pjsua_var.media_cfg.max_media_ports; ++id)
+	{
+		register unsigned int tmp = id + pjsua_var.mport_id + 1;
+		if (tmp >= pjsua_var.media_cfg.max_media_ports)
+			tmp -= pjsua_var.media_cfg.max_media_ports;
+		if (pjsua_var.mport[tmp].slot == PJSUA_INVALID_ID)
+		{
+			pjsua_var.mport_id = id = tmp;
+			break;
+		}
+	}
+	if (id == pjsua_var.media_cfg.max_media_ports)
+	{
+		/* This is unexpected */
+		pj_assert(0);
+		PJSUA_UNLOCK();
+		return PJ_EBUG;
+	}
+
+	pj_log_push_indent();
+
+	pj_status_t status = PJ_SUCCESS;
+	register pjsua_mport_data *const p = &pjsua_var.mport[id];
+	p->pool = pjsua_pool_create(p->base.info.name.ptr, 1000, 1000);
+	if (p->pool == NULL)
+	{
+		status = PJ_ENOMEM;
+		goto on_error;
+	}
+
+	name[sizeof(name) - 1] = '\0';
+
+	p->listener_cnt = p->participant_cnt = 0U;
+	p->listeners = p->participants = NULL;
+	p->mix_buf = NULL;
+	p->last_mix_adj = p->mix_adj = NORMAL_LEVEL;
+
+	p->record_data.vad = NULL;
+	p->record_data.buffer_size = 0U;
+	p->record_data.buffer = NULL;
+	p->record_data.event = NULL;
+	p->record_data.signaled = PJ_FALSE;
+	p->record_data.status = PJSUA_REC_IDLE;
+	if (dir & PJMEDIA_DIR_CAPTURE)
+	{
+		if (enable_vad)
+		{
+			status = pjmedia_silence_det_create(p->pool, pjsua_var.media_cfg.clock_rate, pjsua_var.mconf_cfg.samples_per_frame, &p->record_data.vad);
+			if (status != PJ_SUCCESS)
+				goto on_error;
+			status = pjmedia_silence_det_set_name(p->record_data.vad, p->base.info.name.ptr);
+		}
+		if (!record_buffer_size)
+		{
+			record_buffer_size = pjsua_var.media_cfg.mport_record_buffer_size;
+			if (!record_buffer_size)
+				record_buffer_size = 1250;
+		}
+		if (record_buffer_size < 40)
+			record_buffer_size = 40;
+		else if (record_buffer_size > 5000)
+			record_buffer_size = 5000;
+		record_buffer_size = ((record_buffer_size + (pjsua_var.media_cfg.audio_frame_ptime - 1)) / pjsua_var.media_cfg.audio_frame_ptime);
+		p->record_data.buffer_size = record_buffer_size * pjsua_var.mconf_cfg.samples_per_frame;
+		_snprintf(name, sizeof(name)-1, "mp_rec%d", id);
+		status = pj_event_create(p->pool, name, PJ_TRUE, PJ_FALSE, &p->record_data.event);
+		if (status != PJ_SUCCESS)
+			goto on_error;
+		if (!record_data_threshold)
+			record_data_threshold = 250;
+		record_data_threshold = ((record_data_threshold + (pjsua_var.media_cfg.audio_frame_ptime - 1)) / pjsua_var.media_cfg.audio_frame_ptime);
+		if (record_data_threshold > record_buffer_size)
+			record_data_threshold = record_buffer_size;
+		p->record_data.threshold = record_data_threshold * pjsua_var.mconf_cfg.samples_per_frame;
+		_snprintf(name, sizeof(name)-1, "mp_rgn%d", id);
+		status = pj_event_create(p->pool, name, PJ_TRUE, PJ_FALSE, &p->recogntion_data.event);
+		if (status != PJ_SUCCESS)
+			goto on_error;
+	}
+
+	p->play_data.buffer_size = 0U;
+	p->play_data.timestamp.u64 = 0;
+	p->play_data.buffer = NULL;
+	p->play_data.event = NULL;
+	p->play_data.signaled = PJ_FALSE;
+	p->play_data.status = PJSUA_REP_IDLE;
+	if (dir & PJMEDIA_DIR_PLAYBACK)
+	{
+		if (!play_buffer_size)
+		{
+			play_buffer_size = pjsua_var.media_cfg.mport_replay_buffer_size;
+			if (!play_buffer_size)
+				play_buffer_size = 1250;
+		}
+		if (play_buffer_size < 40)
+			play_buffer_size = 40;
+		else if (play_buffer_size > 5000)
+			play_buffer_size = 5000;
+		play_buffer_size = ((play_buffer_size + (pjsua_var.media_cfg.audio_frame_ptime - 1)) / pjsua_var.media_cfg.audio_frame_ptime);
+		p->play_data.buffer_size = play_buffer_size * pjsua_var.mconf_cfg.samples_per_frame;
+		_snprintf(name, sizeof(name)-1, "mp_pla%d", id);
+		status = pj_event_create(p->pool, name, PJ_TRUE, PJ_FALSE, &p->play_data.event);
+		if (status != PJ_SUCCESS)
+			goto on_error;
+		if (!play_data_threshold)
+			play_data_threshold = 250;
+		play_data_threshold = ((play_data_threshold + (pjsua_var.media_cfg.audio_frame_ptime - 1)) / pjsua_var.media_cfg.audio_frame_ptime);
+		if (play_data_threshold > play_buffer_size)
+			play_data_threshold = play_buffer_size;
+		p->play_data.threshold = play_data_threshold * pjsua_var.mconf_cfg.samples_per_frame;
+	}
+
+	status = pjsua_conf_add_port(p->pool, &p->base, &p->slot);
+	if (status != PJ_SUCCESS)
+	{
+		pjsua_perror(THIS_FILE, "Unable to add media port to conference bridge", status);
+		goto on_error;
+	}
+
+	p->base.info.dir = dir;
+
+	++pjsua_var.mport_cnt;
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4,(THIS_FILE, "Media port %d allocated: slot=%d", id, p->slot));
+
+	if (p_id)
+		*p_id = id;
+
+	pj_log_pop_indent();
+	return PJ_SUCCESS;
+
+on_error:
+	p->listeners = p->participants = NULL;
+	p->mix_buf = NULL;
+	if (p->recogntion_data.event != NULL)
+	{
+		pj_event_destroy(p->recogntion_data.event);
+		p->recogntion_data.event = NULL;
+	}
+	if (p->record_data.event != NULL)
+	{
+		pj_event_destroy(p->record_data.event);
+		p->record_data.event = NULL;
+	}
+	p->record_data.vad = NULL;
+	p->record_data.buffer = NULL;
+	if (p->play_data.event != NULL)
+	{
+		pj_event_destroy(p->play_data.event);
+		p->play_data.event = NULL;
+	}
+	p->play_data.buffer = NULL;
+	if (p->pool != NULL)
+	{
+		pj_pool_release(p->pool);
+		p->pool = NULL;
+	}
+	p->base.info.dir = PJMEDIA_DIR_NONE;
+	p->slot = PJSUA_INVALID_ID;
+	PJSUA_UNLOCK();
+	pj_log_pop_indent();
+	return status;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_free(pjsua_mport_id id)
+{
+	if ((id < 0) || ((unsigned int)id >= pjsua_var.media_cfg.max_media_ports))
+	{
+		pj_assert(0);
+		return PJ_EINVAL;
+	}
+
+	PJSUA_LOCK();
+
+	pjsua_mport_data *p = &pjsua_var.mport[id];
+
+	if (!p->pool)
+	{
+		PJSUA_UNLOCK();
+		return PJ_SUCCESS;
+	}
+
+	pjsua_mport_conf_stop(id);
+	while (p->listener_cnt > 0)
+		pjsua_mport_conf_remove(p->listeners[p->listener_cnt - 1], id);
+
+	pj_enter_critical_section();
+
+	p->listeners = p->participants = NULL;
+	p->mix_buf = NULL;
+
+	if (p->recogntion_data.event_cnt > 0U)
+	{
+		if (p->recogntion_data.signaled)
+		{
+			p->recogntion_data.signaled = PJ_FALSE;
+			pj_event_reset(p->recogntion_data.event);
+		}
+		p->recogntion_data.event_cnt = 0U;
+	}
+	if (p->record_data.buffer)
+	{
+		pjmedia_circ_buf_reset(p->record_data.buffer);
+		p->record_data.buffer = NULL;
+	}
+	if (p->record_data.status != PJSUA_REC_IDLE)
+	{
+		if ((p->record_data.event != NULL) &&
+			!p->record_data.signaled)
+		{
+			p->record_data.signaled = PJ_TRUE;
+			pj_event_set(p->record_data.event);
+		}
+		p->record_data.status = PJSUA_REC_IDLE;
+	}
+	p->record_data.vad = NULL;
+
+	if (p->play_data.buffer)
+	{
+		pjmedia_circ_buf_reset(p->play_data.buffer);
+		p->play_data.buffer = NULL;
+	}
+	if (p->play_data.status != PJSUA_REP_IDLE)
+	{
+		if ((p->play_data.status != PJSUA_REP_CONFERENCING) &&
+			(p->play_data.event != NULL) &&
+			!p->play_data.signaled)
+		{
+			p->play_data.signaled = PJ_TRUE;
+			pj_event_set(p->play_data.event);
+		}
+		p->play_data.status = PJSUA_REP_IDLE;
+	}
+
+	pj_leave_critical_section();
+
+	if (p->slot != PJSUA_INVALID_ID)
+	{
+		pjsua_conf_remove_port(p->slot);
+		p->slot = PJSUA_INVALID_ID;
+	}
+
+	if (p->recogntion_data.event != NULL)
+	{
+		pj_event_destroy(p->recogntion_data.event);
+		p->recogntion_data.event = NULL;
+		p->recogntion_data.signaled = PJ_FALSE;
+	}
+
+	if (p->record_data.event != NULL)
+	{
+		pj_event_destroy(p->record_data.event);
+		p->record_data.event = NULL;
+		p->record_data.signaled = PJ_FALSE;
+	}
+
+	if (p->play_data.event != NULL)
+	{
+		pj_event_destroy(p->play_data.event);
+		p->play_data.event = NULL;
+		p->play_data.signaled = PJ_FALSE;
+	}
+
+	if (p->pool != NULL)
+	{
+		pj_pool_release(p->pool);
+		p->pool = NULL;
+	}
+
+	p->base.info.dir = PJMEDIA_DIR_NONE;
+
+	pj_assert(pjsua_var.mport_cnt > 0);
+	--pjsua_var.mport_cnt;
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4, (THIS_FILE, "Media port %d freed", id));
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pjsua_conf_port_id) pjsua_mport_get_conf_port(pjsua_mport_id id)
+{
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports,PJSUA_INVALID_ID);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJSUA_INVALID_ID);
+
+	return pjsua_var.mport[id].slot;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_get_port( pjsua_mport_id id, pjmedia_port **p_port)
+{
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports,PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(p_port != NULL, PJ_EINVAL);
+
+	*p_port = &pjsua_var.mport[id].base;
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pjmedia_dir) pjsua_mport_get_dir(pjsua_mport_id id)
+{
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJMEDIA_DIR_NONE);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJMEDIA_DIR_NONE);
+
+	return pjsua_var.mport[id].base.info.dir;
+}
+
+PJ_DEF(pj_event_t *) pjsua_mport_get_play_event(pjsua_mport_id id)
+{
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports,NULL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, NULL);
+
+	return pjsua_var.mport[id].play_data.event;
+}
+
+PJ_DEF(pj_event_t *) pjsua_mport_get_record_event(pjsua_mport_id id)
+{
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports,NULL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, NULL);
+
+	return pjsua_var.mport[id].record_data.event;
+}
+
+PJ_DEF(pj_event_t *) pjsua_mport_get_recognition_event(pjsua_mport_id id)
+{
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports,NULL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, NULL);
+
+	return pjsua_var.mport[id].recogntion_data.event;
+}
+
+static void add_replay_data(pjmedia_format_id fmt_id,
+	pjmedia_circ_buf *buffer,
+	const void *data,
+	pj_size_t size,
+	pj_size_t *count)
+{
+	pj_int16_t *reg1, *reg2;
+	unsigned reg1cnt, reg2cnt;
+	pj_size_t avl = buffer->capacity - buffer->len;
+	if (avl)
+	{
+		if (fmt_id == PJMEDIA_FORMAT_PCM)
+		{
+			size = size >> 1;
+			if (size > avl)
+				size = avl;
+			pjmedia_circ_buf_write(buffer, (pj_int16_t*)data, (unsigned int)size);
+			size = size << 1;
+		}
+		else
+		{
+			if (size > avl)
+				size = avl;
+			pjmedia_circ_buf_get_write_regions(buffer, &reg1, &reg1cnt, &reg2, &reg2cnt);
+			if (reg1cnt >= size)
+			{
+				switch (fmt_id)
+				{
+				case PJMEDIA_FORMAT_PCMA:
+					pjmedia_alaw_decode(reg1, data, size);
+					break;
+				case PJMEDIA_FORMAT_PCMU:
+					pjmedia_ulaw_decode(reg1, data, size);
+					break;
+				default:
+					pj_assert(0);
+					break;
+				}
+			}
+			else
+			{
+				switch (fmt_id)
+				{
+				case PJMEDIA_FORMAT_PCMA:
+					pjmedia_alaw_decode(reg1, data, reg1cnt);
+					pjmedia_alaw_decode(reg2, (const pj_uint8_t*)data + reg1cnt, size - reg1cnt);
+					break;
+				case PJMEDIA_FORMAT_PCMU:
+					pjmedia_ulaw_decode(reg1, data, reg1cnt);
+					pjmedia_ulaw_decode(reg2, (const pj_uint8_t*)data + reg1cnt, size - reg1cnt);
+					break;
+				default:
+					pj_assert(0);
+					break;
+				}
+			}
+			pjmedia_circ_buf_adv_write_ptr(buffer, (unsigned int)size);
+		}
+		*count = size;
+	}
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_play_start(
+	pjsua_mport_id id,
+	const pjmedia_format *fmt,
+	const void *data,
+	pj_size_t size,
+	pj_size_t *count)
+{
+	pjsua_mport_replay_data *p;
+
+	PJ_ASSERT_RETURN(count != NULL, PJ_EINVAL);
+
+	*count = 0;
+
+	PJ_ASSERT_RETURN(id>=0&&(unsigned int)id<pjsua_var.media_cfg.max_media_ports,PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(fmt != NULL, PJ_EINVAL);
+
+	PJSUA_LOCK();
+
+	p = &pjsua_var.mport[id].play_data;
+	if (!(pjsua_var.mport[id].base.info.dir & PJMEDIA_DIR_PLAYBACK))
+	{
+		PJSUA_UNLOCK();
+		return PJ_EINVALIDOP;
+	}
+	if (p->status != PJSUA_REP_IDLE)
+	{
+		PJSUA_UNLOCK();
+		return PJ_EBUSY;
+	}
+	if (((fmt->id != PJMEDIA_FORMAT_PCM) && (fmt->id != PJMEDIA_FORMAT_PCMA) && (fmt->id != PJMEDIA_FORMAT_PCMU)) ||
+		(fmt->det.aud.clock_rate != pjsua_var.media_cfg.clock_rate) ||
+		(fmt->det.aud.channel_count != pjsua_var.media_cfg.channel_count))
+	{
+		PJSUA_UNLOCK();
+		return PJ_ENOTSUP;
+	}
+	if (!p->buffer)
+	{
+		pj_status_t status = pjmedia_circ_buf_create(pjsua_var.mport[id].pool, (unsigned int)p->buffer_size, &p->buffer);
+		if (status != PJ_SUCCESS)
+		{
+			PJSUA_UNLOCK();
+			return status;
+		}
+	}
+
+	pjmedia_circ_buf_reset(p->buffer);
+	if ((data != NULL) && size)
+		add_replay_data(fmt->id, p->buffer, data, size, count);
+	p->samples_played = 0;
+	p->underrun = PJ_FALSE;
+	if (p->buffer->len < p->threshold)
+	{
+		pj_event_set(p->event);
+		p->signaled = PJ_TRUE;
+	}
+	else
+	{
+		pj_event_reset(p->event);
+		p->signaled = PJ_FALSE;
+	}
+	p->fmt_id = fmt->id;
+	p->status = PJSUA_REP_RUNNING;
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4, (THIS_FILE, "Started replay on media port %d", id));
+
+	pjmedia_conf_configure_port(pjsua_var.mconf, pjsua_var.mport[id].slot, PJMEDIA_PORT_NO_CHANGE, PJMEDIA_PORT_ENABLE_ALWAYS);
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_play_status(pjsua_mport_id id,
+	pjs_mport_play_info *info)
+{
+	pjsua_mport_replay_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(info != NULL, PJ_EINVAL);
+
+	pj_bzero(info, sizeof(*info));
+
+	pj_enter_critical_section();
+
+	p = &pjsua_var.mport[id].play_data;
+
+	if ((p->status != PJSUA_REP_RUNNING) && (p->status != PJSUA_REP_STOPPING))
+	{
+		pj_leave_critical_section();
+		return PJ_ENOTFOUND;
+	}
+
+	info->samples_played = p->samples_played;
+	info->underrun = p->underrun;
+	if (info->underrun)
+		p->underrun = PJ_FALSE;
+	if (p->status == PJSUA_REP_STOPPING)
+	{
+		if (!p->buffer->len)
+		{
+			if (p->signaled)
+			{
+				pj_event_reset(p->event);
+				p->signaled = PJ_FALSE;
+			}
+			info->completed = PJ_TRUE;
+			p->status = PJSUA_REP_IDLE;
+
+			PJ_LOG(4, (THIS_FILE, "Replay completed on media port %d - %I64u samples were played",
+				id, p->samples_played));
+		}
+	}
+	else
+	{
+		info->free_buffer_size = p->buffer->capacity - p->buffer->len;
+	}
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_play_put_data(pjsua_mport_id id,
+	const void *data,
+	pj_size_t size,
+	pj_size_t *count)
+{
+	pjsua_mport_replay_data *p;
+
+	PJ_ASSERT_RETURN(count != NULL, PJ_EINVAL);
+
+	*count = 0;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+
+	pj_enter_critical_section();
+
+	p = &pjsua_var.mport[id].play_data;
+
+	if (p->status != PJSUA_REP_RUNNING)
+	{
+		pj_status_t status = (p->status == PJSUA_REP_STOPPING) ? PJ_EEOF : PJ_ENOTFOUND;
+		pj_leave_critical_section();
+		return status;
+	}
+
+	if ((data != NULL) && size)
+	{
+		add_replay_data(p->fmt_id, p->buffer, data, size, count);
+		if (p->buffer->len >= p->threshold)
+		{
+			if (p->signaled)
+			{
+				pj_event_reset(p->event);
+				p->signaled = PJ_FALSE;
+			}
+		}
+		else
+		{
+			if (!p->signaled)
+			{
+				pj_event_set(p->event);
+				p->signaled = PJ_TRUE;
+			}
+		}
+	}
+	else
+	{
+		if (p->buffer->len)
+		{
+			if (p->signaled)
+			{
+				pj_event_reset(p->event);
+				p->signaled = PJ_FALSE;
+			}
+		}
+		else
+		{
+			if (!p->signaled)
+			{
+				pj_event_set(p->event);
+				p->signaled = PJ_TRUE;
+			}
+		}
+		p->status = PJSUA_REP_STOPPING;
+	}
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_play_stop(pjsua_mport_id id, pj_bool_t discard)
+{
+	pjsua_mport_replay_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+
+	pj_enter_critical_section();
+
+	p = &pjsua_var.mport[id].play_data;
+
+	if ((p->status != PJSUA_REP_RUNNING) && (p->status != PJSUA_REP_STOPPING))
+	{
+		pj_leave_critical_section();
+		return PJ_ENOTFOUND;
+	}
+
+	if (discard)
+		p->buffer->len = 0;
+	if (p->buffer->len)
+	{
+		if (p->signaled)
+		{
+			pj_event_reset(p->event);
+			p->signaled = PJ_FALSE;
+		}
+	}
+	else
+	{
+		if (!p->signaled)
+		{
+			pj_event_set(p->event);
+			p->signaled = PJ_TRUE;
+		}
+	}
+	if (p->status == PJSUA_REP_RUNNING)
+		p->status = PJSUA_REP_STOPPING;
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_record_start(pjsua_mport_id id,
+	const pjmedia_format *fmt,
+	pj_bool_t rec_output,
+	pj_size_t max_duration,
+	pj_size_t max_samples,
+	pj_size_t max_silence,
+	pj_size_t eliminate_silence)
+{
+	pjsua_mport_record_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(fmt != NULL, PJ_EINVAL);
+
+	PJSUA_LOCK();
+
+	p = &pjsua_var.mport[id].record_data;
+	if (!(pjsua_var.mport[id].base.info.dir & PJMEDIA_DIR_CAPTURE))
+	{
+		PJSUA_UNLOCK();
+		return PJ_EINVALIDOP;
+	}
+	if (rec_output && !(pjsua_var.mport[id].base.info.dir & PJMEDIA_DIR_PLAYBACK))
+	{
+		PJSUA_UNLOCK();
+		return PJ_EINVALIDOP;
+	}
+	if (p->status != PJSUA_REC_IDLE)
+	{
+		PJSUA_UNLOCK();
+		return PJ_EBUSY;
+	}
+	if (((fmt->id != PJMEDIA_FORMAT_PCM) && (fmt->id != PJMEDIA_FORMAT_PCMA) && (fmt->id != PJMEDIA_FORMAT_PCMU)) ||
+		(fmt->det.aud.clock_rate != pjsua_var.media_cfg.clock_rate) ||
+		(fmt->det.aud.channel_count != pjsua_var.media_cfg.channel_count))
+	{
+		PJSUA_UNLOCK();
+		return PJ_ENOTSUP;
+	}
+	if (!p->buffer)
+	{
+		pj_status_t status = pjmedia_circ_buf_create(pjsua_var.mport[id].pool, (unsigned int)p->buffer_size, &p->buffer);
+		if (status != PJ_SUCCESS)
+		{
+			PJSUA_UNLOCK();
+			return status;
+		}
+	}
+
+	// Convert all the time based arguments to the corresponding sample counts
+	// and ensure that they are truncated to complete blocks if necessary
+	if (max_duration)
+	{
+		max_duration = max_duration * fmt->det.aud.clock_rate / 1000;
+		max_duration -= (max_duration % fmt->det.aud.channel_count);
+	}
+	if (max_silence)
+	{
+		max_silence = max_silence * fmt->det.aud.clock_rate / 1000;
+		max_silence -= (max_silence % fmt->det.aud.channel_count);
+	}
+	if (eliminate_silence)
+	{
+		eliminate_silence = eliminate_silence * fmt->det.aud.clock_rate / 1000;
+		eliminate_silence -= (eliminate_silence % fmt->det.aud.channel_count);
+	}
+
+	if (p->signaled)
+	{
+		pj_event_reset(p->event);
+		p->signaled = PJ_FALSE;
+	}
+	pjmedia_circ_buf_reset(p->buffer);
+	p->samples_seen = 0;
+	p->samples_recorded = 0;
+	p->vad_timestamp.u64 = 0;
+	p->is_silence = PJ_FALSE;
+	p->overrun = PJ_FALSE;
+	p->er = PJSUA_REC_ER_NONE;
+	p->fmt_id = fmt->id;
+	p->rec_output = rec_output;
+	p->max_samples = max_samples;
+	p->max_duration = max_duration;
+	p->max_silence = max_silence;
+	p->eliminate_silence = eliminate_silence;
+	p->status = PJSUA_REC_RUNNING;
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4, (THIS_FILE, "Started recording on media port %d; event=%p", id, p->event));
+
+	if (rec_output)
+		pjmedia_conf_configure_port(pjsua_var.mconf, pjsua_var.mport[id].slot, PJMEDIA_PORT_NO_CHANGE, PJMEDIA_PORT_ENABLE_ALWAYS);
+	else
+		pjmedia_conf_configure_port(pjsua_var.mconf, pjsua_var.mport[id].slot, PJMEDIA_PORT_ENABLE_ALWAYS, PJMEDIA_PORT_NO_CHANGE);
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_record_status(pjsua_mport_id id,
+	pjs_mport_record_info *info)
+{
+	pjsua_mport_record_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(info != NULL, PJ_EINVAL);
+
+	pj_bzero(info, sizeof(*info));
+
+	pj_enter_critical_section();
+
+	p = &pjsua_var.mport[id].record_data;
+
+	if ((p->status != PJSUA_REP_RUNNING) && (p->status != PJSUA_REP_STOPPING))
+	{
+		pj_leave_critical_section();
+		return PJ_ENOTFOUND;
+	}
+
+	info->samples_recorded = p->samples_recorded;
+	info->overrun = p->overrun;
+	if (info->overrun)
+		p->overrun = PJ_FALSE;
+	info->samples_available = p->buffer->len;
+	info->end_reason = p->er;
+	if ((p->status == PJSUA_REC_STOPPING) && !info->samples_available)
+	{
+		if (p->signaled)
+		{
+			pj_event_reset(p->event);
+			p->signaled = PJ_FALSE;
+		}
+		info->completed = PJ_TRUE;
+		p->status = PJSUA_REC_IDLE;
+
+		PJ_LOG(4, (THIS_FILE, "Recording completed on media port %d - %I64u samples were recorded",
+			id, p->samples_recorded));
+	}
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+static void get_record_data(pjmedia_format_id fmt_id,
+	pjmedia_circ_buf *buffer,
+	void *data,
+	pj_size_t size,	/* Size of the data buffer in bytes - not samples! */
+	pj_size_t *count)
+{
+	pj_int16_t *reg1, *reg2;
+	unsigned reg1cnt, reg2cnt;
+	if (buffer->len)
+	{
+		if (fmt_id == PJMEDIA_FORMAT_PCM)
+		{
+			if (size == 1U)
+			{
+				pj_int16_t buf;
+				pjmedia_circ_buf_read(buffer, &buf, 1U);
+				memcpy(data, &buf, 1U);
+			}
+			else
+			{
+				unsigned int samples = (unsigned int)(size >> 1);
+				if (samples > buffer->len)
+				{
+					samples = buffer->len;
+					size = samples << 1;
+				}
+				pjmedia_circ_buf_read(buffer, (pj_int16_t*)data, samples);
+			}
+		}
+		else
+		{
+			if (size > buffer->len)
+				size = buffer->len;
+			pjmedia_circ_buf_get_read_regions(buffer, &reg1, &reg1cnt, &reg2, &reg2cnt);
+			if (reg1cnt >= size)
+			{
+				switch (fmt_id)
+				{
+				case PJMEDIA_FORMAT_PCMA:
+					pjmedia_alaw_encode((pj_uint8_t*)data, reg1, size);
+					break;
+				case PJMEDIA_FORMAT_PCMU:
+					pjmedia_ulaw_encode((pj_uint8_t*)data, reg1, size);
+					break;
+				default:
+					pj_assert(0);
+					break;
+				}
+			}
+			else
+			{
+				switch (fmt_id)
+				{
+				case PJMEDIA_FORMAT_PCMA:
+					pjmedia_alaw_encode((pj_uint8_t*)data, reg1, reg1cnt);
+					pjmedia_alaw_encode((pj_uint8_t*)data + reg1cnt, reg2, size - reg1cnt);
+					break;
+				case PJMEDIA_FORMAT_PCMU:
+					pjmedia_ulaw_encode((pj_uint8_t*)data, reg1, reg1cnt);
+					pjmedia_ulaw_encode((pj_uint8_t*)data + reg1cnt, reg2, size - reg1cnt);
+					break;
+				default:
+					pj_assert(0);
+					break;
+				}
+			}
+			pjmedia_circ_buf_adv_read_ptr(buffer, (unsigned int)size);
+		}
+		*count = size;
+	}
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_record_get_data(pjsua_mport_id id,
+	void *buffer,
+	pj_size_t size,
+	pj_size_t *count)
+{
+	pjsua_mport_record_data *p;
+
+	PJ_ASSERT_RETURN(count != NULL, PJ_EINVAL);
+
+	*count = 0;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(buffer && size, PJ_EINVAL);
+
+	pj_enter_critical_section();
+
+	p = &pjsua_var.mport[id].record_data;
+
+	if ((p->status != PJSUA_REC_RUNNING) && (p->status != PJSUA_REC_STOPPING))
+	{
+		pj_leave_critical_section();
+		return PJ_ENOTFOUND;
+	}
+
+	get_record_data(p->fmt_id, p->buffer, buffer, size, count);
+	if ((p->status == PJSUA_REC_RUNNING) &&
+		((p->buffer->capacity - p->buffer->len) >= p->threshold))
+	{
+		if (p->signaled)
+		{
+			pj_event_reset(p->event);
+			p->signaled = PJ_FALSE;
+		}
+	}
+	else
+	{
+		if (!p->signaled)
+		{
+			pj_event_set(p->event);
+			p->signaled = PJ_TRUE;
+		}
+	}
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_record_stop(pjsua_mport_id id, pj_bool_t discard)
+{
+	pjsua_mport_record_data *p;
+	int rec_output = -1;
+	pj_event_t* signaled_event = NULL;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pjsua_var.mport[id].pool != NULL, PJ_EINVAL);
+
+	PJ_LOG(4, (THIS_FILE, "Stopping recording on media port %d%s...", id, discard ? " and discarding buffered data" : ""));
+
+	pj_enter_critical_section();
+
+	p = &pjsua_var.mport[id].record_data;
+
+	if ((p->status != PJSUA_REC_RUNNING) && (p->status != PJSUA_REC_STOPPING))
+	{
+		pj_leave_critical_section();
+		return PJ_ENOTFOUND;
+	}
+
+	if (discard)
+		p->buffer->len = 0;
+	if (p->status == PJSUA_REC_RUNNING)
+	{
+		p->er = PJSUA_REC_ER_STOP;
+		p->status = PJSUA_REC_STOPPING;
+		rec_output = p->rec_output;
+	}
+	if (!p->signaled)
+	{
+		signaled_event = p->event;
+		pj_event_set(p->event);
+		p->signaled = PJ_TRUE;
+	}
+
+	pj_leave_critical_section();
+
+	if (rec_output >= 0)
+	{
+		if (rec_output)
+			pjmedia_conf_configure_port(pjsua_var.mconf, pjsua_var.mport[id].slot, PJMEDIA_PORT_NO_CHANGE, PJMEDIA_PORT_ENABLE);
+		else
+			pjmedia_conf_configure_port(pjsua_var.mconf, pjsua_var.mport[id].slot, PJMEDIA_PORT_ENABLE, PJMEDIA_PORT_NO_CHANGE);
+	}
+
+	PJ_LOG(4, (THIS_FILE, "rec_output=%d, event=%p", rec_output, signaled_event));
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_conf_start(pjsua_mport_id id)
+{
+	register pjsua_mport_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+
+	PJSUA_LOCK();
+
+	if (!(p->base.info.dir & PJMEDIA_DIR_PLAYBACK))
+	{
+		PJSUA_UNLOCK();
+		return PJ_EINVALIDOP;
+	}
+	if (p->play_data.status != PJSUA_REP_IDLE)
+	{
+		PJSUA_UNLOCK();
+		return PJ_EBUSY;
+	}
+	if (!p->participants)
+	{
+		p->participants = (pjsua_mport_id*)pj_pool_zalloc(p->pool, sizeof(pjsua_mport_id) * PJSUA_MAX_CONF_PORTS);
+		if (!p->participants)
+		{
+			PJSUA_UNLOCK();
+			return PJ_ENOMEM;
+		}
+		for (register int i = 0; i < PJSUA_MAX_CONF_PORTS; ++i)
+			p->participants[i] = PJSUA_INVALID_ID;
+	}
+	if (!p->mix_buf)
+	{
+		p->mix_buf = (pj_int32_t*)pj_pool_zalloc(p->pool, pjsua_var.mconf_cfg.samples_per_frame * sizeof(p->mix_buf[0]));
+		if (!p->mix_buf)
+		{
+			PJSUA_UNLOCK();
+			return PJ_ENOMEM;
+		}
+		p->last_mix_adj = NORMAL_LEVEL;
+	}
+
+	p->mix_cnt = 0U;
+	p->mix_adj = NORMAL_LEVEL;
+	p->play_data.status = PJSUA_REP_CONFERENCING;
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4, (THIS_FILE, "Started conference on media port %d", id));
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_conf_add(pjsua_mport_id id, pjsua_mport_id pid)
+{
+	register pjsua_mport_data *p, *pp;
+	register int i;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pid >= 0 && (unsigned int)pid<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	pp = &pjsua_var.mport[pid];
+	PJ_ASSERT_RETURN(pp->pool != NULL, PJ_EINVAL);
+
+	PJSUA_LOCK();
+
+	if (p->play_data.status != PJSUA_REP_CONFERENCING)
+	{
+		PJSUA_UNLOCK();
+		return PJ_ENOTFOUND;
+	}
+
+	for (i = (int)p->participant_cnt - 1; i >= 0; --i)
+	{
+		if (p->participants[i] == pid)
+		{
+			PJSUA_UNLOCK();
+			return PJ_SUCCESS;
+		}
+	}
+
+	if (p->participant_cnt >= PJSUA_MAX_CONF_PORTS)
+	{
+			PJSUA_UNLOCK();
+			return PJ_ETOOMANY;
+	}
+
+	if (!pp->listeners)
+	{
+		pp->listeners = (pjsua_mport_id*)pj_pool_zalloc(pp->pool, sizeof(pjsua_mport_id) * pjsua_var.media_cfg.max_media_ports);
+		if (!pp->listeners)
+		{
+			PJSUA_UNLOCK();
+			return PJ_ENOMEM;
+		}
+		for (i = 0; i < (int)pjsua_var.media_cfg.max_media_ports; ++i)
+			pp->listeners[i] = PJSUA_INVALID_ID;
+	}
+
+	pj_enter_critical_section();
+
+	p->participants[p->participant_cnt++] = pid;
+
+	for (i = (int)pp->listener_cnt - 1; i >= 0; --i)
+	{
+		if (pp->listeners[i] == id)
+			break;
+	}
+	if (i < 0)
+	{
+		pj_assert(pp->listener_cnt < pjsua_var.media_cfg.max_media_ports);
+		pp->listeners[pp->listener_cnt++] = id;
+	}
+
+	pj_leave_critical_section();
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4, (THIS_FILE, "Added media port %d to conference on media port %d", pid, id));
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_conf_remove(pjsua_mport_id id, pjsua_mport_id pid)
+{
+	register pjsua_mport_data *p, *pp;
+	register int i, j;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(pid >= 0 && (unsigned int)pid<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	pp = &pjsua_var.mport[pid];
+	PJ_ASSERT_RETURN(pp->pool != NULL, PJ_EINVAL);
+
+	PJSUA_LOCK();
+
+	if (p->play_data.status != PJSUA_REP_CONFERENCING)
+	{
+		PJSUA_UNLOCK();
+		return PJ_ENOTFOUND;
+	}
+
+	pj_enter_critical_section();
+
+	for (i = (int)(p->participant_cnt) - 1; i >= 0; --i)
+	{
+		if (p->participants[i] != pid)
+			continue;
+		for (j = (int)(pp->listener_cnt) - 1; j >= 0; --j)
+		{
+			if (pp->listeners[j] == id)
+			{
+				pp->listener_cnt--;
+				if (j == (int)pp->listener_cnt)
+				{
+					pp->listeners[j] = PJSUA_INVALID_ID;
+				}
+				else
+				{
+					pp->listeners[j] = pp->listeners[pp->listener_cnt];
+					pp->listeners[pp->listener_cnt] = PJSUA_INVALID_ID;
+				}
+				break;
+			}
+		}
+		p->participant_cnt--;
+		if (i == (int)p->participant_cnt)
+		{
+			p->participants[i] = PJSUA_INVALID_ID;
+		}
+		else
+		{
+			p->participants[i] = p->participants[p->participant_cnt];
+			p->participants[p->participant_cnt] = PJSUA_INVALID_ID;
+		}
+		break;
+	}
+
+	pj_leave_critical_section();
+
+	PJSUA_UNLOCK();
+
+	if (i < 0)
+		return PJ_ENOTFOUND;
+
+	PJ_LOG(4, (THIS_FILE, "Removed media port %d from conference on media port %d", pid, id));
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_conf_stop(pjsua_mport_id id)
+{
+	register pjsua_mport_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+
+	PJSUA_LOCK();
+
+	if (p->play_data.status != PJSUA_REP_CONFERENCING)
+	{
+		PJSUA_UNLOCK();
+		return PJ_ENOTFOUND;
+	}
+
+	pj_enter_critical_section();
+
+	for (register int i = (int)(p->participant_cnt) - 1; i >= 0; --i)
+	{
+		register pjsua_mport_data *pp = &pjsua_var.mport[p->participants[i]];
+		for (register int j = (int)(pp->listener_cnt) - 1; j >= 0; --j)
+		{
+			if (pp->listeners[j] == id)
+			{
+				pp->listener_cnt--;
+				if (j == (int)pp->listener_cnt)
+				{
+					pp->listeners[j] = PJSUA_INVALID_ID;
+				}
+				else
+				{
+					pp->listeners[j] = pp->listeners[pp->listener_cnt];
+					pp->listeners[pp->listener_cnt] = PJSUA_INVALID_ID;
+				}
+				break;
+			}
+		}
+		p->participants[i] = PJSUA_INVALID_ID;
+		p->participant_cnt--;
+	}
+
+	p->play_data.status = PJSUA_REP_IDLE;
+
+	pj_leave_critical_section();
+
+	PJSUA_UNLOCK();
+
+	PJ_LOG(4, (THIS_FILE, "Stopped conference on media port %d", id));
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_listen_for(pjsua_mport_id id, pjs_listen_for_parms* params)
+{
+	register pjsua_mport_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+
+	if (params && (params->types == PJSUA_RCG_NONE))
+		params = NULL;
+
+	PJSUA_LOCK();
+
+	if (!(p->base.info.dir & PJMEDIA_DIR_CAPTURE))
+	{
+		PJSUA_UNLOCK();
+		return PJ_EINVALIDOP;
+	}
+
+	pj_enter_critical_section();
+
+	if (params)
+		p->recogntion_data.params = *params;
+	else
+		p->recogntion_data.params.types = PJSUA_RCG_NONE;
+
+	pj_leave_critical_section();
+
+	PJSUA_UNLOCK();
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_get_recognised(pjsua_mport_id id, pjs_recognition_info* info)
+{
+	register pjsua_mport_data *p;
+
+	PJ_ASSERT_RETURN(info != NULL, PJ_EINVAL);
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+
+	pj_enter_critical_section();
+
+	if (p->recogntion_data.event_cnt > 0U)
+	{
+		*info = p->recogntion_data.events[0U];
+		pj_array_erase(p->recogntion_data.events, sizeof(p->recogntion_data.events[0]), p->recogntion_data.event_cnt, 0U);
+		if (!--p->recogntion_data.event_cnt)
+		{
+			if (p->recogntion_data.signaled)
+			{
+				pj_event_reset(p->recogntion_data.event);
+				p->recogntion_data.signaled = PJ_FALSE;
+			}
+		}
+	}
+	else
+	{
+		info->type = PJSUA_RCG_NONE;
+	}
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_discard_recognised(pjsua_mport_id id)
+{
+	register pjsua_mport_data *p;
+
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+
+	pj_enter_critical_section();
+
+	if (p->recogntion_data.event_cnt > 0U)
+	{
+		p->recogntion_data.event_cnt = 0U;
+		if (p->recogntion_data.signaled)
+		{
+			pj_event_reset(p->recogntion_data.event);
+			p->recogntion_data.signaled = PJ_FALSE;
+		}
+	}
+
+	pj_leave_critical_section();
+
+	return PJ_SUCCESS;
+}
+
+static pj_status_t pjsua_mport_add_recognition_event(pjsua_mport_id id, const pjs_recognition_info* ri)
+{
+	register pjsua_mport_data *p;
+
+	PJ_ASSERT_RETURN(ri != NULL && ri->type != PJSUA_RCG_NONE, PJ_EINVAL);
+	PJ_ASSERT_RETURN(id >= 0 && (unsigned int)id<pjsua_var.media_cfg.max_media_ports, PJ_EINVAL);
+	p = &pjsua_var.mport[id];
+	PJ_ASSERT_RETURN(p->pool != NULL, PJ_EINVAL);
+
+	register pj_status_t pje = PJ_SUCCESS;
+
+	pj_enter_critical_section();
+
+	if (!(ri->type & p->recogntion_data.params.types))
+	{
+		pje = PJ_EIGNORED;
+	}
+	else
+	{
+		if ((ri->type & PJSUA_RCG_DTMF) &&
+			((p->recogntion_data.params.types & PJSUA_RCG_DTMF) == PJSUA_RCG_DTMF))
+			p->recogntion_data.params.types &=
+				~(!(ri->type & PJSUA_RCG_DTMF_RFC2833) ? PJSUA_RCG_DTMF_RFC2833 : PJSUA_RCG_DTMF_TONE);
+		if (p->recogntion_data.event_cnt >= PJ_ARRAY_SIZE(p->recogntion_data.events))
+		{
+			pje = PJ_ETOOMANY;
+		}
+		else
+		{
+			p->recogntion_data.events[p->recogntion_data.event_cnt++] = *ri;
+			if (!p->recogntion_data.signaled)
+			{
+				pj_event_set(p->recogntion_data.event);
+				p->recogntion_data.signaled = PJ_TRUE;
+			}
+		}
+	}
+
+	pj_leave_critical_section();
+
+	return pje;
+}
+
+PJ_DEF(pj_status_t) pjsua_mport_add_rfc2833_dtmf_digit(pjsua_mport_id id, char digit, unsigned timestamp, unsigned duration)
+{
+	pjs_recognition_info ri;
+	ri.type = PJSUA_RCG_DTMF_RFC2833;
+	ri.timestamp = timestamp;
+	ri.param0 = (unsigned)(pj_uint8_t)digit;
+	ri.param1 = duration;
+	return pjsua_mport_add_recognition_event(id, &ri);
+}
 
 /*****************************************************************************
  * Sound devices.

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -200,7 +200,7 @@ static pj_status_t deallocate_conference_slot(pjsua_call* call)
         }     
     }
     call->conf_slot = PJSUA_INVALID_ID;
-    return pjsua_conf_distroy_port(call->null_port);
+    return pjmedia_port_destroy(call->null_port);
 }
 /*
  * Reset call descriptor.

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -79,10 +79,6 @@ pj_status_t pjsua_media_subsys_init(const pjsua_media_config *cfg)
         pjsua_var.media_cfg.thread_cnt = 1;
     }
 
-    if (pjsua_var.media_cfg.max_media_ports < pjsua_var.ua_cfg.max_calls) {
-        pjsua_var.media_cfg.max_media_ports = pjsua_var.ua_cfg.max_calls + 2;
-    }
-
     /* Create media endpoint. */
     status = pjmedia_endpt_create(&pjsua_var.cp.factory, 
                                   pjsua_var.media_cfg.has_ioqueue? NULL :
@@ -2788,7 +2784,7 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
                         const pjmedia_sdp_session *s_;
                         pjmedia_sdp_neg_get_active_local(call->inv->neg, &s_);
 
-                        if (mi < s_->media_count) {
+                        if (s_ && mi < s_->media_count) {
                             m = pjmedia_sdp_media_clone(pool, s_->media[mi]);
                             m->desc.port = 0;
                         } else {
@@ -3096,7 +3092,7 @@ on_error:
 static void stop_media_stream(pjsua_call *call, unsigned med_idx)
 {
     pjsua_call_media *call_med;
-    
+
     if (pjsua_call_media_is_changing(call)) {
         call_med = &call->media_prov[med_idx];
         if (med_idx >= call->med_prov_cnt)

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3164,18 +3164,6 @@ static void stop_media_session(pjsua_call_id call_id)
     for (unsigned mi=0; mi<call->med_cnt; ++mi) {
         stop_media_stream(call, mi);
     }
-
-    if (pjsua_var.mconf && call->conf_slot!= PJSUA_INVALID_ID) {
-        if (pjsua_conf_remove_port(call->conf_slot) == PJ_SUCCESS)
-        {
-            PJ_LOG(4, (THIS_FILE, "stop_media_session::pjsua_conf_remove_port done id: %d", call->conf_slot));
-        }
-        else
-        {
-            PJ_LOG(2, (THIS_FILE, "stop_media_session::pjsua_conf_remove_port failed"));
-        }
-        call->conf_slot = PJSUA_INVALID_ID;
-    }
 }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3161,10 +3161,20 @@ static void stop_media_stream(pjsua_call *call, unsigned med_idx)
 static void stop_media_session(pjsua_call_id call_id)
 {
     pjsua_call *call = &pjsua_var.calls[call_id];
-    unsigned mi;
-
-    for (mi=0; mi<call->med_cnt; ++mi) {
+    for (unsigned mi=0; mi<call->med_cnt; ++mi) {
         stop_media_stream(call, mi);
+    }
+
+    if (pjsua_var.mconf && call->conf_slot!= PJSUA_INVALID_ID) {
+        if (pjsua_conf_remove_port(call->conf_slot) == PJ_SUCCESS)
+        {
+            PJ_LOG(4, (THIS_FILE, "stop_media_session::pjsua_conf_remove_port done id: %d", call->conf_slot));
+        }
+        else
+        {
+            PJ_LOG(2, (THIS_FILE, "stop_media_session::pjsua_conf_remove_port failed"));
+        }
+        call->conf_slot = PJSUA_INVALID_ID;
     }
 }
 


### PR DESCRIPTION
### change log
•	Added new Call recording and play capability through media ports. [pjsip/include/pjsua-lib/pjsua.h]
•	Added "Get queued DTMF Digits" functionality. [pjsip/include/pjsua-lib/pjsua.h]
•	A Conference slot and a null port is added to the call and provide the capability of maintaining connectivity while transition between ports. This allows calls to change ports before call setup. [pjmedia/include/pjmedia/conference.h]
•	New pjsua_call_make_call2 function with source uri and contact uri as input arguments. [pjsip/include/pjsua-lib/pjsua.h]
•	New pjsua_create2 with pjsua_logging_config as input argument. [pjsip/include/pjsua-lib/pjsua.h]
•	pj_assert put logs in non-debug modes.
•	Extend logs in the library.
•	Add warning to pj_mutex_lock failure.

•	**Bug fixes in**
o	pjlib/src/pj/os_core_win32.c:pj_thread_local_get
o	pjmedia/Circbuf:pjmedia_circ_buf_create
o	pjmedia/src/pjmedia/null_port.c: null_get_frame
o	pjsip/src/pjsip/sip_transaction.c
o	pjsip/src/pjsua-lib/pjsua_acc.c
o	pjsip/src/pjsua-lib/pjsua_media.c: pjsua_media_subsys_init
