### PR TITLE
Memory leak caused by change in media port behavior due to implementation of asynchronous conference bridge

### DIFF
--- a/pjmedia/src/test/mips_test.c
+++ b/pjmedia/src/test/mips_test.c
@@ -502,6 +502,9 @@ static pjmedia_port* init_conf_port(unsigned nb_participant,
         if (status != PJ_SUCCESS)
             return NULL;
 
+        status = pjmedia_port_destroy(gen_port);
+        pj_assert(status == PJ_SUCCESS);
+
         /* Connect gen_port to sound dev */
         status = pjmedia_conf_connect_port(conf, slot1, 0, 0);
         if (status != PJ_SUCCESS)
@@ -517,6 +520,9 @@ static pjmedia_port* init_conf_port(unsigned nb_participant,
         status = pjmedia_conf_add_port(conf, pool, null_port, NULL, &slot2);
         if (status != PJ_SUCCESS)
             return NULL;
+
+        status = pjmedia_port_destroy(null_port);
+        pj_assert(status == PJ_SUCCESS);
 
         /* connect sound to null sink port */
         status = pjmedia_conf_connect_port(conf, 0, slot2, 0);
@@ -2385,6 +2391,8 @@ static pj_timestamp run_entry(unsigned clock_rate, struct test_entry *e)
     pj_get_timestamp(&t1);
 
     pj_sub_timestamp(&t1, &t0);
+
+    pjmedia_port_destroy(gen_port);
 
     if (e->custom_deinit)
         e->custom_deinit(e);


### PR DESCRIPTION
This PR fixes memory leak in pjmedia_test app mips_test caused by change in media port behavior due to implementation of Asynchronous conference bridge operation #3928.

Before #3928 evreything was fine with this code (pseudocode):
Option 1
(a) pjmedia_mem_player_create(pool, &port)
(b) pj_pool_release(pool);

But currently step (a) creates a new pool that is not accessible to the user application and is leaked.

Option 2
(a) pjmedia_mem_player_create(pool, &port)
(b) pjmedia_conf_add_port(conf, pool, port);
(c) pjmedia_conf_destroy(conf);
(d) pj_pool_release(pool);

Currently both (a) and (b) create new pools, (b) creates grp_lock whose ref_counter == 2.
Step (c) decrements the grp_lock ref_counter only once, causing both pools to leak..

The same is true for any media port's type even for null_port.

The solution is common to reference-counted memory management: the application must decrement the reference count when a reference goes out of scope.
In this fix I added pjmedia_port_destroy() wherever needed. This fixes the memory leak (but only in this function...)

This may not be clear to the reader of the source code, but the best code sequence now is to call pjmedia_port_destroy() immediately after a successful call to pjmedia_conf_add_port(). The pjmedia_port_destroy() function does not actually destroy the media port, it only decrements the reference count of the port!

Let's hope that this type of memory leak does not become a typical behavior for applications...
I think calling pjmedia_port_destroy() when port reference goes out of scope should be clearly documented as a new requirement of pjsip.






