### PR TITLE
CI: change sleep_test() and timestamp_test() to exclusive on Windows

### DIFF
--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -242,8 +242,18 @@ static int features_tests(int argc, char *argv[])
     UT_ADD_TEST(&test_app.ut_app, hash_test, 0);
 #endif
 
+    /* Windows GH CI oftent fails with:
+
+    07:27:13.217 ...testing frequency accuracy (pls wait)
+    07:27:23.440 ....error: timestamp drifted by 3800 usec after 10020 msec
+    */
 #if INCLUDE_TIMESTAMP_TEST
+#  if defined(PJ_WIN32) && PJ_WIN32!=0
+    UT_ADD_TEST(&test_app.ut_app, timestamp_test,
+                PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
+#  else
     UT_ADD_TEST(&test_app.ut_app, timestamp_test, 0);
+#  endif
 #endif
 
 #if INCLUDE_ATOMIC_TEST

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -254,8 +254,17 @@ static int features_tests(int argc, char *argv[])
     UT_ADD_TEST(&test_app.ut_app, timer_test, 0);
 #endif
 
+    /* Very often sleep test failed on GitHub Windows CI, with
+       the thread sleeping for much longer than tolerated. So
+       as a workaround, set it as exclusive.
+     */
 #if INCLUDE_SLEEP_TEST
+#  if defined(PJ_WIN32) && PJ_WIN32!=0
+    UT_ADD_TEST(&test_app.ut_app, sleep_test,
+                PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
+#  else
     UT_ADD_TEST(&test_app.ut_app, sleep_test, 0);
+#  endif
 #endif
 
 #if INCLUDE_FILE_TEST
@@ -299,7 +308,8 @@ static int features_tests(int argc, char *argv[])
     */
 #if INCLUDE_IOQUEUE_STRESS_TEST
 #  if defined(PJ_WIN32) && PJ_WIN32!=0
-    UT_ADD_TEST(&test_app.ut_app, ioqueue_stress_test, PJ_TEST_EXCLUSIVE);
+    UT_ADD_TEST(&test_app.ut_app, ioqueue_stress_test,
+                PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
 #  else
     UT_ADD_TEST(&test_app.ut_app, ioqueue_stress_test, 0);
 #  endif


### PR DESCRIPTION
pjlib-test's `sleep_test()` often fails on Windows GH CI, sleeping for longer than tolerated, even with `--ci-mode`. Similarly, `timestamp_test()` also often fails, drifting for more than tolerated. This probably depends on the load of GH runner, because sometimes it works reliably for many days.

As a workaround, this PR sets `sleep_test()` and `timestamp_test()` to run as exclusive test (=no other test will run while exclusive test is running) on Windows only.

Also while at it, set exclusive tests in `pjlib-test` to run last for slightly more efficient testing time