### PR TITLE
Fixed timer remove node safeguard

### DIFF
--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -330,8 +330,9 @@ static pj_timer_entry_dup * remove_node( pj_timer_heap_t *ht, size_t slot)
 #if ASSERT_IF_ENTRY_DESTROYED
         pj_assert(removed_node->dup._timer_id==removed_node->entry->_timer_id);
 #endif
+    } else {
+        GET_ENTRY(removed_node)->_timer_id = -1;
     }
-    GET_ENTRY(removed_node)->_timer_id = -1;
     GET_FIELD(removed_node, _timer_id) = -1;
 
 #if !PJ_TIMER_USE_LINKED_LIST


### PR DESCRIPTION
When the timer use copy (PJ_TIMER_USE_COPY), we can detect if original entry has been deallocated by comparing if the copy differs from the original entry.

This is supposed to be a safeguard that can help detect hard-to-find bug and prevent it from crashing (we will write warning log instead). Unfortunately, we still overwrite the original entry, and the crash would still occur.

Example log:
```
07:31:16.638 Bug! Trying to remove entry 0x11e0162a8 from ../src/pjlib-test/timer.c line 649, which has been deallocated without being cancelled
07:31:16.638 Bug! Polling entry 0x11e0162a8 from ../src/pjlib-test/timer.c line 649 has been deallocated without being cancelled
Error: signal 11:
0   pjlib-test-arm-apple-darwin23.6.0   0x00000001040c1484 print_stack + 32
1   libsystem_platform.dylib            0x000000019c922584 _sigtramp + 56
2   pjlib-test-arm-apple-darwin23.6.0   0x00000001040fef68 pj_ioqueue_destroy + 340
3   pjlib-test-arm-apple-darwin23.6.0   0x00000001040fef68 pj_ioqueue_destroy + 340
4   pjlib-test-arm-apple-darwin23.6.0   0x00000001040d6e78 compliance_test_2 + 3660
5   pjlib-test-arm-apple-darwin23.6.0   0x00000001040d51d4 tcp_ioqueue_test_impl + 540
6   pjlib-test-arm-apple-darwin23.6.0   0x00000001040d4e78 tcp_ioqueue_test + 196
7   pjlib-test-arm-apple-darwin23.6.0   0x000000010412f0e0 run_test_case + 296
8   pjlib-test-arm-apple-darwin23.6.0   0x000000010412eef0 text_runner_thread_proc + 104
9   pjlib-test-arm-apple-darwin23.6.0   0x0000000104102b58 thread_main + 212
10  libsystem_pthread.dylib             0x000000019c8f1f94 _pthread_start + 136
11  libsystem_pthread.dylib             0x000000019c8ecd34 thread_start + 8
```
Here we overwrite a memory location which has been deallocated and used by another object.
