### PR TITLE
Fix stream lingering issues due to using transport's group lock

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2357,7 +2357,6 @@ static void on_rx_rtcp( void *data,
     }
 
     pjmedia_rtcp_rx_rtcp(&stream->rtcp, pkt, bytes_read);
-    pjmedia_rtcp_rx_rtcp(&stream->rtcp, pkt, bytes_read);
 }
 
 

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2004,7 +2004,11 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
         }
     }
 
+    /* Add ref counter to avoid premature destroy from callbacks */
+    pj_grp_lock_add_ref(stream->grp_lock);
+
     pj_bzero(&seq_st, sizeof(seq_st));
+
     /* Ignore the packet if decoder is paused */
     if (channel->paused) {
         goto on_return;
@@ -2319,6 +2323,8 @@ on_return:
             stream->initial_rr = PJ_TRUE;
         }
     }
+
+    pj_grp_lock_dec_ref(stream->grp_lock);
 }
 
 
@@ -2933,13 +2939,16 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
     att_param.rtp_cb2 = &on_rx_rtp;
     att_param.rtcp_cb = &on_rx_rtcp;
 
-    /* Attach handler to group lock from transport */
-    if (tp->grp_lock) {
-        stream->grp_lock = stream->port.grp_lock = tp->grp_lock;
-        pj_grp_lock_add_ref(stream->grp_lock);
-        pj_grp_lock_add_handler(stream->grp_lock, pool, stream,
-                                &stream_on_destroy);
-    }
+    /* Create group lock & attach handler */
+    status = pj_grp_lock_create_w_handler(pool, NULL, stream,
+                                          &stream_on_destroy,
+                                          &stream->grp_lock);
+    if (status != PJ_SUCCESS)
+        goto err_cleanup;
+
+    /* Add ref */
+    pj_grp_lock_add_ref(stream->grp_lock);
+    stream->port.grp_lock = stream->grp_lock;
 
     /* Only attach transport when stream is ready. */
     stream->transport = tp;


### PR DESCRIPTION
To fix https://github.com/pjsip/pjproject/pull/3970#issuecomment-2499583512 by using its own group lock instead of transport's group lock.

Also, maintain ref to transport just in case stream still tries to send something after returning from callback which has just destroyed the stream.