### PR TITLE
Add helper APIs for adding & removing port destroy handler

### DIFF
--- a/pjmedia/include/pjmedia/conference.h
+++ b/pjmedia/include/pjmedia/conference.h
@@ -425,6 +425,10 @@ PJ_DECL(unsigned) pjmedia_conf_get_connect_count(pjmedia_conf *conf);
  * should not assume that the port will no longer receive/send audio frame
  * after this function has returned.
  *
+ * If the port uses any app's resources, application should maintain
+ * the resources validity until the port is completely removed. Application
+ * can schedule the resource release via #pjmedia_conf_add_destroy_handler().
+ *
  * @param conf          The conference bridge.
  * @param slot          The port index to be removed.
  *
@@ -601,6 +605,47 @@ PJ_DECL(pj_status_t) pjmedia_conf_adjust_conn_level( pjmedia_conf *conf,
                                                      unsigned sink_slot,
                                                      int adj_level );
 
+
+/**
+ * Add port destructor handler.
+ *
+ * Application can use this function to schedule resource release.
+ * Note that application cannot release any app's resources used by the port,
+ * e.g: memory pool, database connection, immediately after removing the port
+ * from the conference bridge as port removal is asynchronous.
+ *
+ * Usually this function is called after adding the port to the conference
+ * bridge.
+ *
+ * @param conf              The conference bridge.
+ * @param slot              The port slot index.
+ * @param member            A pointer to be passed to the handler.
+ * @param handler           The destroy handler.
+ *
+ * @return                  PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_conf_add_destroy_handler(
+                                            pjmedia_conf* conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler);
+
+
+/**
+ * Remove previously registered destructor handler.
+ *
+ * @param conf              The conference bridge.
+ * @param slot              The port slot index.
+ * @param member            A pointer to be passed to the handler.
+ * @param handler           The destroy handler.
+ *
+ * @return                  PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_conf_del_destroy_handler(
+                                            pjmedia_conf* conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler);
 
 
 PJ_END_DECL

--- a/pjmedia/include/pjmedia/port.h
+++ b/pjmedia/include/pjmedia/port.h
@@ -563,6 +563,37 @@ PJ_DECL(pj_status_t) pjmedia_port_add_ref( pjmedia_port *port );
 PJ_DECL(pj_status_t) pjmedia_port_dec_ref( pjmedia_port *port );
 
 
+/**
+ * This is a helper function to add port destructor handler.
+ *
+ * @param port              The PJMEDIA port.
+ * @param member            A pointer to be passed to the handler.
+ * @param handler           The destroy handler.
+ *
+ * @return                  PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_port_add_destroy_handler(
+                                            pjmedia_port* port,
+                                            void *member,
+                                            pj_grp_lock_handler handler);
+
+
+/**
+ * This is a helper function to remove previously registered
+ * destructor handler.
+ *
+ * @param port              The PJMEDIA port.
+ * @param member            A pointer to be passed to the handler.
+ * @param handler           The destroy handler.
+ *
+ * @return                  PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_port_del_destroy_handler(
+                                            pjmedia_port* port,
+                                            void *member,
+                                            pj_grp_lock_handler handler);
+
+
 PJ_END_DECL
 
 /**

--- a/pjmedia/include/pjmedia/vid_conf.h
+++ b/pjmedia/include/pjmedia/vid_conf.h
@@ -221,7 +221,7 @@ PJ_DECL(unsigned) pjmedia_vid_conf_get_port_count(pjmedia_vid_conf *vid_conf);
 /**
  * Enumerate occupied slots in the video conference bridge.
  *
- * @param vid_conf              The video conference bridge.
+ * @param vid_conf      The video conference bridge.
  * @param slots         Array of slot to be filled in.
  * @param count         On input, specifies the maximum number of slot
  *                      in the array. On return, it will be filled with
@@ -253,7 +253,7 @@ PJ_DECL(pj_status_t) pjmedia_vid_conf_get_port_info(
  * Enable unidirectional video flow from the specified source slot to
  * the specified sink slot.
  *
- * @param vid_conf              The video conference bridge.
+ * @param vid_conf      The video conference bridge.
  * @param src_slot      Source slot.
  * @param sink_slot     Sink slot.
  * @param opt           The option, for future use, currently this must
@@ -272,7 +272,7 @@ PJ_DECL(pj_status_t) pjmedia_vid_conf_connect_port(
  * Disconnect unidirectional video flow from the specified source to
  * the specified sink slot.
  *
- * @param vid_conf              The video conference bridge.
+ * @param vid_conf      The video conference bridge.
  * @param src_slot      Source slot.
  * @param sink_slot     Sink slot.
  *
@@ -299,6 +299,49 @@ PJ_DECL(pj_status_t) pjmedia_vid_conf_disconnect_port(
  */
 PJ_DECL(pj_status_t) pjmedia_vid_conf_update_port(pjmedia_vid_conf *vid_conf,
                                                   unsigned slot);
+
+
+
+/**
+ * Add port destructor handler.
+ *
+ * Application can use this function to schedule resource release.
+ * Note that application cannot release any app's resources used by the port,
+ * e.g: memory pool, database connection, immediately after removing the port
+ * from the conference bridge as port removal is asynchronous.
+ *
+ * Usually this function is called after adding the port to the conference
+ * bridge.
+ *
+ * @param vid_conf          The video conference bridge.
+ * @param slot              The port slot index.
+ * @param member            A pointer to be passed to the handler.
+ * @param handler           The destroy handler.
+ *
+ * @return                  PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_vid_conf_add_destroy_handler(
+                                            pjmedia_vid_conf* vid_conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler);
+
+
+/**
+ * Remove previously registered destructor handler.
+ *
+ * @param conf              The video conference bridge.
+ * @param slot              The port slot index.
+ * @param member            A pointer to be passed to the handler.
+ * @param handler           The destroy handler.
+ *
+ * @return                  PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_vid_conf_del_destroy_handler(
+                                            pjmedia_vid_conf* vid_conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler);
 
 
 PJ_END_DECL

--- a/pjmedia/src/pjmedia/conf_switch.c
+++ b/pjmedia/src/pjmedia/conf_switch.c
@@ -1585,4 +1585,41 @@ static pj_status_t put_frame(pjmedia_port *this_port,
     return PJ_SUCCESS;
 }
 
+
+/*
+ * Add destructor handler.
+ */
+PJ_DEF(pj_status_t) pjmedia_conf_add_destroy_handler(
+                                            pjmedia_conf* conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler)
+{
+    PJ_UNUSED_ARG(conf);
+    PJ_UNUSED_ARG(slot);
+    PJ_UNUSED_ARG(member);
+    PJ_UNUSED_ARG(handler);
+
+    return PJ_ENOTSUP;
+}
+
+
+/*
+ * Remove previously registered destructor handler.
+ */
+PJ_DEF(pj_status_t) pjmedia_conf_del_destroy_handler(
+                                            pjmedia_conf* conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler)
+{
+    PJ_UNUSED_ARG(conf);
+    PJ_UNUSED_ARG(slot);
+    PJ_UNUSED_ARG(member);
+    PJ_UNUSED_ARG(handler);
+
+    return PJ_ENOTSUP;
+}
+
+
 #endif

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -232,3 +232,33 @@ PJ_DEF(pj_status_t) pjmedia_port_dec_ref( pjmedia_port *port )
 
     return pj_grp_lock_dec_ref(port->grp_lock);
 }
+
+
+/**
+ * Add destructor handler.
+ */
+PJ_DEF(pj_status_t) pjmedia_port_add_destroy_handler(
+                                            pjmedia_port* port,
+                                            void* member,
+                                            pj_grp_lock_handler handler)
+{
+    PJ_ASSERT_RETURN(port && handler, PJ_EINVAL);
+    PJ_ASSERT_RETURN(port->grp_lock, PJ_EINVALIDOP);
+
+    return pj_grp_lock_add_handler(port->grp_lock, NULL, member, handler);
+}
+
+
+/**
+ * Remove previously registered destructor handler.
+ */
+PJ_DEF(pj_status_t) pjmedia_port_del_destroy_handler(
+                                            pjmedia_port* port,
+                                            void* member,
+                                            pj_grp_lock_handler handler)
+{
+    PJ_ASSERT_RETURN(port && handler, PJ_EINVAL);
+    PJ_ASSERT_RETURN(port->grp_lock, PJ_EINVALIDOP);
+
+    return pj_grp_lock_del_handler(port->grp_lock, member, handler);
+}

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -1733,4 +1733,66 @@ static void op_update_port(pjmedia_vid_conf *vid_conf,
 }
 
 
+/*
+ * Add destructor handler.
+ */
+PJ_DEF(pj_status_t) pjmedia_vid_conf_add_destroy_handler(
+                                            pjmedia_vid_conf* vid_conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler)
+{
+    struct vconf_port* cport;
+    pj_grp_lock_t* grp_lock;
+
+    PJ_ASSERT_RETURN(vid_conf && handler && slot < vid_conf->opt.max_slot_cnt,
+                     PJ_EINVAL);
+
+    pj_mutex_lock(vid_conf->mutex);
+
+    /* Port must be valid and has group lock. */
+    cport = vid_conf->ports[slot];
+    if (!cport || !cport->port || !cport->port->grp_lock) {
+        pj_mutex_unlock(vid_conf->mutex);
+        return cport ? PJ_EINVALIDOP : PJ_EINVAL;
+    }
+    grp_lock = cport->port->grp_lock;
+
+    pj_mutex_unlock(vid_conf->mutex);
+
+    return pj_grp_lock_add_handler(grp_lock, NULL, member, handler);
+}
+
+
+/*
+ * Remove previously registered destructor handler.
+ */
+PJ_DEF(pj_status_t) pjmedia_vid_conf_del_destroy_handler(
+                                            pjmedia_vid_conf* vid_conf,
+                                            unsigned slot,
+                                            void* member,
+                                            pj_grp_lock_handler handler)
+{
+    struct vconf_port* cport;
+    pj_grp_lock_t* grp_lock;
+
+    PJ_ASSERT_RETURN(vid_conf && handler && slot < vid_conf->opt.max_slot_cnt,
+                     PJ_EINVAL);
+
+    pj_mutex_lock(vid_conf->mutex);
+
+    /* Port must be valid and has group lock. */
+    cport = vid_conf->ports[slot];
+    if (!cport || !cport->port || !cport->port->grp_lock) {
+        pj_mutex_unlock(vid_conf->mutex);
+        return cport ? PJ_EINVALIDOP : PJ_EINVAL;
+    }
+    grp_lock = cport->port->grp_lock;
+
+    pj_mutex_unlock(vid_conf->mutex);
+
+    return pj_grp_lock_del_handler(grp_lock, member, handler);
+}
+
+
 #endif /* PJMEDIA_HAS_VIDEO */


### PR DESCRIPTION
As suggested by @LeonidGoltsblat ([here](https://github.com/pjsip/pjproject/pull/3928#issuecomment-2566719281) & [here](https://github.com/pjsip/pjproject/pull/3928#issuecomment-2573848554)):

> I think we need an API to add/remove the grp_lock port conf handle - it's simple and gives the application the ability to safely close all the resources it needs.

> Real world applications may use pjsip as one of many other libraries and may not be written only in C/C++. The application manages resources outside the pjsip logic and may not be able to use the pool API to allocate memory, but in some cases the closing of application resources must be synchronized with the destruction of conference bridge ports.
> 
> For example, an application may implement a special media port proxy to play audio data stored in a BLOB field of a database. With an asynchronous switch, the application cannot close the database connection not only when performing a disconnect, but also when calling remove port, because the conference bridge may try to receive the next frame of data after that. The application must know the exact moment when to release resources, close the database connection, etc. This moment is the "grp_lock handle call".