### PR TITLE
pcaputil: Support parsing decoder options from FMTP input

### DIFF
--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -117,6 +117,21 @@ PJ_DECL(pj_status_t) pjmedia_stream_info_parse_fmtp(pj_pool_t *pool,
                                                     pjmedia_codec_fmtp *fmtp);
 
 
+/**
+ * This is an internal function for parsing fmtp data from a raw buffer.
+ *
+ * @param pool          Pool to allocate memory, if pool is NULL, the fmtp
+ *                      string pointers will point to the original string.
+ * @param str           The fmtp string to be parsed.
+ * @param fmtp          The format parameter to store the parsing result.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_stream_info_parse_fmtp_data(pj_pool_t *pool,
+                                                         const pj_str_t *str,
+                                                         pjmedia_codec_fmtp *fmtp);
+
+
 PJ_END_DECL
 
 

--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -43,7 +43,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_parse_fmtp( pj_pool_t *pool,
 {
     const pjmedia_sdp_attr *attr;
     pjmedia_sdp_fmtp sdp_fmtp;
-    char *p, *p_end, fmt_buf[8];
+    char fmt_buf[8];
     pj_str_t fmt;
     pj_status_t status;
 
@@ -63,9 +63,16 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_parse_fmtp( pj_pool_t *pool,
     if (status != PJ_SUCCESS)
         return status;
 
+    return pjmedia_stream_info_parse_fmtp_data(pool, &sdp_fmtp.fmt_param, fmtp);
+}
+
+PJ_DECL(pj_status_t) pjmedia_stream_info_parse_fmtp_data(pj_pool_t *pool,
+                                                         const pj_str_t *str,
+                                                         pjmedia_codec_fmtp *fmtp)
+{
     /* Prepare parsing */
-    p = sdp_fmtp.fmt_param.ptr;
-    p_end = p + sdp_fmtp.fmt_param.slen;
+    char *p = str->ptr;
+    char *p_end = p + str->slen;
 
     /* Parse */
     while (p < p_end) {


### PR DESCRIPTION
pcaputil: Support parsing decoder options from FMTP input

Some codecs need specific flags that are given in the SDP media description. For example, AMR has octet-align=1.

Instead of adding distinct flags for each codec, allow pcaputil to accept the fmtp content and parse the attributes from there.

Example:
```
pcaputil \
  --dst-port=52422 \
  --codec=AMR/8000 \
  --codec-fmtp='mode-set=0,1,2,3,4,5,6,7;octet-align=1' \
  amr.pcap amr.wav
```