### PR TITLE
Fix the info_cnt of pjsip_dlg_event_status when parsing dialog info

### DIFF
--- a/pjsip/include/pjsip-simple/dlg_event.h
+++ b/pjsip/include/pjsip-simple/dlg_event.h
@@ -70,7 +70,7 @@ PJ_DECL(pjsip_module*) pjsip_bdlg_event_instance(void);
  * Maximum dialog event status info items which can handled by application.
  *
  */
-#define PJSIP_DLG_EVENT_STATUS_MAX_INFO  8
+#define PJSIP_DLG_EVENT_STATUS_MAX_INFO  1
 
 
 /**

--- a/pjsip/src/pjsip-simple/dlg_event.c
+++ b/pjsip/src/pjsip-simple/dlg_event.c
@@ -332,11 +332,10 @@ pjsip_dlg_event_parse_dialog_info2(char *body, unsigned body_len,
     pjsip_dlg_info_dialog_info *dialog_info;
     pjsip_dlg_info_dialog *dialog;
 
+    dlgev_st->info_cnt = 0;
     dialog_info = pjsip_dlg_info_parse(pool, body, body_len);
     if (dialog_info == NULL)
         return PJSIP_SIMPLE_EBADPIDF;
-
-    dlgev_st->info_cnt = 0;
 
     dialog = pjsip_dlg_info_dialog_info_get_dialog(dialog_info);
     pj_strdup(pool, &dlgev_st->info[dlgev_st->info_cnt].dialog_info_entity,
@@ -402,6 +401,7 @@ pjsip_dlg_event_parse_dialog_info2(char *body, unsigned body_len,
     } else {
         dlgev_st->info[dlgev_st->info_cnt].dialog_node = NULL;
     }
+    dlgev_st->info_cnt++;
 
     return PJ_SUCCESS;
 }


### PR DESCRIPTION
This is to fix #4213.
Since the `pjsip_dlg_event_parse_dialog_info()` will only parse single dialog info, it is better to change the `PJSIP_DLG_EVENT_STATUS_MAX_INFO` too.
