### PR TITLE
Modify ALSA default max devices

### DIFF
--- a/pjmedia/include/pjmedia-audiodev/config.h
+++ b/pjmedia/include/pjmedia-audiodev/config.h
@@ -42,6 +42,15 @@ PJ_BEGIN_DECL
  */
 
 /**
+ * This setting controls the maximum number of supported audio devices.
+ *
+ * Default: 64
+ */
+#ifndef PJMEDIA_AUD_DEV_MAX_DEVS
+#   define PJMEDIA_AUD_DEV_MAX_DEVS 64
+#endif
+
+/**
  * This setting controls the buffer length of audio device name.
  *
  * Default: 128 for Windows platforms, 64 for others

--- a/pjmedia/include/pjmedia/audiodev.h
+++ b/pjmedia/include/pjmedia/audiodev.h
@@ -79,7 +79,6 @@ typedef pj_int32_t pjmedia_aud_dev_index;
 #define PJMEDIA_AUD_INVALID_DEV     -3
 
 #define PJMEDIA_AUD_MAX_DRIVERS 16
-#define PJMEDIA_AUD_MAX_DEVS    64
 
 
 /** Forward declaration for pjmedia_aud_stream */
@@ -117,7 +116,7 @@ typedef struct pjmedia_aud_subsys
     pjmedia_aud_driver  drv[PJMEDIA_AUD_MAX_DRIVERS];/* Array of drivers.   */
 
     unsigned            dev_cnt;        /* Total number of devices.         */
-    pj_uint32_t         dev_list[PJMEDIA_AUD_MAX_DEVS];/* Array of dev IDs. */
+    pj_uint32_t         dev_list[PJMEDIA_AUD_DEV_MAX_DEVS];/* Array dev IDs.*/
 
 } pjmedia_aud_subsys;
 

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -43,7 +43,7 @@
 #define ALSASOUND_CAPTURE               2
 #define MAX_SOUND_CARDS                 5
 #define MAX_SOUND_DEVICES_PER_CARD      5
-#define MAX_DEVICES                     32
+#define MAX_DEVICES                     PJMEDIA_AUD_MAX_DEVS
 #define MAX_MIX_NAME_LEN                64 
 
 /* Set to 1 to enable tracing */

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -43,7 +43,7 @@
 #define ALSASOUND_CAPTURE               2
 #define MAX_SOUND_CARDS                 5
 #define MAX_SOUND_DEVICES_PER_CARD      5
-#define MAX_DEVICES                     PJMEDIA_AUD_MAX_DEVS
+#define MAX_DEVICES                     PJMEDIA_AUD_DEV_MAX_DEVS
 #define MAX_MIX_NAME_LEN                64 
 
 /* Set to 1 to enable tracing */

--- a/pjmedia/src/pjmedia/audiodev.c
+++ b/pjmedia/src/pjmedia/audiodev.c
@@ -103,12 +103,12 @@ PJ_DEF(pj_status_t) pjmedia_aud_driver_init(unsigned drv_idx,
 
     /* Get number of devices */
     dev_cnt = f->op->get_dev_count(f);
-    if (dev_cnt + aud_subsys.dev_cnt > PJMEDIA_AUD_MAX_DEVS) {
+    if (dev_cnt + aud_subsys.dev_cnt > PJMEDIA_AUD_DEV_MAX_DEVS) {
         PJ_LOG(4,(THIS_FILE, "%d device(s) cannot be registered because"
                               " there are too many devices",
                               aud_subsys.dev_cnt + dev_cnt -
-                              PJMEDIA_AUD_MAX_DEVS));
-        dev_cnt = PJMEDIA_AUD_MAX_DEVS - aud_subsys.dev_cnt;
+                              PJMEDIA_AUD_DEV_MAX_DEVS));
+        dev_cnt = PJMEDIA_AUD_DEV_MAX_DEVS - aud_subsys.dev_cnt;
     }
 
     /* enabling this will cause pjsua-lib initialization to fail when there


### PR DESCRIPTION
It's reported that the MAX_DEVICES number for ALSA is too low on some machines. Besides, it requires modifying the source to increase this number.

So, it's better to create a configurable setting `PJMEDIA_AUD_DEV_MAX_DEVS`, similar to what we already have for video.
