### PR TITLE
Assertion in sending BYE after transaction timeout

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4673,6 +4673,10 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
         /* Send BYE */
         status = pjsip_dlg_create_request(inv->dlg, pjsip_get_bye_method(), 
                                           -1, &bye);
+        if (status == PJ_SUCCESS && tsx->status_text.slen) {
+            status = add_reason_warning_hdr(bye, tsx->status_code,
+                                            &tsx->status_text);
+        }
         if (status == PJ_SUCCESS) {
             pjsip_inv_send_msg(inv, bye);
         }
@@ -5385,6 +5389,10 @@ static void inv_on_state_connecting( pjsip_inv_session *inv, pjsip_event *e)
                     status = pjsip_dlg_create_request(inv->dlg,
                                                       pjsip_get_bye_method(),
                                                       -1, &bye);
+                    if (status == PJ_SUCCESS && tsx->status_text.slen) {
+                        status = add_reason_warning_hdr(bye, tsx->status_code,
+                                                        &tsx->status_text);
+                    }
                     if (status == PJ_SUCCESS) {
                         pjsip_inv_send_msg(inv, bye);
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4664,7 +4664,11 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
         pj_status_t status;
 
         inv_set_cause(inv, tsx->status_code, &tsx->status_text);
-        inv_set_state(inv, PJSIP_INV_STATE_DISCONNECTED, e);
+
+        /* Do not shift state to DISCONNECTED here, as it will destroy the
+         * invite session and the BYE sending below will raise an assertion.
+         */
+        //inv_set_state(inv, PJSIP_INV_STATE_DISCONNECTED, e);
 
         /* Send BYE */
         status = pjsip_dlg_create_request(inv->dlg, pjsip_get_bye_method(), 


### PR DESCRIPTION
When a request within dialog gets timeout, the invite session will terminate the session, and in the attempt of sending BYE, an assertion is raised:
```
src/pjsip-ua/sip_inv.c:287: pjsip_inv_add_ref: Assertion `inv && inv->ref_cnt' failed.
```
with call stack:
```
pjsip_inv_add_ref()
pjsip_inv_send_msg()
handle_uac_tsx_response()
mod_inv_on_tsx_state()
pjsip_dlg_on_tsx_state()
tsx_set_state()
tsx_on_state_calling()
tsx_timer_callback()
pj_timer_heap_poll()
```
Thanks to Taisto Qvist for the report.

After investigation, the transaction timeout handler in the invite sesion shift the invite sesion state to DISCONNECTED before sending BYE. The DISCONNECTED state will decrement the reference counter and may destroy the invite session.

The transaction timeout handler code is actually quite old, it did not raise an assertion because the invite session destructor is not as complex as now (basically it was only decrementing the dialog's session counter, code [here](https://github.com/pjsip/pjproject/blob/0b4c57b8de7e782fe4c18849f3511460cb84ab34/pjsip/src/pjsip-ua/sip_inv.c#L218-L228)).