### PR TITLE
Revert "Fixed warnings of duplicate libs"

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -7064,7 +7064,7 @@ if ac_fn_c_try_link "$LINENO"
 then :
 
                 CFLAGS="$CFLAGS -DPJNATH_HAS_UPNP=1 $UPNP_CFLAGS"
-                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS"
+                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS $UPNP_LIBS"
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -8566,6 +8566,7 @@ printf "%s\n" "not found" >&6; }
             ac_sdl_cflags="-DPJMEDIA_VIDEO_DEV_HAS_SDL=1 $ac_sdl_cflags"
             ac_sdl_ldflags=`$SDL_CONFIG --libs`
             ac_sdl_ldflags=`echo "${ac_sdl_ldflags}" | sed -e 's/-mwindows//g'`
+            LIBS="$LIBS $ac_sdl_ldflags"
         else
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Unsupported SDL version" >&5
 printf "%s\n" "Unsupported SDL version" >&6; }
@@ -9230,7 +9231,7 @@ if ac_fn_c_try_link "$LINENO"
 then :
 
                 ac_vpx_cflags="-DPJMEDIA_HAS_VPX_CODEC=1 $VPX_CFLAGS"
-                ac_vpx_ldflags="$VPX_LDFLAGS"
+                ac_vpx_ldflags="$VPX_LDFLAGS $VPX_LIBS"
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -750,7 +750,7 @@ AC_ARG_ENABLE(upnp,
             ],
             [
                 CFLAGS="$CFLAGS -DPJNATH_HAS_UPNP=1 $UPNP_CFLAGS"
-                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS"
+                LDFLAGS="$LDFLAGS $UPNP_LDFLAGS $UPNP_LIBS"
                 AC_MSG_RESULT(yes)
             ],
             [
@@ -1546,6 +1546,7 @@ AC_ARG_ENABLE(sdl,
             ac_sdl_cflags="-DPJMEDIA_VIDEO_DEV_HAS_SDL=1 $ac_sdl_cflags"
             ac_sdl_ldflags=`$SDL_CONFIG --libs`
             ac_sdl_ldflags=`echo "${ac_sdl_ldflags}" | sed -e 's/-mwindows//g'`
+            LIBS="$LIBS $ac_sdl_ldflags"
         else
             AC_MSG_RESULT([Unsupported SDL version])
         fi
@@ -1805,7 +1806,7 @@ AC_ARG_ENABLE(vpx,
             ],
             [
                 ac_vpx_cflags="-DPJMEDIA_HAS_VPX_CODEC=1 $VPX_CFLAGS"
-                ac_vpx_ldflags="$VPX_LDFLAGS"
+                ac_vpx_ldflags="$VPX_LDFLAGS $VPX_LIBS"
                 AC_MSG_RESULT(yes)
             ],
             [

--- a/build.mak.in
+++ b/build.mak.in
@@ -331,6 +331,7 @@ export APP_LDLIBS := $(PJSUA_LIB_LDLIB) \
         $(PJLIB_LDLIB) \
         @LIBS@
 export APP_LDXXLIBS := $(PJSUA2_LIB_LDLIB) \
+        -lstdc++ \
         $(APP_LDLIBS)
 
 # Here are the variables to use if application is using the library


### PR DESCRIPTION
Reverts pjsip/pjproject#4177.

This causes build failure on Linux when linking with any of those libraries.