### PR TITLE
Fix to compile error in on_make_call_med_tp_complete while accessing calls array with invalid call id.

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -433,14 +433,20 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
 {
     pjmedia_sdp_session *offer = NULL;
     pjsip_inv_session *inv = NULL;
-    pjsua_call *call = &pjsua_var.calls[call_id];
-    pjsua_acc *acc = &pjsua_var.acc[call->acc_id];
-    pjsip_dialog *dlg = call->async_call.dlg;
+    pjsua_call *call;
+    pjsua_acc *acc;
+    pjsip_dialog *dlg;
     unsigned options = 0;
     pjsip_tx_data *tdata;
     pj_bool_t cb_called = PJ_FALSE;
     pjsip_tpselector tp_sel;
     pj_status_t status = (info? info->status: PJ_SUCCESS);
+
+    /* Get call, account, and dialog */
+    PJ_ASSERT_RETURN(call_id != PJSUA_INVALID_ID, PJ_EINVAL);
+    call = &pjsua_var.calls[call_id];
+    acc = &pjsua_var.acc[call->acc_id];
+    dlg = call->async_call.dlg;
 
     PJSUA_LOCK();
 


### PR DESCRIPTION
Fixes compile warning/error on certain GCC versions using optimized -O2 builds:
```
pjsip/src/pjsua-lib/pjsua_call.c: In function 'on_make_call_med_tp_complete':
pjsip/src/pjsua-lib/pjsua_call.c:436:40: warning: array subscript -1 is below array bounds of 'pjsua_call[3]' [-Warray-bounds=]
  436 |     pjsua_call *call = &pjsua_var.calls[call_id];
```

`call_id` being invalid at this point should be impossible, but a particular ARM GCC version 13.2.1 does not detect that `if (call_id == PJSUA_INVALID_ID)` on line 861 of `pjsua_call_make_call` makes it impossible.