### PR TITLE
Apply stricter rule for pool name with percent char

### DIFF
--- a/pjlib/src/pj/pool.c
+++ b/pjlib/src/pj/pool.c
@@ -177,7 +177,9 @@ PJ_DEF(void) pj_pool_init_int(  pj_pool_t *pool,
     pool->callback = callback;
 
     if (name) {
-        if (strchr(name, '%') != NULL) {
+        char *p = pj_ansi_strchr(name, '%');
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            /* Special name with "%p" suffix */
             pj_ansi_snprintf(pool->obj_name, sizeof(pool->obj_name), 
                              name, pool);
         } else {


### PR DESCRIPTION
To fix https://github.com/pjsip/pjproject/pull/4164#issuecomment-2489854989.

Currently several apps specify pool name with "%p" suffix (e.g: group lock, SSL socket) to make it unique. Unfortunately there is a potential issue as described in the link above.