### PR TITLE
Misc fix (Coverity and build warning)

### DIFF
--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -576,7 +576,7 @@ static pj_status_t create_identity_from_cert(applessl_sock_t *assock,
                 identity = (SecIdentityRef)
                            CFDictionaryGetValue((CFDictionaryRef) item,
                                                 kSecImportItemIdentity);
-                identity = CFRetain(identity);
+                CFRetain(identity);
                 break;
             }
 #if !TARGET_OS_IPHONE
@@ -1416,6 +1416,11 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
      * is started.
      */
     PJ_UNUSED_ARG(ssock);
+
+    /* Suppress warnings */
+    PJ_UNUSED_ARG(circ_reset);
+    PJ_UNUSED_ARG(circ_read_cancel);
+
     return PJ_SUCCESS;
 }
 

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -102,7 +102,8 @@ void writeSipHeaders(ContainerNode &node,
 ///////////////////////////////////////////////////////////////////////////////
 
 AuthCredInfo::AuthCredInfo()
-: scheme("digest"), realm("*"), dataType(0)
+: scheme("digest"), realm("*"), dataType(0),
+  algoType(PJSIP_AUTH_ALGORITHM_NOT_SET)
 {
 }
 
@@ -112,7 +113,8 @@ AuthCredInfo::AuthCredInfo(const string &param_scheme,
                            const int param_data_type,
                            const string param_data)
 : scheme(param_scheme), realm(param_realm), username(param_user_name),
-  dataType(param_data_type), data(param_data)
+  dataType(param_data_type), data(param_data),
+  algoType(PJSIP_AUTH_ALGORITHM_NOT_SET)
 {
 }
 


### PR DESCRIPTION
Coverity:
1565417-1565420 siptypes.cpp: Uninitialized scalar field algoType

Warnings:
../src/pj/ssl_sock_apple.m:579:26: warning: assigning to 'SecIdentityRef' (aka 'struct __SecIdentity *') from 'CFTypeRef' (aka 'const void *') discards qualifiers
../src/pj/ssl_sock_imp_common.c:91:13: warning: unused function 'circ_reset'
../src/pj/ssl_sock_imp_common.c:141:13: warning: unused function 'circ_read_cancel'
