### PR TITLE
Fixed warnings of duplicate libs

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -7064,7 +7064,7 @@ if ac_fn_c_try_link "$LINENO"
 then :
 
                 CFLAGS="$CFLAGS -DPJNATH_HAS_UPNP=1 $UPNP_CFLAGS"
-                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS $UPNP_LIBS"
+                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS"
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -8566,7 +8566,6 @@ printf "%s\n" "not found" >&6; }
             ac_sdl_cflags="-DPJMEDIA_VIDEO_DEV_HAS_SDL=1 $ac_sdl_cflags"
             ac_sdl_ldflags=`$SDL_CONFIG --libs`
             ac_sdl_ldflags=`echo "${ac_sdl_ldflags}" | sed -e 's/-mwindows//g'`
-            LIBS="$LIBS $ac_sdl_ldflags"
         else
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Unsupported SDL version" >&5
 printf "%s\n" "Unsupported SDL version" >&6; }
@@ -9231,7 +9230,7 @@ if ac_fn_c_try_link "$LINENO"
 then :
 
                 ac_vpx_cflags="-DPJMEDIA_HAS_VPX_CODEC=1 $VPX_CFLAGS"
-                ac_vpx_ldflags="$VPX_LDFLAGS $VPX_LIBS"
+                ac_vpx_ldflags="$VPX_LDFLAGS"
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -750,7 +750,7 @@ AC_ARG_ENABLE(upnp,
             ],
             [
                 CFLAGS="$CFLAGS -DPJNATH_HAS_UPNP=1 $UPNP_CFLAGS"
-                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS $UPNP_LIBS"
+                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS"
                 AC_MSG_RESULT(yes)
             ],
             [
@@ -1546,7 +1546,6 @@ AC_ARG_ENABLE(sdl,
             ac_sdl_cflags="-DPJMEDIA_VIDEO_DEV_HAS_SDL=1 $ac_sdl_cflags"
             ac_sdl_ldflags=`$SDL_CONFIG --libs`
             ac_sdl_ldflags=`echo "${ac_sdl_ldflags}" | sed -e 's/-mwindows//g'`
-            LIBS="$LIBS $ac_sdl_ldflags"
         else
             AC_MSG_RESULT([Unsupported SDL version])
         fi
@@ -1806,7 +1805,7 @@ AC_ARG_ENABLE(vpx,
             ],
             [
                 ac_vpx_cflags="-DPJMEDIA_HAS_VPX_CODEC=1 $VPX_CFLAGS"
-                ac_vpx_ldflags="$VPX_LDFLAGS $VPX_LIBS"
+                ac_vpx_ldflags="$VPX_LDFLAGS"
                 AC_MSG_RESULT(yes)
             ],
             [

--- a/build.mak.in
+++ b/build.mak.in
@@ -331,7 +331,6 @@ export APP_LDLIBS := $(PJSUA_LIB_LDLIB) \
         $(PJLIB_LDLIB) \
         @LIBS@
 export APP_LDXXLIBS := $(PJSUA2_LIB_LDLIB) \
-        -lstdc++ \
         $(APP_LDLIBS)
 
 # Here are the variables to use if application is using the library

--- a/pjmedia/src/pjmedia-videodev/metal_dev.m
+++ b/pjmedia/src/pjmedia-videodev/metal_dev.m
@@ -626,7 +626,6 @@ static pj_status_t metal_factory_create_stream(
     pjmedia_video_format_detail *vfd;
     const pjmedia_video_format_info *vfi;
     metal_fmt_info *mfi;
-    pj_status_t status = PJ_SUCCESS;
 
     PJ_ASSERT_RETURN(f && param && p_vid_strm, PJ_EINVAL);
     PJ_ASSERT_RETURN(param->fmt.type == PJMEDIA_TYPE_VIDEO &&
@@ -678,11 +677,6 @@ static pj_status_t metal_factory_create_stream(
     *p_vid_strm = &strm->base;
     
     return PJ_SUCCESS;
-    
-on_error:
-    metal_stream_destroy((pjmedia_vid_dev_stream *)strm);
-    
-    return status;
 }
 
 /* API: Get stream info. */


### PR DESCRIPTION
Fixed the following warnings:
`ld: warning: ignoring duplicate libraries: '-lSDL2', '-lc++, '-lixml', '-lupnp', '-lvpx'`
