### PR TITLE
iocp: fix crash, GetQueuedCompletionStatus() write freed WSAOVERLAPPED memory

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -593,16 +593,13 @@ jobs:
     - name: MSBuild
       working-directory: .
       run: |
-        set /P OPENSSL_DIR=<openssl_dir.txt
         call "%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
-        set INCLUDE=%INCLUDE%;%OPENSSL_DIR%\include
-        set LIB=%LIB%;%OPENSSL_DIR%\lib
         msbuild pjproject-vs14.sln /p:PlatformToolset=v143 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
+    - name: get SSL info
+      run: ./pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp-test-fail
     - name: pjlib-test
       run: |
-        $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
-        $env:PATH+=";$env:OPENSSL_DIR\bin"
         cd pjlib/bin
         ./pjlib-test-i386-Win32-vc14-Release.exe ${{ vars.CI_WIN_ARGS }} ${{ vars.CI_MODE }}
       shell: powershell

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -599,7 +599,7 @@ jobs:
     - name: verify ioqueue type is iocp
       run: |
         cd pjlib/bin
-        pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp
+        pjlib-test-i386-Win32-vc14-Release.exe -c -L | findstr /C:"ioqueue type" | findstr iocp
       shell: cmd
     - name: pjlib-test
       run: |

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -599,7 +599,7 @@ jobs:
     - name: verify ioqueue type is iocp
       run: |
         cd pjlib/bin
-        ./pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp
+        pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp
       shell: cmd
     - name: pjlib-test
       run: |

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -600,6 +600,7 @@ jobs:
       run: |
         cd pjlib/bin
         ./pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp
+      shell: cmd
     - name: pjlib-test
       run: |
         cd pjlib/bin

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -617,5 +617,6 @@ jobs:
     - name: pjlib-test
       run: |
         cd pjlib/bin
-        ./pjlib-test-i386-Win32-vc14-Release.exe ${{ vars.CI_WIN_ARGS }} ${{ vars.CI_MODE }}
+        $args = $env:CI_WIN_ARGS -split ' '
+        ./pjlib-test-i386-Win32-vc14-Release.exe $args $env:CI_MODE
       shell: powershell

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -596,8 +596,10 @@ jobs:
         call "%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
         msbuild pjproject-vs14.sln /p:PlatformToolset=v143 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
-    - name: get SSL info
-      run: ./pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp-test-fail
+    - name: verify ioqueue type is iocp
+      run: |
+        cd pjlib/bin
+        ./pjlib-test-i386-Win32-vc14-Release.exe  | findstr /C:"ioqueue type" | findstr iocp
     - name: pjlib-test
       run: |
         cd pjlib/bin

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -577,3 +577,32 @@ jobs:
         set LIB=%LIB%;%FFMPEG_DIR%\lib;%SDL_DIR%\lib\x86
         msbuild pjproject-vs14.sln /p:PlatformToolset=v143 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
       shell: cmd
+
+  iocp:
+    runs-on: windows-latest
+    name: IOCP / pjlib
+    steps:
+    - uses: actions/checkout@master
+    - name: config site
+      run:
+        cd pjlib/include/pj; cp config_site_test.h config_site.h; Add-Content config_site.h "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_IOCP"
+      shell: powershell
+    - name: check VsDevCmd.bat
+      run: dir "%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+      shell: cmd
+    - name: MSBuild
+      working-directory: .
+      run: |
+        set /P OPENSSL_DIR=<openssl_dir.txt
+        call "%PROGRAMFILES%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        set INCLUDE=%INCLUDE%;%OPENSSL_DIR%\include
+        set LIB=%LIB%;%OPENSSL_DIR%\lib
+        msbuild pjproject-vs14.sln /p:PlatformToolset=v143 /p:Configuration=Release /p:Platform=win32 /p:UseEnv=true
+      shell: cmd
+    - name: pjlib-test
+      run: |
+        $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
+        $env:PATH+=";$env:OPENSSL_DIR\bin"
+        cd pjlib/bin
+        ./pjlib-test-i386-Win32-vc14-Release.exe ${{ vars.CI_WIN_ARGS }} ${{ vars.CI_MODE }}
+      shell: powershell

--- a/pjlib/build/Makefile
+++ b/pjlib/build/Makefile
@@ -47,7 +47,7 @@ export PJLIB_LDFLAGS += $(_LDFLAGS)
 export TEST_SRCDIR = ../src/pjlib-test
 export TEST_OBJS += activesock.o atomic.o echo_clt.o errno.o exception.o \
 		    fifobuf.o file.o hash_test.o ioq_perf.o ioq_udp.o \
-		    ioq_stress_test.o ioq_unreg.o ioq_tcp.o \
+		    ioq_stress_test.o ioq_unreg.o ioq_tcp.o ioq_iocp_unreg_test.o \
 		    list.o mutex.o os.o pool.o pool_perf.o rand.o rbtree.o \
 		    select.o sleep.o sock.o sock_perf.o ssl_sock.o \
 		    string.o test.o thread.o timer.o timestamp.o \

--- a/pjlib/build/pjlib_test.vcxproj
+++ b/pjlib/build/pjlib_test.vcxproj
@@ -717,6 +717,7 @@
     <ClCompile Include="..\src\pjlib-test\fifobuf.c" />
     <ClCompile Include="..\src\pjlib-test\file.c" />
     <ClCompile Include="..\src\pjlib-test\hash_test.c" />
+    <ClCompile Include="..\src\pjlib-test\ioq_iocp_unreg_test.c" />
     <ClCompile Include="..\src\pjlib-test\ioq_perf.c" />
     <ClCompile Include="..\src\pjlib-test\ioq_stress_test.c" />
     <ClCompile Include="..\src\pjlib-test\ioq_tcp.c" />

--- a/pjlib/build/pjlib_test.vcxproj.filters
+++ b/pjlib/build/pjlib_test.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="..\src\pjlib-test\ioq_stress_test.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\pjlib-test\ioq_iocp_unreg_test.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\pjlib-test\test.h">

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -754,7 +754,6 @@ static void cancel_all_pending_op(pj_ioqueue_key_t *key)
             if (rc)
                 PJ_PERROR(2, (THIS_FILE, PJ_RETURN_OS_ERROR(GetLastError()), "cancel io error"));
         }
-        fnCancelIoEx(key->hnd, NULL);
         pj_mutex_unlock(key->mutex);
     }
 }

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -1042,6 +1042,9 @@ static void scan_closing_keys(pj_ioqueue_t *ioqueue)
             pj_assert(key->closing != 0);
 
             if (PJ_TIME_VAL_GTE(now, key->free_time)) {
+                /* Confirm that there're no any pending operations */
+                pj_assert(pj_list_empty(&key->pending_list));
+
                 pj_list_erase(key);
                 pj_list_push_back(&ioqueue->free_list, key);
             }

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -794,9 +794,9 @@ static struct pending_op *alloc_pending_op(pj_ioqueue_key_t *key,
 
 static void release_pending_op(pj_ioqueue_key_t *key, struct pending_op *op)
 {
-    pj_assert(key && op);
     int ref_cnt;
 
+    pj_assert(key && op);
     pj_ioqueue_lock_key(key);
     pj_list_erase(op);
     pj_list_push_back(&key->free_pending_list, op);

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -746,16 +746,8 @@ static void cancel_all_pending_op(pj_ioqueue_key_t *key)
 {
     if (!fnCancelIoEx)
         fnCancelIoEx = (FnCancelIoEx)GetProcAddress(GetModuleHandle(PJ_T("Kernel32.dll")), "CancelIoEx");
-    if (fnCancelIoEx) {
-        struct pending_op *op;
-        pj_mutex_lock(key->mutex);
-        for (op = key->pending_list.next; op != &key->pending_list; op = op->next) {
-            BOOL rc = fnCancelIoEx(key->ioqueue->iocp, (LPOVERLAPPED)&op->pending_key);
-            if (rc)
-                PJ_PERROR(2, (THIS_FILE, PJ_RETURN_OS_ERROR(GetLastError()), "cancel io error"));
-        }
-        pj_mutex_unlock(key->mutex);
-    }
+    if (fnCancelIoEx)
+        fnCancelIoEx(key->hnd, NULL);
 }
 
 /*

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -28,6 +28,10 @@
 #include <pj/errno.h>
 #include <pj/compat/socket.h>
 
+#define THIS_FILE "iocp"
+
+typedef BOOL (WINAPI *FnCancelIoEx)(HANDLE hFile, LPOVERLAPPED lpOverlapped);
+static FnCancelIoEx fnCancelIoEx = NULL;
 
 #if defined(PJ_HAS_WINSOCK2_H) && PJ_HAS_WINSOCK2_H != 0
 #  include <winsock2.h>
@@ -92,6 +96,14 @@ union operation_key
 #endif
 };
 
+struct pending_op
+{
+    PJ_DECL_LIST_MEMBER(struct pending_op);
+    union operation_key pending_key;
+    pj_ioqueue_op_key_t *op_key;
+    pj_pool_t *pool;
+};
+
 /* Type of handle in the key. */
 enum handle_type
 {
@@ -125,9 +137,10 @@ struct pj_ioqueue_key_t
     pj_atomic_t        *ref_count;
     pj_bool_t           closing;
     pj_time_val         free_time;
-    pj_mutex_t         *mutex;
 #endif
 
+    pj_mutex_t         *mutex;
+    struct pending_op pending_list;
 };
 
 /*
@@ -135,6 +148,7 @@ struct pj_ioqueue_key_t
  */
 struct pj_ioqueue_t
 {
+    pj_pool_t        *pool;
     pj_ioqueue_cfg    cfg;
     HANDLE            iocp;
     pj_lock_t        *lock;
@@ -375,6 +389,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create2(pj_pool_t *pool,
 
     /* Create IOCP */
     ioqueue = pj_pool_zalloc(pool, sizeof(*ioqueue));
+    ioqueue->pool = pool;
     if (cfg)
         pj_memcpy(&ioqueue->cfg, cfg, sizeof(*cfg));
     else
@@ -409,7 +424,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create2(pj_pool_t *pool,
         pj_ioqueue_key_t *key;
 
         key = pj_pool_alloc(pool, sizeof(pj_ioqueue_key_t));
-
+        pj_list_init(&key->pending_list);
         rc = pj_atomic_create(pool, 0, &key->ref_count);
         if (rc != PJ_SUCCESS) {
             key = ioqueue->free_list.next;
@@ -577,6 +592,8 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
 
 #else
     rec = (pj_ioqueue_key_t *)pj_pool_zalloc(pool, sizeof(pj_ioqueue_key_t));
+    pj_mutex_create_recursive(pool, "ioqkey", rec->mutex);
+    pj_list_init(&rec->pending_list);
 #endif
 
     /* Build the key for this socket. */
@@ -711,11 +728,16 @@ static pj_bool_t poll_iocp( HANDLE hIocp, DWORD dwTimeout,
     pj_ioqueue_key_t *key;
     pj_ssize_t size_status = -1;
     BOOL rcGetQueued;
+    struct pending_op *xpending_op = NULL;
+    pj_pool_t *xpending_pool = NULL;
+    pj_ioqueue_op_key_t *op_key = NULL;
 
     /* Poll for completion status. */
     rcGetQueued = GetQueuedCompletionStatus(hIocp, &dwBytesTransferred,
                                             &dwKey, (OVERLAPPED**)&pOv, 
                                             dwTimeout);
+    if (!rcGetQueued && pOv)
+        PJ_PERROR(4, (THIS_FILE, PJ_STATUS_FROM_OS(GetLastError()), "GetQueuedCompletionStatus() error dwKey:%p, pOv:%p", (void *)dwKey, pOv));
 
     /* The return value is:
      * - nonzero if event was dequeued.
@@ -735,10 +757,31 @@ static pj_bool_t poll_iocp( HANDLE hIocp, DWORD dwTimeout,
         if (p_key)
             *p_key = key;
 
+        switch(pOv->operation)
+        {
+            case PJ_IOQUEUE_OP_RECV:
+            case PJ_IOQUEUE_OP_RECV_FROM:
+            case PJ_IOQUEUE_OP_SEND:
+            case PJ_IOQUEUE_OP_SEND_TO:
+            case PJ_IOQUEUE_OP_ACCEPT:
+                xpending_op = (struct pending_op *)((char *)pOv - offsetof(struct pending_op, pending_key));
+                pj_mutex_lock(key->mutex);
+                pj_list_erase(xpending_op);
+                pj_mutex_unlock(key->mutex);
+                xpending_pool = xpending_op->pool;
+                op_key = xpending_op->op_key;
+                break;
+            default:
+                break;
+        }
+
 #if PJ_IOQUEUE_HAS_SAFE_UNREG
         /* We shouldn't call callbacks if key is quitting. */
-        if (key->closing)
+        if (key->closing) {
+            if (xpending_pool)
+                pj_pool_release(xpending_pool);
             return PJ_TRUE;
+        }
 
         /* If concurrency is disabled, lock the key 
          * (and save the lock status to local var since app may change
@@ -755,6 +798,8 @@ static pj_bool_t poll_iocp( HANDLE hIocp, DWORD dwTimeout,
             if (has_lock) {
                 pj_mutex_unlock(key->mutex);
             }
+            if (xpending_pool)
+                pj_pool_release(xpending_pool);
             return PJ_TRUE;
         }
 
@@ -773,16 +818,14 @@ static pj_bool_t poll_iocp( HANDLE hIocp, DWORD dwTimeout,
         case PJ_IOQUEUE_OP_RECV_FROM:
             pOv->operation = 0;
             if (key->cb.on_read_complete)
-                key->cb.on_read_complete(key, (pj_ioqueue_op_key_t*)pOv, 
-                                         size_status);
+                key->cb.on_read_complete(key, op_key, size_status);
             break;
         case PJ_IOQUEUE_OP_WRITE:
         case PJ_IOQUEUE_OP_SEND:
         case PJ_IOQUEUE_OP_SEND_TO:
             pOv->operation = 0;
             if (key->cb.on_write_complete)
-                key->cb.on_write_complete(key, (pj_ioqueue_op_key_t*)pOv, 
-                                                size_status);
+                key->cb.on_write_complete(key, op_key, size_status);
             break;
 #if PJ_HAS_TCP
         case PJ_IOQUEUE_OP_ACCEPT:
@@ -802,9 +845,7 @@ static pj_bool_t poll_iocp( HANDLE hIocp, DWORD dwTimeout,
                     status = PJ_RETURN_OS_ERROR(dwError);
                 }
 
-                key->cb.on_accept_complete(key, (pj_ioqueue_op_key_t*)pOv,
-                                           newsock, status);
-                
+                key->cb.on_accept_complete(key, op_key, newsock, status);
             }
             break;
         case PJ_IOQUEUE_OP_CONNECT:
@@ -819,6 +860,9 @@ static pj_bool_t poll_iocp( HANDLE hIocp, DWORD dwTimeout,
         if (has_lock)
             pj_mutex_unlock(key->mutex);
 #endif
+
+        if (xpending_pool)
+            pj_pool_release(xpending_pool);
 
         return PJ_TRUE;
     }
@@ -874,7 +918,22 @@ PJ_DEF(pj_status_t) pj_ioqueue_unregister( pj_ioqueue_key_t *key )
 #else
     PJ_UNUSED_ARG(has_lock);
 #endif
-    
+
+    /* Cancel all penging I/O operations in order to free all pending memory */
+    if (!fnCancelIoEx)
+        fnCancelIoEx = (FnCancelIoEx)GetProcAddress(GetModuleHandle(PJ_T("Kernel32.dll")), "CancelIoEx");
+    if (fnCancelIoEx) {
+        struct pending_op *op;
+        pj_mutex_lock(key->mutex);
+        for (op = key->pending_list.next; op != &key->pending_list; op = op->next) {
+            BOOL rc = fnCancelIoEx(key->ioqueue->iocp, (LPOVERLAPPED)&op->pending_key);
+            if (rc)
+                PJ_PERROR(2, (THIS_FILE, PJ_RETURN_OS_ERROR(GetLastError()), "cancel io error"));
+        }
+        fnCancelIoEx(key->hnd, NULL);
+        pj_mutex_unlock(key->mutex);
+    }
+
     /* Close handle (the only way to disassociate handle from IOCP). 
      * We also need to close handle to make sure that no further events
      * will come to the handle.
@@ -1028,6 +1087,8 @@ PJ_DEF(pj_status_t) pj_ioqueue_recv(  pj_ioqueue_key_t *key,
     DWORD bytesRead;
     DWORD dwFlags = 0;
     union operation_key *op_key_rec;
+    pj_pool_t *pool;
+    struct pending_op *op;
 
     PJ_CHECK_STACK();
     PJ_ASSERT_RETURN(key && op_key && buffer && length, PJ_EINVAL);
@@ -1062,6 +1123,13 @@ PJ_DEF(pj_status_t) pj_ioqueue_recv(  pj_ioqueue_key_t *key,
         }
     }
 
+    pool = pj_pool_create(key->ioqueue->pool->factory, "pending_op%p", 512, 512, NULL);
+    op = PJ_POOL_ZALLOC_T(pool, struct pending_op);
+    op->pool = pool;
+    op->op_key = op_key;
+    memcpy(&op->pending_key, op_key_rec, sizeof(union operation_key));
+    op_key_rec = &op->pending_key;
+
     dwFlags &= ~(PJ_IOQUEUE_ALWAYS_ASYNC);
 
     /*
@@ -1079,9 +1147,14 @@ PJ_DEF(pj_status_t) pj_ioqueue_recv(  pj_ioqueue_key_t *key,
         DWORD dwStatus = WSAGetLastError();
         if (dwStatus!=WSA_IO_PENDING) {
             *length = -1;
+            pj_pool_release(pool);
             return PJ_STATUS_FROM_OS(dwStatus);
         }
     }
+
+    pj_mutex_lock(key->mutex);
+    pj_list_push_back(&key->pending_list, op);
+    pj_mutex_unlock(key->mutex);
 
     /* Pending operation has been scheduled. */
     return PJ_EPENDING;
@@ -1104,6 +1177,8 @@ PJ_DEF(pj_status_t) pj_ioqueue_recvfrom( pj_ioqueue_key_t *key,
     DWORD bytesRead;
     DWORD dwFlags = 0;
     union operation_key *op_key_rec;
+    pj_pool_t *pool;
+    struct pending_op *op;
 
     PJ_CHECK_STACK();
     PJ_ASSERT_RETURN(key && op_key && buffer, PJ_EINVAL);
@@ -1138,6 +1213,13 @@ PJ_DEF(pj_status_t) pj_ioqueue_recvfrom( pj_ioqueue_key_t *key,
         }
     }
 
+    pool = pj_pool_create(key->ioqueue->pool->factory, "pending_op%p", 512, 512, NULL);
+    op = PJ_POOL_ZALLOC_T(pool, struct pending_op);
+    op->pool = pool;
+    op->op_key = op_key;
+    memcpy(&op->pending_key, op_key_rec, sizeof(union operation_key));
+    op_key_rec = &op->pending_key;
+
     dwFlags &= ~(PJ_IOQUEUE_ALWAYS_ASYNC);
 
     /*
@@ -1155,10 +1237,15 @@ PJ_DEF(pj_status_t) pj_ioqueue_recvfrom( pj_ioqueue_key_t *key,
         DWORD dwStatus = WSAGetLastError();
         if (dwStatus!=WSA_IO_PENDING) {
             *length = -1;
+            pj_pool_release(pool);
             return PJ_STATUS_FROM_OS(dwStatus);
         }
     } 
-    
+
+    pj_mutex_lock(key->mutex);
+    pj_list_push_back(&key->pending_list, op);
+    pj_mutex_unlock(key->mutex);
+
     /* Pending operation has been scheduled. */
     return PJ_EPENDING;
 }
@@ -1195,6 +1282,8 @@ PJ_DEF(pj_status_t) pj_ioqueue_sendto( pj_ioqueue_key_t *key,
     DWORD bytesWritten;
     DWORD dwFlags;
     union operation_key *op_key_rec;
+    pj_pool_t *pool;
+    struct pending_op *op;
 
     PJ_CHECK_STACK();
     PJ_ASSERT_RETURN(key && op_key && data, PJ_EINVAL);
@@ -1231,6 +1320,13 @@ PJ_DEF(pj_status_t) pj_ioqueue_sendto( pj_ioqueue_key_t *key,
         }
     }
 
+    pool = pj_pool_create(key->ioqueue->pool->factory, "pending_op%p", 512, 512, NULL);
+    op = PJ_POOL_ZALLOC_T(pool, struct pending_op);
+    op->pool = pool;
+    op->op_key = op_key;
+    memcpy(&op->pending_key, op_key_rec, sizeof(union operation_key));
+    op_key_rec = &op->pending_key;
+
     dwFlags &= ~(PJ_IOQUEUE_ALWAYS_ASYNC);
 
     /*
@@ -1246,9 +1342,15 @@ PJ_DEF(pj_status_t) pj_ioqueue_sendto( pj_ioqueue_key_t *key,
                    &op_key_rec->overlapped.overlapped, NULL);
     if (rc == SOCKET_ERROR) {
         DWORD dwStatus = WSAGetLastError();
-        if (dwStatus!=WSA_IO_PENDING)
+        if (dwStatus!=WSA_IO_PENDING) {
+            pj_pool_release(pool);
             return PJ_STATUS_FROM_OS(dwStatus);
+        }
     }
+
+    pj_mutex_lock(key->mutex);
+    pj_list_push_back(&key->pending_list, op);
+    pj_mutex_unlock(key->mutex);
 
     /* Asynchronous operation successfully submitted. */
     return PJ_EPENDING;
@@ -1273,6 +1375,8 @@ PJ_DEF(pj_status_t) pj_ioqueue_accept( pj_ioqueue_key_t *key,
     pj_status_t status;
     union operation_key *op_key_rec;
     SOCKET sock;
+    pj_pool_t *pool;
+    struct pending_op *op;
 
     PJ_CHECK_STACK();
     PJ_ASSERT_RETURN(key && op_key && new_sock, PJ_EINVAL);
@@ -1323,12 +1427,18 @@ PJ_DEF(pj_status_t) pj_ioqueue_accept( pj_ioqueue_key_t *key,
      * No connection is immediately available.
      * Must schedule an asynchronous operation.
      */
-    op_key_rec = (union operation_key*)op_key->internal__;
-    
+    pool = pj_pool_create(key->ioqueue->pool->factory, "pending_op%p", 512, 512, NULL);
+    op = PJ_POOL_ZALLOC_T(pool, struct pending_op);
+    op->pool = pool;
+    op->op_key = op_key;
+    op_key_rec = &op->pending_key;
+
     status = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0, 
                             &op_key_rec->accept.newsock);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+        pj_pool_release(pool);
         return status;
+    }
 
     op_key_rec->accept.operation = PJ_IOQUEUE_OP_ACCEPT;
     op_key_rec->accept.addrlen = addrlen;
@@ -1346,12 +1456,19 @@ PJ_DEF(pj_status_t) pj_ioqueue_accept( pj_ioqueue_key_t *key,
 
     if (rc == TRUE) {
         ioqueue_on_accept_complete(key, &op_key_rec->accept);
+        pj_pool_release(pool);
         return PJ_SUCCESS;
     } else {
         DWORD dwStatus = WSAGetLastError();
-        if (dwStatus!=WSA_IO_PENDING)
+        if (dwStatus!=WSA_IO_PENDING) {
+            pj_pool_release(pool);
             return PJ_STATUS_FROM_OS(dwStatus);
+        }
     }
+
+    pj_mutex_lock(key->mutex);
+    pj_list_push_back(&key->pending_list, op);
+    pj_mutex_unlock(key->mutex);
 
     /* Asynchronous Accept() has been submitted. */
     return PJ_EPENDING;
@@ -1493,20 +1610,12 @@ PJ_DEF(pj_status_t) pj_ioqueue_set_concurrency(pj_ioqueue_key_t *key,
 
 PJ_DEF(pj_status_t) pj_ioqueue_lock_key(pj_ioqueue_key_t *key)
 {
-#if PJ_IOQUEUE_HAS_SAFE_UNREG
     return pj_mutex_lock(key->mutex);
-#else
-    PJ_ASSERT_RETURN(!"PJ_IOQUEUE_HAS_SAFE_UNREG is disabled", PJ_EINVALIDOP);
-#endif
 }
 
 PJ_DEF(pj_status_t) pj_ioqueue_unlock_key(pj_ioqueue_key_t *key)
 {
-#if PJ_IOQUEUE_HAS_SAFE_UNREG
     return pj_mutex_unlock(key->mutex);
-#else
-    PJ_ASSERT_RETURN(!"PJ_IOQUEUE_HAS_SAFE_UNREG is disabled", PJ_EINVALIDOP);
-#endif
 }
 
 PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -484,7 +484,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create2(pj_pool_t *pool,
 
         pj_list_push_back(&ioqueue->free_list, key);
     }
-    ioqueue->max_fd = pj_list_size(&ioqueue->free_list); // max_fd;
+    ioqueue->max_fd = max_fd;
 
     *p_ioqueue = ioqueue;
 
@@ -545,7 +545,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_destroy( pj_ioqueue_t *ioqueue )
         if (PJ_TIME_VAL_GTE(timeout, stop)) {
             PJ_LOG(3, (THIS_FILE, "Warning, IOCP destroy timeout in waiting "
                        "for cancelling ops, after %dms, pending keys=%d",
-                       TIMEOUT_CANCEL_OP, pending_key_cnt));
+                       TIMEOUT_CANCEL_OP, (int)pending_key_cnt));
             break;
         }
     }

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -135,7 +135,6 @@ struct pj_ioqueue_key_t
 
     pj_atomic_t        *ref_count;
     pj_bool_t           closing;
-    pj_time_val         free_time;
     pj_mutex_t         *mutex;
     struct pending_op pending_list;
 };
@@ -662,10 +661,6 @@ static void decrement_counter(pj_ioqueue_key_t *key)
         pj_lock_acquire(key->ioqueue->lock);
 
         pj_assert(key->closing == 1);
-        pj_gettickcount(&key->free_time);
-        key->free_time.msec += PJ_IOQUEUE_KEY_FREE_DELAY;
-        pj_time_val_normalize(&key->free_time);
-
         pj_list_erase(key);
         pj_list_push_back(&key->ioqueue->free_list, key);
 

--- a/pjlib/src/pjlib-test/ioq_iocp_unreg_test.c
+++ b/pjlib/src/pjlib-test/ioq_iocp_unreg_test.c
@@ -1,0 +1,188 @@
+/*
+ * IOCP crash reproduce test (issue #985).
+ * The code is taken from PR #4172 with few minor changes.
+ * Issue fix attempt is done in #4136.
+ *
+ * Note:
+ * - The crash was reproducible on Windows 10 & MSVC2005 (Win32),
+ *   but not reproducible on Windows 11 & MSVC2022 (Win32 &x64).
+ * - Test can be run for any ioqueue and normally take less than one second.
+ */
+#include <pjlib.h>
+#include "test.h"
+
+#define THIS_FILE "iocp_unregister_test.c"
+
+#define CLIENT_NUM (PJ_IOQUEUE_MAX_HANDLES-1)
+
+/**
+ * socket info
+ * has an independent memory pool, which is the key to successful
+ * reproduce crash
+ */
+struct sock_info_t {
+    pj_pool_t *pool;
+    pj_activesock_t *asock;
+    pj_sockaddr bound_addr;
+};
+
+struct iocp_test_t {
+    pj_pool_t *pool;
+    pj_ioqueue_t *ioq;
+    pj_thread_t *tid;
+    pj_bool_t quit;
+    struct sock_info_t *socks[CLIENT_NUM];
+    pj_activesock_t *asock_send;
+};
+
+
+static int worker_thread(void *p)
+{
+    struct iocp_test_t *test = (struct iocp_test_t *)p;
+
+    while(!test->quit) {
+        pj_time_val timeout = {0, 100};
+        pj_ioqueue_poll(test->ioq, &timeout);
+    }
+
+    return 0;
+}
+
+static unsigned recv_cnt;
+
+static pj_bool_t on_data_recvfrom(pj_activesock_t *asock,
+                                  void *data,
+                                  pj_size_t size,
+                                  const pj_sockaddr_t *src_addr,
+                                  int addr_len,
+                                  pj_status_t status)
+{
+    (void)asock;
+    (void)src_addr;
+    (void)addr_len;
+    PJ_LOG(3, (THIS_FILE, "on_data_recvfrom() data:%.*s, status:%d",
+                          (int)size, (char *)data, status));
+    ++recv_cnt;
+    return PJ_TRUE;
+}
+
+int iocp_unregister_test(void)
+{
+    struct iocp_test_t *test;
+    pj_pool_t *pool;
+    pj_status_t status;
+    unsigned i;
+    pj_activesock_cfg cfg;
+    pj_activesock_cb cb;
+    struct sock_info_t *sock_info;
+    pj_sockaddr loc_addr;
+    pj_str_t loop = {"127.0.0.1", 9};
+
+    // Let's just do it for any ioqueue.
+    //if (strcmp(pj_ioqueue_name(), "iocp")) {
+    //    /* skip if ioqueue framework is not iocp */
+    //    return PJ_SUCCESS;
+    //}
+
+    pool = pj_pool_create(mem, "iocp-crash-test", 500, 500, NULL);
+    test = PJ_POOL_ZALLOC_T(pool, struct iocp_test_t);
+    test->pool = pool;
+    status = pj_ioqueue_create(pool, CLIENT_NUM+1, &test->ioq);
+    if (status != PJ_SUCCESS) {
+        status = -900;
+        goto on_error;
+    }
+
+    status = pj_thread_create(pool, "iocp-crash-test", worker_thread,
+                              test, 0, 0, &test->tid);
+    if (status != PJ_SUCCESS) {
+        status = -901;
+        goto on_error;
+    }
+
+    pj_activesock_cfg_default(&cfg);
+    pj_bzero(&cb, sizeof(cb));
+    cb.on_data_recvfrom = on_data_recvfrom;
+
+    /* create send socket */
+    status = pj_activesock_create_udp(pool, NULL, &cfg, test->ioq, &cb, NULL,
+                                      &test->asock_send, NULL);
+    if (status != PJ_SUCCESS) {
+        status = -902;
+        goto on_error;
+    }
+
+    /* create sockets to recevie */
+    pj_sockaddr_init(pj_AF_INET(), &loc_addr, &loop, 0);
+    for (i = 0; i < PJ_ARRAY_SIZE(test->socks); i++) {
+        pool = pj_pool_create(mem, "sock%p", 500, 500, NULL);
+        sock_info = PJ_POOL_ZALLOC_T(pool, struct sock_info_t);
+        sock_info->pool = pool;
+
+        status = pj_activesock_create_udp(pool, &loc_addr, &cfg, test->ioq,
+                                          &cb, NULL, &sock_info->asock,
+                                          &sock_info->bound_addr);
+        if (status != PJ_SUCCESS) {
+            status = -903;
+            pj_pool_release(pool);
+            goto on_error;
+        }
+        test->socks[i] = sock_info;
+        pj_activesock_start_recvfrom(sock_info->asock, pool, 256, 0);
+    }
+
+    /* send 'hello' to every socks */
+    for (i = 0; i < PJ_ARRAY_SIZE(test->socks); i++) {
+        pj_ioqueue_op_key_t *send_key;
+        pj_str_t data;
+        pj_ssize_t sent;
+
+        sock_info = test->socks[i];
+        send_key = PJ_POOL_ZALLOC_T(test->pool, pj_ioqueue_op_key_t);
+        pj_strdup2_with_null(test->pool, &data, "hello");
+        sent = data.slen;
+        status = pj_activesock_sendto(test->asock_send, send_key, data.ptr,
+                                &sent, 0, &sock_info->bound_addr,
+                                pj_sockaddr_get_len(&sock_info->bound_addr));
+        if (status != PJ_SUCCESS && status != PJ_EPENDING) {
+            char buf[80];
+            pj_sockaddr_print(&sock_info->bound_addr, buf, sizeof(buf), 3);
+            PJ_PERROR(2, (THIS_FILE, status, "send error, dest:%s", buf));
+        }
+    }
+
+    pj_thread_sleep(20);
+
+    /* close all socks */
+    for (i = 0; i < PJ_ARRAY_SIZE(test->socks); i++) {
+        sock_info = test->socks[i];
+        pj_activesock_close(sock_info->asock);
+        pj_pool_release(sock_info->pool);
+        test->socks[i] = NULL;
+    }
+
+    pj_thread_sleep(20);
+
+    /* quit */
+    test->quit = PJ_TRUE;
+    status = PJ_SUCCESS;
+
+on_error:
+    if (test->tid)
+        pj_thread_join(test->tid);
+    for (i = 0; i < PJ_ARRAY_SIZE(test->socks); i++) {
+        sock_info = test->socks[i];
+        if (!sock_info)
+            break;
+        pj_activesock_close(sock_info->asock);
+        pj_pool_release(sock_info->pool);
+    }
+    if(test->asock_send)
+        pj_activesock_close(test->asock_send);
+    if (test->ioq)
+        pj_ioqueue_destroy(test->ioq);
+    pj_pool_release(test->pool);
+
+    PJ_LOG(3, (THIS_FILE, "Recv cnt = %u", recv_cnt));
+    return status;
+}

--- a/pjlib/src/pjlib-test/ioq_iocp_unreg_test.c
+++ b/pjlib/src/pjlib-test/ioq_iocp_unreg_test.c
@@ -1,4 +1,24 @@
 /*
+ * Copyright (C) 2024 jimying at github dot com.
+ * Copyright (C) 2024 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+ 
+ 
+ /*
  * IOCP crash reproduce test (issue #985).
  * The code is taken from PR #4172 with few minor changes.
  * Issue fix attempt is done in #4136.
@@ -112,7 +132,7 @@ int iocp_unregister_test(void)
         goto on_error;
     }
 
-    /* create sockets to recevie */
+    /* create sockets to receive */
     pj_sockaddr_init(pj_AF_INET(), &loc_addr, &loop, 0);
     for (i = 0; i < PJ_ARRAY_SIZE(test->socks); i++) {
         pool = pj_pool_create(mem, "sock%p", 500, 500, NULL);

--- a/pjlib/src/pjlib-test/ioq_iocp_unreg_test.c
+++ b/pjlib/src/pjlib-test/ioq_iocp_unreg_test.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2024 jimying at github dot com.
  * Copyright (C) 2024 Teluu Inc. (http://www.teluu.com)
+ * Copyright (C) 2024 jimying at github dot com.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pjlib/src/pjlib-test/ioq_stress_test.c
+++ b/pjlib/src/pjlib-test/ioq_stress_test.c
@@ -333,7 +333,7 @@ static void on_accept_complete(pj_ioqueue_key_t *key,
     status = pj_ioqueue_register_sock2(test->state.pool,
                                        test->state.ioq,
                                        test->state.socks[SERVER],
-                                       test->state.grp_lock,
+                                       NULL, //test->state.grp_lock,
                                        test,
                                        &test_cb,
                                        &test->state.keys[SERVER]);
@@ -446,7 +446,8 @@ static int worker_thread(void *p)
             op_key_user_data *okud = &test->state.okuds[CLIENT][i];
             pj_lock_acquire((pj_lock_t*)test->state.grp_lock);
             if (!pj_ioqueue_is_pending(test->state.keys[CLIENT],
-                                       &okud->client.send_op)) {
+                                       &okud->client.send_op))
+            {
                 on_write_complete(test->state.keys[CLIENT],
                                   &okud->client.send_op, -12345);
             }
@@ -529,7 +530,7 @@ static int perform_single_pass(test_desc *test)
         CHECK(24, pj_ioqueue_register_sock2(test->state.pool,
                                             test->state.ioq,
                                             test->state.listen_sock,
-                                            test->state.grp_lock,
+                                            NULL, //test->state.grp_lock,
                                             test,
                                             &test_cb,
                                             &test->state.listen_key));
@@ -559,7 +560,7 @@ static int perform_single_pass(test_desc *test)
         CHECK(33, pj_ioqueue_register_sock2(test->state.pool,
                                             test->state.ioq,
                                             test->state.socks[SERVER],
-                                            test->state.grp_lock,
+                                            NULL, //test->state.grp_lock,
                                             test,
                                             &test_cb,
                                             &test->state.keys[SERVER]));
@@ -607,7 +608,7 @@ static int perform_single_pass(test_desc *test)
     CHECK(42, pj_ioqueue_register_sock2(test->state.pool,
                                         test->state.ioq,
                                         test->state.socks[CLIENT],
-                                        test->state.grp_lock,
+                                        NULL, //test->state.grp_lock,
                                         test,
                                         &test_cb,
                                         &test->state.keys[CLIENT]));

--- a/pjlib/src/pjlib-test/ioq_stress_test.c
+++ b/pjlib/src/pjlib-test/ioq_stress_test.c
@@ -605,6 +605,14 @@ static int perform_single_pass(test_desc *test)
                                      pj_SO_RCVBUF(),
                                      &value, sizeof(value)));
     }
+
+    /* We cannot use the global group lock for registering keys (here and
+     * all below) because currently IOCP key uses the group lock handler for
+     * releasing its resources including the key itself. If the key is not
+     * released (the global group lock destroy is done very late) and
+     * as the ioqueue capacity for the tests are quite limited (~4-6 keys),
+     * ioqueue will get full quickly and tests will fail.
+     */
     CHECK(42, pj_ioqueue_register_sock2(test->state.pool,
                                         test->state.ioq,
                                         test->state.socks[CLIENT],

--- a/pjlib/src/pjlib-test/ioq_udp.c
+++ b/pjlib/src/pjlib-test/ioq_udp.c
@@ -940,7 +940,6 @@ static int bench_test(const pj_ioqueue_cfg *cfg, int bufsize,
     pj_timestamp t1, t2, t_elapsed;
     int rc=0, i;    /* i must be signed */
     pj_str_t temp;
-    char errbuf[PJ_ERR_MSG_SIZE];
 
     TRACE__((THIS_FILE, "   bench test %d", inactive_sock_count));
 
@@ -1161,8 +1160,7 @@ static int bench_test(const pj_ioqueue_cfg *cfg, int bufsize,
     return rc;
 
 on_error:
-    pj_strerror(pj_get_netos_error(), errbuf, sizeof(errbuf));
-    PJ_LOG(1,(THIS_FILE, "...ERROR: %s", errbuf));
+    PJ_PERROR(1,(THIS_FILE, pj_get_netos_error(), "...ERROR"));
     if (ssock >= 0)
         pj_sock_close(ssock);
     if (csock >= 0)

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -342,6 +342,10 @@ static int features_tests(int argc, char *argv[])
     UT_ADD_TEST(&test_app.ut_app, ssl_sock_test, 0);
 #endif
 
+#if INCLUDE_IOCP_UNREG_TEST
+    UT_ADD_TEST(&test_app.ut_app, iocp_unregister_test, 0);
+#endif
+
 
 #undef ADD_TEST
 

--- a/pjlib/src/pjlib-test/test.h
+++ b/pjlib/src/pjlib-test/test.h
@@ -65,6 +65,7 @@
 #define INCLUDE_IOQUEUE_STRESS_TEST (PJ_HAS_THREADS && GROUP_NETWORK)
 #define INCLUDE_UDP_IOQUEUE_TEST    GROUP_NETWORK
 #define INCLUDE_TCP_IOQUEUE_TEST    GROUP_NETWORK
+#define INCLUDE_IOCP_UNREG_TEST     GROUP_NETWORK
 #define INCLUDE_ACTIVESOCK_TEST     GROUP_NETWORK
 #define INCLUDE_SSLSOCK_TEST        (PJ_HAS_SSL_SOCK && GROUP_NETWORK)
 #define INCLUDE_IOQUEUE_PERF_TEST   (PJ_HAS_THREADS && GROUP_NETWORK && WITH_BENCHMARK)
@@ -114,6 +115,7 @@ extern int tcp_ioqueue_test(void);
 extern int ioqueue_perf_test0(void);
 extern int ioqueue_perf_test1(void);
 extern int ioqueue_stress_test(void);
+extern int iocp_unregister_test(void);
 extern int activesock_test(void);
 extern int file_test(void);
 extern int ssl_sock_test(void);


### PR DESCRIPTION
Try to fix issue #985. The idea is to call [CancelIoEx()](https://learn.microsoft.com/en-us/windows/win32/fileio/cancelioex-func) for the unregistering socket/key to cancel all pending operations of the key. However, as `CancelIoEx()` is basically asynchronous, this also makes the key unregistration asynchronous, so here are some consequences:
- The memory for operation key must not be freed until the operation cancellation is completed, so instead of using app supplied operation key, the IOCP will use an internal copy.
- Key must always have a group lock (can be supplied by app), which will handle key's resources release.
