### PR TITLE
Reset regc info transport

### DIFF
--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -489,6 +489,7 @@ PJ_DEF(pj_status_t) pjsip_regc_release_transport(pjsip_regc *regc)
     if (regc->last_transport) {
         pjsip_transport_dec_ref(regc->last_transport);
         regc->last_transport = NULL;
+        regc->info_transport = NULL;
     }
     return PJ_SUCCESS;
 }

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -489,6 +489,8 @@ PJ_DEF(pj_status_t) pjsip_regc_release_transport(pjsip_regc *regc)
     if (regc->last_transport) {
         pjsip_transport_dec_ref(regc->last_transport);
         regc->last_transport = NULL;
+    }
+    if (regc->info_transport) {
         regc->info_transport = NULL;
     }
     return PJ_SUCCESS;


### PR DESCRIPTION
Consider the scenario:
1. Registration Sent
2. SIP connection used by the registration is closed, no response has been received yet
3. `pjsua_handle_ip_change()` is called. 
4. Later the process will check the transport used by the registration and tried to shutdown it.
   https://github.com/pjsip/pjproject/blob/2e6a988deb58d1532b8968d76bc2eae5445d8df3/pjsip/src/pjsua-lib/pjsua_core.c#L3729
   The `info.transport` will contain an already shutdown/destroyed transport since from `info_transport` which is not reset when `pjsip_regc_release_transport` is called.

Note:
Since `pjsua_handle_ip_change()` has the option to shutdown all the transport, then checking all the transport used by the registration to shutdown is redundant and no longer needed.