### PR TITLE
Fixed Buddy to use correct account during subscription

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6554,10 +6554,18 @@ typedef struct pjsua_buddy_config
     pj_bool_t   subscribe_dlg_event;
 
     /**
-     * Specify arbitrary application data to be associated with with
+     * Specify arbitrary application data to be associated with
      * the buddy object.
      */
     void       *user_data;
+
+    /**
+     * Specify account to be associated with the buddy object. The account
+     * will be used for creating the subscription.
+     *
+     * Default: PJSUA_INVALID_ID (buddy is not associated to any account)
+     */
+    pjsua_acc_id acc_id;
 
 } pjsua_buddy_config;
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6563,6 +6563,9 @@ typedef struct pjsua_buddy_config
      * Specify account to be associated with the buddy object. The account
      * will be used for creating the subscription.
      *
+     * IMPORTANT: Account must remain valid throughout the entire lifetime
+     * of the buddy object.
+     *
      * Default: PJSUA_INVALID_ID (buddy is not associated to any account)
      */
     pjsua_acc_id acc_id;
@@ -6610,6 +6613,12 @@ typedef struct pjsua_buddy_info
      * The full URI of the buddy, as specified in the configuration.
      */
     pj_str_t            uri;
+
+    /**
+     * The account ID associated with this buddy. If not associated
+     * with any account, the value will be PJSUA_INVALID_ID.
+     */
+    pjsua_acc_id        acc_id;
 
     /**
      * Buddy's Contact, only available when presence subscription has

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -368,6 +368,7 @@ typedef struct pjsua_buddy
 {
     pj_pool_t           *pool;      /**< Pool for this buddy.           */
     unsigned             index;     /**< Buddy index.                   */
+    pjsua_acc_id         acc_id;    /**< Account index.                 */
     void                *user_data; /**< Application data.              */
     pj_str_t             uri;       /**< Buddy URI.                     */
     pj_str_t             contact;   /**< Contact learned from subscrp.  */

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -128,6 +128,12 @@ struct BuddyInfo
     string               contact;
 
     /**
+     * The account ID associated with this buddy. If not associated
+     * with any account, the value will be PJSUA_INVALID_ID.
+     */
+    pjsua_acc_id         accId;
+
+    /**
      * Flag to indicate that we should monitor the presence information for
      * this buddy (normally yes, unless explicitly disabled).
      */
@@ -237,6 +243,9 @@ public:
      * Note that application should maintain the Buddy original instance, i.e:
      * the instance that calls this create() method as it is only the original
      * instance destructor that will delete the underlying Buddy in PJSUA-LIB.
+     *
+     * IMPORTANT: Application must make sure that the Account instance remains
+     * valid for the entire lifetime of the Buddy object.
      *
      * @param acc               The account for this buddy.
      * @param cfg               The buddy config.

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -678,6 +678,19 @@ PJ_DEF(pj_status_t) pjsua_acc_del(pjsua_acc_id acc_id)
 
     acc = &pjsua_var.acc[acc_id];
 
+    for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.buddy); ++i) {
+        pjsua_buddy *b = &pjsua_var.buddy[i];
+
+        if (!pjsua_buddy_is_valid(i))
+            continue;
+        if (b->acc_id == acc_id) {
+            PJ_LOG(3, (THIS_FILE, "Warning: Account %d is used by "
+                                  "buddy %d. Disassociating it.",
+                                  acc_id, i));
+            b->acc_id = PJSUA_INVALID_ID;
+        }
+    }
+
     /* Cancel keep-alive timer, if any */
     if (acc->ka_timer.id) {
         pjsip_endpt_cancel_timer(pjsua_var.endpt, &acc->ka_timer);

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -390,6 +390,7 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
 PJ_DEF(void) pjsua_buddy_config_default(pjsua_buddy_config *cfg)
 {
     pj_bzero(cfg, sizeof(*cfg));
+    cfg->acc_id = PJSUA_INVALID_ID;
 }
 
 PJ_DEF(void) pjsua_media_config_default(pjsua_media_config *cfg)

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -561,6 +561,7 @@ PJ_DEF(pj_status_t) pjsua_buddy_add( const pjsua_buddy_config *cfg,
     pjsua_var.buddy[index].host = sip_uri->host;
     pjsua_var.buddy[index].port = sip_uri->port;
     pjsua_var.buddy[index].monitor = cfg->subscribe;
+    pjsua_var.buddy[index].acc_id = cfg->acc_id;
     if (pjsua_var.buddy[index].port == 0)
         pjsua_var.buddy[index].port = 5060;
 
@@ -574,7 +575,12 @@ PJ_DEF(pj_status_t) pjsua_buddy_add( const pjsua_buddy_config *cfg,
 
     PJSUA_UNLOCK();
 
-    PJ_LOG(4,(THIS_FILE, "Buddy %d added.", index));
+    if (cfg->acc_id != PJSUA_INVALID_ID) {
+        PJ_LOG(4,(THIS_FILE, "Buddy %d added for account %d.", index,
+                             cfg->acc_id));
+    } else {
+        PJ_LOG(4,(THIS_FILE, "Buddy %d added.", index));
+    }
 
     if (cfg->subscribe) {
         pjsua_buddy_subscribe_pres(index, cfg->subscribe);

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -2022,6 +2022,11 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
     buddy = &pjsua_var.buddy[buddy_id];
     acc_id = (buddy->acc_id != PJSUA_INVALID_ID)? buddy->acc_id:
              pjsua_acc_find_for_outgoing(&buddy->uri);
+    if (!pjsua_acc_is_valid(acc_id)) {
+        PJ_LOG(4,(THIS_FILE, "Buddy %d: subscription failed, account %d is "
+                             "invalid!", buddy_id, acc_id));
+        return;
+    }
 
     acc = &pjsua_var.acc[acc_id];
 

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -467,6 +467,7 @@ static void reset_buddy(pjsua_buddy_id id)
     pj_bzero(&pjsua_var.buddy[id], sizeof(pjsua_var.buddy[id]));
     pjsua_var.buddy[id].pool = pool;
     pjsua_var.buddy[id].index = id;
+    pjsua_var.buddy[id].acc_id = PJSUA_INVALID_ID;
 }
 
 
@@ -2013,7 +2014,8 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
     dlg_event_callback.on_rx_notify = &pjsua_evsub_on_rx_dlg_event_notify;
 
     buddy = &pjsua_var.buddy[buddy_id];
-    acc_id = pjsua_acc_find_for_outgoing(&buddy->uri);
+    acc_id = (buddy->acc_id != PJSUA_INVALID_ID)? buddy->acc_id:
+             pjsua_acc_find_for_outgoing(&buddy->uri);
 
     acc = &pjsua_var.acc[acc_id];
 

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -246,6 +246,9 @@ PJ_DEF(pj_status_t) pjsua_buddy_get_info( pjsua_buddy_id buddy_id,
     pj_strncpy(&info->uri, &buddy->uri, sizeof(info->buf_)-total);
     total += info->uri.slen;
 
+    /* acc id */
+    info->acc_id = buddy->acc_id;
+
     /* contact */
     if (total < sizeof(info->buf_)) {
         info->contact.ptr = info->buf_ + total;

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -1134,7 +1134,12 @@ BuddyVector2 Account::enumBuddies2() const PJSUA2_THROW(Error)
 
     PJSUA2_CHECK_EXPR( pjsua_enum_buddies(ids, &count) );
     for (i = 0; i < count; ++i) {
-        bv2.push_back(Buddy(ids[i]));
+        pjsua_buddy_info pbi;
+
+        pjsua_buddy_get_info(ids[i], &pbi);
+        if (id == pbi.acc_id) {
+            bv2.push_back(Buddy(ids[i]));
+        }
     }
 
     return bv2;
@@ -1161,11 +1166,17 @@ Buddy Account::findBuddy2(string uri) const PJSUA2_THROW(Error)
 {
     pj_str_t pj_uri;
     pjsua_buddy_id bud_id;
+    pjsua_buddy_info pbi;
 
     pj_strset2(&pj_uri, (char*)uri.c_str());
 
     bud_id = pjsua_buddy_find(&pj_uri);
-    if (id == PJSUA_INVALID_ID) {
+    if (bud_id == PJSUA_INVALID_ID) {
+        PJSUA2_RAISE_ERROR(PJ_ENOTFOUND);
+    }
+
+    pjsua_buddy_get_info(bud_id, &pbi);
+    if (id != pbi.acc_id) {
         PJSUA2_RAISE_ERROR(PJ_ENOTFOUND);
     }
 

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -22,6 +22,8 @@
 using namespace pj;
 using namespace std;
 
+#include <pjsua-lib/pjsua_internal.h>
+
 #define THIS_FILE               "presence.cpp"
 
 
@@ -141,6 +143,7 @@ void Buddy::create(Account &account, const BuddyConfig &cfg)
     PJSUA2_CHECK_EXPR( pjsua_buddy_add(&pj_cfg, &id) );
     
     account.addBuddy(this);
+    pjsua_var.buddy[id].acc_id = account.getId();
 }
 
 int Buddy::getId() const

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -57,6 +57,7 @@ void BuddyInfo::fromPj(const pjsua_buddy_info &pbi)
 {
     uri                 = pj2Str(pbi.uri);
     contact             = pj2Str(pbi.contact);
+    accId               = pbi.acc_id;
     presMonitorEnabled  = PJ2BOOL(pbi.monitor_pres);
     subState            = pbi.sub_state;
     subStateName        = string(pbi.sub_state_name);
@@ -113,9 +114,13 @@ Buddy::~Buddy()
         pjsua_buddy_set_user_data(id, NULL);
         pjsua_buddy_del(id);
 
+#if !DEPRECATED_FOR_TICKET_2232
         /* Remove from account buddy list */
         if (acc)
             acc->removeBuddy(this);
+#else
+        PJ_UNUSED_ARG(acc);
+#endif
     }
 }
     
@@ -197,7 +202,7 @@ void Buddy::sendInstantMessage(const SendInstantMessageParam &prm)
     BuddyUserData *bud = (BuddyUserData*)pjsua_buddy_get_user_data(id);
     Account *acc = bud? bud->acc : NULL;
 
-    if (!bud || !acc || !acc->isValid()) {
+    if (!bud || bi.accId == PJSUA_INVALID_ID || !acc || !acc->isValid()) {
         PJSUA2_RAISE_ERROR3(PJ_EINVAL, "sendInstantMessage()",
                             "Invalid Buddy");
     }
@@ -223,7 +228,7 @@ void Buddy::sendTypingIndication(const SendTypingIndicationParam &prm)
     BuddyUserData *bud = (BuddyUserData*)pjsua_buddy_get_user_data(id);
     Account *acc = bud? bud->acc : NULL;
 
-    if (!bud || !acc || !acc->isValid()) {
+    if (!bud || bi.accId == PJSUA_INVALID_ID || !acc || !acc->isValid()) {
         PJSUA2_RAISE_ERROR3(PJ_EINVAL, "sendInstantMessage()",
                             "Invalid Buddy");
     }

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -22,8 +22,6 @@
 using namespace pj;
 using namespace std;
 
-#include <pjsua-lib/pjsua_internal.h>
-
 #define THIS_FILE               "presence.cpp"
 
 
@@ -140,10 +138,10 @@ void Buddy::create(Account &account, const BuddyConfig &cfg)
     pj_cfg.uri = str2Pj(cfg.uri);
     pj_cfg.subscribe = cfg.subscribe;
     pj_cfg.user_data = (void*)bud;
+    pj_cfg.acc_id = account.getId();
     PJSUA2_CHECK_EXPR( pjsua_buddy_add(&pj_cfg, &id) );
     
     account.addBuddy(this);
-    pjsua_var.buddy[id].acc_id = account.getId();
 }
 
 int Buddy::getId() const


### PR DESCRIPTION
To fix #4226 

The issue occurs because in pjsua, buddy is not tied to any account, so it will always call `pjsua_acc_find_for_outgoing()` to find the appropriate account for outgoing subscription.

Also in this PR:
Fixed bug in Account::findBuddy2() and enumBuddies2() to only return buddies associated with the account.
