### PR TITLE
Add support of out-of-dialog SIP transactions

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1197,6 +1197,19 @@ typedef struct pjsua_callback
                               pjsip_event *e);
 
     /**
+     * Notify application when a transaction started by pjsua_acc_send_request()
+     * has been completed,i.e. when a response has been received.
+     *
+     * @param acc_id   Account identification.
+     * @param token    Arbitrary data owned by the application
+     *                 that was specified when sending the request.
+     * @param event    Transaction event that caused the state change.
+     */
+    void (*on_acc_send_request)(pjsua_acc_id acc_id,
+                                void *token,
+                                pjsip_event *event);
+
+    /**
      * Notify application when media state in the call has changed.
      * Normal application would need to implement this callback, e.g.
      * to connect the call's media to sound device. When ICE is used,
@@ -4921,6 +4934,30 @@ PJ_DECL(pj_status_t) pjsua_acc_get_config(pjsua_acc_id acc_id,
 PJ_DECL(pj_status_t) pjsua_acc_modify(pjsua_acc_id acc_id,
                                       const pjsua_acc_config *acc_cfg);
 
+/**
+ * Send arbitrary out-of-dialog requests from an account, e.g. OPTIONS.
+ * The application should use the call or presence API to create
+ * dialog-related requests.
+ *
+ * @param acc_id        The account ID.
+ * @param dest_uri      URI to be put into the To header (normally is the same
+ *                      as the target URI).
+ * @param method        The SIP method of the request.
+ * @param options       This is for future use (currently only NULL is supported).
+ * @param token         Arbitrary token (user data owned by the application)
+ *                      to be passed back to the application in callback
+ *                      on_acc_send_request().
+ * @param msg_data      Optional headers etc. to be added to the outgoing
+ *                      request, or NULL if no custom header is desired.
+ *
+ * @return              PJ_SUCCESS or the error code.
+ */
+PJ_DECL(pj_status_t) pjsua_acc_send_request(pjsua_acc_id acc_id,
+                                            const pj_str_t *dest_uri,
+                                            const pj_str_t *method,
+                                            void *options,
+                                            void *token,
+                                            const pjsua_msg_data *msg_data);
 
 /**
  * Modify account's presence status to be advertised to remote/presence

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -800,6 +800,37 @@ public:
 };
 
 /**
+ * This structure contains parameters for Account::sendRequest()
+ */
+struct SendRequestParam
+{
+    /**
+     * Token or arbitrary user data ownd by the application,
+     * which will be passed back in callback Account::onSendRequest().
+     */
+    Token        userData;
+
+    /**
+     * SIP method of the request.
+     */
+    string       method;
+
+    /**
+     * Message body and/or list of headers etc. to be included in
+     * the outgoing request.
+     */
+    SipTxOption  txOption;
+
+public:
+    /**
+     * Default constructor initializes with zero/empty values.
+     */
+    SendRequestParam();
+};
+
+
+
+/**
  * SRTP crypto.
  */
 struct SrtpCrypto
@@ -1726,6 +1757,24 @@ struct OnMwiInfoParam
 };
 
 /**
+ * This structure contains parameters for Account::onSendRequest() callback.
+ */
+struct OnSendRequestParam
+{
+    /**
+     * Token or arbitrary user data owned by the application,
+     * which was passed to Endpoint::sendRquest() function.
+     */
+    Token               userData;
+
+    /**
+     * Transaction event that caused the state change.
+     */
+    SipEvent    e;
+};
+
+
+/**
  * Parameters for presNotify() account method.
  */
 struct PresNotifyParam
@@ -1900,6 +1949,18 @@ public:
      * @return                  Account info.
      */
     AccountInfo getInfo() const PJSUA2_THROW(Error);
+
+    /**
+     * Send arbitrary requests using the account. Application should only use
+     * this function to create auxiliary requests outside dialog, such as
+     * OPTIONS, and use the call or presence API to create dialog related
+     * requests.
+     *
+     * @param prm.method    SIP method of the request.
+     * @param prm.txOption  Optional message body and/or list of headers to be
+     *                      included in outgoing request.
+     */
+    void sendRequest(const pj::SendRequestParam& prm) PJSUA2_THROW(Error);
 
     /**
      * Update registration or perform unregistration. Application normally
@@ -2080,6 +2141,15 @@ public:
      * @param prm           Callback parameter.
      */
     virtual void onInstantMessageStatus(OnInstantMessageStatusParam &prm)
+    { PJ_UNUSED_ARG(prm); }
+
+    /**
+     * Notify application when a transaction started by Account::sendRequest()
+     * has been completed,i.e. when a response has been received.
+     *
+     * @param prm       Callback parameter.
+     */
+    virtual void onSendRequest(OnSendRequestParam &prm)
     { PJ_UNUSED_ARG(prm); }
 
     /**

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -2023,6 +2023,9 @@ private:
                                pj_bool_t renew);
     static void on_reg_state2(pjsua_acc_id acc_id,
                               pjsua_reg_info *info);
+    static void on_acc_send_request(pjsua_acc_id acc_id,
+                                    void* token,
+                                    pjsip_event *event);
     static void on_incoming_subscribe(pjsua_acc_id acc_id,
                                       pjsua_srv_pres *srv_pres,
                                       pjsua_buddy_id buddy_id,

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1510,6 +1510,76 @@ on_return:
     return status;
 }
 
+typedef struct send_request_data
+{
+    pjsua_acc_id acc_id;
+    void *token;
+} send_request_data;
+
+static void on_send_request(void *request_data, pjsip_event *event)
+{
+    send_request_data *data = (send_request_data*) request_data;
+    if (data && pjsua_var.ua_cfg.cb.on_acc_send_request)
+        (pjsua_var.ua_cfg.cb.on_acc_send_request)(data->acc_id, data->token, event);
+}
+
+PJ_DEF(pj_status_t) pjsua_acc_send_request(pjsua_acc_id acc_id,
+                                           const pj_str_t *dest_uri,
+                                           const pj_str_t *method,
+                                           void *options,
+                                           void *token,
+                                           const pjsua_msg_data *msg_data)
+{
+    const pjsip_hdr *cap_hdr = NULL;
+    pjsip_method method_;
+    pj_status_t status;
+    pjsip_tx_data *tdata = NULL;
+    send_request_data *request_data = NULL;
+
+    PJ_ASSERT_RETURN(acc_id>=0, PJ_EINVAL);
+    PJ_ASSERT_RETURN(dest_uri, PJ_EINVAL);
+    PJ_ASSERT_RETURN(method, PJ_EINVAL);
+    PJ_UNUSED_ARG(options);
+    PJ_ASSERT_RETURN(msg_data, PJ_EINVAL);
+
+    PJ_LOG(4,(THIS_FILE, "Account %d sending %.*s request..",
+                          acc_id, (int)method->slen, method->ptr));
+    pj_log_push_indent();
+
+    pjsip_method_init_np(&method_, (pj_str_t*)method);
+    status = pjsua_acc_create_request(acc_id, &method_, &msg_data->target_uri, &tdata);
+    if (status != PJ_SUCCESS) {
+        pjsua_perror(THIS_FILE, "Unable to create request", status);
+        goto on_return;
+    }
+
+    request_data = PJ_POOL_ZALLOC_T(tdata->pool, send_request_data);
+    if (!request_data) {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
+    request_data->acc_id = acc_id;
+    request_data->token = token;
+
+    pjsua_process_msg_data(tdata, msg_data);
+
+    cap_hdr = pjsip_endpt_get_capability(pjsua_var.endpt, PJSIP_H_ACCEPT, NULL);
+    if (cap_hdr) {
+        pjsip_msg_add_hdr(tdata->msg,
+                          (pjsip_hdr*) pjsip_hdr_clone(tdata->pool, cap_hdr));
+    }
+
+    status = pjsip_endpt_send_request(pjsua_var.endpt, tdata, -1, request_data, &on_send_request);
+    if (status != PJ_SUCCESS) {
+        pjsua_perror(THIS_FILE, "Unable to send request", status);
+        goto on_return;
+    }
+
+on_return:
+   pj_log_pop_indent();
+   return status;
+}
+
 
 /*
  * Modify account's presence status to be advertised to remote/presence

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -117,6 +117,13 @@ void RtcpFbConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
 
 ///////////////////////////////////////////////////////////////////////////////
 
+SendRequestParam::SendRequestParam()
+: userData(NULL), method("")
+{
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 void SrtpCrypto::fromPj(const pjmedia_srtp_crypto &prm)
 {
     this->key       = pj2Str(prm.key);
@@ -1060,6 +1067,16 @@ AccountInfo Account::getInfo() const PJSUA2_THROW(Error)
     PJSUA2_CHECK_EXPR( pjsua_acc_get_info(id, &pj_ai) );
     ai.fromPj(pj_ai);
     return ai;
+}
+
+void Account::sendRequest(const pj::SendRequestParam& prm) PJSUA2_THROW(Error)
+{
+    pj_str_t method = str2Pj(prm.method);
+    pj_str_t dest_uri = str2Pj(prm.txOption.targetUri);
+    pjsua_msg_data msg_data;
+    prm.txOption.toPj(msg_data);
+
+    PJSUA2_CHECK_EXPR(pjsua_acc_send_request(id, &dest_uri, &method, NULL, prm.userData, &msg_data));
 }
 
 void Account::setRegistration(bool renew) PJSUA2_THROW(Error)

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -920,6 +920,22 @@ void Endpoint::on_reg_state2(pjsua_acc_id acc_id, pjsua_reg_info *info)
     acc->onRegState(prm);
 }
 
+void Endpoint::on_acc_send_request(pjsua_acc_id acc_id,
+                                   void *token,
+                                   pjsip_event *event)
+{
+    Account *acc = lookupAcc(acc_id, "on_acc_send_request:response()");
+    if (!acc) {
+        return;
+    }
+
+    OnSendRequestParam prm;
+    prm.userData = token;
+    prm.e.fromPj(*event);
+
+    acc->onSendRequest(prm);
+}
+
 void Endpoint::on_incoming_subscribe(pjsua_acc_id acc_id,
                                      pjsua_srv_pres *srv_pres,
                                      pjsua_buddy_id buddy_id,
@@ -1926,16 +1942,17 @@ void Endpoint::libInit(const EpConfig &prmEpConfig) PJSUA2_THROW(Error)
     ua_cfg.cb.on_nat_detect     = &Endpoint::on_nat_detect;
     ua_cfg.cb.on_transport_state = &Endpoint::on_transport_state;
 
-    ua_cfg.cb.on_incoming_call  = &Endpoint::on_incoming_call;
-    ua_cfg.cb.on_reg_started    = &Endpoint::on_reg_started;
-    ua_cfg.cb.on_reg_state2     = &Endpoint::on_reg_state2;
-    ua_cfg.cb.on_incoming_subscribe = &Endpoint::on_incoming_subscribe;
-    ua_cfg.cb.on_pager2         = &Endpoint::on_pager2;
-    ua_cfg.cb.on_pager_status2  = &Endpoint::on_pager_status2;
-    ua_cfg.cb.on_typing2        = &Endpoint::on_typing2;
-    ua_cfg.cb.on_mwi_info       = &Endpoint::on_mwi_info;
-    ua_cfg.cb.on_buddy_state    = &Endpoint::on_buddy_state;
-    ua_cfg.cb.on_buddy_evsub_state = &Endpoint::on_buddy_evsub_state;
+    ua_cfg.cb.on_acc_send_request       = &Endpoint::on_acc_send_request;
+    ua_cfg.cb.on_incoming_call          = &Endpoint::on_incoming_call;
+    ua_cfg.cb.on_reg_started            = &Endpoint::on_reg_started;
+    ua_cfg.cb.on_reg_state2             = &Endpoint::on_reg_state2;
+    ua_cfg.cb.on_incoming_subscribe     = &Endpoint::on_incoming_subscribe;
+    ua_cfg.cb.on_pager2                 = &Endpoint::on_pager2;
+    ua_cfg.cb.on_pager_status2          = &Endpoint::on_pager_status2;
+    ua_cfg.cb.on_typing2                = &Endpoint::on_typing2;
+    ua_cfg.cb.on_mwi_info               = &Endpoint::on_mwi_info;
+    ua_cfg.cb.on_buddy_state            = &Endpoint::on_buddy_state;
+    ua_cfg.cb.on_buddy_evsub_state      = &Endpoint::on_buddy_evsub_state;
     ua_cfg.cb.on_acc_find_for_incoming  = &Endpoint::on_acc_find_for_incoming;
     ua_cfg.cb.on_ip_change_progress     = &Endpoint::on_ip_change_progress;
 


### PR DESCRIPTION
This commit adds support of out-of-dialog transactions to PJSUA and PJSUA2. The requests are sent in the context of an account. The API is similar to that of an in-dialog transaction.

Example: The new interface can be used to send SIP OPTIONS.

Issue: https://github.com/pjsip/pjproject/issues/4156