### PR TITLE
pjmedia_wav_player_port_create() fix

### DIFF
--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -88,10 +88,8 @@ static struct file_reader_port *create_file_port(pj_pool_t *pool)
     struct file_reader_port *port;
 
     port = PJ_POOL_ZALLOC_T(pool, struct file_reader_port);
-    if (!port) {
-        pj_pool_release(pool);
+    if (!port)
         return NULL;
-    }
 
     /* Put in default values.
      * These will be overriden once the file is read.


### PR DESCRIPTION
Fix: If create_file_port() fails to allocate memory, the pool is destroyed twice. First time there, and second time in the on_error of the calling function (pjmedia_wav_player_port_create).