### PR TITLE
Add queried names to server address record, and add the address record in parameter for on_verify_cb callback

### DIFF
--- a/pjsip/include/pjsip/sip_resolve.h
+++ b/pjsip/include/pjsip/sip_resolve.h
@@ -174,6 +174,9 @@ PJ_BEGIN_DECL
 /** Address records. */
 typedef struct pjsip_server_address_record
 {
+    /** The queried name.   */
+    pj_str_t                name;
+
     /** Preferable transport to be used to contact this address. */
     pjsip_transport_type_e  type;
 

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -118,6 +118,11 @@ typedef struct pjsip_tls_on_verify_param {
     const pj_sockaddr_t *remote_addr;
 
     /**
+     * Describes resolved server addresses.
+     */
+    const pjsip_server_addresses *server_addr;
+
+    /**
      * Describes transport direction.
      */
     pjsip_transport_dir tp_dir;

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -387,6 +387,7 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
                       pjsip_transport_get_type_name(type),
                       pjsip_transport_get_type_desc(type)));
 
+            svr_addr.entry[i].name = target->addr.host;
             svr_addr.entry[i].priority = 0;
             svr_addr.entry[i].weight = 0;
             svr_addr.entry[i].type = type;
@@ -571,6 +572,7 @@ static void dns_a_callback(void *user_data,
             if (rec.addr[i].af != pj_AF_INET())
                 continue;
 
+            srv->entry[srv->count].name = rec.name;
             srv->entry[srv->count].type = query->naptr[0].type;
             srv->entry[srv->count].priority = 0;
             srv->entry[srv->count].weight = 0;
@@ -633,6 +635,7 @@ static void dns_aaaa_callback(void *user_data,
             if (rec.addr[i].af != pj_AF_INET6())
                 continue;
 
+            srv->entry[srv->count].name = rec.name;
             srv->entry[srv->count].type = query->naptr[0].type |
                                           PJSIP_TRANSPORT_IPV6;
             srv->entry[srv->count].priority = 0;
@@ -692,6 +695,7 @@ static void srv_resolver_cb(void *user_data,
         for (j = 0; j < s->addr_count &&
                     srv.count < PJSIP_MAX_RESOLVED_ADDRESSES; ++j)
         {
+            srv.entry[srv.count].name = rec->entry[i].server.name;
             srv.entry[srv.count].type = query->naptr[0].type;
             srv.entry[srv.count].priority = rec->entry[i].priority;
             srv.entry[srv.count].weight = rec->entry[i].weight;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -87,6 +87,7 @@ struct tls_transport
     pjsip_transport          base;
     pj_bool_t                is_server;
     pj_str_t                 remote_name;
+    pjsip_server_addresses   server_addr;
 
     pj_bool_t                is_registered;
     pj_bool_t                is_closing;
@@ -166,6 +167,7 @@ static pj_status_t tls_create(struct tls_listener *listener,
                               const pj_sockaddr *local,
                               const pj_sockaddr *remote,
                               const pj_str_t *remote_name,
+                              const pjsip_server_addresses *addr,
                               pj_grp_lock_t *glock,
                               struct tls_transport **p_tls);
 
@@ -851,6 +853,7 @@ static pj_status_t tls_create( struct tls_listener *listener,
                                const pj_sockaddr *local,
                                const pj_sockaddr *remote,
                                const pj_str_t *remote_name,
+                               const pjsip_server_addresses *addr,
                                pj_grp_lock_t *glock,
                                struct tls_transport **p_tls)
 {
@@ -925,6 +928,14 @@ static pj_status_t tls_create( struct tls_listener *listener,
         tls->base.remote_name.port = pj_sockaddr_get_port(remote);
     } else {
         sockaddr_to_host_port(pool, &tls->base.remote_name, remote);
+    }
+
+    if (addr) {
+        pj_memcpy( &tls->server_addr, addr,
+                   sizeof(pjsip_server_addresses));
+        for (int i = 0; i < addr->count; ++i) {
+            pj_strdup(pool, &tls->server_addr.entry[i].name, &addr->entry[i].name);
+        }
     }
 
     tls->base.endpt = listener->endpt;
@@ -1303,7 +1314,7 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
 
     /* Create the transport descriptor */
     status = tls_create(listener, pool, ssock, PJ_FALSE, &local_addr, 
-                        rem_addr, &remote_name, glock, &tls);
+                        rem_addr, &remote_name, &tdata->dest_info.addr, glock, &tls);
     if (status != PJ_SUCCESS)
         return status;
 
@@ -1482,7 +1493,7 @@ static pj_bool_t on_accept_complete2(pj_ssl_sock_t *ssock,
      * Create TLS transport for the new socket.
      */
     status = tls_create( listener, NULL, new_ssock, PJ_TRUE,
-                         &ssl_info.local_addr, &tmp_src_addr, NULL,
+                         &ssl_info.local_addr, &tmp_src_addr, NULL, NULL,
                          ssl_info.grp_lock, &tls);
     
     if (status != PJ_SUCCESS) {
@@ -1635,17 +1646,15 @@ static pj_bool_t on_data_sent(pj_ssl_sock_t *ssock,
 static pj_bool_t on_verify_cb(pj_ssl_sock_t* ssock, pj_bool_t is_server)
 {
     pj_bool_t(*verify_cb)(const pjsip_tls_on_verify_param * param) = NULL;
+    struct tls_listener* tls_list = NULL;
+    struct tls_transport* tls_trans = NULL;
 
     if (is_server) {
-        struct tls_listener* tls;
-
-        tls = (struct tls_listener*)pj_ssl_sock_get_user_data(ssock);
-        verify_cb = tls->tls_setting.on_verify_cb;
+       tls_list = (struct tls_listener*)pj_ssl_sock_get_user_data(ssock);
+       verify_cb = tls_list->tls_setting.on_verify_cb;
     } else {
-        struct tls_transport* tls;
-
-        tls = (struct tls_transport*)pj_ssl_sock_get_user_data(ssock);
-        verify_cb = tls->on_verify_cb;
+        tls_trans = (struct tls_transport*)pj_ssl_sock_get_user_data(ssock);
+        verify_cb = tls_trans->on_verify_cb;
     }
 
     if (verify_cb) {
@@ -1655,6 +1664,9 @@ static pj_bool_t on_verify_cb(pj_ssl_sock_t* ssock, pj_bool_t is_server)
         pj_bzero(&param, sizeof(param));
         pj_ssl_sock_get_info(ssock, &info);
 
+        if (tls_trans) {
+            param.server_addr = &tls_trans->server_addr;
+        }
         param.local_addr = &info.local_addr;
         param.remote_addr = &info.remote_addr;
         param.local_cert_info = info.local_cert_info;

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1371,6 +1371,9 @@ stateless_send_resolver_callback( pj_status_t status,
     if (addr && addr != &tdata->dest_info.addr) {
         pj_memcpy( &tdata->dest_info.addr, addr, 
                    sizeof(pjsip_server_addresses));
+        for (int i = 0; i < addr->count; ++i) {
+            pj_strdup(tdata->pool, &tdata->dest_info.addr.entry[i].name, &addr->entry[i].name);
+        }
     }
     pj_assert(tdata->dest_info.addr.count != 0);
 
@@ -1832,6 +1835,9 @@ static void send_response_resolver_cb( pj_status_t status, void *token,
 
     /* Update address in send_state. */
     pj_memcpy(&send_state->tdata->dest_info.addr, addr, sizeof(*addr));
+    for (int i = 0; i < send_state->tdata->dest_info.addr.count; ++i) {
+        pj_strdup(send_state->tdata->pool, &send_state->tdata->dest_info.addr.entry[i].name, &addr->entry[i].name);
+    }
 
     /* Send response using the transoprt. */
     status = pjsip_transport_send( send_state->cur_transport, 


### PR DESCRIPTION
Add bookkeeping to be able to retrieve a list of all the resolved addresses in the on_verify_cb callback. This is to make it possible to check certificate common name or alternative name against FQDN obtained in DNS SRV response.