### PR TITLE
Modify failed pjlib test to exclusive

### DIFF
--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -242,7 +242,7 @@ static int features_tests(int argc, char *argv[])
     UT_ADD_TEST(&test_app.ut_app, hash_test, 0);
 #endif
 
-    /* Windows GH CI oftent fails with:
+    /* GH CI oftent fails with:
 
     07:27:13.217 ...testing frequency accuracy (pls wait)
     07:27:23.440 ....error: timestamp drifted by 3800 usec after 10020 msec
@@ -264,7 +264,7 @@ static int features_tests(int argc, char *argv[])
     UT_ADD_TEST(&test_app.ut_app, timer_test, 0);
 #endif
 
-    /* Very often sleep test failed on GitHub Windows CI, with
+    /* Very often sleep test failed on GitHub CI, with
        the thread sleeping for much longer than tolerated. So
        as a workaround, set it as exclusive.
      */
@@ -317,7 +317,7 @@ static int features_tests(int argc, char *argv[])
     Therefore we'll disable parallelism on Windows for this test. [blp]
     */
 #if INCLUDE_IOQUEUE_STRESS_TEST
-#  if 1 //defined(PJ_WIN32) && PJ_WIN32!=0
+#  if defined(PJ_WIN32) && PJ_WIN32!=0
     UT_ADD_TEST(&test_app.ut_app, ioqueue_stress_test,
                 PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
 #  else

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -248,7 +248,7 @@ static int features_tests(int argc, char *argv[])
     07:27:23.440 ....error: timestamp drifted by 3800 usec after 10020 msec
     */
 #if INCLUDE_TIMESTAMP_TEST
-#  if defined(PJ_WIN32) && PJ_WIN32!=0
+#  if 1 //defined(PJ_WIN32) && PJ_WIN32!=0
     UT_ADD_TEST(&test_app.ut_app, timestamp_test,
                 PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
 #  else
@@ -269,7 +269,7 @@ static int features_tests(int argc, char *argv[])
        as a workaround, set it as exclusive.
      */
 #if INCLUDE_SLEEP_TEST
-#  if defined(PJ_WIN32) && PJ_WIN32!=0
+#  if 1 //defined(PJ_WIN32) && PJ_WIN32!=0
     UT_ADD_TEST(&test_app.ut_app, sleep_test,
                 PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
 #  else
@@ -317,7 +317,7 @@ static int features_tests(int argc, char *argv[])
     Therefore we'll disable parallelism on Windows for this test. [blp]
     */
 #if INCLUDE_IOQUEUE_STRESS_TEST
-#  if defined(PJ_WIN32) && PJ_WIN32!=0
+#  if 1 //defined(PJ_WIN32) && PJ_WIN32!=0
     UT_ADD_TEST(&test_app.ut_app, ioqueue_stress_test,
                 PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
 #  else


### PR DESCRIPTION
Re #4246 (CI: change sleep_test() and timestamp_test() to exclusive on Windows), the failure also happens on other platforms such as Mac, not just on Windows.

Example log from CI Mac test:
```
06:09:03.889 ------------ Logs for sleep_test [rc:-30]: ------------
05:57:37.097 ...2025-00-21 05:57:37.097
05:57:38.139 ...2025-00-21 05:57:38.139
05:57:39.229 ...2025-00-21 05:57:39.229
05:57:39.229 ..running sleep duration test
05:57:41.379 ...error: slept for 2150 ms instead of 2000 ms (outside 20 msec tolerance)
05:57:42.403 ...error: slept for 1024 ms instead of 1000 ms (outside 20 msec tolerance)
05:57:42.977 ...error: slept for 574 ms instead of 500 ms (outside 20 msec tolerance)
05:57:43.305 ...error: slept for 121 ms instead of 100 ms (outside 20 msec tolerance)
05:57:43.305 ...avg/max slippage: 54/150 ms
```

