### PR TITLE
Removed unnecessary prechecks in async conference bridge operations

### DIFF
--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -594,8 +594,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_remove_port( pjmedia_vid_conf *vid_conf,
 {
     vconf_port *cport;
     op_entry *ope;
+    pj_status_t status = PJ_SUCCESS;
 
-    PJ_LOG(5,(THIS_FILE, "Port %d remove requested", slot));
+    pj_log_push_indent();
+
+    PJ_LOG(5,(THIS_FILE, "Remove video port %d remove requested", slot));
 
     PJ_ASSERT_RETURN(vid_conf && slot<vid_conf->opt.max_slot_cnt, PJ_EINVAL);
 
@@ -604,22 +607,32 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_remove_port( pjmedia_vid_conf *vid_conf,
     /* Port must be valid. */
     cport = vid_conf->ports[slot];
     if (cport == NULL) {
-        PJ_PERROR(3, (THIS_FILE, PJ_EINVAL, "Remove port failed"));
-        pj_mutex_unlock(vid_conf->mutex);
-        return PJ_EINVAL;
+        status = PJ_EINVAL;
+        goto on_return;
     }
-
-    PJ_LOG(4,(THIS_FILE, "Video port %d remove queued", slot));
 
     /* Queue the operation */
     ope = get_free_op_entry(vid_conf);
-    ope->type = OP_REMOVE_PORT;
-    ope->param.remove_port.port = slot;
-    pj_list_push_back(vid_conf->op_queue, ope);
+    if (ope) {
+        ope->type = OP_REMOVE_PORT;
+        ope->param.remove_port.port = slot;
+        pj_list_push_back(vid_conf->op_queue, ope);
+        PJ_LOG(4,(THIS_FILE, "Remove video port %d queued", slot));
+    } else {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
 
+on_return:
     pj_mutex_unlock(vid_conf->mutex);
 
-    return PJ_SUCCESS;
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(3,(THIS_FILE, status, "Remove video port %d failed", slot));
+    }
+
+    pj_log_pop_indent();
+
+    return status;
 }
 
 
@@ -759,16 +772,19 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_connect_port(
                                             void *opt)
 {
     vconf_port *src_port, *dst_port;
-    unsigned i;
-
-    PJ_LOG(5,(THIS_FILE, "Connect ports %d->%d requested",
-                         src_slot, sink_slot));
+    op_entry *ope;
+    pj_status_t status = PJ_SUCCESS;
 
     /* Check arguments */
     PJ_ASSERT_RETURN(vid_conf &&
                      src_slot<vid_conf->opt.max_slot_cnt && 
                      sink_slot<vid_conf->opt.max_slot_cnt, PJ_EINVAL);
     PJ_UNUSED_ARG(opt);
+
+    pj_log_push_indent();
+
+    PJ_LOG(5,(THIS_FILE, "Connect video ports %d->%d requested",
+                         src_slot, sink_slot));
 
     pj_mutex_lock(vid_conf->mutex);
 
@@ -778,46 +794,43 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_connect_port(
     if (!src_port || !src_port->port->get_frame ||
         !dst_port || !dst_port->port->put_frame)
     {
-        PJ_LOG(3,(THIS_FILE,"Failed connecting video ports, make sure that "
-                            "source has get_frame() & sink has put_frame()"));
-        pj_mutex_unlock(vid_conf->mutex);
-        return PJ_EINVAL;
-    }
-
-    /* Check if connection has been made */
-    for (i=0; i<src_port->listener_cnt; ++i) {
-        if (src_port->listener_slots[i] == sink_slot)
-            break;
+        status = PJ_EINVAL;
+        goto on_return;
     }
 
     /* Queue the operation */
-    if (i == src_port->listener_cnt) {
-        op_entry *ope;
-
-        PJ_LOG(4,(THIS_FILE, "Video connect ports %d->%d queued",
-                             src_slot, sink_slot));
-
-        ope = get_free_op_entry(vid_conf);
+    ope = get_free_op_entry(vid_conf);
+    if (ope) {
         ope->type = OP_CONNECT_PORTS;
         ope->param.connect_ports.src = src_slot;
         ope->param.connect_ports.sink = sink_slot;
         pj_list_push_back(vid_conf->op_queue, ope);
+        PJ_LOG(4,(THIS_FILE, "Connect video ports %d->%d queued",
+                             src_slot, sink_slot));
+    } else {
+        status = PJ_ENOMEM;
+        goto on_return;
     }
 
     /* Start clock (if not yet) */
     if (vid_conf->connect_cnt == 0) {
-        pj_status_t status;
         status = pjmedia_clock_start(vid_conf->clock);
         if (status != PJ_SUCCESS) {
             PJ_PERROR(2, (THIS_FILE, status, "Failed to start clock"));
-            pj_mutex_unlock(vid_conf->mutex);
-            return status;
+            goto on_return;
         }
     }
 
+on_return:
     pj_mutex_unlock(vid_conf->mutex);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(3,(THIS_FILE, status, "Connect video ports %d->%d failed",
+                     src_slot, sink_slot));
+    }
 
-    return PJ_SUCCESS;
+    pj_log_pop_indent();
+
+    return status;
 }
 
 static void op_connect_ports(pjmedia_vid_conf *vid_conf,
@@ -869,15 +882,18 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_disconnect_port(
                                             unsigned sink_slot)
 {
     vconf_port *src_port, *dst_port;
-    unsigned i, j;
-
-    PJ_LOG(5,(THIS_FILE, "Disconnect ports %d->%d requested",
-                         src_slot, sink_slot));
+    op_entry *ope;
+    pj_status_t status = PJ_SUCCESS;
 
     /* Check arguments */
     PJ_ASSERT_RETURN(vid_conf &&
                      src_slot<vid_conf->opt.max_slot_cnt && 
                      sink_slot<vid_conf->opt.max_slot_cnt, PJ_EINVAL);
+
+    pj_log_push_indent();
+
+    PJ_LOG(5,(THIS_FILE, "Disconnect video ports %d->%d requested",
+                         src_slot, sink_slot));
 
     pj_mutex_lock(vid_conf->mutex);
 
@@ -885,49 +901,35 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_disconnect_port(
     src_port = vid_conf->ports[src_slot];
     dst_port = vid_conf->ports[sink_slot];
     if (!src_port || !dst_port) {
-        PJ_PERROR(3,(THIS_FILE, PJ_EINVAL,
-                     "Disconnect ports failed, src=0x%p dst=0x%p",
-                     src_port, dst_port));
-        pj_mutex_unlock(vid_conf->mutex);
-        return PJ_EINVAL;
+        status = PJ_EINVAL;
+        goto on_return;
     }
 
-    /* Check if connection has been made */
-    for (i=0; i<src_port->listener_cnt; ++i) {
-        if (src_port->listener_slots[i] == sink_slot)
-            break;
-    }
-    for (j=0; j<dst_port->transmitter_cnt; ++j) {
-        if (dst_port->transmitter_slots[j] == src_slot)
-            break;
-    }
-
-    if (i != src_port->listener_cnt && j != dst_port->transmitter_cnt) {
-        op_entry *ope;
-
-        pj_assert(src_port->listener_cnt > 0 && 
-                  src_port->listener_cnt < vid_conf->opt.max_slot_cnt);
-        pj_assert(dst_port->transmitter_cnt > 0 && 
-                  dst_port->transmitter_cnt < vid_conf->opt.max_slot_cnt);
-
-        /* Queue the operation */
-        PJ_LOG(4,(THIS_FILE, "Video disconnect ports %d->%d queued",
-                             src_slot, sink_slot));
-
-        ope = get_free_op_entry(vid_conf);
+    /* Queue the operation */
+    ope = get_free_op_entry(vid_conf);
+    if (ope) {
         ope->type = OP_DISCONNECT_PORTS;
         ope->param.disconnect_ports.src = src_slot;
         ope->param.disconnect_ports.sink = sink_slot;
         pj_list_push_back(vid_conf->op_queue, ope);
-    } else {
-        PJ_PERROR(3,(THIS_FILE, PJ_EINVAL,
-                     "Disconnect ports failed, src=0x%p dst=0x%p",
-                     src_port, dst_port));
-    }
 
+        PJ_LOG(4,(THIS_FILE, "Disconnect video ports %d->%d queued",
+                             src_slot, sink_slot));
+    } else {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
+on_return:
     pj_mutex_unlock(vid_conf->mutex);
 
-    return PJ_SUCCESS;
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(3,(THIS_FILE, status, "Disconnect video ports %d->%d failed",
+                     src_slot, sink_slot));
+    }
+
+    pj_log_pop_indent();
+
+    return status;
 }
 
 static void op_disconnect_ports(pjmedia_vid_conf *vid_conf,
@@ -987,7 +989,6 @@ static void op_disconnect_ports(pjmedia_vid_conf *vid_conf,
         status = pjmedia_clock_stop(vid_conf->clock);
         if (status != PJ_SUCCESS) {
             PJ_PERROR(4, (THIS_FILE, status, "Failed to stop clock"));
-            return;
         }
     }
 
@@ -1508,31 +1509,47 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_update_port( pjmedia_vid_conf *vid_conf,
 {
     vconf_port *cport;
     op_entry *ope;
-
-    PJ_LOG(5,(THIS_FILE, "Update port %d requested", slot));
+    pj_status_t status = PJ_SUCCESS;
 
     PJ_ASSERT_RETURN(vid_conf && slot<vid_conf->opt.max_slot_cnt, PJ_EINVAL);
+
+    pj_log_push_indent();
+
+    PJ_LOG(5,(THIS_FILE, "Update video port %d requested", slot));
 
     pj_mutex_lock(vid_conf->mutex);
 
     /* Port must be valid. */
     cport = vid_conf->ports[slot];
     if (cport == NULL) {
-        PJ_PERROR(3,(THIS_FILE, PJ_EINVAL, "Update port failed"));
-        pj_mutex_unlock(vid_conf->mutex);
-        return PJ_EINVAL;
+        status = PJ_EINVAL;
+        goto on_return;
     }
 
     /* Queue the operation */
     ope = get_free_op_entry(vid_conf);
-    ope->type = OP_UPDATE_PORT;
-    ope->param.update_port.port = slot;
-    pj_list_push_back(vid_conf->op_queue, ope);
+    if (ope) {
+        ope->type = OP_UPDATE_PORT;
+        ope->param.update_port.port = slot;
+        pj_list_push_back(vid_conf->op_queue, ope);
 
-    PJ_LOG(4,(THIS_FILE, "Update port %d queued", slot));
+        PJ_LOG(4,(THIS_FILE, "Update video port %d queued", slot));
+    } else {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
+
+on_return:
     pj_mutex_unlock(vid_conf->mutex);
 
-    return PJ_SUCCESS;
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(3,(THIS_FILE, status, "Update video port %d failed",
+                     slot));
+    }
+
+    pj_log_pop_indent();
+
+    return status;
 }
 
 
@@ -1652,7 +1669,7 @@ static void op_update_port(pjmedia_vid_conf *vid_conf,
 
     /* Update cport format info */
     cport->format = *new_fmt;
-    PJ_LOG(4,(THIS_FILE, "Port %d updated", slot));
+    PJ_LOG(4,(THIS_FILE, "Video port %d updated", slot));
 }
 
 

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -598,7 +598,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_remove_port( pjmedia_vid_conf *vid_conf,
 
     pj_log_push_indent();
 
-    PJ_LOG(5,(THIS_FILE, "Remove video port %d remove requested", slot));
+    PJ_LOG(5,(THIS_FILE, "Remove video port %d requested", slot));
 
     PJ_ASSERT_RETURN(vid_conf && slot<vid_conf->opt.max_slot_cnt, PJ_EINVAL);
 


### PR DESCRIPTION
After #3928, reported that when connecting & disconnecting ports requests are issued in a very short interval (e.g: when auto answer with resp code 200 is enabled in pjsua app), the disconnect request may fail which cause the ports to remain connected (undesirable). The failure in disconnection request happens because there is precheck of connection availability. Those prechecks are still be performed in the operation execution, but not in the operation request. This PR will remove such prechecks in all async operations requests.

This PR also contain some minor updates, e.g:
- add check for possible failure in memory allocation (for operation entry)
- use ```on_return``` label to clean up error handling.
- logging update: add word "video" when referring a video port's slot without port's name.