### PR TITLE
Fixed AudioMediaPort use after free

### DIFF
--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -163,8 +163,12 @@ PJ_DEF(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
      * If media port is using app's pool, and the app destroys the port
      * and then destroys the pool immediately, it may cause crash as the port
      * may have not really been destroyed and may still be accessed.
-     * If port uses app's pool, it needs to implement on_destroy() for releasing
-     * the pool, so here we check availability of on_destroy implementation.
+     *
+     * Thus, media port needs to create and manage its own pool. Since
+     * app MUST NOT free this pool, port typically needs to implement
+     * on_destroy() for releasing the pool. Alternatively, port can also
+     * add a group lock handler for this purpose, but since we can't check
+     * this, here we just check the availability of on_destroy implementation.
      */
     if (port->on_destroy == NULL) {
         PJ_LOG(2,(THIS_FILE, "Warning! Port %s on_destroy() not found. To "

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -166,10 +166,12 @@ PJ_DEF(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
      * If port uses app's pool, it needs to implement on_destroy() for releasing
      * the pool, so here we check availability of on_destroy implementation.
      */
-    if (!grp_lock && port->on_destroy == NULL) {
-        PJ_LOG(2,(THIS_FILE, "Warning! media port %s MUST either: - implement"
-                             " on_destroy() and release the pool there, or"
-                             " - supply its own group lock.",
+    if (port->on_destroy == NULL) {
+        PJ_LOG(2,(THIS_FILE, "Warning! Port %s on_destroy() not found. To "
+                             "avoid premature destroy, media port must "
+                             "manage its own pool, which can only be "
+                             "released in on_destroy() or in its grp lock "
+                             "handler. See PR #3928 for more info.",
                              port->info.name.ptr));
     }
 

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -159,16 +159,17 @@ PJ_DEF(pj_status_t) pjmedia_port_init_grp_lock( pjmedia_port *port,
     PJ_ASSERT_RETURN(port && pool, PJ_EINVAL);
     PJ_ASSERT_RETURN(port->grp_lock == NULL, PJ_EEXISTS);
 
-    /* We need to be caution on ports that do not have its own pool,
-     * such port is likely using app's pool, so if the app destroys the port
+    /* We need to be extra cautious here!
+     * If media port is using app's pool, and the app destroys the port
      * and then destroys the pool immediately, it may cause crash as the port
      * may have not really been destroyed and may still be accessed.
-     * When port has a pool, it usually implements on_destroy() for releasing
+     * If port uses app's pool, it needs to implement on_destroy() for releasing
      * the pool, so here we check availability of on_destroy implementation.
      */
-    if (port->on_destroy == NULL) {
-        PJ_LOG(2,(THIS_FILE, "Warning, media port %s is using group lock, but "
-                             "it does not seem to have a pool.",
+    if (!grp_lock && port->on_destroy == NULL) {
+        PJ_LOG(2,(THIS_FILE, "Warning! media port %s MUST either: - implement"
+                             " on_destroy() and release the pool there, or"
+                             " - supply its own group lock.",
                              port->info.name.ptr));
     }
 

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -528,7 +528,7 @@ public:
 
 private:
     pj_pool_t *pool;
-    pjmedia_port port;
+    pjmedia_port *port;
 };
 
 /**

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -281,6 +281,11 @@ AudioMedia* AudioMedia::typecastFromMedia(Media *media)
 
 ///////////////////////////////////////////////////////////////////////////////
 
+struct port_data {
+    AudioMediaPort *mport;
+    pj_pool_t      *pool;
+};
+
 AudioMediaPort::AudioMediaPort()
 : pool(NULL), port(NULL)
 {
@@ -289,22 +294,36 @@ AudioMediaPort::AudioMediaPort()
 AudioMediaPort::~AudioMediaPort()
 {
     PJSUA2_CATCH_IGNORE( unregisterMediaPort() );
-    if (port) pjmedia_port_destroy(port);
-    /* We release the pool later in port.on_destroy since
-     * the unregistration is async and may not have completed yet.
-     */
-}
+    if (port) {
+        struct port_data *pdata = static_cast<struct port_data *>
+                                  (port->port_data.pdata);
 
-struct port_data {
-    AudioMediaPort *mport;
-    pj_pool_t      *pool;
-};
+        /* Make sure port no longer accesses this object in its
+         * get/put_frame() callback.
+         */
+        if (port->grp_lock) {
+            pj_grp_lock_acquire(port->grp_lock);
+            pdata->mport = NULL;
+            pj_grp_lock_release(port->grp_lock);
+        }
+
+        pjmedia_port_destroy(port);
+        /* We release the pool later in port.on_destroy since
+         * the unregistration is async and may not have completed yet.
+         */
+    }
+}
 
 static pj_status_t get_frame(pjmedia_port *port, pjmedia_frame *frame)
 {
-    struct port_data *pdata = (struct port_data *) port->port_data.pdata;
-    AudioMediaPort *mport = pdata->mport;
+    struct port_data *pdata = static_cast<struct port_data *>
+                              (port->port_data.pdata);
+    AudioMediaPort *mport;
     MediaFrame frame_;
+
+    pj_grp_lock_acquire(port->grp_lock);
+    if ((mport = pdata->mport) == NULL)
+        goto on_return;
 
     frame_.size = (unsigned)frame->size;
     mport->onFrameRequested(frame_);
@@ -320,27 +339,36 @@ static pj_status_t get_frame(pjmedia_port *port, pjmedia_frame *frame)
     pj_memcpy(frame->buf, frame_.buf.data(), frame->size);
 #endif
 
-
+on_return:
+    pj_grp_lock_release(port->grp_lock);
     return PJ_SUCCESS;
 }
 
 static pj_status_t put_frame(pjmedia_port *port, pjmedia_frame *frame)
 {
-    struct port_data *pdata = (struct port_data *)port->port_data.pdata;
-    AudioMediaPort *mport = pdata->mport;
+    struct port_data *pdata = static_cast<struct port_data *>
+                              (port->port_data.pdata);
+    AudioMediaPort *mport;
     MediaFrame frame_;
+
+    pj_grp_lock_acquire(port->grp_lock);
+    if ((mport = pdata->mport) == NULL)
+        goto on_return;
 
     frame_.type = frame->type;
     frame_.buf.assign((char *)frame->buf, ((char *)frame->buf) + frame->size);
     frame_.size = (unsigned)frame->size;
     mport->onFrameReceived(frame_);
 
+on_return:
+    pj_grp_lock_release(port->grp_lock);
     return PJ_SUCCESS;
 }
 
 static pj_status_t port_on_destroy(pjmedia_port *port)
 {
-    struct port_data *pdata = (struct port_data *)port->port_data.pdata;
+    struct port_data *pdata = static_cast<struct port_data *>
+                              (port->port_data.pdata);
     pj_pool_t *pool = pdata->pool;
 
     if (pool) {
@@ -383,7 +411,7 @@ void AudioMediaPort::createPort(const string &name, MediaFormatAudio &fmt)
     port->get_frame = &get_frame;
 
     /* Must implement on_destroy() and create group lock to avoid
-     * premature destroy.
+     * race and premature destroy.
      */
     port->on_destroy = &port_on_destroy;
     status = pjmedia_port_init_grp_lock(port, pool, NULL);


### PR DESCRIPTION
As described in #3928 point 1, due to the now async nature of the conference bridge, we need to make sure that the port is not prematurely destroyed.

```
==41294==ERROR: AddressSanitizer: heap-use-after-free on address 0x6190000f3178 at pc 0x00010296eecc bp 0x00016dec8bb0 sp 0x00016dec8ba8
READ of size 8 at 0x6190000f3178 thread T19
    #0 0x10296eec8 in op_remove_port conference.c:1728
    #1 0x10296e1b4 in handle_op_queue conference.c:355
    #2 0x102969ae0 in get_frame conference.c:2416

0x6190000f3178 is located 1016 bytes inside of 1056-byte region [0x6190000f2d80,0x6190000f31a0)
freed by thread T0 here:
    #1 0x1024b1388 in MyAudioMediaPort::~MyAudioMediaPort()
