### PR TITLE
Add full support for SHA-256 and SHA-512-256 digest algorithms

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -713,6 +713,7 @@ static pj_status_t init_openssl(void)
 #if OPENSSL_VERSION_NUMBER < 0x009080ffL
     /* This is now synonym of SSL_library_init() */
     OpenSSL_add_all_algorithms();
+    OpenSSL_add_all_digests();
 #endif
 
     /* Init available ciphers */

--- a/pjsip/include/pjsip/sip_auth_aka.h
+++ b/pjsip/include/pjsip/sip_auth_aka.h
@@ -56,7 +56,7 @@ PJ_BEGIN_DECL
  * Application then specifies digest AKA credential by initializing the 
  * authentication credential as follows:
  *
- @code
+ \verbatim
 
     pjsip_cred_info cred;
 
@@ -65,20 +65,19 @@ PJ_BEGIN_DECL
     cred.scheme = pj_str("Digest");
     cred.realm = pj_str("ims-domain.test");
     cred.username = pj_str("user@ims-domain.test");
-    cred.data_type = PJSIP_CRED_DATA_PLAIN_PASSWD | PJSIP_CRED_DATA_EXT_AKA;
-    cred.data = pj_str("password");
+    cred.data_type = PJSIP_CRED_DATA_EXT_AKA;
 
     // AKA extended info
     cred.ext.aka.k = pj_str("password");
     cred.ext.aka.cb = &pjsip_auth_create_aka_response
 
- @endcode
+ \endverbatim
  *
  * Description:
- * - To support AKA, application adds \a PJSIP_CRED_DATA_EXT_AKA flag in the
+ * - To support AKA, application adds #PJSIP_CRED_DATA_EXT_AKA flag in the
  * \a data_type field. This indicates that extended information specific to
  * AKA authentication is available in the credential, and that response 
- * digest computation will use the callback function instead of the usual MD5
+ * digest computation will use the callback function instead of the usual
  * digest computation.
  *
  * - The \a scheme for the credential is "Digest". 
@@ -86,12 +85,6 @@ PJ_BEGIN_DECL
  * - The \a realm is the expected realm in the challenge. Application may 
  * also specify wildcard realm ("*") if it wishes to respond to any realms 
  * in the challenge.
- *
- * - The \a data field is optional. Application may fill this with the password
- * if it wants to support both MD5 and AKA MD5 in a single credential. The
- * pjsip_auth_create_aka_response() function will use this field if the
- * challenge indicates "MD5" as the algorithm instead of "AKAv1-MD5" or
- * "AKAv2-MD5".
  *
  * - The \a ext.aka.k field specifies the permanent subscriber key to be used
  * for AKA authentication. Application may specify binary password containing
@@ -164,7 +157,7 @@ PJ_BEGIN_DECL
 #define PJSIP_AKA_SQNLEN        6
 
 /**
- * This function creates MD5, AKAv1-MD5, or AKAv2-MD5 response for
+ * This function creates an AKAv1-MD5, or AKAv2-MD5 response for
  * the specified challenge in \a chal, according to the algorithm 
  * specified in the challenge, and based on the information in the 
  * credential \a cred.

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1345,10 +1345,25 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #endif
 
 /**
- * Allow client to send multiple Authorization header when receiving multiple 
- * WWW-Authenticate header fields. If this is disabled, the stack will send
- * Authorization header field containing credentials that match the
- * topmost header field.
+ * RFC-7616 and RFC-8760 state that for each realm a UAS requires authentication
+ * for it can send a WWW/Proxy-Authenticate header for each digest algorithm it
+ * supports and for each realm, they must be added in most-preferred to least-
+ * preferred order.  The RFCs also state that the UAS MUST NOT send multiple
+ * WWW/Proxy-Authenticate headers with the same realm and algorithm.
+ *
+ * The RFCs also state that the UAC SHOULD respond to the topmost header
+ * for each realm containing a digest algorithm it supports.  Neither RFC
+ * however, states whether the UAC should send multiple Authorization headers
+ * for the same realm if it can support multiple digest algorithms.  Common
+ * sense dicates though that the UAC should NOT send additional Authorization
+ * headers for the same realm once it's already sent a more preferred one.
+ * The reasoning is simple...  If a UAS sends two WWW-Authenticate headers,
+ * the first for SHA-256 and the second for MD5, a UAC responding to both
+ * completely defeats the purpose of the UAS sending the more secure SHA-256.
+ *
+ * Having said that, if there is some corner case where continuing to send
+ * additional Authorization headers for the same realm is necessary, then
+ * this define can be set to 1 to allow it.
  *
  * Default is 0
  */

--- a/pjsip/src/pjsip/sip_auth_aka.c
+++ b/pjsip/src/pjsip/sip_auth_aka.c
@@ -147,9 +147,10 @@ PJ_DEF(pj_status_t) pjsip_auth_create_aka_response(
         aka_cred.data.ptr = (char*)res;
         aka_cred.data.slen = PJSIP_AKA_RESLEN;
 
-        status = pjsip_auth_create_digest(&auth->response, &chal->nonce, 
+        status = pjsip_auth_create_digest2(&auth->response, &chal->nonce,
                                  &auth->nc, &auth->cnonce, &auth->qop, 
-                                 &auth->uri, &chal->realm, &aka_cred, method);  
+                                 &auth->uri, &chal->realm, &aka_cred, method,
+                                 PJSIP_AUTH_ALGORITHM_MD5);
 
     } else if (aka_version == 2) {
 
@@ -186,9 +187,10 @@ PJ_DEF(pj_status_t) pjsip_auth_create_aka_response(
                          aka_cred.data.ptr, &len);
         aka_cred.data.slen = hmac64_len;
 
-        status = pjsip_auth_create_digest(&auth->response, &chal->nonce, 
+        status = pjsip_auth_create_digest2(&auth->response, &chal->nonce,
                                  &auth->nc, &auth->cnonce, &auth->qop, 
-                                 &auth->uri, &chal->realm, &aka_cred, method);
+                                 &auth->uri, &chal->realm, &aka_cred, method,
+                                 PJSIP_AUTH_ALGORITHM_MD5);
 
     } else {
         pj_assert(!"Bug!");


### PR DESCRIPTION
There are no breaking changes for this work however several structures
were extended with new fields.  See below.

In order to use the new algorithms, you MUST set the new
pjsip_cred_info.ext.algorithm_type field to the appropriate value
when the credential data type is PJSIP_CRED_DATA_DIGEST and when
acting as a server, you must also use pjsip_auth_srv_challenge2()
to send challenges so you can specify algorithms other than MD5.

Summary of changes:

* Added enum pjsip_auth_algorithm_type which list all digest algorithms
supported.

* Added struct pjsip_auth_algorithm which defines parameters for each
algorithm including its IANA name, OpenSSL name, digest length and
digest string representation length.

* Added pjsip_auth_algorithm_type to the pjsip_cred_info structure
so the digest algorithm can be specified when the cred data type
is PJSIP_CRED_DATA_DIGEST.

* Added pjsip_auth_algorithm_type to the pjsip_cached_auth_hdr
structure so we can match on specific algorithm.

* Added functions pjsip_auth_get_algorithm_by_type(),
pjsip_auth_get_algorithm_by_iana_name(), and
pjsip_auth_is_digest_algorithm_supported() to find and search
for supported algorithms.

* Added pjsip_authorization_hdr to the pjsip_auth_lookup_cred_param
structure so we can look up credentiials by specific algorithm.

* Added the pjsip_auth_srv_challenge2() function that takes
a pjsip_auth_algorithm_type so users can create challenges with
specific algorithms instead of defaulting to MD5.

* pjsip_auth_create_digest() was heavily refactored to use the
new algorithm_type contained in pjsip_cred_info to determine the
algorithm to use when creating the digest.  The function is now
generic and can use any supported algorithm.  If OpenSSL isn't
available, it will fall back to the internal MD5 implementation.

* pjsip_auth_create_digestSHA256() is now marked as deprecated and
simply calls the new function with PJSIP_AUTH_ALGORITHM_SHA256.

* sip_auth_client.c and sip_auth_server.c were refactored to support
multiple digest algorithms.

* sip_auth_client was updated to allow the AKEv2-MD5 algorithm
to pass through to the callback specified in pjsip_cred_info.

* A bug was fixed with the PJSIP_AUTH_ALLOW_MULTIPLE_AUTH_HEADER
option where the default setting of 0 prevented sip_auth_client
from responding to WWW/Proxy-Authenticate headers from different
realms.  The RFCs state that this behavior should be allowed.
The comment for this option in sip_config.h was also updated to
indicate that setting this option to 1 is probably not a good idea
for security reasons.

Resolves: #4119
