### PR TITLE
add duration support for rfc2833 DTMF

### DIFF
--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -413,6 +413,26 @@ PJ_DECL(pj_status_t) pjmedia_stream_resume(pjmedia_stream *stream,
 PJ_DECL(pj_status_t) pjmedia_stream_dial_dtmf(pjmedia_stream *stream,
                                               const pj_str_t *ascii_digit);
 
+/**
+ * Transmit DTMF to this stream. The DTMF will be transmitted using
+ * RTP telephone-events as described in RFC 2833. This operation is
+ * only valid for audio stream.
+ *
+ * @param stream        The media stream.
+ * @param ascii_digit   String containing digits to be sent to remote as
+ *                      described on RFC 2833 section 3.10.
+ *                      If PJMEDIA_HAS_DTMF_FLASH is enabled, character 'R' is
+ *                      used to represent the event type 16 (flash) as stated
+ *                      in RFC 4730.
+ *                      Currently the maximum number of digits are 32.
+ * @param duration      duration of event in ms or 0 to use default
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_stream_dial_dtmf2(pjmedia_stream *stream,
+                                              const pj_str_t *ascii_digit,
+                                              unsigned duration);
+
 
 /**
  * Check if the stream has incoming DTMF digits in the incoming DTMF

--- a/pjsip-apps/src/samples/footprint.c
+++ b/pjsip-apps/src/samples/footprint.c
@@ -563,6 +563,7 @@ int dummy_function()
     pjmedia_stream_pause(NULL, PJMEDIA_DIR_ENCODING);
     pjmedia_stream_resume(NULL, PJMEDIA_DIR_ENCODING);
     pjmedia_stream_dial_dtmf(NULL, NULL);
+    pjmedia_stream_dial_dtmf2(NULL, NULL, 0);
     pjmedia_stream_check_dtmf(NULL);
     pjmedia_stream_get_dtmf(NULL, NULL, NULL);
 #endif

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6192,6 +6192,25 @@ PJ_DECL(pj_status_t) pjsua_call_dial_dtmf(pjsua_call_id call_id,
                                           const pj_str_t *digits);
 
 /**
+ * Send DTMF digits to remote using RFC 2833 payload formats. Use 
+ * #pjsua_call_send_dtmf() to send DTMF using SIP INFO or other method in 
+ * \a pjsua_dtmf_method. App can use \a on_dtmf_digit() or \a on_dtmf_digit2() 
+ * callback to monitor incoming DTMF.
+ *
+ * @param call_id       Call identification.
+ * @param digits        DTMF string digits to be sent as described on RFC 2833 
+ *                      section 3.10. If PJMEDIA_HAS_DTMF_FLASH is enabled, 
+ *                      character 'R' is used to represent the 
+ *                      event type 16 (flash) as stated in RFC 4730.
+ * @param duration      duration of event in ms or 0 to use default
+ *
+ * @return              PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsua_call_dial_dtmf2(pjsua_call_id call_id, 
+                                          const pj_str_t *digits,
+                                          unsigned duration);
+
+/**
  * Send DTMF digits to remote. Use this method to send DTMF using the method in
  * \a pjsua_dtmf_method. This method will call #pjsua_call_dial_dtmf() when
  * sending DTMF using \a PJSUA_DTMF_METHOD_RFC2833. Note that 

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -245,6 +245,13 @@ on_return:
 PJ_DEF(pj_status_t) pjsua_call_dial_dtmf( pjsua_call_id call_id,
                                           const pj_str_t *digits)
 {
+    return pjsua_call_dial_dtmf2(call_id, digits, 0);
+}
+
+PJ_DEF(pj_status_t) pjsua_call_dial_dtmf2( pjsua_call_id call_id,
+                                          const pj_str_t *digits,
+                                          unsigned duration)
+{
     pjsua_call *call;
     pjsip_dialog *dlg = NULL;
     pj_status_t status;
@@ -266,8 +273,8 @@ PJ_DEF(pj_status_t) pjsua_call_dial_dtmf( pjsua_call_id call_id,
         goto on_return;
     }
 
-    status = pjmedia_stream_dial_dtmf(
-                call->media[call->audio_idx].strm.a.stream, digits);
+    status = pjmedia_stream_dial_dtmf2(
+                call->media[call->audio_idx].strm.a.stream, digits, duration);
 
 on_return:
     if (dlg) pjsip_dlg_dec_lock(dlg);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -3777,7 +3777,7 @@ PJ_DEF(pj_status_t) pjsua_call_send_dtmf(pjsua_call_id call_id,
                        get_dtmf_method_name(param->method)));
 
     if (param->method == PJSUA_DTMF_METHOD_RFC2833) {
-        status = pjsua_call_dial_dtmf(call_id, &param->digits);
+        status = pjsua_call_dial_dtmf2(call_id, &param->digits, param->duration);
     } else if (param->method == PJSUA_DTMF_METHOD_SIP_INFO) {
         const pj_str_t SIP_INFO = pj_str("INFO");
         int i;


### PR DESCRIPTION
This adds the missing implementation for the duration parameter when sending DTMF events with `pjsua_call_send_dtmf` when using RFC2833. This is part of issue https://github.com/pjsip/pjproject/issues/4091.

The code respects the different `clock_rate` behavior of G.722 and Opus. It also respects the old behavior, by adding an additional function `pjsua_call_dial_dtmf2()` and setting a default of `0` for duration when using `pjsua_call_dial_dtmf()`. Then, the existing behavior of using `stream->dtmf_duration` is used.