### PR TITLE
Check for unregistered video factory in lookup_dev(#4129)

### DIFF
--- a/pjmedia/src/pjmedia/videodev.c
+++ b/pjmedia/src/pjmedia/videodev.c
@@ -362,13 +362,13 @@ static pj_status_t lookup_dev(pjmedia_vid_dev_index id,
 
         for (i=0; i<vid_subsys.drv_cnt; ++i) {
             pjmedia_vid_driver *drv = &vid_subsys.drv[i];
-            if (id==PJMEDIA_VID_DEFAULT_CAPTURE_DEV && 
+            if (id==PJMEDIA_VID_DEFAULT_CAPTURE_DEV && drv->f &&
                 drv->cap_dev_idx >= 0) 
             {
                 id = drv->cap_dev_idx;
                 make_global_index(i, &id);
                 break;
-            } else if (id==PJMEDIA_VID_DEFAULT_RENDER_DEV && 
+            } else if (id==PJMEDIA_VID_DEFAULT_RENDER_DEV && drv->f &&
                 drv->rend_dev_idx >= 0) 
             {
                 id = drv->rend_dev_idx;


### PR DESCRIPTION
This prevents `lookup_dev() `in pjmedia/src/pjmedia/videodev.c form look for `PJMEDIA_VID_DEFAULT_CAPTURE_DEV `and `PJMEDIA_VID_DEFAULT_RENDER_DEV` in drivers unregistered with `pjmedia_vid_unregister_factory()`.
This affects to such high-level functions as: `pjmedia_vid_dev_get_local_index`, `pjmedia_vid_dev_get_info`, `pjmedia_vid_dev_default_param`, `pjmedia_vid_dev_stream_create`, `pjmedia_vid_dev_stream_set_cap` 