### PR TITLE
Compile time option to enable using original form of SIP URI

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -606,6 +606,20 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #endif
 
 
+ /**
+  * If non-zero, SIP parser will parse the user/password part of the URI,
+  * and use it in its original form. Otherwise the parser will unescape it,
+  * and then store and use it in its unescaped form.
+  * 
+  * To store the URI in the original form, set this to Yes/1.
+  *
+  * Default: 0
+  */
+#ifndef PJSIP_URI_USE_ORIG_USERPASS
+#   define PJSIP_URI_USE_ORIG_USERPASS      0
+#endif
+
+
 /**
  * Specify port number should be allowed to appear in To and From
  * header. Note that RFC 3261 disallow this, see Table 1 in section

--- a/pjsip/include/pjsip/sip_uri.h
+++ b/pjsip/include/pjsip/sip_uri.h
@@ -339,7 +339,9 @@ typedef struct pjsip_sip_uri
     pjsip_uri_vptr *vptr;               /**< Pointer to virtual function table.*/
     pj_str_t        user;               /**< Optional user part. */
     pj_str_t        passwd;             /**< Optional password part. */
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
     pj_str_t        orig_userpass;      /**< Optional original user&pass. */
+#endif
     pj_str_t        host;               /**< Host part, always exists. */
     int             port;               /**< Optional port number, or zero. */
     pj_str_t        user_param;         /**< Optional user parameter */

--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1531,14 +1531,17 @@ static void* int_parse_sip_url( pj_scanner *scanner,
     }
 
     if (int_is_next_user(scanner)) {
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
         char *start = scanner->curptr;
         pj_str_t orig;
+#endif
 
-        start = scanner->curptr;
         int_parse_user_pass(scanner, pool, &url->user, &url->passwd);
 
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
         pj_strset3(&orig, start, scanner->curptr - 1);
         pj_strdup(pool, &url->orig_userpass, &orig);
+#endif
     }
 
     /* Get host:port */

--- a/pjsip/src/pjsip/sip_uri.c
+++ b/pjsip/src/pjsip/sip_uri.c
@@ -269,10 +269,12 @@ static pj_ssize_t pjsip_url_print(  pjsip_uri_context_e context,
 
     /* Print "user:password@", if any. */
     if (url->user.slen) {
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
         /* Use the URI's original username and password, if any. */
         if (url->orig_userpass.slen) {
             copy_advance_check(buf, url->orig_userpass);
         } else {
+#endif
             const pj_cis_t *spec = pjsip_cfg()->endpt.allow_tx_hash_in_uri ?
                                     &pc->pjsip_USER_SPEC_LENIENT :
                                     &pc->pjsip_USER_SPEC;
@@ -281,8 +283,9 @@ static pj_ssize_t pjsip_url_print(  pjsip_uri_context_e context,
                 copy_advance_char_check(buf, ':');
                 copy_advance_escape(buf, url->passwd, pc->pjsip_PASSWD_SPEC);
             }
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
         }
-
+#endif
         copy_advance_char_check(buf, '@');
     }
 
@@ -513,7 +516,9 @@ PJ_DEF(void) pjsip_sip_uri_assign(pj_pool_t *pool, pjsip_sip_uri *url,
 {
     pj_strdup( pool, &url->user, &rhs->user);
     pj_strdup( pool, &url->passwd, &rhs->passwd);
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
     pj_strdup( pool, &url->orig_userpass, &rhs->orig_userpass);
+#endif
     pj_strdup( pool, &url->host, &rhs->host);
     url->port = rhs->port;
     pj_strdup( pool, &url->user_param, &rhs->user_param);

--- a/pjsip/src/test/uri_test.c
+++ b/pjsip/src/test/uri_test.c
@@ -571,7 +571,9 @@ static pjsip_uri *create_uri14(pj_pool_t *pool)
     pj_strdup2(pool, &name_addr->display, "This is -. !% *_+`'~ me");
     pj_strdup2(pool, &url->user, "a19A&=+$,;?/,");
     pj_strdup2(pool, &url->passwd, "@a&Zz=+$,");
+#if defined (PJSIP_URI_USE_ORIG_USERPASS) && (PJSIP_URI_USE_ORIG_USERPASS)
     pj_strdup2(pool, &url->orig_userpass, "a19A&=+$,;?/%2c:%40a&Zz=+$,");
+#endif
     pj_strdup2(pool, &url->host, "my_proxy09.MY-domain.com");
     url->port = 9801;
     return (pjsip_uri*)name_addr;


### PR DESCRIPTION
This patch will add a compile time option to enable #4043.
The changes in #4043 the SIP parser will parse and store the user/password part of an URI as the original form, which means that
any changes to it will not be represented when the URI is printed.

