### PR TITLE
Fixed pjsua2 unnecessary object copy

### DIFF
--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -259,7 +259,7 @@ static void mainProg1(MyEndpoint &ep)
     AuthCredInfo aci("digest", "*", "test1", 0, "test1");
 #endif
 
-    acc_cfg.sipConfig.authCreds.push_back(aci);
+    acc_cfg.sipConfig.authCreds.push_back(std::move(aci));
     MyAccount *acc(new MyAccount);
     try {
         acc->create(acc_cfg);
@@ -412,7 +412,7 @@ static void mainProg(MyEndpoint &)
         SipHeader h;
         h.hName = "X-Header";
         h.hValue = "User header";
-        accCfg.regConfig.headers.push_back(h);
+        accCfg.regConfig.headers.push_back(std::move(h));
 
         accCfg.sipConfig.proxies.push_back("<sip:sip.pjsip.org;transport=tcp>");
         accCfg.sipConfig.proxies.push_back("<sip:sip.pjsip.org;transport=tls>");
@@ -431,7 +431,7 @@ static void mainProg(MyEndpoint &)
         aci.dataType |= PJSIP_CRED_DATA_EXT_AKA;
         aci.akaK = "key";
 #endif
-        accCfg.sipConfig.authCreds.push_back(aci);
+        accCfg.sipConfig.authCreds.push_back(std::move(aci));
 
         jdoc.writeObject(accCfg);
         json_str = jdoc.saveString();

--- a/pjsip-apps/src/samples/pjsua2_demo.cpp
+++ b/pjsip-apps/src/samples/pjsua2_demo.cpp
@@ -177,6 +177,8 @@ void MyCall::onCallMediaState(OnCallMediaStateParam &prm)
     AudioMedia& play_dev_med =
         MyEndpoint::instance().audDevManager().getPlaybackDevMedia();
 
+        std::cout << "Getting playback dev media" << std::endl;
+
     try {
         // Get the first audio media
         aud_med = getAudioMedia(-1);
@@ -240,7 +242,7 @@ static void mainProg1(MyEndpoint &ep)
 
     // Transport
     TransportConfig tcfg;
-    tcfg.port = 5060;
+    tcfg.port = 6000;
     ep.transportCreate(PJSIP_TRANSPORT_UDP, tcfg);
 
     // Start library
@@ -249,17 +251,17 @@ static void mainProg1(MyEndpoint &ep)
 
     // Add account
     AccountConfig acc_cfg;
-    acc_cfg.idUri = "sip:test1@pjsip.org";
+    acc_cfg.idUri = "sip:401@pjsip.org";
     acc_cfg.regConfig.registrarUri = "sip:sip.pjsip.org";
 
 #if PJSIP_HAS_DIGEST_AKA_AUTH
     AuthCredInfo aci("Digest", "*", "test", PJSIP_CRED_DATA_EXT_AKA | PJSIP_CRED_DATA_PLAIN_PASSWD, "passwd");
     aci.akaK = "passwd";
 #else
-    AuthCredInfo aci("digest", "*", "test1", 0, "test1");
+    AuthCredInfo aci("digest", "*", "401", 0, "pw401");
 #endif
 
-    acc_cfg.sipConfig.authCreds.push_back(std::move(aci));
+    acc_cfg.sipConfig.authCreds.push_back(PJSUA2_MOVE(aci));
     MyAccount *acc(new MyAccount);
     try {
         acc->create(acc_cfg);
@@ -275,7 +277,7 @@ static void mainProg1(MyEndpoint &ep)
     CallOpParam prm(true);
     prm.opt.audioCount = 1;
     prm.opt.videoCount = 0;
-    call->makeCall("sip:test1@pjsip.org", prm);
+    call->makeCall("sip:402@sip.pjsip.org", prm);
     
     // Hangup all calls
     pj_thread_sleep(4000);
@@ -412,7 +414,7 @@ static void mainProg(MyEndpoint &)
         SipHeader h;
         h.hName = "X-Header";
         h.hValue = "User header";
-        accCfg.regConfig.headers.push_back(std::move(h));
+        accCfg.regConfig.headers.push_back(PJSUA2_MOVE(h));
 
         accCfg.sipConfig.proxies.push_back("<sip:sip.pjsip.org;transport=tcp>");
         accCfg.sipConfig.proxies.push_back("<sip:sip.pjsip.org;transport=tls>");
@@ -431,7 +433,7 @@ static void mainProg(MyEndpoint &)
         aci.dataType |= PJSIP_CRED_DATA_EXT_AKA;
         aci.akaK = "key";
 #endif
-        accCfg.sipConfig.authCreds.push_back(std::move(aci));
+        accCfg.sipConfig.authCreds.push_back(PJSUA2_MOVE(aci));
 
         jdoc.writeObject(accCfg);
         json_str = jdoc.saveString();

--- a/pjsip/include/pjsua2/config.hpp
+++ b/pjsip/include/pjsua2/config.hpp
@@ -66,6 +66,15 @@
 #endif
 
 /**
+ * std::move() is only supported from C++11.
+ */
+#if __cplusplus >= 201103L
+    #define PJSUA2_MOVE(x) std::move(x)
+#else
+    #define PJSUA2_MOVE(x) (x)
+#endif
+
+/**
  * @}  PJSUA2_CFG
  */
 

--- a/pjsip/include/pjsua2/config.hpp
+++ b/pjsip/include/pjsua2/config.hpp
@@ -68,7 +68,8 @@
 /**
  * std::move() is only supported from C++11.
  */
-#if __cplusplus >= 201103L
+#if (defined(_MSVC_LANG) && _MSVC_LANG >= 201103L) || \
+    (__cplusplus >= 201103L)
     #define PJSUA2_MOVE(x) std::move(x)
 #else
     #define PJSUA2_MOVE(x) (x)

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -179,7 +179,8 @@ public:
      * Default constructor
      */
     BuddyInfo() 
-    : presMonitorEnabled(true),
+    : accId(PJSUA_INVALID_ID),
+      presMonitorEnabled(true),
       subState(PJSIP_EVSUB_STATE_UNKNOWN),
       subTermCode(PJSIP_SC_NULL)
     {}

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -65,7 +65,7 @@ void RtcpFbConfig::fromPj(const pjmedia_rtcp_fb_setting &prm)
     for (unsigned i = 0; i < prm.cap_count; ++i) {
         RtcpFbCap cap;
         cap.fromPj(prm.caps[i]);
-        this->caps.push_back(std::move(cap));
+        this->caps.push_back(PJSUA2_MOVE(cap));
     }
 }
 
@@ -96,7 +96,7 @@ void RtcpFbConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
         NODE_READ_NUM_T         (cap_node, pjmedia_rtcp_fb_type, cap.type);
         NODE_READ_STRING        (cap_node, cap.typeName);
         NODE_READ_STRING        (cap_node, cap.param);
-        this->caps.push_back(std::move(cap));
+        this->caps.push_back(PJSUA2_MOVE(cap));
     }
 }
 
@@ -157,7 +157,7 @@ void SrtpOpt::fromPj(const pjsua_srtp_opt &prm)
     for (unsigned i = 0; i < prm.crypto_count; ++i) {
         SrtpCrypto crypto;
         crypto.fromPj(prm.crypto[i]);
-        this->cryptos.push_back(std::move(crypto));
+        this->cryptos.push_back(PJSUA2_MOVE(crypto));
     }
 
     this->keyings.clear();
@@ -196,7 +196,7 @@ void SrtpOpt::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
         NODE_READ_STRING        (crypto_node, crypto.key);
         NODE_READ_STRING        (crypto_node, crypto.name);
         NODE_READ_UNSIGNED      (crypto_node, crypto.flags);
-        this->cryptos.push_back(std::move(crypto));
+        this->cryptos.push_back(PJSUA2_MOVE(crypto));
     }
 
     ContainerNode keying_node = this_node.readArray("keyings");
@@ -287,7 +287,7 @@ void AccountSipConfig::readObject(const ContainerNode &node)
     while (creds_node.hasUnread()) {
         AuthCredInfo cred;
         cred.readObject(creds_node);
-        authCreds.push_back(std::move(cred));
+        authCreds.push_back(PJSUA2_MOVE(cred));
     }
 }
 
@@ -762,7 +762,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
         SipHeader new_hdr;
         new_hdr.fromPj(hdr);
 
-        regConfig.headers.push_back(std::move(new_hdr));
+        regConfig.headers.push_back(PJSUA2_MOVE(new_hdr));
 
         hdr = hdr->next;
     }
@@ -782,7 +782,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
         cred.akaOp      = pj2Str(src.ext.aka.op);
         cred.akaAmf     = pj2Str(src.ext.aka.amf);
 
-        sipConfig.authCreds.push_back(std::move(cred));
+        sipConfig.authCreds.push_back(PJSUA2_MOVE(cred));
     }
     sipConfig.proxies.clear();
     for (i=0; i<prm.proxy_cnt; ++i) {
@@ -810,7 +810,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     while (hdr != &prm.sub_hdr_list) {
         SipHeader new_hdr;
         new_hdr.fromPj(hdr);
-        presConfig.headers.push_back(std::move(new_hdr));
+        presConfig.headers.push_back(PJSUA2_MOVE(new_hdr));
         hdr = hdr->next;
     }
     presConfig.publishEnabled   = PJ2BOOL(prm.publish_enabled);

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -65,7 +65,7 @@ void RtcpFbConfig::fromPj(const pjmedia_rtcp_fb_setting &prm)
     for (unsigned i = 0; i < prm.cap_count; ++i) {
         RtcpFbCap cap;
         cap.fromPj(prm.caps[i]);
-        this->caps.push_back(cap);
+        this->caps.push_back(std::move(cap));
     }
 }
 
@@ -96,7 +96,7 @@ void RtcpFbConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
         NODE_READ_NUM_T         (cap_node, pjmedia_rtcp_fb_type, cap.type);
         NODE_READ_STRING        (cap_node, cap.typeName);
         NODE_READ_STRING        (cap_node, cap.param);
-        this->caps.push_back(cap);
+        this->caps.push_back(std::move(cap));
     }
 }
 
@@ -157,7 +157,7 @@ void SrtpOpt::fromPj(const pjsua_srtp_opt &prm)
     for (unsigned i = 0; i < prm.crypto_count; ++i) {
         SrtpCrypto crypto;
         crypto.fromPj(prm.crypto[i]);
-        this->cryptos.push_back(crypto);
+        this->cryptos.push_back(std::move(crypto));
     }
 
     this->keyings.clear();
@@ -196,7 +196,7 @@ void SrtpOpt::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
         NODE_READ_STRING        (crypto_node, crypto.key);
         NODE_READ_STRING        (crypto_node, crypto.name);
         NODE_READ_UNSIGNED      (crypto_node, crypto.flags);
-        this->cryptos.push_back(crypto);
+        this->cryptos.push_back(std::move(crypto));
     }
 
     ContainerNode keying_node = this_node.readArray("keyings");
@@ -287,7 +287,7 @@ void AccountSipConfig::readObject(const ContainerNode &node)
     while (creds_node.hasUnread()) {
         AuthCredInfo cred;
         cred.readObject(creds_node);
-        authCreds.push_back(cred);
+        authCreds.push_back(std::move(cred));
     }
 }
 
@@ -762,7 +762,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
         SipHeader new_hdr;
         new_hdr.fromPj(hdr);
 
-        regConfig.headers.push_back(new_hdr);
+        regConfig.headers.push_back(std::move(new_hdr));
 
         hdr = hdr->next;
     }
@@ -782,7 +782,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
         cred.akaOp      = pj2Str(src.ext.aka.op);
         cred.akaAmf     = pj2Str(src.ext.aka.amf);
 
-        sipConfig.authCreds.push_back(cred);
+        sipConfig.authCreds.push_back(std::move(cred));
     }
     sipConfig.proxies.clear();
     for (i=0; i<prm.proxy_cnt; ++i) {
@@ -810,7 +810,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     while (hdr != &prm.sub_hdr_list) {
         SipHeader new_hdr;
         new_hdr.fromPj(hdr);
-        presConfig.headers.push_back(new_hdr);
+        presConfig.headers.push_back(std::move(new_hdr));
         hdr = hdr->next;
     }
     presConfig.publishEnabled   = PJ2BOOL(prm.publish_enabled);

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -130,7 +130,7 @@ void SslCertInfo::fromPj(const pj_ssl_cert_info &info)
         SslCertName cname;
         cname.type = info.subj_alt_name.entry[i].type;
         cname.name = pj2Str(info.subj_alt_name.entry[i].name);
-        subjectAltName.push_back(std::move(cname));
+        subjectAltName.push_back(PJSUA2_MOVE(cname));
     }
 }
 
@@ -1843,7 +1843,7 @@ void Endpoint::on_create_media_transport_srtp(pjsua_call_id call_id,
         crypto.key   = pj2Str(srtp_opt->crypto[i].key);
         crypto.name  = pj2Str(srtp_opt->crypto[i].name);
         crypto.flags = srtp_opt->crypto[i].flags;
-        prm.cryptos.push_back(std::move(crypto));
+        prm.cryptos.push_back(PJSUA2_MOVE(crypto));
     }
     
     call->onCreateMediaTransportSrtp(prm);
@@ -2480,7 +2480,7 @@ CodecInfoVector2 Endpoint::codecEnum2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count; ++i) {
         CodecInfo codec_info;
         codec_info.fromPj(pj_codec[i]);
-        civ2.push_back(std::move(codec_info));
+        civ2.push_back(PJSUA2_MOVE(codec_info));
     }
     return civ2;
 }
@@ -2627,7 +2627,7 @@ CodecInfoVector2 Endpoint::videoCodecEnum2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count; ++i) {
         CodecInfo codec_info;
         codec_info.fromPj(pj_codec[i]);
-        civ2.push_back(std::move(codec_info));
+        civ2.push_back(PJSUA2_MOVE(codec_info));
     }
 #endif
     return civ2;

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -130,7 +130,7 @@ void SslCertInfo::fromPj(const pj_ssl_cert_info &info)
         SslCertName cname;
         cname.type = info.subj_alt_name.entry[i].type;
         cname.name = pj2Str(info.subj_alt_name.entry[i].name);
-        subjectAltName.push_back(cname);
+        subjectAltName.push_back(std::move(cname));
     }
 }
 
@@ -1843,7 +1843,7 @@ void Endpoint::on_create_media_transport_srtp(pjsua_call_id call_id,
         crypto.key   = pj2Str(srtp_opt->crypto[i].key);
         crypto.name  = pj2Str(srtp_opt->crypto[i].name);
         crypto.flags = srtp_opt->crypto[i].flags;
-        prm.cryptos.push_back(crypto);
+        prm.cryptos.push_back(std::move(crypto));
     }
     
     call->onCreateMediaTransportSrtp(prm);
@@ -2480,7 +2480,7 @@ CodecInfoVector2 Endpoint::codecEnum2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count; ++i) {
         CodecInfo codec_info;
         codec_info.fromPj(pj_codec[i]);
-        civ2.push_back(codec_info);
+        civ2.push_back(std::move(codec_info));
     }
     return civ2;
 }
@@ -2627,7 +2627,7 @@ CodecInfoVector2 Endpoint::videoCodecEnum2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count; ++i) {
         CodecInfo codec_info;
         codec_info.fromPj(pj_codec[i]);
-        civ2.push_back(codec_info);
+        civ2.push_back(std::move(codec_info));
     }
 #endif
     return civ2;

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -749,7 +749,7 @@ ToneDigitMapVector ToneGenerator::getDigitMap() const PJSUA2_THROW(Error)
         d.freq1 = pdm->digits[i].freq1;
         d.freq2 = pdm->digits[i].freq2;
 
-        tdm.push_back(d);
+        tdm.push_back(std::move(d));
     }
 
     return tdm;
@@ -796,7 +796,7 @@ void AudioDevInfo::fromPj(const pjmedia_aud_dev_info &dev_info)
         MediaFormatAudio format;
         format.fromPj(dev_info.ext_fmt[i]);
         if (format.type == PJMEDIA_TYPE_AUDIO)
-            extFmt.push_back(format);
+            extFmt.push_back(std::move(format));
     }
 }
 
@@ -946,7 +946,7 @@ AudioDevInfoVector2 AudDevManager::enumDev2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count ;++i) {
         AudioDevInfo di;
         di.fromPj(pj_info[i]);
-        adiv2.push_back(di);
+        adiv2.push_back(std::move(di));
     }
 
     return adiv2;
@@ -1677,7 +1677,7 @@ void VideoDevInfo::fromPj(const pjmedia_vid_dev_info &dev_info)
         MediaFormatVideo format;
         format.fromPj(dev_info.fmt[i]);
         if (format.type == PJMEDIA_TYPE_VIDEO)
-            fmt.push_back(format);
+            fmt.push_back(std::move(format));
     }
 #else
     PJ_UNUSED_ARG(dev_info);
@@ -1765,7 +1765,7 @@ VideoDevInfoVector2 VidDevManager::enumDev2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count;++i) {
         VideoDevInfo vdi;
         vdi.fromPj(pj_info[i]);
-        vdiv2.push_back(vdi);
+        vdiv2.push_back(std::move(vdi));
     }
 #endif
     return vdiv2;
@@ -1979,7 +1979,7 @@ public:
             fmtp.name = pj2Str(in_fmtp.param[i].name);
             fmtp.val = pj2Str(in_fmtp.param[i].val);
         
-            out_fmtp.push_back(fmtp);
+            out_fmtp.push_back(std::move(fmtp));
        }
     }
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -749,7 +749,7 @@ ToneDigitMapVector ToneGenerator::getDigitMap() const PJSUA2_THROW(Error)
         d.freq1 = pdm->digits[i].freq1;
         d.freq2 = pdm->digits[i].freq2;
 
-        tdm.push_back(std::move(d));
+        tdm.push_back(PJSUA2_MOVE(d));
     }
 
     return tdm;
@@ -796,7 +796,7 @@ void AudioDevInfo::fromPj(const pjmedia_aud_dev_info &dev_info)
         MediaFormatAudio format;
         format.fromPj(dev_info.ext_fmt[i]);
         if (format.type == PJMEDIA_TYPE_AUDIO)
-            extFmt.push_back(std::move(format));
+            extFmt.push_back(PJSUA2_MOVE(format));
     }
 }
 
@@ -946,7 +946,7 @@ AudioDevInfoVector2 AudDevManager::enumDev2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count ;++i) {
         AudioDevInfo di;
         di.fromPj(pj_info[i]);
-        adiv2.push_back(std::move(di));
+        adiv2.push_back(PJSUA2_MOVE(di));
     }
 
     return adiv2;
@@ -1677,7 +1677,7 @@ void VideoDevInfo::fromPj(const pjmedia_vid_dev_info &dev_info)
         MediaFormatVideo format;
         format.fromPj(dev_info.fmt[i]);
         if (format.type == PJMEDIA_TYPE_VIDEO)
-            fmt.push_back(std::move(format));
+            fmt.push_back(PJSUA2_MOVE(format));
     }
 #else
     PJ_UNUSED_ARG(dev_info);
@@ -1765,7 +1765,7 @@ VideoDevInfoVector2 VidDevManager::enumDev2() const PJSUA2_THROW(Error)
     for (unsigned i = 0; i<count;++i) {
         VideoDevInfo vdi;
         vdi.fromPj(pj_info[i]);
-        vdiv2.push_back(std::move(vdi));
+        vdiv2.push_back(PJSUA2_MOVE(vdi));
     }
 #endif
     return vdiv2;
@@ -1979,7 +1979,7 @@ public:
             fmtp.name = pj2Str(in_fmtp.param[i].name);
             fmtp.val = pj2Str(in_fmtp.param[i].val);
         
-            out_fmtp.push_back(std::move(fmtp));
+            out_fmtp.push_back(PJSUA2_MOVE(fmtp));
        }
     }
 

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -82,7 +82,7 @@ void readSipHeaders( const ContainerNode &node,
         ContainerNode header_node = headers_node.readContainer("header");
         hdr.hName = header_node.readString("hname");
         hdr.hValue = header_node.readString("hvalue");
-        headers.push_back(hdr);
+        headers.push_back(std::move(hdr));
     }
 }
 
@@ -113,7 +113,7 @@ AuthCredInfo::AuthCredInfo(const string &param_scheme,
                            const int param_data_type,
                            const string param_data)
 : scheme(param_scheme), realm(param_realm), username(param_user_name),
-  dataType(param_data_type), data(param_data),
+  dataType(param_data_type), data(std::move(param_data)),
   algoType(PJSIP_AUTH_ALGORITHM_NOT_SET)
 {
 }
@@ -357,7 +357,7 @@ void SockOptParams::fromPj(const pj_sockopt_params &prm)
         if (prm.options[i].optlen == sizeof(int)) {
             so.setOptValInt(*((int *)prm.options[i].optval));
         }
-        this->sockOpts.push_back(so);
+        this->sockOpts.push_back(std::move(so));
     }
 }
 
@@ -375,7 +375,7 @@ void SockOptParams::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
             int optVal = so_node.readInt("optVal");
             so.setOptValInt(optVal);
         }
-        sockOpts.push_back(so);
+        sockOpts.push_back(std::move(so));
     }
 }
 
@@ -609,7 +609,7 @@ void SipMultipartPart::fromPj(const pjsip_multipart_part &prm)
     while (pj_hdr != &prm.hdr) {
         SipHeader sh;
         sh.fromPj(pj_hdr);
-        headers.push_back(sh);
+        headers.push_back(std::move(sh));
         pj_hdr = pj_hdr->next;
     }
 
@@ -757,7 +757,7 @@ void SipTxOption::fromPj(const pjsua_msg_data &prm) PJSUA2_THROW(Error)
     while (pj_hdr != &prm.hdr_list) {
         SipHeader sh;
         sh.fromPj(pj_hdr);
-        headers.push_back(sh);
+        headers.push_back(std::move(sh));
         pj_hdr = pj_hdr->next;
     }
 
@@ -770,7 +770,7 @@ void SipTxOption::fromPj(const pjsua_msg_data &prm) PJSUA2_THROW(Error)
     while (pj_mp != &prm.multipart_parts) {
         SipMultipartPart smp;
         smp.fromPj(*pj_mp);
-        multipartParts.push_back(smp);
+        multipartParts.push_back(std::move(smp));
         pj_mp = pj_mp->next;
     }
 }

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -82,7 +82,7 @@ void readSipHeaders( const ContainerNode &node,
         ContainerNode header_node = headers_node.readContainer("header");
         hdr.hName = header_node.readString("hname");
         hdr.hValue = header_node.readString("hvalue");
-        headers.push_back(std::move(hdr));
+        headers.push_back(PJSUA2_MOVE(hdr));
     }
 }
 
@@ -113,7 +113,7 @@ AuthCredInfo::AuthCredInfo(const string &param_scheme,
                            const int param_data_type,
                            const string param_data)
 : scheme(param_scheme), realm(param_realm), username(param_user_name),
-  dataType(param_data_type), data(std::move(param_data)),
+  dataType(param_data_type), data(PJSUA2_MOVE(param_data)),
   algoType(PJSIP_AUTH_ALGORITHM_NOT_SET)
 {
 }
@@ -357,7 +357,7 @@ void SockOptParams::fromPj(const pj_sockopt_params &prm)
         if (prm.options[i].optlen == sizeof(int)) {
             so.setOptValInt(*((int *)prm.options[i].optval));
         }
-        this->sockOpts.push_back(std::move(so));
+        this->sockOpts.push_back(PJSUA2_MOVE(so));
     }
 }
 
@@ -375,7 +375,7 @@ void SockOptParams::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
             int optVal = so_node.readInt("optVal");
             so.setOptValInt(optVal);
         }
-        sockOpts.push_back(std::move(so));
+        sockOpts.push_back(PJSUA2_MOVE(so));
     }
 }
 
@@ -609,7 +609,7 @@ void SipMultipartPart::fromPj(const pjsip_multipart_part &prm)
     while (pj_hdr != &prm.hdr) {
         SipHeader sh;
         sh.fromPj(pj_hdr);
-        headers.push_back(std::move(sh));
+        headers.push_back(PJSUA2_MOVE(sh));
         pj_hdr = pj_hdr->next;
     }
 
@@ -757,7 +757,7 @@ void SipTxOption::fromPj(const pjsua_msg_data &prm) PJSUA2_THROW(Error)
     while (pj_hdr != &prm.hdr_list) {
         SipHeader sh;
         sh.fromPj(pj_hdr);
-        headers.push_back(std::move(sh));
+        headers.push_back(PJSUA2_MOVE(sh));
         pj_hdr = pj_hdr->next;
     }
 
@@ -770,7 +770,7 @@ void SipTxOption::fromPj(const pjsua_msg_data &prm) PJSUA2_THROW(Error)
     while (pj_mp != &prm.multipart_parts) {
         SipMultipartPart smp;
         smp.fromPj(*pj_mp);
-        multipartParts.push_back(std::move(smp));
+        multipartParts.push_back(PJSUA2_MOVE(smp));
         pj_mp = pj_mp->next;
     }
 }


### PR DESCRIPTION
Fix coverity warning in pjsua2:
Variable copied when it could be moved
Unnecessary object copies can affect performance.
(https://scan6.scan.coverity.com/doc/en/cov_checker_ref.html#static_checker_COPY_INSTEAD_OF_MOVE)

Basically, when we insert (push_back) an object into a vector, we can use `std::move` (instead of relying of copy ctor), if the object will no longer be used for any other purpose.
