### PR TITLE
Various fixes for Apple SSL backend

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -144,15 +144,17 @@ jobs:
     - name: pjsip-test
       run: make pjsip-test
 
-  gnu-tls-1:
+  apple-ssl-1:
     runs-on: macos-latest
-    name: GnuTLS / pjlib,util,pjmedia,pjnath
+    name: AppleSSL / pjlib,util,pjmedia,pjnath
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install gnutls swig
+      run: brew install swig
     - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=`brew --prefix gnutls`
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" LDFLAGS="-framework Network -framework Security" ./configure
+    - name: config site
+      run: echo -e "#undef PJ_SSL_SOCK_IMP\n#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_APPLE\n" > pjlib/include/pj/config_site.h
     - name: make
       run: $MAKE_FAST
     - name: set up Python
@@ -163,8 +165,12 @@ jobs:
       run: cd pjsip-apps/src/swig && make
     - name: get SSL info
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep SSL
-    - name: verify gnu tls is used
-      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+2'
+    - name: verify Apple SSL is used
+      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+4'
+    - name: import private key
+      run: security import pjlib/build/privkey.p12 -k ~/Library/Keychains/login.keychain-db -P "pjsip" -T /usr/bin/codesign -T `pwd`/pjlib/bin/`ls pjlib/bin`
+    - name: unlock keychain
+      run: security unlock-keychain ~/Library/Keychains/login.keychain-db
     - name: pjlib-test
       run: make pjlib-test
     - name: pjlib-util-test
@@ -174,21 +180,23 @@ jobs:
     - name: pjnath-test
       run: make pjnath-test
 
-  gnu-tls-2:
+  apple-ssl-2:
     runs-on: macos-latest
-    name: GnuTLS / pjsip-test
+    name: AppleSSL / pjsip-test
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install gnutls swig
+      run: brew install swig
     - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=`brew --prefix gnutls`
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" LDFLAGS="-framework Network -framework Security" ./configure
+    - name: config site
+      run: echo -e "#undef PJ_SSL_SOCK_IMP\n#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_APPLE\n" > pjlib/include/pj/config_site.h
     - name: make
       run: $MAKE_FAST
     - name: get SSL info
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep SSL
-    - name: verify gnu tls is used
-      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+2'
+    - name: verify Apple SSL is used
+      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+4'
     - name: pjsip-test
       run: make pjsip-test
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -144,17 +144,15 @@ jobs:
     - name: pjsip-test
       run: make pjsip-test
 
-  apple-ssl-1:
+  gnu-tls-1:
     runs-on: macos-latest
-    name: AppleSSL / pjlib,util,pjmedia,pjnath
+    name: GnuTLS / pjlib,util,pjmedia,pjnath
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install swig
+      run: brew install gnutls swig
     - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" LDFLAGS="-framework Network -framework Security" ./configure
-    - name: config site
-      run: echo -e "#define PJ_HAS_SSL_SOCK 1\n#undef PJ_SSL_SOCK_IMP\n#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_APPLE\n" > pjlib/include/pj/config_site.h
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=`brew --prefix gnutls`
     - name: make
       run: $MAKE_FAST
     - name: set up Python
@@ -165,12 +163,8 @@ jobs:
       run: cd pjsip-apps/src/swig && make
     - name: get SSL info
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep SSL
-    - name: verify Apple SSL is used
-      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+4'
-    - name: import private key
-      run: security import pjlib/build/privkey.p12 -k ~/Library/Keychains/login.keychain-db -P "pjsip" -T /usr/bin/codesign -T `pwd`/pjlib/bin/`ls pjlib/bin`
-    - name: unlock keychain
-      run: security unlock-keychain ~/Library/Keychains/login.keychain-db
+    - name: verify gnu tls is used
+      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+2'
     - name: pjlib-test
       run: make pjlib-test
     - name: pjlib-util-test
@@ -180,23 +174,21 @@ jobs:
     - name: pjnath-test
       run: make pjnath-test
 
-  apple-ssl-2:
+  gnu-tls-2:
     runs-on: macos-latest
-    name: AppleSSL / pjsip-test
+    name: GnuTLS / pjsip-test
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install swig
+      run: brew install gnutls swig
     - name: configure
-      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" LDFLAGS="-framework Network -framework Security" ./configure
-    - name: config site
-      run: echo -e "#undef PJ_SSL_SOCK_IMP\n#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_APPLE\n" > pjlib/include/pj/config_site.h
+      run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --with-gnutls=`brew --prefix gnutls`
     - name: make
       run: $MAKE_FAST
     - name: get SSL info
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep SSL
-    - name: verify Apple SSL is used
-      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+4'
+    - name: verify gnu tls is used
+      run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+2'
     - name: pjsip-test
       run: make pjsip-test
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -154,7 +154,7 @@ jobs:
     - name: configure
       run: CFLAGS="-fPIC" CXXFLAGS="-fPIC" LDFLAGS="-framework Network -framework Security" ./configure
     - name: config site
-      run: echo -e "#undef PJ_SSL_SOCK_IMP\n#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_APPLE\n" > pjlib/include/pj/config_site.h
+      run: echo -e "#define PJ_HAS_SSL_SOCK 1\n#undef PJ_SSL_SOCK_IMP\n#define PJ_SSL_SOCK_IMP PJ_SSL_SOCK_IMP_APPLE\n" > pjlib/include/pj/config_site.h
     - name: make
       run: $MAKE_FAST
     - name: set up Python

--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -297,7 +297,7 @@ pj_status_t ssl_network_event_poll()
 
         if (ssock->is_closing || !ssock->pool ||
             (!ssock->is_server && !assock->connection) ||
-            (ssock->is_server && !assock->listener))
+            (ssock->is_server && !assock->listener && !assock->connection))
         {
             PJ_LOG(3, (THIS_FILE, "Warning: Discarding SSL event type %d of "
                        "a closing socket %p", event->type, ssock));
@@ -804,10 +804,8 @@ static pj_status_t network_start_read(pj_ssl_sock_t *ssock,
             if (is_complete &&
                 (context == NULL || nw_content_context_get_is_final(context)))
             {
-                return;
-            }
-
-            if (error != NULL) {
+                status = PJ_EEOF;
+            } else if (error != NULL) {
                 errno = nw_error_get_error_code(error);
                 if (errno == 89) {
                     /* Since error 89 is network intentionally cancelled by
@@ -823,7 +821,7 @@ static pj_status_t network_start_read(pj_ssl_sock_t *ssock,
             dispatch_block_t schedule_next_receive = 
             ^{
                 /* If there was no error in receiving, request more data. */
-                if (!error && !is_complete && assock->connection) {
+                if (!error && !is_complete && status != PJ_EEOF) {
                     network_start_read(ssock, async_count, buff_size,
                                        readbuf, flags);
                 }
@@ -1000,9 +998,11 @@ static pj_status_t network_create_params(pj_ssl_sock_t * ssock,
          */
         sec_protocol_options_set_tls_resumption_enabled(sec_options, false);
         
-        /* SSL verification options */
-        sec_protocol_options_set_peer_authentication_required(sec_options,
-            true);
+        /* SSL peer authentication options */
+        if (ssock->is_server && ssock->param.require_client_cert) {
+            sec_protocol_options_set_peer_authentication_required(sec_options,
+                                                                  true);
+        }
 
         /* Handshake flow:
          * 1. Server's challenge block, provide server's trust
@@ -1164,10 +1164,8 @@ static pj_status_t network_setup_connection(pj_ssl_sock_t *ssock,
             errno = nw_error_get_error_code(error);
             warn("Connection failed %p", assock);
             status = PJ_STATUS_FROM_OS(errno);
-#if SSL_DEBUG
-            PJ_LOG(3, (THIS_FILE, "SSL state and errno %d %d", state, errno));
-#endif
-            call_cb = PJ_TRUE;  
+            if (ssock->ssl_state == SSL_STATE_HANDSHAKING)
+                call_cb = PJ_TRUE;
         }
 
         if (state == nw_connection_state_ready) {
@@ -1398,7 +1396,8 @@ static pj_ssl_sock_t *ssl_alloc(pj_pool_t *pool)
     
     assock = PJ_POOL_ZALLOC_T(pool, applessl_sock_t);    
 
-    assock->queue = dispatch_queue_create("ssl_queue", DISPATCH_QUEUE_SERIAL);
+    assock->queue = dispatch_queue_create("ssl_queue",
+                                          DISPATCH_QUEUE_CONCURRENT);
     assock->ev_semaphore = dispatch_semaphore_create(0);    
     if (!assock->queue || !assock->ev_semaphore) {
         ssl_destroy(&assock->base);
@@ -1430,7 +1429,6 @@ static void close_connection(applessl_sock_t *assock)
         
         assock->connection = nil;
         nw_connection_force_cancel(conn);
-        nw_release(conn);
 
         /* We need to wait until the connection is at cancelled state,
          * otherwise events will still be delivered even though we
@@ -1447,6 +1445,9 @@ static void close_connection(applessl_sock_t *assock)
             PJ_LOG(3, (THIS_FILE, "Warning: Failed to cancel SSL connection "
                                   "%p %d", assock, assock->con_state));
         }
+
+        nw_connection_set_state_changed_handler(assock->connection, nil);
+        nw_release(conn);
 
 #if SSL_DEBUG
         PJ_LOG(3, (THIS_FILE, "SSL connection %p closed", assock));

--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -1446,7 +1446,7 @@ static void close_connection(applessl_sock_t *assock)
                                   "%p %d", assock, assock->con_state));
         }
 
-        nw_connection_set_state_changed_handler(assock->connection, nil);
+        nw_connection_set_state_changed_handler(conn, nil);
         nw_release(conn);
 
 #if SSL_DEBUG


### PR DESCRIPTION
There are several problem found in Apple SSL backend:
- Occasionally, the connection can fail to be closed, as indicated by the log `Warning: Failed to cancel SSL connection`. This may cause access to its already destroyed parent SSL socket. Switching from serial to concurrent queue seems to fix the issue and the connection cancellation seems to never fail now.
- SSL socket may not report disconnection immediately. The patch now adds EOF check in `nw_connection_receive()`.
- Fix issue that cause on_handshake_complete() to be called even if we are not in a state of handshaking.

Server socket:
- Fix issue in server's socket to incorrectly discard events.
- Fix issue that causes client cert to always be required (instead of based on `ssock->param.require_client_cert`).

SSL test:
- Fix memory leak for sockets that's scheduled to be closed after `PJ_SSL_SOCK_DELAYED_CLOSE_TIMEOUT`.
