### PR TITLE
Limit number of Oboe auto restart

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -924,7 +924,6 @@ private:
 
                 /* Increment timestamp */
                 pj_add_timestamp32(&this_->ts, ts_inc);
-                this_->nrestart = 0;
             }
         }
 

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -783,8 +783,9 @@ public:
             Stop();
 
             if (nrestart < MAX_RESTART) {
+                ++nrestart;
                 PJ_LOG(3, (THIS_FILE, "Trying to restart Oboe %s stream #%d",
-                                      dir_st, ++nrestart));
+                                      dir_st, nrestart));
                 status = Start();
             } else {
                 status = PJMEDIA_EAUD_SYSERR;
@@ -889,7 +890,7 @@ private:
                     /* Increment timestamp */
                     pj_add_timestamp32(&this_->ts, ts_inc);
                     ++cnt;
-                    this_-> nrestart = 0;
+                    this_->nrestart = 0;
                 }
 
                 if (stop_stream)
@@ -925,7 +926,7 @@ private:
 
                 /* Increment timestamp */
                 pj_add_timestamp32(&this_->ts, ts_inc);
-                this_-> nrestart = 0;
+                this_->nrestart = 0;
             }
         }
 

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -747,6 +747,7 @@ public:
             }
         }
 
+        this->nrestart = 0;
         sem_post(&sem);
 
         return (thread_quit? oboe::DataCallbackResult::Stop :
@@ -890,7 +891,6 @@ private:
                     /* Increment timestamp */
                     pj_add_timestamp32(&this_->ts, ts_inc);
                     ++cnt;
-                    this_->nrestart = 0;
                 }
 
                 if (stop_stream)
@@ -905,8 +905,6 @@ private:
                               this_->dir_st, cnt));
                 }
             } else {
-                this_->nrestart = 0;
-
                 /* Get audio frame from app via callback play_cb() */
                 pjmedia_frame frame;
                 frame.type = PJMEDIA_FRAME_TYPE_AUDIO;

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -790,7 +790,8 @@ public:
             }
 
             nrestart++;
-            PJ_LOG(3,(THIS_FILE, "Trying to restart Oboe %s stream", dir_st));
+            PJ_LOG(3, (THIS_FILE, "Trying to restart Oboe %s stream #%d",
+                                  dir_st, nrestart));
             status = Start();
 
             if (status != PJ_SUCCESS) {

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -782,17 +782,13 @@ public:
 
             Stop();
 
-            if (nrestart >= MAX_RESTART) {
-                PJ_LOG(3, (THIS_FILE, "Oboe %s stream permanently stopped",
-                                      dir_st));
-                pj_mutex_unlock(mutex);
-                return;
+            if (nrestart < MAX_RESTART) {
+                PJ_LOG(3, (THIS_FILE, "Trying to restart Oboe %s stream #%d",
+                                      dir_st, ++nrestart));
+                status = Start();
+            } else {
+                status = PJMEDIA_EAUD_SYSERR;
             }
-
-            nrestart++;
-            PJ_LOG(3, (THIS_FILE, "Trying to restart Oboe %s stream #%d",
-                                  dir_st, nrestart));
-            status = Start();
 
             if (status != PJ_SUCCESS) {
                 pjmedia_event e;


### PR DESCRIPTION
To fix #4218.

It is reported that Oboe will keep restarting indefinitely upon error.

Also in this PR:
minor: remove unused label `on_skip_dev`.
