### PR TITLE
Fix set/get locale for error string never work in mingw

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -5770,7 +5770,7 @@ case $target in
     *mingw* | *cygw* | *win32* | *w32* )
         printf "%s\n" "#define PJ_WIN32 1" >>confdefs.h
 
-        printf "%s\n" "#define PJ_WIN32_WINNT 0x0400" >>confdefs.h
+        printf "%s\n" "#define PJ_WIN32_WINNT 0x0501" >>confdefs.h
 
         printf "%s\n" "#define WIN32_LEAN_AND_MEAN 1" >>confdefs.h
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -181,7 +181,7 @@ case $target in
     ;;
     *mingw* | *cygw* | *win32* | *w32* )
         AC_DEFINE(PJ_WIN32,1)
-        AC_DEFINE(PJ_WIN32_WINNT,0x0400)
+        AC_DEFINE(PJ_WIN32_WINNT,0x0501)
         AC_DEFINE(WIN32_LEAN_AND_MEAN)
         case $target in
             *_64-w64-mingw* )


### PR DESCRIPTION
In mingw, autoconf set PJ_WIN32_WINNT/WINVER to 0x0400, 
but SetThreadLocale/GetThreadLocale need WINVER >= 0x0500

https://github.com/pjsip/pjproject/blob/4aa26a9e7474794ac5376a6b45e3a4592fecb466/pjlib/src/pj/os_error_win32.c#L178

https://github.com/pjsip/pjproject/blob/4aa26a9e7474794ac5376a6b45e3a4592fecb466/pjlib/src/pjlib-test/errno.c#L89

fixed by set PJ_WIN32_WINNT to 0x0501 (xp)
