### PR TITLE
Miscelaneous Coverity fixes (29 Oct 2024)

### DIFF
--- a/pjlib/src/pj/atomic_queue.cpp
+++ b/pjlib/src/pj/atomic_queue.cpp
@@ -126,7 +126,7 @@ private:
         return old_ptr;
     }
 
-    AtomicQueue() {}
+    AtomicQueue():name_(""){}
 };
 
 struct pj_atomic_queue_t

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -3077,11 +3077,8 @@ static void stream_on_destroy(void *arg)
     pjmedia_stream* stream = (pjmedia_stream*)arg;
 
     /* This function may be called when stream is partly initialized. */
-    if (stream->jb_mutex)
-        pj_mutex_lock(stream->jb_mutex);
 
     /* Free codec. */
-
     if (stream->codec) {
         pjmedia_codec_close(stream->codec);
         pjmedia_codec_mgr_dealloc_codec(stream->codec_mgr, stream->codec);
@@ -3089,9 +3086,7 @@ static void stream_on_destroy(void *arg)
     }
 
     /* Free mutex */
-
     if (stream->jb_mutex) {
-        pj_mutex_unlock(stream->jb_mutex);
         pj_mutex_destroy(stream->jb_mutex);
         stream->jb_mutex = NULL;
     }

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -342,7 +342,9 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_destroy(pjmedia_vid_conf *vid_conf)
     }
 
     /* Flush any pending operation (connect, disconnect, etc) */
-    handle_op_queue(vid_conf);
+    if (vid_conf->op_queue && vid_conf->op_queue_free) {
+        handle_op_queue(vid_conf);
+    }
 
     /* Remove any registered ports (at least to cleanup their pool) */
     for (i=0; i < vid_conf->opt.max_slot_cnt; ++i) {

--- a/pjmedia/src/pjmedia/wav_playlist.c
+++ b/pjmedia/src/pjmedia/wav_playlist.c
@@ -352,9 +352,10 @@ PJ_DEF(pj_status_t) pjmedia_wav_playlist_create(pj_pool_t *pool_,
     /* Create fport instance. */
     fport = create_file_list_port(pool, port_label);
     if (!fport) {
-        status = PJ_ENOMEM;
-        goto on_error;
+        PJ_PERROR(4,(THIS_FILE, PJ_ENOMEM, "WAV playlist create failed"));
+        return PJ_ENOMEM;
     }
+
     fport->pool = pool;
 
     afd = pjmedia_format_get_audio_format_detail(&fport->base.info.fmt, 1);
@@ -646,16 +647,18 @@ PJ_DEF(pj_status_t) pjmedia_wav_playlist_create(pj_pool_t *pool_,
 
 on_error:
 
-    for (index=0; index<file_count; ++index) {
-        if (fport->fd_list[index] != 0)
-            pj_file_close(fport->fd_list[index]);
+    if (fport->fd_list) {
+        for (index=0; index<file_count; ++index) {
+            if (fport->fd_list[index] != 0)
+                pj_file_close(fport->fd_list[index]);
+        }
     }
 
     if (pool)
         pj_pool_release(pool);
 
     PJ_PERROR(1,(THIS_FILE, status,
-                 "Failed creating WAV playlist '%s'",
+                 "Failed creating WAV playlist '%.*s'",
                  (int)port_label->slen, port_label->ptr));
 
     return status;


### PR DESCRIPTION
Fixed CIDs:
- 1564742:  API usage errors  (PW.TOO_MANY_PRINTF_ARGS)
- 1564741:  API usage errors  (PRINTF_ARGS)
- 1564740:  Null pointer dereferences  (FORWARD_NULL)
- 1564739:  API usage errors  (PRINTF_ARGS)
- 1564738:  Null pointer dereferences  (FORWARD_NULL)
- 1564737:  Null pointer dereferences  (FORWARD_NULL)
- 1564736:  Data race undermines locking  (LOCK_EVASION)
- 1564734:  API usage errors  (PW.PRINTF_ARG_MISMATCH)
- 1564733:  Null pointer dereferences  (FORWARD_NULL)
- 1564735:  Uninitialized members  (UNINIT_CTOR)