### PR TITLE
Fix SSL to continue decrypting data after renego completes

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -867,6 +867,11 @@ static pj_bool_t ssock_on_data_read (pj_ssl_sock_t *ssock,
                                      "Failed to flush delayed send"));
                         goto on_error;
                     }
+
+                    /* If renego has been completed, continue reading data */
+                    if (status == PJ_SUCCESS)
+                        continue;
+
                 } else if (status != PJ_EPENDING) {
                     PJ_PERROR(1,(ssock->pool->obj_name, status, 
                                  "Renegotiation failed"));


### PR DESCRIPTION
SSL socket test may get stuck in performance test. After investigation, it turns out that the scenario involves processing message containing both SSL renegotiation and data. When SSL renegotiation completes immediately, the SSL socket will not process the data (until another message is received). Unfortunately in the SSL socket test scenario there is no further message received, so the test get stuck waiting for the data.