### PR TITLE
Fixed SIP transport selection used to reach destination

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2520,6 +2520,12 @@ static pj_status_t tsx_send_msg( pjsip_transaction *tsx,
         if (status == PJ_EPENDING)
             status = PJ_SUCCESS;
         if (status != PJ_SUCCESS) {
+            char errmsg[PJ_ERR_MSG_SIZE];
+            pj_str_t err;
+
+            err = pj_strerror(status, errmsg, sizeof(errmsg));
+            tsx_set_status_code(tsx, PJSIP_SC_TSX_TRANSPORT_ERROR, &err);
+
             tsx->transport_flag &= ~(TSX_HAS_PENDING_TRANSPORT);
             pj_grp_lock_dec_ref(tsx->grp_lock);
             pjsip_tx_data_dec_ref(tdata);


### PR DESCRIPTION
When account is bound to a particular transport or listener, the transport/listener will be used regardless of the specified transport for a destination. For example, a local account bound to a TCP transport will connect successfully to "sip:localhost;transport=tls" using TCP.

With the proposed patch, we will return failure instead.

