### PR TITLE
Fixed video media transport leak

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -2216,7 +2216,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_destroy( pjmedia_vid_stream *stream )
      */
     if (stream->transport) {
         pjmedia_transport_detach(stream->transport, stream);
-        stream->transport = NULL;
+        //stream->transport = NULL;
     }
 
     /* This function may be called when stream is partly initialized,


### PR DESCRIPTION
This is due to #4184.

Since media transport has been NULL-ed, it will never be released.

Note that the same line has been commented in audio stream in  #3928 (async conf bridge).
