### PR TITLE
Fixes GnuTLS unit test failures

### DIFF
--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -1644,12 +1644,15 @@ int ssl_sock_test(void)
     if (ret != 0)
         return ret;
 
+    /* SSLv23 is deprecated */
+    /*
     PJ_LOG(3,("", "..echo test w/ SSLv23 and PJ_TLS_RSA_WITH_AES_256_CBC_SHA cipher"));
     ret = echo_test(PJ_SSL_SOCK_PROTO_SSL23, PJ_SSL_SOCK_PROTO_SSL23, 
                     PJ_TLS_RSA_WITH_AES_256_CBC_SHA, PJ_TLS_RSA_WITH_AES_256_CBC_SHA,
                     PJ_FALSE, PJ_FALSE);
     if (ret != 0)
         return ret;
+    */
 #endif
 
     PJ_LOG(3,("", "..echo test w/ compatible proto: server TLSv1.2 vs client TLSv1.2"));


### PR DESCRIPTION
* Fixes protocol setting in GnuTLS.
Currently, by default GnuTLS will enable all TLS protocols. This will cause unit test failure such as:
`echo test w/ incompatible proto: server TLSv1 vs client SSL3`.
The patch fixes this by only enabling the protocols specified in the ssock param.
* Fixes cipher setting in GnuTLS
Currently, by default GnuTLS will enable all ciphers.
The patch fixes this by only enabling the ciphers specified in the ssock param.
* Fixes crash if handshake failed.
```
11:02:28.798 Handshake failed on 127.0.0.1:61429 in connecting to 127.0.0.1:61428: Invalid value or argument (PJ_EINVAL)
Error: signal 11:
3   libgnutls.30.dylib                  0x0000000100c830ac gnutls_alert_send + 168
4   libgnutls.30.dylib                  0x0000000100c56d94 gnutls_bye + 92
5   pjlib-test-arm-apple-darwin24.1.0   0x00000001006b6070 ssl_destroy + 188
6   pjlib-test-arm-apple-darwin24.1.0   0x00000001006aa2f8 ssl_on_destroy + 48
7   pjlib-test-arm-apple-darwin24.1.0   0x00000001006aa988 pj_ssl_sock_close + 1152
8   pjlib-test-arm-apple-darwin24.1.0   0x000000010061d248 ssl_on_connect_complete + 2248
9   pjlib-test-arm-apple-darwin24.1.0   0x00000001006b38f4 on_handshake_complete + 4964
```
According to the doc https://linux.die.net/man/3/gnutls_bye seems to be only needed if the connection has been established.

Also in this PR:
- Disable ssl sock test with SSLv23 protocol. This used to be specific to OpenSSL backend (which is then expanded to other backends as well), but now even for OpenSSL, it has been deprecated:
https://docs.openssl.org/master/man3/SSL_CTX_new/#notes
```
SSLv23_method(), SSLv23_server_method(), SSLv23_client_method()
These functions do not exist anymore, they have been renamed to TLS_method(),
```
 