### PR TITLE
Fixed Coverity warnings

### DIFF
--- a/pjsip-apps/src/samples/pjsua2_hello_reg.cpp
+++ b/pjsip-apps/src/samples/pjsua2_hello_reg.cpp
@@ -42,7 +42,7 @@ int main()
     acfg.idUri = "sip:test@sip.pjsip.org";
     acfg.regConfig.registrarUri = "sip:sip.pjsip.org";
     AuthCredInfo cred("digest", "*", "test", 0, "secret");
-    acfg.sipConfig.authCreds.push_back( cred );
+    acfg.sipConfig.authCreds.push_back( PJSUA2_MOVE(cred) );
 
     // Create the account
     MyAccount *acc = new MyAccount;

--- a/pjsip/include/pjsip/sip_parser.h
+++ b/pjsip/include/pjsip/sip_parser.h
@@ -51,7 +51,7 @@ PJ_BEGIN_DECL
 #define PJSIP_MIN_Q1000             0           /**< For limit checks */
 #define PJSIP_MAX_Q1000             PJ_MAXINT32 / 1000/**< For limit checks */
 #define PJSIP_MIN_EXPIRES           0           /**< For limit checks */
-#define PJSIP_MAX_EXPIRES           ((pj_uint32_t)0xFFFFFFFFUL)/**< for chk */
+//#define PJSIP_MAX_EXPIRES           ((pj_uint32_t)0xFFFFFFFFUL)/**< for chk */
 #define PJSIP_MIN_CSEQ              0           /**< For limit checks */
 #define PJSIP_MAX_CSEQ              PJ_MAXINT32 /**< For limit checks */
 #define PJSIP_MIN_RETRY_AFTER       0           /**< For limit checks */

--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1916,8 +1916,8 @@ static void int_parse_contact_param( pjsip_contact_hdr *hdr,
             hdr->expires = pj_strtoul(&pvalue);
             if (hdr->expires == PJSIP_EXPIRES_NOT_SPECIFIED)
                 hdr->expires--;
-            if (hdr->expires > PJSIP_MAX_EXPIRES)
-                hdr->expires = PJSIP_MAX_EXPIRES;
+            //if (hdr->expires > PJSIP_MAX_EXPIRES)
+            //    hdr->expires = PJSIP_MAX_EXPIRES;
 #if PJSIP_MIN_EXPIRES > 0
             if (hdr->expires < PJSIP_MIN_EXPIRES)
                 hdr->expires = PJSIP_MIN_EXPIRES;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3006,7 +3006,9 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
         /* Check if request supports PJSIP_INV_REQUIRE_SIPREC. If so Get label
          * attribute in SDP offer and add label attribute to SDP answer
          */
-        if (call->inv && (call->inv->options & PJSIP_INV_REQUIRE_SIPREC)) {
+        if (call->inv && (call->inv->options & PJSIP_INV_REQUIRE_SIPREC) &&
+            rem_sdp)
+        {
             pjmedia_sdp_attr *label_attr;
             const pj_str_t STR_LABEL_ATTR = {"label", 5};
 


### PR DESCRIPTION
sip_parser.c: hdr->expires cannot be greater than `PJSIP_MAX_EXPIRES`
pjsua_media.c: rem_sdp can be NULL
