### PR TITLE
Add option whether to add port in on_stream_created2() callback

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -652,6 +652,14 @@ typedef struct pjsua_on_stream_created_param
     pj_bool_t            destroy_port;
 
     /**
+     * Specify if PJSUA should add the port returned in the port parameter
+     * below to the conference bridge.
+     *
+     * Default: PJ_TRUE
+     */
+    pj_bool_t            add_port;
+
+    /**
      * On input, it specifies the audio media port of the stream. Application
      * may modify this pointer to point to different media port to be
      * registered to the conference bridge.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -822,6 +822,14 @@ struct OnStreamCreatedParam
     bool        destroyPort;
 
     /**
+     * Specify if PJSUA2 should add the port returned in the pPort parameter
+     * below to the conference bridge.
+     *
+     * Default: true
+     */
+    bool        addPort;
+
+    /**
      * On input, it specifies the audio media port of the stream. Application
      * may modify this pointer to point to different media port to be
      * registered to the conference bridge.

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -723,6 +723,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
 
     /* Check if no media is active */
     if (local_sdp->media[strm_idx]->desc.port != 0) {
+        pj_bool_t add_port = PJ_TRUE;
 
         /* Optionally, application may modify other stream settings here
          * (such as jitter buffer parameters, codec ptime, etc.)
@@ -822,10 +823,12 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             prm.stream = call_med->strm.a.stream;
             prm.stream_idx = strm_idx;
             prm.destroy_port = PJ_FALSE;
+            prm.add_port = PJ_TRUE;
             prm.port = call_med->strm.a.media_port;
             (*pjsua_var.ua_cfg.cb.on_stream_created2)(call->index, &prm);
-            
+
             call_med->strm.a.destroy_port = prm.destroy_port;
+            add_port = prm.add_port;
             call_med->strm.a.media_port = prm.port;
 
         } else if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_stream_created)
@@ -839,7 +842,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
         /*
          * Add the call to conference bridge.
          */
-        {
+        if (add_port) {
             char tmp[PJSIP_MAX_URL_SIZE];
             pj_str_t port_name;
 

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1289,11 +1289,13 @@ void Endpoint::on_stream_created2(pjsua_call_id call_id,
     prm.stream = param->stream;
     prm.streamIdx = param->stream_idx;
     prm.destroyPort = (param->destroy_port != PJ_FALSE);
+    prm.addPort = (param->add_port != PJ_FALSE);
     prm.pPort = (MediaPort)param->port;
     
     call->onStreamCreated(prm);
     
     param->destroy_port = prm.destroyPort;
+    param->add_port = prm.addPort;
     param->port = (pjmedia_port *)prm.pPort;
 }
 


### PR DESCRIPTION
Currently, pjsua will always add call media port to its conference bridge. But there may be situations when users may not want to do this, for example if the conference bridge is currently not connected to any clock source.

If needed, app can store the call media port specified in `on_stream_created2()` callback and add it to the conference at a later timing.
