### PR TITLE
Fix crash on incoming TLS call with only unsupported cipher offered

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2045,7 +2045,7 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
                                       NULL);
                 }               
 
-                if (call->inv->dlg) {
+                if (call->inv && call->inv->dlg) {
                     pjsip_inv_terminate(call->inv, sip_err_code, PJ_FALSE);
                 }
                 pjsip_dlg_dec_lock(dlg);


### PR DESCRIPTION
A null-pointer exception occurs if we get an incoming TLS/SRTP call with only cipher offered which we do not support in our PJSIP application.

The cipher which are offered are: AEAD_AES_256_GCM, AEAD_AES_256_GCM_8
We have not activated these ciphers in our app

We are using PJSIP v2.14.1 on Linux and Windows and developing with C/C++ (pjsua/pjsua2)

This is just a quick-fix right where the null-pointer exception happens
Maybe this situation has to be properly handled in a different software layer/module of PJSIP