### PR TITLE
Add software clock to sound port

### DIFF
--- a/pjlib/include/pj/config_site_sample.h
+++ b/pjlib/include/pj/config_site_sample.h
@@ -390,8 +390,10 @@
     /* Fine tune Speex's default settings for best performance/quality */
     #define PJMEDIA_CODEC_SPEEX_DEFAULT_QUALITY 5
 
-    /* Software clock for sound device can improve quality */
-    #define PJSUA_DEFAULT_SND_USE_SOFT_CLOCK    PJ_TRUE
+    /* Using software clock for media flow can improve quality,
+     * i.e: more consistent RTP timing and less jitter/burst.
+     */
+    #define PJSUA_DEFAULT_SND_USE_SW_CLOCK      PJ_TRUE
 
     /*
      * PJSIP settings.

--- a/pjlib/include/pj/config_site_sample.h
+++ b/pjlib/include/pj/config_site_sample.h
@@ -389,7 +389,10 @@
 
     /* Fine tune Speex's default settings for best performance/quality */
     #define PJMEDIA_CODEC_SPEEX_DEFAULT_QUALITY 5
-    
+
+    /* Software clock for sound device can improve quality */
+    #define PJSUA_DEFAULT_SND_USE_SOFT_CLOCK    PJ_TRUE
+
     /*
      * PJSIP settings.
      */

--- a/pjmedia/include/pjmedia/sound_port.h
+++ b/pjmedia/include/pjmedia/sound_port.h
@@ -75,11 +75,11 @@ enum pjmedia_snd_port_option
 
     /**
      * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
-     * clock, generally this will be able to reduce jitter and clock skew.
+     * clock, generally this will be able to reduce jitter and clock drift.
      *
      * This option is not applicable for encoded/non-PCM format.
      */
-    PJMEDIA_SND_PORT_USE_SOFT_CLOCK = 2
+    PJMEDIA_SND_PORT_USE_SW_CLOCK  = 2
 };
 
 /**

--- a/pjmedia/include/pjmedia/sound_port.h
+++ b/pjmedia/include/pjmedia/sound_port.h
@@ -71,7 +71,15 @@ enum pjmedia_snd_port_option
     /** 
      * Don't start the audio device when creating a sound port.
      */    
-    PJMEDIA_SND_PORT_NO_AUTO_START = 1
+    PJMEDIA_SND_PORT_NO_AUTO_START = 1,
+
+    /**
+     * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
+     * clock, generally this will be able to reduce jitter and clock skew.
+     *
+     * This option is not applicable for encoded/non-PCM format.
+     */
+    PJMEDIA_SND_PORT_USE_SOFT_CLOCK = 2
 };
 
 /**
@@ -87,7 +95,7 @@ typedef struct pjmedia_snd_port_param
     pjmedia_aud_param base;
     
     /**
-     * Sound port creation options.
+     * Sound port creation options (see #pjmedia_snd_port_option).
      */
     unsigned options;
 
@@ -161,7 +169,7 @@ typedef struct pjmedia_snd_port pjmedia_snd_port;
  * @param samples_per_frame Number of samples per frame.
  * @param bits_per_sample   Set the number of bits per sample. The normal 
  *                          value for this parameter is 16 bits per sample.
- * @param options           Options flag.
+ * @param options           Options flag (see #pjmedia_snd_port_option).
  * @param p_port            Pointer to receive the sound device port instance.
  *
  * @return                  PJ_SUCCESS on success, or the appropriate error
@@ -191,7 +199,7 @@ PJ_DECL(pj_status_t) pjmedia_snd_port_create( pj_pool_t *pool,
  * @param samples_per_frame Number of samples per frame.
  * @param bits_per_sample   Set the number of bits per sample. The normal 
  *                          value for this parameter is 16 bits per sample.
- * @param options           Options flag.
+ * @param options           Options flag (see #pjmedia_snd_port_option).
  * @param p_port            Pointer to receive the sound device port instance.
  *
  * @return                  PJ_SUCCESS on success, or the appropriate error
@@ -220,7 +228,7 @@ PJ_DECL(pj_status_t) pjmedia_snd_port_create_rec(pj_pool_t *pool,
  * @param samples_per_frame Number of samples per frame.
  * @param bits_per_sample   Set the number of bits per sample. The normal 
  *                          value for this parameter is 16 bits per sample.
- * @param options           Options flag.
+ * @param options           Options flag (see #pjmedia_snd_port_option).
  * @param p_port            Pointer to receive the sound device port instance.
  *
  * @return                  PJ_SUCCESS on success, or the appropriate error

--- a/pjmedia/src/pjmedia/sound_port.c
+++ b/pjmedia/src/pjmedia/sound_port.c
@@ -89,7 +89,7 @@ static pj_status_t play_cb(void *user_data, pjmedia_frame *frame)
     if (port == NULL)
         goto no_frame;
 
-    if (snd_port->options & PJMEDIA_SND_PORT_USE_SOFT_CLOCK) {
+    if (snd_port->options & PJMEDIA_SND_PORT_USE_SW_CLOCK) {
         pj_assert(frame->size >= snd_port->samples_per_frame*2);
         status = pjmedia_delay_buf_get(snd_port->play_dbuf, frame->buf);
         if (status != PJ_SUCCESS)
@@ -171,7 +171,7 @@ static pj_status_t rec_cb(void *user_data, pjmedia_frame *frame)
     if (port == NULL)
         return PJ_SUCCESS;
 
-    if (snd_port->options & PJMEDIA_SND_PORT_USE_SOFT_CLOCK) {
+    if (snd_port->options & PJMEDIA_SND_PORT_USE_SW_CLOCK) {
         pjmedia_delay_buf_put(snd_port->cap_dbuf, frame->buf);
     } else {
         pjmedia_clock_src_update(&snd_port->cap_clocksrc, &frame->timestamp);
@@ -388,7 +388,7 @@ static pj_status_t start_sound_device( pj_pool_t *pool,
     }
 
     /* Create clock and buffers, if configured */
-    if ((snd_port->options & PJMEDIA_SND_PORT_USE_SOFT_CLOCK) &&
+    if ((snd_port->options & PJMEDIA_SND_PORT_USE_SW_CLOCK) &&
         (snd_port->aud_param.ext_fmt.id == PJMEDIA_FORMAT_L16))
     {
         unsigned ptime;
@@ -438,7 +438,7 @@ static pj_status_t start_sound_device( pj_pool_t *pool,
         if (status != PJ_SUCCESS)
             goto on_error;
 
-        PJ_LOG(4,(THIS_FILE, "Sound port does not use native clock"));
+        PJ_LOG(4,(THIS_FILE, "Sound port uses internal (or software) clock"));
     } else {
         PJ_LOG(4,(THIS_FILE, "Sound port uses native clock"));
     }

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7141,10 +7141,10 @@ PJ_DECL(pj_status_t) pjsua_im_typing(pjsua_acc_id acc_id,
 /**
  * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
  * clock. This setting is the default value for
- * pjsua_media_config.snd_use_soft_clock.
+ * pjsua_media_config.snd_use_sw_clock.
  */
-#ifndef PJSUA_DEFAULT_SND_USE_SOFT_CLOCK
-#   define PJSUA_DEFAULT_SND_USE_SOFT_CLOCK PJ_FALSE
+#ifndef PJSUA_DEFAULT_SND_USE_SW_CLOCK
+#   define PJSUA_DEFAULT_SND_USE_SW_CLOCK  PJ_FALSE
 #endif
 
 /**
@@ -7236,13 +7236,13 @@ struct pjsua_media_config
 
     /**
      * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
-     * clock, generally this will be able to reduce jitter and clock skew.
+     * clock, generally this will be able to reduce jitter and clock drift.
      *
      * This option is not applicable for encoded/non-PCM format.
      *
-     * Default value: PJSUA_DEFAULT_SND_USE_SOFT_CLOCK
+     * Default value: PJSUA_DEFAULT_SND_USE_SW_CLOCK
      */
-    pj_bool_t           snd_use_soft_clock;
+    pj_bool_t           snd_use_sw_clock;
 
     /**
      * Channel count be applied when opening the sound device and

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -7139,6 +7139,15 @@ PJ_DECL(pj_status_t) pjsua_im_typing(pjsua_acc_id acc_id,
 #endif
 
 /**
+ * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
+ * clock. This setting is the default value for
+ * pjsua_media_config.snd_use_soft_clock.
+ */
+#ifndef PJSUA_DEFAULT_SND_USE_SOFT_CLOCK
+#   define PJSUA_DEFAULT_SND_USE_SOFT_CLOCK PJ_FALSE
+#endif
+
+/**
  * Default frame length in the conference bridge. This setting
  * is the default value for pjsua_media_config.audio_frame_ptime.
  */
@@ -7224,6 +7233,16 @@ struct pjsua_media_config
      * If value is zero, conference bridge clock rate will be used.
      */
     unsigned            snd_clock_rate;
+
+    /**
+     * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
+     * clock, generally this will be able to reduce jitter and clock skew.
+     *
+     * This option is not applicable for encoded/non-PCM format.
+     *
+     * Default value: PJSUA_DEFAULT_SND_USE_SOFT_CLOCK
+     */
+    pj_bool_t           snd_use_soft_clock;
 
     /**
      * Channel count be applied when opening the sound device and

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -946,13 +946,13 @@ public:
 
     /**
      * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
-     * clock, generally this will be able to reduce jitter and clock skew.
+     * clock, generally this will be able to reduce jitter and clock drift.
      *
      * This option is not applicable for encoded/non-PCM format.
      *
-     * Default value: PJSUA_DEFAULT_SND_USE_SOFT_CLOCK
+     * Default value: PJSUA_DEFAULT_SND_USE_SW_CLOCK
      */
-    bool                sndUseSoftClock;
+    bool                sndUseSwClock;
 
     /**
      * Channel count be applied when opening the sound device and

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -945,6 +945,16 @@ public:
     unsigned            sndClockRate;
 
     /**
+     * Sound device uses \ref PJMEDIA_CLOCK instead of native sound device
+     * clock, generally this will be able to reduce jitter and clock skew.
+     *
+     * This option is not applicable for encoded/non-PCM format.
+     *
+     * Default value: PJSUA_DEFAULT_SND_USE_SOFT_CLOCK
+     */
+    bool                sndUseSoftClock;
+
+    /**
      * Channel count be applied when opening the sound device and
      * conference bridge.
      */

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -2358,8 +2358,8 @@ PJ_DEF(pj_status_t) pjsua_set_snd_dev2(const pjsua_snd_dev_param *snd_param)
 
         /* Open! */
         param.options = 0;
-        if (pjsua_var.media_cfg.snd_use_soft_clock)
-            param.options |= PJMEDIA_SND_PORT_USE_SOFT_CLOCK;
+        if (pjsua_var.media_cfg.snd_use_sw_clock)
+            param.options |= PJMEDIA_SND_PORT_USE_SW_CLOCK;
         status = open_snd_dev(&param);
         if (status == PJ_SUCCESS)
             break;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -2358,6 +2358,8 @@ PJ_DEF(pj_status_t) pjsua_set_snd_dev2(const pjsua_snd_dev_param *snd_param)
 
         /* Open! */
         param.options = 0;
+        if (pjsua_var.media_cfg.snd_use_soft_clock)
+            param.options |= PJMEDIA_SND_PORT_USE_SOFT_CLOCK;
         status = open_snd_dev(&param);
         if (status == PJ_SUCCESS)
             break;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -411,6 +411,7 @@ PJ_DEF(void) pjsua_media_config_default(pjsua_media_config *cfg)
     } else {
         cfg->snd_clock_rate = 0;
     }
+    cfg->snd_use_soft_clock = PJSUA_DEFAULT_SND_USE_SOFT_CLOCK;
     cfg->channel_count = 1;
     cfg->audio_frame_ptime = PJSUA_DEFAULT_AUDIO_FRAME_PTIME;
     cfg->max_media_ports = PJSUA_MAX_CONF_PORTS;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -411,7 +411,7 @@ PJ_DEF(void) pjsua_media_config_default(pjsua_media_config *cfg)
     } else {
         cfg->snd_clock_rate = 0;
     }
-    cfg->snd_use_soft_clock = PJSUA_DEFAULT_SND_USE_SOFT_CLOCK;
+    cfg->snd_use_sw_clock = PJSUA_DEFAULT_SND_USE_SW_CLOCK;
     cfg->channel_count = 1;
     cfg->audio_frame_ptime = PJSUA_DEFAULT_AUDIO_FRAME_PTIME;
     cfg->max_media_ports = PJSUA_MAX_CONF_PORTS;

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -433,7 +433,7 @@ void MediaConfig::fromPj(const pjsua_media_config &mc)
 {
     this->clockRate = mc.clock_rate;
     this->sndClockRate = mc.snd_clock_rate;
-    this->sndUseSoftClock = PJ2BOOL(mc.snd_use_soft_clock);
+    this->sndUseSwClock = PJ2BOOL(mc.snd_use_sw_clock);
     this->channelCount = mc.channel_count;
     this->audioFramePtime = mc.audio_frame_ptime;
     this->maxMediaPorts = mc.max_media_ports;
@@ -466,7 +466,7 @@ pjsua_media_config MediaConfig::toPj() const
 
     mcfg.clock_rate = this->clockRate;
     mcfg.snd_clock_rate = this->sndClockRate;
-    mcfg.snd_use_soft_clock = this->sndUseSoftClock;
+    mcfg.snd_use_sw_clock = this->sndUseSwClock;
     mcfg.channel_count = this->channelCount;
     mcfg.audio_frame_ptime = this->audioFramePtime;
     mcfg.max_media_ports = this->maxMediaPorts;
@@ -521,7 +521,7 @@ void MediaConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
     NODE_READ_NUM_T   ( this_node, pjmedia_jb_discard_algo, jbDiscardAlgo);
     NODE_READ_INT     ( this_node, sndAutoCloseTime);
     NODE_READ_BOOL    ( this_node, vidPreviewEnableNative);
-    NODE_READ_BOOL    ( this_node, sndUseSoftClock);
+    NODE_READ_BOOL    ( this_node, sndUseSwClock);
 }
 
 void MediaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
@@ -552,7 +552,7 @@ void MediaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
     NODE_WRITE_NUM_T   ( this_node, pjmedia_jb_discard_algo, jbDiscardAlgo);
     NODE_WRITE_INT     ( this_node, sndAutoCloseTime);
     NODE_WRITE_BOOL    ( this_node, vidPreviewEnableNative);
-    NODE_WRITE_BOOL    ( this_node, sndUseSoftClock);
+    NODE_WRITE_BOOL    ( this_node, sndUseSwClock);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -433,6 +433,7 @@ void MediaConfig::fromPj(const pjsua_media_config &mc)
 {
     this->clockRate = mc.clock_rate;
     this->sndClockRate = mc.snd_clock_rate;
+    this->sndUseSoftClock = PJ2BOOL(mc.snd_use_soft_clock);
     this->channelCount = mc.channel_count;
     this->audioFramePtime = mc.audio_frame_ptime;
     this->maxMediaPorts = mc.max_media_ports;
@@ -465,6 +466,7 @@ pjsua_media_config MediaConfig::toPj() const
 
     mcfg.clock_rate = this->clockRate;
     mcfg.snd_clock_rate = this->sndClockRate;
+    mcfg.snd_use_soft_clock = this->sndUseSoftClock;
     mcfg.channel_count = this->channelCount;
     mcfg.audio_frame_ptime = this->audioFramePtime;
     mcfg.max_media_ports = this->maxMediaPorts;
@@ -519,6 +521,7 @@ void MediaConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
     NODE_READ_NUM_T   ( this_node, pjmedia_jb_discard_algo, jbDiscardAlgo);
     NODE_READ_INT     ( this_node, sndAutoCloseTime);
     NODE_READ_BOOL    ( this_node, vidPreviewEnableNative);
+    NODE_READ_BOOL    ( this_node, sndUseSoftClock);
 }
 
 void MediaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
@@ -549,6 +552,7 @@ void MediaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
     NODE_WRITE_NUM_T   ( this_node, pjmedia_jb_discard_algo, jbDiscardAlgo);
     NODE_WRITE_INT     ( this_node, sndAutoCloseTime);
     NODE_WRITE_BOOL    ( this_node, vidPreviewEnableNative);
+    NODE_WRITE_BOOL    ( this_node, sndUseSoftClock);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a better approach to handle [sound device timing problem](https://docs.pjsip.org/en/latest/specific-guides/media/audio_flow.html#sound-device-timing-problem), as features such as auto-close and stereo will work.

Application can enable this via PJSUA settings:
- Compile time, set `PJSUA_DEFAULT_SND_USE_SW_CLOCK` to `PJ_TRUE` in `config_site.h`.
   Note: In `config_site_sample.h` it is enabled by default for Android (i.e: when `PJ_CONFIG_ANDROID == 1`).
- Run time, set `pjsua_media_config.snd_use_sw_clock`  to `PJ_TRUE` in PJSUA or `MediaConfig.sndUseSwClock` to `true` in PJSUA2.