### PR TITLE
Select I/O queue backend using macro PJ_IOQUEUE_IMP

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -732,7 +732,6 @@ ac_external_gsm
 ac_external_speex
 ac_no_pjsua2
 ac_shared_libraries
-ac_linux_poll
 ac_os_objs
 ac_std_cpp_lib
 ac_target_arch
@@ -6839,12 +6838,8 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
 
-
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ioqueue backend" >&5
 printf %s "checking ioqueue backend... " >&6; }
-
-ac_os_objs=ioqueue_select.o
-ac_linux_poll=select
 
 case $target in
     *darwin* | *bsd*)
@@ -6853,18 +6848,23 @@ if test ${enable_kqueue+y}
 then :
   enableval=$enable_kqueue;
                 if test "$enable_kqueue" = "yes"; then
-                    ac_os_objs=ioqueue_kqueue.o
                     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: kqueue()" >&5
 printf "%s\n" "kqueue()" >&6; }
+                    printf "%s\n" "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_KQUEUE" >>confdefs.h
+
                 else
                     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
 printf "%s\n" "select()" >&6; }
+                    printf "%s\n" "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_SELECT" >>confdefs.h
+
                 fi
 
 else case e in #(
   e)
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
 printf "%s\n" "select()" >&6; }
+                printf "%s\n" "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_SELECT" >>confdefs.h
+
 
          ;;
 esac
@@ -6877,21 +6877,23 @@ if test ${enable_epoll+y}
 then :
   enableval=$enable_epoll;
                 if test "$enable_epoll" = "yes"; then
-                    ac_os_objs=ioqueue_epoll.o
                     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: /dev/epoll" >&5
 printf "%s\n" "/dev/epoll" >&6; }
-                    printf "%s\n" "#define PJ_HAS_LINUX_EPOLL 1" >>confdefs.h
+                    printf "%s\n" "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_EPOLL" >>confdefs.h
 
-                    ac_linux_poll=epoll
                 else
                     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
 printf "%s\n" "select()" >&6; }
+                    printf "%s\n" "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_SELECT" >>confdefs.h
+
                 fi
 
 else case e in #(
   e)
                 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: select()" >&5
 printf "%s\n" "select()" >&6; }
+                printf "%s\n" "#define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_SELECT" >>confdefs.h
+
 
          ;;
 esac

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -569,11 +569,7 @@ dnl ######################
 dnl # ioqueue selection
 dnl #
 AC_SUBST(ac_os_objs)
-AC_SUBST(ac_linux_poll)
 AC_MSG_CHECKING([ioqueue backend])
-
-ac_os_objs=ioqueue_select.o
-ac_linux_poll=select
 
 case $target in
     *darwin* | *bsd*)
@@ -581,14 +577,16 @@ case $target in
             AS_HELP_STRING([--enable-kqueue], [Use kqueue ioqueue on macos/BSD (experimental)]),
             [
                 if test "$enable_kqueue" = "yes"; then
-                    ac_os_objs=ioqueue_kqueue.o
                     AC_MSG_RESULT([kqueue()])
+                    AC_DEFINE(PJ_IOQUEUE_IMP, PJ_IOQUEUE_IMP_KQUEUE)
                 else
                     AC_MSG_RESULT([select()])
+                    AC_DEFINE(PJ_IOQUEUE_IMP, PJ_IOQUEUE_IMP_SELECT)
                 fi
             ],
             [
                 AC_MSG_RESULT([select()])
+                AC_DEFINE(PJ_IOQUEUE_IMP, PJ_IOQUEUE_IMP_SELECT)
             ]
         )
         ;;
@@ -597,16 +595,16 @@ case $target in
             AS_HELP_STRING([--enable-epoll], [Use /dev/epoll ioqueue on Linux (experimental)]),
             [
                 if test "$enable_epoll" = "yes"; then
-                    ac_os_objs=ioqueue_epoll.o
                     AC_MSG_RESULT([/dev/epoll])
-                    AC_DEFINE(PJ_HAS_LINUX_EPOLL,1)
-                    ac_linux_poll=epoll
+                    AC_DEFINE(PJ_IOQUEUE_IMP, PJ_IOQUEUE_IMP_EPOLL)
                 else
                     AC_MSG_RESULT([select()])
+                    AC_DEFINE(PJ_IOQUEUE_IMP, PJ_IOQUEUE_IMP_SELECT)
                 fi
             ],
             [
                 AC_MSG_RESULT([select()])
+                AC_DEFINE(PJ_IOQUEUE_IMP, PJ_IOQUEUE_IMP_SELECT)
             ]
         )
         ;;

--- a/pjlib/build/os-auto.mak.in
+++ b/pjlib/build/os-auto.mak.in
@@ -10,6 +10,7 @@ AC_OS_OBJS=@ac_os_objs@
 #
 export PJLIB_OBJS +=    $(AC_OS_OBJS) \
                         addr_resolv_sock.o \
+                        ioqueue_dummy.o ioqueue_epoll.o ioqueue_kqueue.o ioqueue_select.o \
                         log_writer_stdout.o \
                         os_timestamp_common.o \
                         pool_policy_malloc.o sock_bsd.o sock_select.o

--- a/pjlib/build/pjlib.vcproj
+++ b/pjlib/build/pjlib.vcproj
@@ -5405,7 +5405,6 @@
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5415,7 +5414,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug|x64"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5425,7 +5423,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release|Win32"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5435,7 +5432,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release|x64"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5445,7 +5441,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug-Static|Win32"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5455,7 +5450,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug-Static|x64"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5465,7 +5459,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release-Dynamic|Win32"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5475,7 +5468,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release-Dynamic|x64"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5485,7 +5477,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug-Dynamic|Win32"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5495,7 +5486,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug-Dynamic|x64"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5505,7 +5495,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release-Static|Win32"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"
@@ -5515,7 +5504,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release-Static|x64"
-					ExcludedFromBuild="true"
 					>
 					<Tool
 						Name="VCCLCompilerTool"

--- a/pjlib/build/pjlib.vcxproj
+++ b/pjlib/build/pjlib.vcxproj
@@ -756,32 +756,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\src\pj\ioqueue_select.c" />
-    <ClCompile Include="..\src\pj\ioqueue_winnt.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|ARM64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Static|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Static|ARM64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Dynamic|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Dynamic|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Dynamic|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Dynamic|ARM64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Static|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Static|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Static|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release-Static|ARM64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="..\src\pj\ioqueue_winnt.c" />
     <ClCompile Include="..\src\pj\ip_helper_winphone8.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|ARM'">true</ExcludedFromBuild>

--- a/pjlib/include/pj/compat/os_auto.h.in
+++ b/pjlib/include/pj/compat/os_auto.h.in
@@ -122,6 +122,9 @@
   typedef int socklen_t;
 #endif
 
+/* Select I/O queue backend. */
+#undef PJ_IOQUEUE_IMP
+
 /**
  * If this macro is set, it tells select I/O Queue that select() needs to
  * be given correct value of nfds (i.e. largest fd + 1). This requires
@@ -133,9 +136,6 @@
  * Default: 0
  */
 #undef PJ_SELECT_NEEDS_NFDS
-
-/* Was Linux epoll support enabled */
-#undef PJ_HAS_LINUX_EPOLL
 
 /* Is errno a good way to retrieve OS errors?
  */

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -690,6 +690,43 @@
 #   define PJ_ACTIVESOCK_MAX_CONSECUTIVE_ACCEPT_ERROR 50
 #endif
 
+
+/*
+ * I/O queue implementation backends.
+ * Select one of these implementations in PJ_IOQUEUE_IMP.
+ */
+
+/** No/dummy I/O queue */
+#define PJ_IOQUEUE_IMP_NONE         0
+
+/** Using select() */
+#define PJ_IOQUEUE_IMP_SELECT       1
+
+/** Using epoll() (experimental) */
+#define PJ_IOQUEUE_IMP_EPOLL        2
+
+/** Using Windows I/O Completion Ports (experimental) */
+#define PJ_IOQUEUE_IMP_IOCP         3
+
+/** Using MacOS/BSD kqueue (experimental) */
+#define PJ_IOQUEUE_IMP_KQUEUE       4
+
+/** Using Windows UWP socket (deprecated) */
+#define PJ_IOQUEUE_IMP_UWP          5
+
+/** Using Symbian (deprecated) */
+#define PJ_IOQUEUE_IMP_SYMBIAN      6
+
+/**
+ * I/O queue implementation backend.
+ *
+ * Default: PJ_IOQUEUE_IMP_SELECT
+ */
+#ifndef PJ_IOQUEUE_IMP
+#   define PJ_IOQUEUE_IMP               PJ_IOQUEUE_IMP_SELECT
+#endif
+
+
 /**
  * Constants for declaring the maximum handles that can be supported by
  * a single IOQ framework. This constant might not be relevant to the 
@@ -1068,7 +1105,7 @@
 /** Using OpenSSL */
 #define PJ_SSL_SOCK_IMP_OPENSSL     1
 
-/**< Using GnuTLS */
+/** Using GnuTLS */
 #define PJ_SSL_SOCK_IMP_GNUTLS      2
 
 /** Using Apple's Secure Transport (deprecated in MacOS 10.15 & iOS 13.0) */

--- a/pjlib/src/pj/ioqueue_dummy.c
+++ b/pjlib/src/pj/ioqueue_dummy.c
@@ -26,6 +26,11 @@
 #include <pj/sock.h>
 #include <pj/errno.h>
 
+
+/* Only build when the backend is using dummy/none. */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_NONE
+
+
 #define THIS_FILE   "ioqueue"
 
 #define PJ_IOQUEUE_IS_READ_OP(op)   \
@@ -196,3 +201,5 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     PJ_UNUSED_ARG(ioqueue);
     return NULL;
 }
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_NONE */

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -36,6 +36,11 @@
 #include <pj/compat/socket.h>
 #include <pj/rand.h>
 
+
+/* Only build when the backend is using epoll. */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_EPOLL
+
+
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <errno.h>
@@ -1082,3 +1087,5 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
 {
     return ioqueue ? (pj_oshandle_t)&ioqueue->epfd : NULL;
 }
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_EPOLL */

--- a/pjlib/src/pj/ioqueue_kqueue.c
+++ b/pjlib/src/pj/ioqueue_kqueue.c
@@ -32,6 +32,9 @@
 #include <pj/sock.h>
 #include <pj/string.h>
 
+/* Only build when the backend is using kqueue. */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_KQUEUE
+
 #include <sys/event.h>
 
 #define os_kqueue_open kqueue
@@ -729,3 +732,5 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
 {
     return ioqueue ? (pj_oshandle_t)&ioqueue->kfd : NULL;
 }
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_KQUEUE */

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -40,6 +40,11 @@
 #include <pj/errno.h>
 #include <pj/rand.h>
 
+
+/* Only build when the backend is using select(). */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_SELECT
+
+
 /* Now that we have access to OS'es <sys/select>, lets check again that
  * PJ_IOQUEUE_MAX_HANDLES is not greater than FD_SETSIZE
  */
@@ -1142,3 +1147,5 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     PJ_UNUSED_ARG(ioqueue);
     return NULL;
 }
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_SELECT */

--- a/pjlib/src/pj/ioqueue_symbian.cpp
+++ b/pjlib/src/pj/ioqueue_symbian.cpp
@@ -24,6 +24,11 @@
 #include <pj/pool.h>
 #include <pj/string.h>
 
+
+/* Only build when the backend is using Symbian. */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_SYMBIAN
+
+
 #include "os_symbian.h"
 
 class CIoqueueCallback;
@@ -869,3 +874,5 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     PJ_UNUSED_ARG(ioqueue);
     return NULL;
 }
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_SYMBIAN */

--- a/pjlib/src/pj/ioqueue_uwp.cpp
+++ b/pjlib/src/pj/ioqueue_uwp.cpp
@@ -22,6 +22,10 @@
 #include <pj/os.h>
 #include <pj/pool.h>
 
+/* Only build when the backend is using Windows UWP socket. */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_UWP
+
+
 #include <ppltasks.h>
 #include <string>
 
@@ -367,3 +371,5 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     PJ_UNUSED_ARG(ioqueue);
     return NULL;
 }
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_UWP */

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -29,6 +29,12 @@
 #include <pj/compat/socket.h>
 
 
+/* Only build when the backend is Windows I/O Completion Ports. */
+#if PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_IOCP
+
+
+#define THIS_FILE "ioq_winnt"
+
 #if defined(PJ_HAS_WINSOCK2_H) && PJ_HAS_WINSOCK2_H != 0
 #  include <winsock2.h>
 #elif defined(PJ_HAS_WINSOCK_H) && PJ_HAS_WINSOCK_H != 0
@@ -1513,3 +1519,6 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
 {
     return ioqueue ? (pj_oshandle_t)ioqueue->iocp : NULL;
 }
+
+
+#endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_IOCP */

--- a/pjlib/src/pjlib-test/ioq_perf.c
+++ b/pjlib/src/pjlib-test/ioq_perf.c
@@ -565,7 +565,7 @@ static int ioqueue_perf_test_imp(const pj_ioqueue_cfg *cfg)
 }
 
 static pj_ioqueue_epoll_flag epoll_flags[] = {
-#if PJ_HAS_LINUX_EPOLL
+#if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     PJ_IOQUEUE_EPOLL_EXCLUSIVE,
     PJ_IOQUEUE_EPOLL_ONESHOT,
     0,

--- a/pjlib/src/pjlib-test/ioq_stress_test.c
+++ b/pjlib/src/pjlib-test/ioq_stress_test.c
@@ -769,7 +769,7 @@ static test_desc tests[128] = {
         .cfg.n_clients = 1,
         .cfg.repeat = 4
     },
-    #if PJ_HAS_LINUX_EPOLL
+    #if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     {
         .cfg.title = "basic udp (single thread, EPOLLEXCLUSIVE)",
         .cfg.max_fd = 4,
@@ -831,7 +831,7 @@ static test_desc tests[128] = {
         .cfg.n_clients = 1,
         .cfg.repeat = 4
     },
-    #if PJ_HAS_LINUX_EPOLL
+    #if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     {
         .cfg.title = "basic tcp (single thread, EPOLLEXCLUSIVE)",
         .cfg.max_fd = 6,
@@ -893,7 +893,7 @@ static test_desc tests[128] = {
         .cfg.n_clients = 1,
         .cfg.repeat = 2
     },
-    #if PJ_HAS_LINUX_EPOLL
+    #if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     {
         .cfg.title = "failed tcp connect (EPOLLEXCLUSIVE)",
         .cfg.expected_ret_code = RETCODE_CONNECT_FAILED,
@@ -980,7 +980,7 @@ static test_desc tests[128] = {
         .cfg.n_clients = MAX_ASYNC,
         .cfg.repeat = 4
     },
-    #if PJ_HAS_LINUX_EPOLL
+    #if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     /* EPOLLEXCLUSIVE (udp).
      */
     {
@@ -1051,7 +1051,7 @@ static test_desc tests[128] = {
         .cfg.n_clients = MAX_ASYNC,
         .cfg.repeat = 4
     },
-    #if PJ_HAS_LINUX_EPOLL
+    #if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     {
         .cfg.title = "tcp (multithreads, EPOLLEXCLUSIVE)",
         .cfg.max_fd = 6,
@@ -1121,7 +1121,7 @@ static test_desc tests[128] = {
         .cfg.n_clients = MAX_ASYNC,
         .cfg.repeat = 4
     },
-    #if PJ_HAS_LINUX_EPOLL
+    #if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
     {
         .cfg.title = "tcp (multithreads, sequenced, concur=0, EPOLLEXCLUSIVE)",
         .cfg.max_fd = 6,

--- a/pjlib/src/pjlib-test/ioq_tcp.c
+++ b/pjlib/src/pjlib-test/ioq_tcp.c
@@ -946,7 +946,7 @@ int tcp_ioqueue_test()
 {
     pj_ioqueue_epoll_flag epoll_flags[] = {
         PJ_IOQUEUE_EPOLL_AUTO,
-#if PJ_HAS_LINUX_EPOLL
+#if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
         PJ_IOQUEUE_EPOLL_EXCLUSIVE,
         PJ_IOQUEUE_EPOLL_ONESHOT,
         0

--- a/pjlib/src/pjlib-test/ioq_udp.c
+++ b/pjlib/src/pjlib-test/ioq_udp.c
@@ -1241,7 +1241,7 @@ static int udp_ioqueue_test_imp(const pj_ioqueue_cfg *cfg)
 int udp_ioqueue_test()
 {
     pj_ioqueue_epoll_flag epoll_flags[] = {
-#if PJ_HAS_LINUX_EPOLL
+#if PJ_IOQUEUE_IMP==PJ_IOQUEUE_IMP_EPOLL
         PJ_IOQUEUE_EPOLL_AUTO,
         PJ_IOQUEUE_EPOLL_EXCLUSIVE,
         PJ_IOQUEUE_EPOLL_ONESHOT,


### PR DESCRIPTION
Currently switching an I/O queue backend need to re-run `configure` for GNU build system or modify the PJLIB project for Visual Studio. With this PR, the backend can be selected by setting macro `PJ_IOQUEUE_IMP` in [`config_site.h`](https://docs.pjsip.org/en/latest/get-started/guidelines-development.html#config-site-h), the default is `PJ_IOQUEUE_IMP_SELECT` or using `select()`. Available backends are:

https://github.com/pjsip/pjproject/blob/b3c8a814705ea7855401fa699b0bc5a56c5f01cc/pjlib/include/pj/config.h#L699-L718

The existing `configure` params, `--enable-epoll` & `--enable-kqueue`, will still work.