### PR TITLE
Fixed various Coverity warnings

### DIFF
--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -366,6 +366,7 @@ int test_inner(int argc, char *argv[])
 
     pj_log_set_level(3);
     pj_log_set_decor(test_app.param_log_decor);
+    pj_bzero(&stat, sizeof(pj_test_stat));
 
     rc = pj_init();
     if (rc != 0) {

--- a/pjmedia/src/test/vid_codec_test.c
+++ b/pjmedia/src/test/vid_codec_test.c
@@ -276,8 +276,10 @@ static int encode_decode_test(pj_pool_t *pool, const char *codec_id,
         pjmedia_vid_dev_info cdi;
 
         status = pjmedia_vid_dev_get_info(i, &cdi);
-        if (status != PJ_SUCCESS)
-            rc = 211; goto on_return;
+        if (status != PJ_SUCCESS) {
+            rc = 211;
+            goto on_return;
+        }
 
         /* Only interested with render device */
         if ((cdi.dir & PJMEDIA_DIR_RENDER) != 0) {

--- a/pjnath/src/pjnath-test/test.c
+++ b/pjnath/src/pjnath-test/test.c
@@ -64,9 +64,9 @@ pj_status_t create_stun_config(app_sess_t *app_sess)
                      { status=PJ_ENOMEM; goto on_error;});
 
     PJ_TEST_SUCCESS(pj_ioqueue_create(app_sess->pool, 64, &ioqueue), NULL, 
-                    goto on_error);
+                    {status = tmp_status_; goto on_error;});
     PJ_TEST_SUCCESS(pj_timer_heap_create(app_sess->pool, 256, &timer_heap),
-                    NULL, goto on_error);
+                    NULL, {status = tmp_status_; goto on_error;});
 
     pj_lock_create_recursive_mutex(app_sess->pool, NULL, &lock);
     pj_timer_heap_set_lock(timer_heap, lock, PJ_TRUE);
@@ -82,8 +82,11 @@ on_error:
         pj_ioqueue_destroy(ioqueue);
     if (timer_heap)
         pj_timer_heap_destroy(timer_heap);
+    // Lock should have been destroyed by timer heap.
+    /*
     if (lock)
         pj_lock_destroy(lock);
+    */
     if (app_sess->pool)
         pj_pool_release(app_sess->pool);
     pj_caching_pool_destroy(&app_sess->cp);

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -140,7 +140,6 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
     pj_status_t status = PJ_SUCCESS;
     const char *warn_text = NULL;
     pjsip_hdr res_hdr_list;
-    pjsip_param  *param;
 
     /* Init return arguments. */
     if (p_tdata) *p_tdata = NULL;

--- a/pjsip/src/test/transport_loop_test.c
+++ b/pjsip/src/test/transport_loop_test.c
@@ -103,10 +103,11 @@ int transport_loop_multi_test(void)
     pjsip_transport *loops[N];
     int i, rc;
 
+    pj_bzero(loops, sizeof(loops));
+
     PJ_TEST_SUCCESS(pjsip_endpt_register_module(endpt, &loop_tester_mod),
                     NULL, ERR(-5));
 
-    pj_bzero(loops, sizeof(loops));
     for (i=0; i<N; ++i) {
         PJ_TEST_SUCCESS(pjsip_loop_start(endpt, &loops[i]), NULL, ERR(-10));
         pjsip_transport_add_ref(loops[i]);
@@ -402,7 +403,6 @@ int transport_loop_resolve_error_test()
     /* Resolve error */
     status = loop_resolve_error(disable_no_selector);
 
-on_return:
     /* Decrement reference. */
     pjsip_transport_dec_ref(loop);
     return status;

--- a/pjsip/src/test/tsx_bench.c
+++ b/pjsip/src/test/tsx_bench.c
@@ -179,8 +179,7 @@ on_error:
 
         }
     }
-    if (request)
-        pjsip_tx_data_dec_ref(request);
+    pjsip_tx_data_dec_ref(request);
     if (loop) {
         /* Order must be shutdown then dec_ref so it gets destroyed */
         pjsip_transport_shutdown(loop);

--- a/pjsip/src/test/tsx_uas_test.c
+++ b/pjsip/src/test/tsx_uas_test.c
@@ -285,7 +285,7 @@ on_error:
 /* Unregister modules, taking care of premature unregistration attempt */
 static void unregister_modules(unsigned tid)
 {
-    int new_reg_cnt;
+    // int new_reg_cnt;
 
     if (!g[tid].modules_registered)
         return;

--- a/pjsip/src/test/tsx_uas_test.c
+++ b/pjsip/src/test/tsx_uas_test.c
@@ -299,6 +299,7 @@ static void unregister_modules(unsigned tid)
     //  So just let the module registered.
     return;
 
+    /*
     pj_enter_critical_section();
     new_reg_cnt = --modules_reg_cnt;
     pj_leave_critical_section();
@@ -309,6 +310,7 @@ static void unregister_modules(unsigned tid)
         PJ_TEST_SUCCESS(pjsip_endpt_unregister_module(endpt, &msg_sender),
                         "error ignored", {});
     }
+    */
 }
 
 /* Timer callback to send response. */

--- a/pjsip/src/test/uri_test.c
+++ b/pjsip/src/test/uri_test.c
@@ -1033,7 +1033,7 @@ static int uri_benchmark(unsigned *p_parse, unsigned *p_print, unsigned *p_cmp)
     elapsed = pj_elapsed_time(&zero, &var.cmp_time);
     avg_cmp = pj_elapsed_usec(&zero, &var.cmp_time);
     if (PJ_HIGHPREC_VALUE_IS_ZERO(avg_cmp) || var.cmp_len == 0) {
-        avg_cmp == 0;
+        avg_cmp = 0;
     } else {
         pj_highprec_mul(avg_cmp, AVERAGE_URL_LEN);
         pj_highprec_div(avg_cmp, var.cmp_len);

--- a/pjsip/src/test/uri_test.c
+++ b/pjsip/src/test/uri_test.c
@@ -1032,11 +1032,13 @@ static int uri_benchmark(unsigned *p_parse, unsigned *p_print, unsigned *p_cmp)
     pj_highprec_div(kbytes, 100000);
     elapsed = pj_elapsed_time(&zero, &var.cmp_time);
     avg_cmp = pj_elapsed_usec(&zero, &var.cmp_time);
-    pj_highprec_mul(avg_cmp, AVERAGE_URL_LEN);
-    pj_highprec_div(avg_cmp, var.cmp_len);
-    if (avg_cmp == 0)
-        avg_cmp = 1;
-    avg_cmp = 1000000 / avg_cmp;
+    if (PJ_HIGHPREC_VALUE_IS_ZERO(avg_cmp) || var.cmp_len == 0) {
+        avg_cmp == 0;
+    } else {
+        pj_highprec_mul(avg_cmp, AVERAGE_URL_LEN);
+        pj_highprec_div(avg_cmp, var.cmp_len);
+        avg_cmp = 1000000 / avg_cmp;
+    }
 
     PJ_LOG(3,(THIS_FILE,
               "    %u.%u MB of urls compared in %ld.%03lds (avg=%d urls/sec)",


### PR DESCRIPTION
Fixes various build and Coverity warnings. Among them:
```
pjlib-test/test.c 1587337 Uninitialized scalar variable
../src/pjnath-test/test.c:68:5: warning: variable 'status' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
../src/pjsip-ua/sip_siprec.c:143:19: warning: unused variable 'param' [-Wunused-variable]
../src/test/transport_loop_test.c:405:1: warning: unused label 'on_return'
pjsip/src/test/uri_test.c 1587468 Division or modulo by float zero
pjsip/src/test/tsx_bench.c 1587342 Dereference before null check
pjsip/src/test/transport_loop_test.c 1587338 Uninitialized pointer read
```
