### PR TITLE
Fixed alsa dev read pcm bug

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -610,7 +610,20 @@ static int ca_thread_func (void *arg)
 
     while (!stream->quit) {
         pjmedia_frame frame;
-
+        
+        snd_pcm_state_t state;
+        state = snd_pcm_state(pcm);
+        if (state == SND_PCM_STATE_PREPARED) {
+            snd_pcm_start(pcm);
+            contine;
+        } else if (state == SND_PCM_STATE_RUNNING) {
+            snd_pcm_uframes_t avail;
+            avail = snd_pcm_avail(pcm);
+            if (avail >= 0 && avail < nframes) {
+                pj_thread_sleep(5);
+                continue;
+            }
+        }
         pj_bzero (buf, size);
         result = snd_pcm_readi (pcm, buf, nframes);
         if (result == -EPIPE) {


### PR DESCRIPTION
remove sound card device when capture audio data, the alsa audio cache may less than nframes, snd_pcm_readi wait for audio data forever.so when close the audio device ,the ca_thread_func can`t quite.use snd_pcm_avail to make sure audio cache has enough audio data.