### PR TITLE
Revert Swig Python cc_mingw modification

### DIFF
--- a/pjsip-apps/src/swig/python/cc_mingw.c
+++ b/pjsip-apps/src/swig/python/cc_mingw.c
@@ -41,7 +41,7 @@ const char* find_gcc(const char *gcc_exe)
         return NULL;
     }
 
-    pj_ansi_strxcpy(spath, p, sizeof(spath));
+    strncpy(spath, p, sizeof(spath));
     p = strtok(spath, ";");
     while (p) {
         int len;


### PR DESCRIPTION
To close #4092.

Fix accidental modification of `pjsip-apps/src/swig/python/cc_mingw.cc` in https://github.com/pjsip/pjproject/commit/5fe4bc1972f9475c84956969dfdcd1ac058ff224#diff-f6731a261d595261c8085179d517d389e911489edd7324c8398ce7680e3c4358 (Fix usages of strncpy(), pj_ansi_strncpy(), and strncat() by replacing them with pj_ansi_safe_strncpy() and pj_ansi_safe_strcpycat()).

`cc_mingw` is not supposed to use any PJSIP APIs.
