### PR TITLE
Synchronous port removal in audio conference bridge if port is newly added

### DIFF
--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1666,12 +1666,13 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
 
     /* If port is new, remove it synchronously */
     if (conf_port->is_new) {
-        op_param prm;
         pj_bool_t found = PJ_FALSE;
 
         /* Find & cancel the add-op.
-         * Also cancel all following ops involving the slot, note that
-         * after removed, the slot may be reused by another port.
+         * Also cancel all following ops involving the slot.
+         * Note that after removed, the slot may be reused by another port
+         * so if not cancelled, those following ops may be applied to the
+         * wrong port.
          */
         ope = conf->op_queue->next;
         while (ope != conf->op_queue) {
@@ -1708,6 +1709,8 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
          * do not remove it synchronously to avoid race condition.
          */
         if (found) {
+            op_param prm;
+
             /* Release mutex to avoid deadlock */
             pj_mutex_unlock(conf->mutex);
 


### PR DESCRIPTION
Currently with asynchronous conference bridge, port removal can only be done in the conference clock. This PR allows synchronous port removal for newly added port. Sample use case is when conference bridge has no clock (e.g: no sound device), without this the conference bridge slots will get full and never been able to be freed.