### PR TITLE
Fixed SSL check in SIP auth client

### DIFF
--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -33,7 +33,8 @@
 #include <pj/ctype.h>
 
 
-#if defined(PJ_HAS_SSL_SOCK) && PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+#if defined(PJ_HAS_SSL_SOCK) && PJ_HAS_SSL_SOCK != 0 && \
+    PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
 #  include <openssl/opensslv.h>
 #  include <openssl/sha.h>
 #  include <openssl/evp.h>


### PR DESCRIPTION
In machine with old OpenSSL < 1.1, registration will fail even though PJ_HAS_SSL_SOCK has been explicitly disabled by setting it to 0:
```
07:38:55.881           pjsua_core.c  .RX 522 bytes Response msg 401/REGISTER/cseq=56752 (rdata0x2503700) from TCP 139.162.62.29:5060:
SIP/2.0 401 Unauthorized
...
WWW-Authenticate: Digest realm="sip.pjsip.org", nonce="Z0lwu2dJb48tfs8KHqupko9LXU8ZYmRT", qop="auth"
Server: kamailio (4.3.7 (x86_64/linux))
Content-Length: 0


--end msg--
07:38:55.881      sip_auth_client.c  ...The algorithm (MD5) referenced by algorithm_type is not supported
07:38:55.881            pjsua_acc.c  ....SIP registration error: Option/operation is not supported (PJ_ENOTSUP) [status=70012]
```
