### PR TITLE
Update for swig/python

### DIFF
--- a/pjsip-apps/src/swig/modules/win32fix.py
+++ b/pjsip-apps/src/swig/modules/win32fix.py
@@ -1,0 +1,84 @@
+# functions to disable and re-enable the include of pj/compat/socket.h in pj/sock.h
+def disable_include():
+    import os.path as path
+    import re
+    
+    current_dir = path.dirname(path.abspath(__file__))
+    main_project = path.abspath(path.join(current_dir, '../../../../'))
+    file_path = path.abspath(path.join(main_project, 'pjlib/include/pj/sock.h'))
+    print("File to edit: %s" % file_path)
+    
+    global use_new_path
+    
+    yes_no = raw_input("is the path correct? (y/n): ")
+    if yes_no == 'y':
+        is_path_valid = True
+    elif yes_no == 'n':
+        is_path_valid = False
+
+    if is_path_valid == True:
+        
+        use_new_path = False
+        with open(file_path, 'r') as file:
+            content = file.read()
+            
+        # Regular expression to match the line with #include <pj/compat/socket.h>
+        pattern = re.compile(r'#include <pj/compat/socket.h>')
+        
+        # Replace the matched pattern
+        new_content = pattern.sub(r'/* #include <pj/compat/socket.h> */', content)
+        
+        with open(file_path, 'w') as file:
+            file.write(new_content)
+            
+        print("pj/compat/socket.h has been disabled in pj/sock.h!")
+            
+    elif is_path_valid == False:
+        
+
+        use_new_path = True
+        print("Current location is %s" % main_project)
+        print("Use ../ at the start of the path to go back a directory...")
+        new_path = raw_input("Enter the correct path: ")
+        global new_file_path
+        new_file_path = path.abspath(path.join(main_project, new_path))
+        
+        with open(new_file_path, 'r') as file:
+            content = file.read()
+            
+        # Regular expression to match the line with #include <pj/compat/socket.h>
+        pattern = re.compile(r'#include <pj/compat/socket.h>')
+        
+        # Replace the matched pattern
+        new_content = pattern.sub(r'/* #include <pj/compat/socket.h> */', content)
+        
+        with open(new_file_path, 'w') as file:
+            file.write(new_content)
+            
+        print("pj/compat/socket.h has been disabled in pj/sock.h!")
+            
+def re_enable_include():
+    
+    import os.path as path
+    import re
+    
+    current_dir = path.dirname(path.abspath(__file__))
+    main_project = path.abspath(path.join(current_dir, '../../../'))
+    file_path = path.abspath(path.join(main_project, 'pjlib/include/pj/sock.h'))
+    
+    if use_new_path == True:
+        file_path = new_file_path
+    
+    with open(file_path, 'r') as file:
+        content = file.read()
+        
+    # Regular expression to match the line with #include <pj/compat/socket.h>
+    pattern = re.compile(r'/* #include <pj/compat/socket.h> */')
+    
+    # Replace the matched pattern
+    new_content = pattern.sub(r'#include <pj/compat/socket.h>', content)
+    
+    with open(file_path, 'w') as file:
+        file.write(new_content)
+        
+    print("pj/compat/socket.h has been re-enabled in pj/sock.h!")

--- a/pjsip-apps/src/swig/python/setup.py
+++ b/pjsip-apps/src/swig/python/setup.py
@@ -25,6 +25,12 @@ except ImportError:
 import os
 import sys
 import platform
+import transform_docs
+
+try:
+    transform_docs.transform()
+except Exception as e:
+    print(f"Error transforming docs: {e}")
 
 # find pjsip version
 pj_version=""

--- a/pjsip-apps/src/swig/python/transform_docs.py
+++ b/pjsip-apps/src/swig/python/transform_docs.py
@@ -1,0 +1,16 @@
+import re
+
+def transform():
+    file_path = 'pjsua2.py'
+
+    with open(file_path, 'r') as file:
+        content = file.read()
+
+    # Regular expression to match the property with doc=...
+    pattern = re.compile(r'(\w+\s*=\s*property\([^,]+,[^,]+),\s*doc=r?\"\"\"(.*?)\"\"\"\)', re.DOTALL)
+
+    # Replace the matched pattern
+    new_content = pattern.sub(r'\1)\n    """\2"""', content)
+
+    with open(file_path, 'w') as file:
+        file.write(new_content)


### PR DESCRIPTION
i made changes to make importsym more adaptive, along with checking if the system is win32, if it is, it will ask the user the registered path is correct, if not change it to the correct one, then edit and comment #include<pj/compat/socket.h> for them.

at the same time made changes to setup.py, including automatic execution of transform_docs.py, adding code comments for the user without any hassle.

I have tested the changes against linux and windows, and they seem to function as expected.

however i do still happen to hit a roadblock of the actual process function having issues with _fake_typedefs.h "see screenshot for reference.", which is likely just a setup issue on my end/versioning issues....

Linux version: 
![image](https://github.com/user-attachments/assets/5b0161a5-a9f2-4865-87b7-3436c8e2c2ae)

Windows version:
![image](https://github.com/user-attachments/assets/30077b79-0bd7-4266-9f2d-0f00e3566596)



there is also probably some methods i could have done better, tho i would like to hear feedback on the solution!