### PR TITLE
assertion when the ACK response is recognized as a merged request

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -673,7 +673,7 @@ static pj_bool_t mod_pjsua_on_rx_request(pjsip_rx_data *rdata)
         pjsip_dialog *dlg = pjsip_tsx_get_dlg(tsx);
 
         PJ_LOG(4, (THIS_FILE, "Merged request detected (%s) (%s): %s from %s:%d",
-                              dlg ? dlg->obj_name : NULL,
+                              dlg ? dlg->obj_name : "-no-dlg-",
                               tsx->obj_name,
                               pjsip_rx_data_get_info(rdata),
                               rdata->pkt_info.src_name,

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -667,15 +667,31 @@ static pj_bool_t mod_pjsua_on_rx_request(pjsip_rx_data *rdata)
     pj_bool_t processed = PJ_FALSE;
 
 #if PJSUA_DETECT_MERGED_REQUESTS
-    if (pjsip_tsx_detect_merged_requests(rdata)) {
-        PJ_LOG(4, (THIS_FILE, "Merged request detected"));
+    pjsip_transaction *tsx;
+    if ((tsx = pjsip_tsx_detect_merged_requests(rdata)) != NULL) {
 
-        /* Respond with 482 (Loop Detected) */
-        pjsip_endpt_respond(pjsua_var.endpt, NULL, rdata,
-                            PJSIP_SC_LOOP_DETECTED, NULL,
-                            NULL, NULL, NULL);
+        pjsip_dialog *dlg = pjsip_tsx_get_dlg(tsx);
 
-        return PJ_TRUE;
+        PJ_LOG(4, (THIS_FILE, "Merged request detected (%s) (%s): %s from %s:%d",
+                              dlg ? dlg->obj_name : NULL,
+                              tsx->obj_name,
+                              pjsip_rx_data_get_info(rdata),
+                              rdata->pkt_info.src_name,
+                              rdata->pkt_info.src_port));
+
+        /* Don't respond to ACK, even if it looks like a merged request 
+         * Let it be "dropped/unhandled by any modules"
+         */
+        if (pjsip_method_cmp(&rdata->msg_info.msg->line.req.method,
+                             &pjsip_ack_method) == 0) {
+            return PJ_FALSE;
+        } else {
+            /* Respond with 482 (Loop Detected) */
+            pjsip_endpt_respond(pjsua_var.endpt, NULL, rdata,
+                                PJSIP_SC_LOOP_DETECTED, NULL,
+                                NULL, NULL, NULL);
+            return PJ_TRUE;
+        }
     }
 #endif
 


### PR DESCRIPTION
pjsip tries to respond with 482 on any "receiving incoming requests" recognized as a merged request, but if that is ACK, calling 
pjsip_endpt_respond() -> pjsip_endpt_create_response() raise folowing assertion in this last function:
    /* Request MUST NOT be ACK request! */
    PJ_ASSERT_RETURN(req_msg->line.req.method.id != PJSIP_ACK_METHOD,
                                     PJ_EINVALIDOP);

If we consider ACK as a merged request, we should not issue an assertion, but can we consider ACK as a request (merged or not)?
I think this is invalid pjsip behavior, I added a check that the packet is not an ACK before calling pjsip_endpt_respond() (and made the "merged request detected" log message more informative).
This situation now results in a "dropped/not handled by any module" log message, but does not trigger an assertion.
But this is a hack...

See attached file with a trace of the real call: [in-ack.txt](https://github.com/user-attachments/files/18054532/in-ack.txt)

Remote side send us CANCEL (Frame 10), practically simulteniously with our OK (Frame 9). I am not quite sure, but received ACK (Frame 11) treated as merged request looks like the correct answer on our 200 OK (Frame 9). 
I think we should recognize it as a such answer even after received CANCEL. But currently we start timer to retry OK sending, retransmit it during 30 sec and then send BYE.
