### PR TITLE
Fix possible deadlock in conference (audio & video)

### DIFF
--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1399,7 +1399,7 @@ static void op_disconnect_ports(pjmedia_conf *conf,
 {
     unsigned src_slot, sink_slot;
     struct conf_port *src_port = NULL, *dst_port = NULL;
-    unsigned i;
+    int i;
 
     /* Ports must be valid. */
     src_slot = prm->disconnect_ports.src;

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -340,34 +340,53 @@ static op_entry* get_free_op_entry(pjmedia_conf *conf)
 
 static void handle_op_queue(pjmedia_conf *conf)
 {
-    op_entry *op, *next_op;
+    /* The queue may grow while mutex is released, better put a limit? */
+    enum { MAX_PROCESSED_OP = 100 };
+    int i = 0;
 
-    op = conf->op_queue->next;
-    while (op != conf->op_queue) {
-        next_op = op->next;
+    while (i++ < MAX_PROCESSED_OP) {
+        op_entry *op;
+        op_type type;
+        op_param param;
+
+        pj_mutex_lock(conf->mutex);
+
+        /* Stop when queue empty */
+        if (pj_list_empty(conf->op_queue)) {
+            pj_mutex_unlock(conf->mutex);
+            break;
+        }
+
+        /* Copy op */
+        op = conf->op_queue->next;
+        type = op->type;
+        param = op->param;
+
+        /* Free op */
         pj_list_erase(op);
+        op->type = OP_UNKNOWN;
+        pj_list_push_back(conf->op_queue_free, op);
 
-        switch(op->type) {
+        pj_mutex_unlock(conf->mutex);
+
+        /* Process op */
+        switch(type) {
             case OP_ADD_PORT:
-                op_add_port(conf, &op->param);
+                op_add_port(conf, &param);
                 break;
             case OP_REMOVE_PORT:
-                op_remove_port(conf, &op->param);
+                op_remove_port(conf, &param);
                 break;
             case OP_CONNECT_PORTS:
-                op_connect_ports(conf, &op->param);
+                op_connect_ports(conf, &param);
                 break;
             case OP_DISCONNECT_PORTS:
-                op_disconnect_ports(conf, &op->param);
+                op_disconnect_ports(conf, &param);
                 break;
             default:
                 pj_assert(!"Invalid sync-op in conference");
                 break;
         }
-
-        op->type = OP_UNKNOWN;
-        pj_list_push_back(conf->op_queue_free, op);
-        op = next_op;
     }
 }
 
@@ -1380,7 +1399,7 @@ static void op_disconnect_ports(pjmedia_conf *conf,
 {
     unsigned src_slot, sink_slot;
     struct conf_port *src_port = NULL, *dst_port = NULL;
-    int i;
+    unsigned i;
 
     /* Ports must be valid. */
     src_slot = prm->disconnect_ports.src;
@@ -1722,7 +1741,10 @@ static void op_remove_port(pjmedia_conf *conf, const op_param *prm)
     }
 
     /* Remove the port. */
+    pj_mutex_lock(conf->mutex);
     conf->ports[port] = NULL;
+    pj_mutex_unlock(conf->mutex);
+
     if (!conf_port->is_new)
         --conf->port_cnt;
 
@@ -2418,9 +2440,7 @@ static pj_status_t get_frame(pjmedia_port *this_port,
      */
     if (!pj_list_empty(conf->op_queue)) {
         pj_log_push_indent();
-        pj_mutex_lock(conf->mutex);
         handle_op_queue(conf);
-        pj_mutex_unlock(conf->mutex);
         pj_log_pop_indent();
     }
 

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -233,7 +233,7 @@ static void handle_op_queue(pjmedia_vid_conf *conf)
 
         /* Process op */
         switch (type) {
-        case OP_ADD_PORT:
+            case OP_ADD_PORT:
                 op_add_port(conf, &param);
                 break;
             case OP_REMOVE_PORT:

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -1108,9 +1108,9 @@ static void on_clock_tick(const pj_timestamp *now, void *user_data)
      * the clock such as connect, disonnect, remove, update.
      */
     if (!pj_list_empty(vid_conf->op_queue)) {
-        pj_mutex_lock(vid_conf->mutex);
+        pj_log_push_indent();
         handle_op_queue(vid_conf);
-        pj_mutex_unlock(vid_conf->mutex);
+        pj_log_pop_indent();
     }
 
     /* No mutex from this point! Otherwise it may cause deadlock as


### PR DESCRIPTION
As reported by @LeonidGoltsblat [here](https://github.com/pjsip/pjproject/pull/3928#issuecomment-2566719281):

> The OP_REMOVE_PORT function calls the group lock handler while holding the conf->mutex. As with any callback invoked under a lock, there is a potential risk of deadlock. We cannot predict what actions the user’s application may take in the callback, for instance, it might acquire the SIP dialog mutex, which could lead to a lock ordering issue similar to the one described in bug report #3183.
> I don't think it's necessary to call handle_op_queue under the mutex lock. Mutex protection is only required to protect conf->op_queue, not the handle_op_queue() function itself. This way, we can invoke the callback outside the conference mutex lock.

This PR is trying to fix that using the suggested solution, with a couple of additional touches:
- Limit the op processing number, as the op processing is done in media processing thread and the op queue may grow (theoritically indefinitely), a limit will reduce/avoid starvation.
- Protect `conf->ports[port] = NULL` in OP_REMOVE_PORT with mutex to avoid race conditions with other APIs that access `conf->ports[]` (with mutex).