### PR TITLE
Fix audio & video conference bridge: adding port may not update port counter

### DIFF
--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1046,7 +1046,7 @@ static void op_add_port(pjmedia_conf *conf, const op_param *prm)
     cport->is_new = PJ_FALSE;
     ++conf->port_cnt;
 
-    PJ_LOG(5,(THIS_FILE, "Added port %d (%.*s), port count=%d",
+    PJ_LOG(4,(THIS_FILE, "Added port %d (%.*s), port count=%d",
               port, (int)cport->name.slen, cport->name.ptr, conf->port_cnt));
 }
 

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -392,10 +392,15 @@ static pj_status_t create_conf_port( pj_pool_t *parent_pool,
 {
     struct conf_port *conf_port;
     pj_pool_t *pool = NULL;
+    char pname[PJ_MAX_OBJ_NAME];
     pj_status_t status = PJ_SUCCESS;
 
+    /* Make sure pool name is NULL terminated */
+    pj_assert(name);
+    pj_ansi_strxcpy2(pname, name, sizeof(pname));
+
     /* Create own pool */
-    pool = pj_pool_create(parent_pool->factory, name->ptr, 500, 500, NULL);
+    pool = pj_pool_create(parent_pool->factory, pname, 500, 500, NULL);
     if (!pool) {
         status = PJ_ENOMEM;
         goto on_return;

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -281,6 +281,7 @@ static pj_status_t destroy_port_pasv(pjmedia_port *this_port);
 typedef enum op_type
 {
     OP_UNKNOWN,
+    OP_ADD_PORT,
     OP_REMOVE_PORT,
     OP_CONNECT_PORTS,
     OP_DISCONNECT_PORTS,
@@ -289,6 +290,10 @@ typedef enum op_type
 /* Synchronized operation parameter. */
 typedef union op_param
 {
+    struct {
+        unsigned port;
+    } add_port;
+
     struct {
         unsigned port;
     } remove_port;
@@ -314,6 +319,7 @@ typedef struct op_entry {
 } op_entry;
 
 /* Prototypes of synchronized operation */
+static void op_add_port(pjmedia_conf *conf, const op_param *prm);
 static void op_remove_port(pjmedia_conf *conf, const op_param *prm);
 static void op_connect_ports(pjmedia_conf *conf, const op_param *prm);
 static void op_disconnect_ports(pjmedia_conf *conf, const op_param *prm);
@@ -342,6 +348,9 @@ static void handle_op_queue(pjmedia_conf *conf)
         pj_list_erase(op);
 
         switch(op->type) {
+            case OP_ADD_PORT:
+                op_add_port(conf, &op->param);
+                break;
             case OP_REMOVE_PORT:
                 op_remove_port(conf, &op->param);
                 break;
@@ -940,6 +949,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_add_port( pjmedia_conf *conf,
 {
     struct conf_port *conf_port;
     unsigned index;
+    op_entry *ope;
     pj_status_t status = PJ_SUCCESS;
 
     PJ_ASSERT_RETURN(conf && pool && strm_port, PJ_EINVAL);
@@ -992,19 +1002,47 @@ PJ_DEF(pj_status_t) pjmedia_conf_add_port( pjmedia_conf *conf,
     conf->ports[index] = conf_port;
     //conf->port_cnt++;
 
+    /* Queue the operation */
+    ope = get_free_op_entry(conf);
+    if (ope) {
+        ope->type = OP_ADD_PORT;
+        ope->param.add_port.port = index;
+        pj_list_push_back(conf->op_queue, ope);
+        PJ_LOG(4,(THIS_FILE, "Add port %d (%.*s) queued",
+                             index, (int)port_name->slen, port_name->ptr));
+    } else {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
+
     /* Done. */
     if (p_port) {
         *p_port = index;
     }
-
-    PJ_LOG(5,(THIS_FILE, "Adding new port %d (%.*s)",
-                         index, (int)port_name->slen, port_name->ptr));
 
 on_return:
     pj_mutex_unlock(conf->mutex);
     pj_log_pop_indent();
 
     return status;
+}
+
+
+static void op_add_port(pjmedia_conf *conf, const op_param *prm)
+{
+    unsigned port = prm->add_port.port;
+    struct conf_port *cport = conf->ports[port];
+
+    /* Port must be valid and flagged as new. */
+    if (!cport || !cport->is_new)
+        return;
+
+    /* Activate newly added port */
+    cport->is_new = PJ_FALSE;
+    ++conf->port_cnt;
+
+    PJ_LOG(5,(THIS_FILE, "Added port %d (%.*s), port count=%d",
+              port, (int)cport->name.slen, cport->name.ptr, conf->port_cnt));
 }
 
 
@@ -1674,10 +1712,12 @@ static void op_remove_port(pjmedia_conf *conf, const op_param *prm)
 
     /* Remove the port. */
     conf->ports[port] = NULL;
-    --conf->port_cnt;
+    if (!conf_port->is_new)
+        --conf->port_cnt;
 
-    PJ_LOG(4,(THIS_FILE,"Removed port %d (%.*s)",
-              port, (int)conf_port->name.slen, conf_port->name.ptr));
+    PJ_LOG(4,(THIS_FILE,"Removed port %d (%.*s), port count=%d",
+              port, (int)conf_port->name.slen, conf_port->name.ptr,
+              conf->port_cnt));
 
     /* Decrease conf port ref count */
     if (conf_port->port && conf_port->port->grp_lock)
@@ -2368,22 +2408,7 @@ static pj_status_t get_frame(pjmedia_port *this_port,
     if (!pj_list_empty(conf->op_queue)) {
         pj_log_push_indent();
         pj_mutex_lock(conf->mutex);
-
-        /* Activate any newly added port */
-        for (i=0; i<conf->max_ports; ++i) {
-            struct conf_port *port = conf->ports[i];
-            if (!port || !port->is_new)
-                continue;
-
-            port->is_new = PJ_FALSE;
-            ++conf->port_cnt;
-
-            PJ_LOG(5,(THIS_FILE, "New port %d (%.*s) is added",
-                      i, (int)port->name.slen, port->name.ptr));
-        }
-
         handle_op_queue(conf);
-
         pj_mutex_unlock(conf->mutex);
         pj_log_pop_indent();
     }

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -395,6 +395,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_add_port( pjmedia_vid_conf *vid_conf,
     vconf_port *cport = NULL;
     unsigned index;
     op_entry *ope;
+    char pname[PJ_MAX_OBJ_NAME];
     pj_status_t status = PJ_SUCCESS;
 
     PJ_LOG(5,(THIS_FILE, "Add video port %s requested", port->info.name.ptr));
@@ -423,8 +424,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_add_port( pjmedia_vid_conf *vid_conf,
         return PJ_ETOOMANY;
     }
 
+    /* Make sure pool name is NULL terminated */
+    pj_ansi_strxcpy2(pname, name, sizeof(pname));
+
     /* Create pool */
-    pool = pj_pool_create(parent_pool->factory, name->ptr, 500, 500, NULL);
+    pool = pj_pool_create(parent_pool->factory, pname, 500, 500, NULL);
     if (!pool) {
         status = PJ_ENOMEM;
         goto on_error;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -847,8 +847,10 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             port_name.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
                                              call->inv->dlg->remote.info->uri,
                                              tmp, sizeof(tmp));
-            if (port_name.slen < 1) {
-                port_name = pj_str("call");
+            if (port_name.slen < 1 || pj_strchr(&port_name, '%')) {
+                pj_ansi_snprintf(tmp, sizeof(tmp), "call %d:%d",
+                                 call->index, strm_idx);
+                port_name = pj_str(tmp);
             }
             status = pjmedia_conf_add_port(pjsua_var.mconf,
                                            call->inv->pool,

--- a/tests/pjsua/scripts-sendto/001_torture_4475_3_1_1_3.py
+++ b/tests/pjsua/scripts-sendto/001_torture_4475_3_1_1_3.py
@@ -7,7 +7,7 @@ import inc_sdp as sdp
 complete_msg = \
 """INVITE sip:sips%3Auser%40example.com@example.net SIP/2.0
 To: sip:%75se%72@example.com
-From: <sip:I%20have%20spaces@example.net>;tag=$FROM_TAG
+From: <sip:Ihavepaces@example.net>;tag=$FROM_TAG
 Max-Forwards: 87
 i: esc01.239409asdfakjkn23onasd0-3234
 CSeq: 234234 INVITE

--- a/tests/pjsua/scripts-sendto/001_torture_4475_3_1_1_3.py
+++ b/tests/pjsua/scripts-sendto/001_torture_4475_3_1_1_3.py
@@ -7,7 +7,7 @@ import inc_sdp as sdp
 complete_msg = \
 """INVITE sip:sips%3Auser%40example.com@example.net SIP/2.0
 To: sip:%75se%72@example.com
-From: <sip:Ihavepaces@example.net>;tag=$FROM_TAG
+From: <sip:I%20have%20spaces@example.net>;tag=$FROM_TAG
 Max-Forwards: 87
 i: esc01.239409asdfakjkn23onasd0-3234
 CSeq: 234234 INVITE


### PR DESCRIPTION
This is to fix https://github.com/pjsip/pjproject/pull/3928#issuecomment-2484827371.

After investigation, it is caused by invalid port counter (e.g: zero or `-1` while there are actually some ports added). Conference bridge uses the port counter to iterates the ports, so when it is invalid, no media flow will happen. Furthermore, such invalid port counter case may happen when a port is removed before the add port operation, including increasing the port counter, is completed. The add port operation can never be completed when no async operation is queued.

This PR fix it by:
- introducing a new async operation for add port operation,
- only decrement port counter when port add is completed (i.e: internal port state `is_new` is false).