### PR TITLE
Fix sound device auto close after conference bridge updated to asynchronous

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -479,10 +479,11 @@ void pjsua_check_snd_dev_idle()
     /* Activate sound device auto-close timer if sound device is idle.
      * It is idle when there is no port connection in the bridge and
      * there is no active call.
+     * Update: as bridge conn/disconn is now async, the check is moved to
+     *         the timer callback.
      */
     if (pjsua_var.snd_idle_timer.id == PJ_FALSE &&
-        call_cnt == 0 &&
-        pjmedia_conf_get_connect_count(pjsua_var.mconf) == 0)
+        call_cnt == 0)
     {
         pj_time_val delay;
 
@@ -502,14 +503,13 @@ static void close_snd_timer_cb( pj_timer_heap_t *th,
     PJ_UNUSED_ARG(th);
 
     PJSUA_LOCK();
-    if (entry->id) {
+    if (entry->id && pjmedia_conf_get_connect_count(pjsua_var.mconf) == 0) {
         PJ_LOG(4,(THIS_FILE,"Closing sound device after idle for %d second(s)",
                   pjsua_var.media_cfg.snd_auto_close_time));
 
-        entry->id = PJ_FALSE;
-
         close_snd_dev();
     }
+    entry->id = PJ_FALSE;
     PJSUA_UNLOCK();
 }
 


### PR DESCRIPTION
The sound device auto close does not work properly after #3928 because now `pjmedia_conf_disconnect_port()` is asynchrounous so the bridge's port connection count is not updated immediately.