### PR TITLE
Misc Coverity fixes

### DIFF
--- a/pjlib-util/src/pjlib-util/crc32.c
+++ b/pjlib-util/src/pjlib-util/crc32.c
@@ -172,7 +172,7 @@ PJ_DEF(pj_uint32_t) pj_crc32_update(pj_crc32_context *ctx,
         data += 4;
     }
 
-    while (nbytes--) {
+    for (; nbytes; nbytes--) {
         crc = crc_tab[CRC32_INDEX(crc) ^ *data++] ^ CRC32_SHIFTED(crc);
     }
 

--- a/pjlib-util/src/pjlib-util/http_client.c
+++ b/pjlib-util/src/pjlib-util/http_client.c
@@ -684,7 +684,7 @@ static pj_status_t http_response_parse(pj_pool_t *pool,
     pj_scan_fini(&scanner);
 
     /* Parse the response headers. */
-    size = i - 2 - (end_status - newdata);
+    size = (i < 2)? 0: i - 2 - (end_status - newdata);
     if (size > 0) {
         status = http_headers_parse(end_status + 1, size,
                                     &response->headers);

--- a/pjlib/src/pj/atomic_queue.cpp
+++ b/pjlib/src/pj/atomic_queue.cpp
@@ -126,7 +126,9 @@ private:
         return old_ptr;
     }
 
-    AtomicQueue():name_(""){}
+    AtomicQueue():maxItemCnt_(0), itemSize_(0), ptrWrite(0),
+                  ptrRead(0), buffer(NULL), name_("")
+    {}
 };
 
 struct pj_atomic_queue_t

--- a/pjlib/src/pj/pool_caching.c
+++ b/pjlib/src/pj/pool_caching.c
@@ -81,6 +81,8 @@ PJ_DEF(void) pj_caching_pool_init( pj_caching_pool *cp,
      */
     //cp->factory.on_block_alloc = &cpool_on_block_alloc;
     //cp->factory.on_block_free = &cpool_on_block_free;
+    PJ_UNUSED_ARG(cpool_on_block_alloc);
+    PJ_UNUSED_ARG(cpool_on_block_free);
 
     pool = pj_pool_create_on_buf("cachingpool", cp->pool_buf, sizeof(cp->pool_buf));
     status = pj_lock_create_simple_mutex(pool, "cachingpool", &cp->lock);

--- a/pjlib/src/pj/unittest.c
+++ b/pjlib/src/pj/unittest.c
@@ -776,6 +776,7 @@ PJ_DEF(pj_status_t) pj_test_create_text_runner(
     text_runner_t *runner;
     unsigned i;
     pj_status_t status;
+    unsigned nthreads = (PJ_HAS_THREADS? 1: 0);
 
     *p_runner = NULL;
 
@@ -795,13 +796,14 @@ PJ_DEF(pj_status_t) pj_test_create_text_runner(
 
     if (prm) {
         pj_memcpy(&runner->base.prm, prm, sizeof(*prm));
+        nthreads = prm->nthreads;
     } else {
         pj_test_runner_param_default(&runner->base.prm);
     }
     runner->base.prm.nthreads = 0;
-    runner->threads = (pj_thread_t**) pj_pool_calloc(pool, prm->nthreads,
+    runner->threads = (pj_thread_t**) pj_pool_calloc(pool, nthreads,
                                                      sizeof(pj_thread_t*));
-    for (i=0; i<prm->nthreads; ++i) {
+    for (i=0; i<nthreads; ++i) {
         thread_param_t *tprm = PJ_POOL_ZALLOC_T(pool, thread_param_t);
         tprm->runner = runner;
         tprm->tid = i+1;

--- a/pjlib/src/pjlib-test/fifobuf.c
+++ b/pjlib/src/pjlib-test/fifobuf.c
@@ -133,7 +133,6 @@ static int fifobuf_misc_test()
            LOOP=10000 };
     pj_pool_t *pool;
     pj_fifobuf_t fifo;
-    pj_size_t available = SIZE;
     void *entries[MAX_ENTRIES];
     void *buffer;
     int i;

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -540,6 +540,8 @@ static pj_status_t load_cert_to_buf(pj_pool_t *pool, const pj_str_t *file_name,
 }
 #endif
 
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_SCHANNEL)
+
 static pj_status_t load_cert_from_store(pj_pool_t *pool,
                                         pj_ssl_cert_t **p_cert)
 {
@@ -572,6 +574,8 @@ static pj_status_t load_cert_from_store(pj_pool_t *pool,
     return PJ_ENOTFOUND;
 #endif
 }
+
+#endif
 
 static int echo_test(pj_ssl_sock_proto srv_proto, pj_ssl_sock_proto cli_proto,
                      pj_ssl_cipher srv_cipher, pj_ssl_cipher cli_cipher,

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -486,8 +486,10 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
             break;
 
         codec_info = &endpt->codec_mgr.codec_desc[i].info;
-        pjmedia_codec_mgr_get_default_param(&endpt->codec_mgr, codec_info,
-                                            &codec_param);
+        status = pjmedia_codec_mgr_get_default_param(&endpt->codec_mgr,
+                                                     codec_info, &codec_param);
+        if (status != PJ_SUCCESS)
+            return status;
         fmt = &m->desc.fmt[m->desc.fmt_count++];
         pt = codec_info->pt;
 

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -996,7 +996,7 @@ static void create_dtmf_payload(pjmedia_stream *stream,
         }
 #endif
         if (!pj_stricmp2(&stream->si.fmt.encoding_name, "opus")) {
-            ts_modifier = 48000 / stream->codec_param.info.clock_rate;
+            ts_modifier = (float)48000 / stream->codec_param.info.clock_rate;
         }
         duration = ts_modifier * digit->send_duration * stream->codec_param.info.clock_rate / 1000;
     }

--- a/pjsip/src/pjsip/sip_multipart.c
+++ b/pjsip/src/pjsip/sip_multipart.c
@@ -635,7 +635,7 @@ static pjsip_multipart_part *parse_multipart_part(pj_pool_t *pool,
                                                   const pjsip_media_type *pct)
 {
     pjsip_multipart_part *part = pjsip_multipart_create_part(pool);
-    char *p = start, *end = start+len, *end_hdr = NULL, *start_body = NULL;
+    char *p = start, *end = start+len, *end_hdr = NULL, *start_body;
     pjsip_ctype_hdr *ctype_hdr = NULL;
 
     TRACE_((THIS_FILE, "Parsing part: begin--\n%.*s\n--end",
@@ -657,6 +657,7 @@ static pjsip_multipart_part *parse_multipart_part(pj_pool_t *pool,
             /* Empty body section */
             end_hdr = end;
             start_body = ++p;
+            break;
         } else if ((p>=start+1 && *(p-1)=='\n') ||
                    (p>=start+2 && *(p-1)=='\r' && *(p-2)=='\n'))
         {

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1260,7 +1260,7 @@ PJ_DEF(pj_status_t) pjsua_player_create( const pj_str_t *filename,
     pjmedia_port *port;
     pj_status_t status = PJ_SUCCESS;
 
-    PJ_ASSERT_RETURN(filename->slen > 0, PJ_EINVAL);
+    PJ_ASSERT_RETURN(filename && filename->slen > 0, PJ_EINVAL);
 
     if (pjsua_var.player_cnt >= PJ_ARRAY_SIZE(pjsua_var.player))
         return PJ_ETOOMANY;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1260,6 +1260,8 @@ PJ_DEF(pj_status_t) pjsua_player_create( const pj_str_t *filename,
     pjmedia_port *port;
     pj_status_t status = PJ_SUCCESS;
 
+    PJ_ASSERT_RETURN(filename->slen > 0, PJ_EINVAL);
+
     if (pjsua_var.player_cnt >= PJ_ARRAY_SIZE(pjsua_var.player))
         return PJ_ETOOMANY;
 


### PR DESCRIPTION
1102584 endpoint.c: Unchecked return value
1102634 http_client.c: Overflowed constant
1547480 pjsua_aud.c: Overflowed integer argument
1547489 crc32.c: Overflowed constant
1550395 unittest.c: Dereference after null check
1547487 sip_multipart.c: Unused value
1565388 stream.c: Result is not floating-point
1564735 atomic_queue.cpp: Uninitialized pointer field

Also fixes compilation warnings:
../src/pj/pool_caching.c:353:18: warning: unused function 'cpool_on_block_alloc' [-Wunused-function]
../src/pj/pool_caching.c:370:13: warning: unused function 'cpool_on_block_free' [-Wunused-function]
../src/pjlib-test/fifobuf.c:136:15: warning: unused variable 'available' [-Wunused-variable]
../src/pjlib-test/ssl_sock.c:543:20: warning: unused function 'load_cert_from_store' [-Wunused-function]
