### PR TITLE
Fixed assertion in ICE when trying to add candidate for disabled component

### DIFF
--- a/pjnath/src/pjnath/ice_strans.c
+++ b/pjnath/src/pjnath/ice_strans.c
@@ -2536,7 +2536,10 @@ static pj_bool_t stun_on_status(pj_stun_sock *stun_sock,
                     cand->status = PJ_SUCCESS;
 
                     /* Add the candidate (for trickle ICE) */
-                    if (pj_ice_strans_has_sess(ice_st)) {
+                    if (pj_ice_strans_has_sess(ice_st) &&
+                        comp->comp_id <=
+                        pj_ice_strans_get_running_comp_cnt(ice_st))
+                    {
                         status = pj_ice_sess_add_cand(
                                         ice_st->ice,
                                         comp->comp_id,

--- a/pjsip-apps/src/samples/icedemo.c
+++ b/pjsip-apps/src/samples/icedemo.c
@@ -1217,7 +1217,7 @@ int main(int argc, char *argv[])
         switch (c) {
         case 'c':
             icedemo.opt.comp_cnt = atoi(pj_optarg);
-            if (icedemo.opt.comp_cnt < 1 || icedemo.opt.comp_cnt >= PJ_ICE_MAX_COMP) {
+            if (icedemo.opt.comp_cnt < 1 || icedemo.opt.comp_cnt > PJ_ICE_MAX_COMP) {
                 puts("Invalid component count value");
                 return 1;
             }


### PR DESCRIPTION
To fix #4167.

If an endpoint creates ICE with 2 components while remote only uses one, it may lead to an assertion when trying to add candidate for the disabled (i.e. second) component.

Also fix icedemo sample app.
