### PR TITLE
Share an auth session between multiple dialogs/regc

### DIFF
--- a/pjsip/include/pjsip-ua/sip_regc.h
+++ b/pjsip/include/pjsip-ua/sip_regc.h
@@ -493,11 +493,11 @@ PJ_DECL(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata);
  * This will try to reuse authorization headers from another source
  * (e.g. subscribe dialog).
  *
- * If available, the internal auth session will be ignored. To reset
- * call with NULL for session parameter
+ * If available, the internal auth session will be ignored.
+ * To reset client registration, pass NULL as session parameter.
  *
- * @param dlg      The dialog
- * @param session  Pointer to the external session
+ * @param regc     The client registration structure.
+ * @param session  Pointer to the external session.
  */
 PJ_DECL(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
                                               pjsip_auth_clt_sess *session );

--- a/pjsip/include/pjsip-ua/sip_regc.h
+++ b/pjsip/include/pjsip-ua/sip_regc.h
@@ -488,7 +488,6 @@ PJ_DECL(pj_status_t) pjsip_regc_update_expires( pjsip_regc *regc,
 PJ_DECL(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata);
 
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
 /**
  * set a shared auth session to be used by this register client.
  * This will try to reuse authorization headers from another source
@@ -502,7 +501,6 @@ PJ_DECL(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata);
  */
 PJ_DECL(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
                                               pjsip_auth_clt_sess *session );
-#endif
 
 PJ_END_DECL
 

--- a/pjsip/include/pjsip-ua/sip_regc.h
+++ b/pjsip/include/pjsip-ua/sip_regc.h
@@ -488,6 +488,22 @@ PJ_DECL(pj_status_t) pjsip_regc_update_expires( pjsip_regc *regc,
 PJ_DECL(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata);
 
 
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+/**
+ * set a shared auth session to be used by this register client.
+ * This will try to reuse authorization headers from another source
+ * (e.g. subscribe dialog).
+ *
+ * If available, the internal auth session will be ignored. To reset
+ * call with NULL for session parameter
+ *
+ * @param dlg      The dialog
+ * @param session  Pointer to the external session
+ */
+PJ_DECL(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
+                                              pjsip_auth_clt_sess *session );
+#endif
+
 PJ_END_DECL
 
 /**

--- a/pjsip/include/pjsip/sip_auth.h
+++ b/pjsip/include/pjsip/sip_auth.h
@@ -343,10 +343,8 @@ typedef struct pjsip_auth_clt_sess
     unsigned             cred_cnt;      /**< Number of credentials.         */
     pjsip_cred_info     *cred_info;     /**< Array of credential information*/
     pjsip_cached_auth    cached_auth;   /**< Cached authorization info.     */
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
-    pj_lock_t           *lock;          /**< Prevent concurrent usage when shared.*/
+    pj_lock_t           *lock;          /**< Prevent concurrent usage when shared. should only used in parent */
     struct pjsip_auth_clt_sess *parent; /**< allow a common parent for multiple sessions.*/
-#endif
 } pjsip_auth_clt_sess;
 
 

--- a/pjsip/include/pjsip/sip_auth.h
+++ b/pjsip/include/pjsip/sip_auth.h
@@ -343,8 +343,12 @@ typedef struct pjsip_auth_clt_sess
     unsigned             cred_cnt;      /**< Number of credentials.         */
     pjsip_cred_info     *cred_info;     /**< Array of credential information*/
     pjsip_cached_auth    cached_auth;   /**< Cached authorization info.     */
-    pj_lock_t           *lock;          /**< Prevent concurrent usage when shared. should only used in parent */
-    struct pjsip_auth_clt_sess *parent; /**< allow a common parent for multiple sessions.*/
+    pj_lock_t           *lock;          /**< Prevent concurrent usage when
+                                             using a shared parent. Is only
+                                             used in parent. Set up by
+                                             pjsip_auth_clt_set_parent      */
+    struct pjsip_auth_clt_sess *parent; /**< allow a common parent
+                                             for multiple sessions.         */
 } pjsip_auth_clt_sess;
 
 
@@ -602,6 +606,19 @@ PJ_DECL(pj_status_t) pjsip_auth_srv_init( pj_pool_t *pool,
                                           pjsip_auth_lookup_cred *lookup,
                                           unsigned options );
 
+
+/**
+ * Set a parent session to be used instead of the current.
+ * This allows a central caching of authorization headers over multiple
+ * dialogs.
+ *
+ * @param sess          session that will be delegating the requests.
+ * @param p             parent that will be shared.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjsip_auth_clt_set_parent(pjsip_auth_clt_sess *sess,
+                                               const pjsip_auth_clt_sess *p);
 
 /**
  * This structure describes initialization settings of server authorization

--- a/pjsip/include/pjsip/sip_auth.h
+++ b/pjsip/include/pjsip/sip_auth.h
@@ -343,7 +343,10 @@ typedef struct pjsip_auth_clt_sess
     unsigned             cred_cnt;      /**< Number of credentials.         */
     pjsip_cred_info     *cred_info;     /**< Array of credential information*/
     pjsip_cached_auth    cached_auth;   /**< Cached authorization info.     */
-
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+    pj_lock_t           *lock;          /**< Prevent concurrent usage when shared.*/
+    struct pjsip_auth_clt_sess *parent; /**< allow a common parent for multiple sessions.*/
+#endif
 } pjsip_auth_clt_sess;
 
 

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1227,23 +1227,6 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #endif
 
 /**
- * If this flag is set, the stack will allow sharing of a auth session.
- * The session can be set to each dialog and will try to reuse auth headers
- * if possible. This can drastically reduce the amount of messages, that are
- * required to communicate with the same account.
- *
- * May need to have PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
- * enabled to work properly, and also will grow usage of the used pool for
- * the cached headers.
- *
- * Default: 0
- */
-#if !defined(PJSIP_SHARED_AUTH_SESSION)
-#   define PJSIP_SHARED_AUTH_SESSION        0
-#endif
-
-
-/**
  * Support qop="auth" directive.
  * This option also requires client to cache the last challenge offered by
  * server.

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1227,6 +1227,23 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #endif
 
 /**
+ * If this flag is set, the stack will allow sharing of a auth session.
+ * The session can be set to each dialog and will try to reuse auth headers
+ * if possible. This can drastically reduce the amount of messages, that are
+ * required to communicate with the same account.
+ *
+ * May need to have PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
+ * enabled to work properly, and also will grow usage of the used pool for
+ * the cached headers.
+ *
+ * Default: 0
+ */
+#if !defined(PJSIP_SHARED_AUTH_SESSION)
+#   define PJSIP_SHARED_AUTH_SESSION        0
+#endif
+
+
+/**
  * Support qop="auth" directive.
  * This option also requires client to cache the last challenge offered by
  * server.

--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -903,7 +903,6 @@ PJ_DECL(pj_status_t) pjsip_dlg_update_remote_cap(pjsip_dialog *dlg,
                                                  const pjsip_msg *msg,
                                                  pj_bool_t strict);
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
 /**
  * set a shared auth session to be used by this dialog.
  * This will try to reuse authorization headers from another source
@@ -917,7 +916,6 @@ PJ_DECL(pj_status_t) pjsip_dlg_update_remote_cap(pjsip_dialog *dlg,
  */
 PJ_DECL(pj_status_t) pjsip_dlg_set_auth_sess(pjsip_dialog *dlg,
                                              pjsip_auth_clt_sess *session);
-#endif
 
 /**
  * @}

--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -903,7 +903,21 @@ PJ_DECL(pj_status_t) pjsip_dlg_update_remote_cap(pjsip_dialog *dlg,
                                                  const pjsip_msg *msg,
                                                  pj_bool_t strict);
 
-
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+/**
+ * set a shared auth session to be used by this dialog.
+ * This will try to reuse authorization headers from another source
+ * (e.g. register).
+ *
+ * If available, the internal auth session will be ignored. To reset
+ * call with NULL for session parameter
+ *
+ * @param dlg      The dialog
+ * @param session  Pointer to the external session
+ */
+PJ_DECL(pj_status_t) pjsip_dlg_set_auth_sess(pjsip_dialog *dlg,
+                                             pjsip_auth_clt_sess *session);
+#endif
 
 /**
  * @}
@@ -925,7 +939,6 @@ void pjsip_dlg_on_rx_request( pjsip_dialog *dlg,
 /** Internal */
 void pjsip_dlg_on_rx_response( pjsip_dialog *dlg,
                                pjsip_rx_data *rdata );
-
 
 
 PJ_END_DECL

--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -908,8 +908,8 @@ PJ_DECL(pj_status_t) pjsip_dlg_update_remote_cap(pjsip_dialog *dlg,
  * This will try to reuse authorization headers from another source
  * (e.g. register).
  *
- * If available, the internal auth session will be ignored. To reset
- * call with NULL for session parameter
+ * If available, the internal auth session will be ignored.
+ * To reset client registration, pass NULL as session parameter.
  *
  * @param dlg      The dialog
  * @param session  Pointer to the external session

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4661,6 +4661,19 @@ typedef struct pjsua_acc_config
      */
     pj_bool_t           enable_rtcp_xr;
 
+    /**
+     * Use a shared authorization session within this account.
+     * This will use the accounts credentials on outgoing requests,
+     * so that less 401/407 Responses will be returned.
+     *
+     * May need to have PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
+     * enabled to work properly, and also will grow usage of the used pool for
+     * the cached headers.
+     *
+     * Default: PJ_FALSE
+     */
+    pj_bool_t        shared_auth;
+
 } pjsua_acc_config;
 
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4666,7 +4666,7 @@ typedef struct pjsua_acc_config
      * This will use the accounts credentials on outgoing requests,
      * so that less 401/407 Responses will be returned.
      *
-     * May need to have PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
+     * Needs PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
      * enabled to work properly, and also will grow usage of the used pool for
      * the cached headers.
      *

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4672,7 +4672,7 @@ typedef struct pjsua_acc_config
      *
      * Default: PJ_FALSE
      */
-    pj_bool_t        shared_auth;
+    pj_bool_t        use_shared_auth;
 
 } pjsua_acc_config;
 

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -334,9 +334,7 @@ typedef struct pjsua_acc
     pjsip_transport_type_e tp_type; /**< Transport type (for local acc or
                                          transport binding)             */
     pjsua_ip_change_op ip_change_op;/**< IP change process progress.    */
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     pjsip_auth_clt_sess shared_auth_sess; /**< share one auth over all requests */
-#endif
 } pjsua_acc;
 
 

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -334,6 +334,9 @@ typedef struct pjsua_acc
     pjsip_transport_type_e tp_type; /**< Transport type (for local acc or
                                          transport binding)             */
     pjsua_ip_change_op ip_change_op;/**< IP change process progress.    */
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+    pjsip_auth_clt_sess shared_auth_sess; /**< share one auth over all requests */
+#endif
 } pjsua_acc;
 
 

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -266,7 +266,7 @@ struct AccountSipConfig : public PersistentObject
     /**
      * If this flag is set, the authentication client framework will
      * send an empty Authorization header in each initial request.
-     * Default is no.
+     * Default is false.
      */
     bool                authInitialEmpty;
 
@@ -307,9 +307,9 @@ struct AccountSipConfig : public PersistentObject
      * enabled to work properly, and also will grow usage of the used pool for
      * the cached headers.
      *
-     * Default is no
+     * Default is false
      */
-    bool        sharedAuth;
+    bool        useSharedAuth;
 
 public:
     /**

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -303,7 +303,7 @@ struct AccountSipConfig : public PersistentObject
      * This will use the accounts credentials on outgoing requests,
      * so that less 401/407 Responses will be returned.
      *
-     * May need to have PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
+     * Needs PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
      * enabled to work properly, and also will grow usage of the used pool for
      * the cached headers.
      *

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -298,6 +298,19 @@ struct AccountSipConfig : public PersistentObject
      */
     pjsua_ipv6_use      ipv6Use;
 
+    /**
+     * Use a shared authorization session within this account.
+     * This will use the accounts credentials on outgoing requests,
+     * so that less 401/407 Responses will be returned.
+     *
+     * May need to have PJSIP_AUTH_AUTO_SEND_NEXT and PJSIP_AUTH_HEADER_CACHING
+     * enabled to work properly, and also will grow usage of the used pool for
+     * the cached headers.
+     *
+     * Default is no
+     */
+    bool        sharedAuth;
+
 public:
     /**
      * Read this object from a container node.

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -266,7 +266,7 @@ struct AccountSipConfig : public PersistentObject
     /**
      * If this flag is set, the authentication client framework will
      * send an empty Authorization header in each initial request.
-     * Default is false.
+     * Default is no.
      */
     bool                authInitialEmpty;
 
@@ -307,7 +307,7 @@ struct AccountSipConfig : public PersistentObject
      * enabled to work properly, and also will grow usage of the used pool for
      * the cached headers.
      *
-     * Default is false
+     * Default is disabled/false.
      */
     bool        useSharedAuth;
 

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1559,15 +1559,5 @@ PJ_DEF(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata)
 PJ_DEF(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
                                               pjsip_auth_clt_sess *session ) {
     PJ_ASSERT_RETURN(regc, PJ_EINVAL);
-    pj_status_t status = PJ_SUCCESS;
-    status = pj_lock_acquire(regc->auth_sess.lock);
-    if (status != PJ_SUCCESS) {
-        return status;
-    }
-    regc->auth_sess.parent = session;
-    status = pj_lock_release(regc->auth_sess.lock);
-    if (status != PJ_SUCCESS) {
-        return status;
-    }
-    return PJ_SUCCESS;
+    return pjsip_auth_clt_set_parent(&regc->auth_sess, session);
 }

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1556,7 +1556,6 @@ PJ_DEF(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata)
     return status;
 }
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
 PJ_DEF(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
                                               pjsip_auth_clt_sess *session ) {
     PJ_ASSERT_RETURN(regc, PJ_EINVAL);
@@ -1572,4 +1571,3 @@ PJ_DEF(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
     }
     return PJ_SUCCESS;
 }
-#endif

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -96,6 +96,7 @@ struct pjsip_regc
 
     /* Authorization sessions. */
     pjsip_auth_clt_sess          auth_sess;
+    pjsip_auth_clt_sess         *ext_auth_sess; /**< User defined auth session.     */
 
     /* Auto refresh registration. */
     pj_bool_t                    auto_reg;
@@ -1555,4 +1556,20 @@ PJ_DEF(pj_status_t) pjsip_regc_send(pjsip_regc *regc, pjsip_tx_data *tdata)
     return status;
 }
 
-
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+PJ_DEF(pj_status_t) pjsip_regc_set_auth_sess( pjsip_regc *regc,
+                                              pjsip_auth_clt_sess *session ) {
+    PJ_ASSERT_RETURN(regc, PJ_EINVAL);
+    pj_status_t status = PJ_SUCCESS;
+    status = pj_lock_acquire(regc->auth_sess.lock);
+    if (status != PJ_SUCCESS) {
+        return status;
+    }
+    regc->auth_sess.parent = session;
+    status = pj_lock_release(regc->auth_sess.lock);
+    if (status != PJ_SUCCESS) {
+        return status;
+    }
+    return PJ_SUCCESS;
+}
+#endif

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -31,9 +31,7 @@
 #include <pj/guid.h>
 #include <pj/assert.h>
 #include <pj/ctype.h>
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
 #include <pj/lock.h>
-#endif
 
 
 #if defined(PJ_HAS_SSL_SOCK) && PJ_HAS_SSL_SOCK != 0 && \
@@ -108,7 +106,6 @@ const pjsip_auth_algorithm pjsip_auth_algorithms[] = {
 #  define AUTH_TRACE_(expr)
 #endif
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
 #define DO_ON_PARENT_LOCKED(sess, call) \
     do { \
         pj_status_t on_parent, lock_status; \
@@ -129,7 +126,6 @@ const pjsip_auth_algorithm pjsip_auth_algorithms[] = {
             return on_parent; \
         } \
     } while(0)
-#endif
 
 static void dup_bin(pj_pool_t *pool, pj_str_t *dst, const pj_str_t *src)
 {
@@ -737,7 +733,6 @@ static pjsip_cached_auth *find_cached_auth( pjsip_auth_clt_sess *sess,
                                             const pj_str_t *realm,
                                             pjsip_auth_algorithm_type algorithm_type)
 {
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     pj_status_t lock_status;
     pj_bool_t with_parent = PJ_FALSE;
     pjsip_cached_auth * pauth = NULL;
@@ -755,7 +750,6 @@ static pjsip_cached_auth *find_cached_auth( pjsip_auth_clt_sess *sess,
     if (pauth != NULL) {
         return pauth;
     }
-#endif
 
     pjsip_cached_auth *auth = sess->cached_auth.next;
     while (auth != &sess->cached_auth) {
@@ -779,7 +773,6 @@ static const pjsip_cred_info* auth_find_cred( const pjsip_auth_clt_sess *sess,
 
     PJ_UNUSED_ARG(auth_scheme);
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     pj_status_t lock_status;
     pj_bool_t with_parent = PJ_FALSE;
     const pjsip_cred_info * ptr = NULL;
@@ -797,7 +790,6 @@ static const pjsip_cred_info* auth_find_cred( const pjsip_auth_clt_sess *sess,
     if (ptr != NULL) {
         return ptr;
     }
-#endif
 
     for (i=0; i<sess->cred_cnt; ++i) {
         switch(sess->cred_info[i].data_type) {
@@ -860,12 +852,8 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_init(  pjsip_auth_clt_sess *sess,
     sess->cred_info = NULL;
     pj_list_init(&sess->cached_auth);
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     sess->parent = NULL;
     return pj_lock_create_simple_mutex(pool, "auth_clt_lock", &sess->lock);
-#else
-    return PJ_SUCCESS;
-#endif
 }
 
 
@@ -882,12 +870,8 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_deinit(pjsip_auth_clt_sess *sess)
         auth = auth->next;
     }
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     sess->parent = NULL;
     return pj_lock_destroy(sess->lock);
-#else
-    return PJ_SUCCESS;
-#endif
 }
 
 
@@ -924,7 +908,6 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_clone( pj_pool_t *pool,
         }
     }
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     pj_status_t status, lock_status;
     if (sess->parent) {
         lock_status = pj_lock_acquire(sess->parent->lock);
@@ -945,7 +928,6 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_clone( pj_pool_t *pool,
     if (status != PJ_SUCCESS) {
         return status;
     }
-#endif
 
     /* TODO note:
      * Cloning the full authentication client is quite a big task.
@@ -966,9 +948,7 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_set_credentials( pjsip_auth_clt_sess *sess,
                                                     const pjsip_cred_info *c)
 {
     PJ_ASSERT_RETURN(sess && c, PJ_EINVAL);
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     DO_ON_PARENT_LOCKED(sess, pjsip_auth_clt_set_credentials(sess->parent, cred_cnt, c));
-#endif
 
     if (cred_cnt == 0) {
         sess->cred_cnt = 0;
@@ -1044,9 +1024,7 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_set_prefs(pjsip_auth_clt_sess *sess,
                                              const pjsip_auth_clt_pref *p)
 {
     PJ_ASSERT_RETURN(sess && p, PJ_EINVAL);
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     DO_ON_PARENT_LOCKED(sess, pjsip_auth_clt_set_prefs(sess->parent, p));
-#endif
 
     pj_memcpy(&sess->pref, p, sizeof(*p));
     pj_strdup(sess->pool, &sess->pref.algorithm, &p->algorithm);
@@ -1064,9 +1042,7 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_get_prefs(pjsip_auth_clt_sess *sess,
                                              pjsip_auth_clt_pref *p)
 {
     PJ_ASSERT_RETURN(sess && p, PJ_EINVAL);
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     DO_ON_PARENT_LOCKED(sess, pjsip_auth_clt_get_prefs(sess->parent, p));
-#endif
     pj_memcpy(p, &sess->pref, sizeof(pjsip_auth_clt_pref));
     return PJ_SUCCESS;
 }
@@ -1304,9 +1280,7 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_init_req( pjsip_auth_clt_sess *sess,
                      PJSIP_ENOTREQUESTMSG);
 
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     DO_ON_PARENT_LOCKED(sess, pjsip_auth_clt_init_req(sess->parent, tdata));
-#endif
     /* Init list */
     pj_list_init(&added);
 
@@ -1658,9 +1632,7 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_reinit_req(  pjsip_auth_clt_sess *sess,
                      rdata->msg_info.msg->line.status.code == 407,
                      PJSIP_EINVALIDSTATUS);
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     DO_ON_PARENT_LOCKED(sess, pjsip_auth_clt_reinit_req(sess->parent, rdata, old_request, new_request));
-#endif
 
     tdata = old_request;
     tdata->auth_retry = PJ_FALSE;

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -2497,15 +2497,5 @@ PJ_DEF(pj_status_t) pjsip_dlg_remove_remote_cap_hdr(pjsip_dialog *dlg,
 PJ_DEF(pj_status_t) pjsip_dlg_set_auth_sess( pjsip_dialog *dlg,
                                               pjsip_auth_clt_sess *session ) {
     PJ_ASSERT_RETURN(dlg, PJ_EINVAL);
-    pj_status_t status = PJ_SUCCESS;
-    status = pj_lock_acquire(dlg->auth_sess.lock);
-    if (status != PJ_SUCCESS) {
-        return status;
-    }
-    dlg->auth_sess.parent = session;
-    status = pj_lock_release(dlg->auth_sess.lock);
-    if (status != PJ_SUCCESS) {
-        return status;
-    }
-    return PJ_SUCCESS;
+    return pjsip_auth_clt_set_parent(&dlg->auth_sess, session);
 }

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -2493,3 +2493,21 @@ PJ_DEF(pj_status_t) pjsip_dlg_remove_remote_cap_hdr(pjsip_dialog *dlg,
 
     return PJ_SUCCESS;
 }
+
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+PJ_DEF(pj_status_t) pjsip_dlg_set_auth_sess( pjsip_dialog *dlg,
+                                              pjsip_auth_clt_sess *session ) {
+    PJ_ASSERT_RETURN(dlg, PJ_EINVAL);
+    pj_status_t status = PJ_SUCCESS;
+    status = pj_lock_acquire(dlg->auth_sess.lock);
+    if (status != PJ_SUCCESS) {
+        return status;
+    }
+    dlg->auth_sess.parent = session;
+    status = pj_lock_release(dlg->auth_sess.lock);
+    if (status != PJ_SUCCESS) {
+        return status;
+    }
+    return PJ_SUCCESS;
+}
+#endif

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -2494,7 +2494,6 @@ PJ_DEF(pj_status_t) pjsip_dlg_remove_remote_cap_hdr(pjsip_dialog *dlg,
     return PJ_SUCCESS;
 }
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
 PJ_DEF(pj_status_t) pjsip_dlg_set_auth_sess( pjsip_dialog *dlg,
                                               pjsip_auth_clt_sess *session ) {
     PJ_ASSERT_RETURN(dlg, PJ_EINVAL);
@@ -2510,4 +2509,3 @@ PJ_DEF(pj_status_t) pjsip_dlg_set_auth_sess( pjsip_dialog *dlg,
     }
     return PJ_SUCCESS;
 }
-#endif

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -330,6 +330,10 @@ static pj_status_t initialize_acc(unsigned acc_id)
         sip_reg_uri = NULL;
     }
 
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+    pjsip_auth_clt_init( &acc->shared_auth_sess, pjsua_var.endpt, acc->pool, 0);
+#endif
+
     if (sip_reg_uri) {
         acc->srv_port = sip_reg_uri->port;
     }
@@ -2753,6 +2757,10 @@ static pj_status_t pjsua_regc_init(int acc_id)
     /* Set client registration's transport based on acc's config. */
     pjsua_init_tpselector(acc_id, &tp_sel);
     pjsip_regc_set_transport(acc->regc, &tp_sel);
+
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+    pjsip_regc_set_auth_sess(acc->regc, &acc->shared_auth_sess);
+#endif
 
     /* Set credentials
      */

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1299,7 +1299,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     }
 
     /* Shared authentication session */
-    acc->cfg.shared_auth = cfg->shared_auth;
+    acc->cfg.use_shared_auth = cfg->use_shared_auth;
 
     /* Registration */
     if (acc->cfg.reg_timeout != cfg->reg_timeout) {
@@ -2758,7 +2758,7 @@ static pj_status_t pjsua_regc_init(int acc_id)
     pjsua_init_tpselector(acc_id, &tp_sel);
     pjsip_regc_set_transport(acc->regc, &tp_sel);
 
-    if (acc->cfg.shared_auth) {
+    if (acc->cfg.use_shared_auth) {
         pjsip_regc_set_auth_sess(acc->regc, &acc->shared_auth_sess);
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -329,10 +329,7 @@ static pj_status_t initialize_acc(unsigned acc_id)
     } else {
         sip_reg_uri = NULL;
     }
-
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
     pjsip_auth_clt_init( &acc->shared_auth_sess, pjsua_var.endpt, acc->pool, 0);
-#endif
 
     if (sip_reg_uri) {
         acc->srv_port = sip_reg_uri->port;
@@ -1300,6 +1297,9 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
     }
+
+    /* Shared authentication session */
+    acc->cfg.shared_auth = cfg->shared_auth;
 
     /* Registration */
     if (acc->cfg.reg_timeout != cfg->reg_timeout) {
@@ -2758,9 +2758,9 @@ static pj_status_t pjsua_regc_init(int acc_id)
     pjsua_init_tpselector(acc_id, &tp_sel);
     pjsip_regc_set_transport(acc->regc, &tp_sel);
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
-    pjsip_regc_set_auth_sess(acc->regc, &acc->shared_auth_sess);
-#endif
+    if (acc->cfg.shared_auth) {
+        pjsip_regc_set_auth_sess(acc->regc, &acc->shared_auth_sess);
+    }
 
     /* Set credentials
      */

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -983,7 +983,7 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
 
     dlg_set_via(dlg, acc);
 
-    if (acc->cfg.shared_auth) {
+    if (acc->cfg.use_shared_auth) {
         pjsip_dlg_set_auth_sess(dlg, &acc->shared_auth_sess);
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -982,6 +982,10 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
     pjsip_dlg_inc_lock(dlg);
 
     dlg_set_via(dlg, acc);
+    
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+    pjsip_dlg_set_auth_sess(dlg, &acc->shared_auth_sess);
+#endif
 
     /* Calculate call's secure level */
     call->secure_level = get_secure_level(acc_id, dest_uri);

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -982,10 +982,10 @@ PJ_DEF(pj_status_t) pjsua_call_make_call(pjsua_acc_id acc_id,
     pjsip_dlg_inc_lock(dlg);
 
     dlg_set_via(dlg, acc);
-    
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
-    pjsip_dlg_set_auth_sess(dlg, &acc->shared_auth_sess);
-#endif
+
+    if (acc->cfg.shared_auth) {
+        pjsip_dlg_set_auth_sess(dlg, &acc->shared_auth_sess);
+    }
 
     /* Calculate call's secure level */
     call->secure_level = get_secure_level(acc_id, dest_uri);

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -387,7 +387,7 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
                                         PJSUA_CALL_UPDATE_CONTACT |
                                         PJSUA_CALL_UPDATE_VIA;
     cfg->enable_rtcp_xr = (PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR);
-    cfg->shared_auth = PJ_FALSE;
+    cfg->use_shared_auth = PJ_FALSE;
 }
 
 PJ_DEF(void) pjsua_buddy_config_default(pjsua_buddy_config *cfg)

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -387,6 +387,7 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
                                         PJSUA_CALL_UPDATE_CONTACT |
                                         PJSUA_CALL_UPDATE_VIA;
     cfg->enable_rtcp_xr = (PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR);
+    cfg->shared_auth = PJ_FALSE;
 }
 
 PJ_DEF(void) pjsua_buddy_config_default(pjsua_buddy_config *cfg)

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -2127,6 +2127,10 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
         pjsip_dlg_set_route_set(buddy->dlg, &acc->route_set);
     }
 
+#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
+    pjsip_dlg_set_auth_sess(buddy->dlg, &acc->shared_auth_sess);
+#endif
+
     /* Set credentials */
     if (acc->cred_cnt) {
         pjsip_auth_clt_set_credentials( &buddy->dlg->auth_sess, 

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -2127,9 +2127,9 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
         pjsip_dlg_set_route_set(buddy->dlg, &acc->route_set);
     }
 
-#if defined(PJSIP_SHARED_AUTH_SESSION) && PJSIP_SHARED_AUTH_SESSION
-    pjsip_dlg_set_auth_sess(buddy->dlg, &acc->shared_auth_sess);
-#endif
+    if (acc->cfg.shared_auth) {
+        pjsip_dlg_set_auth_sess(buddy->dlg, &acc->shared_auth_sess);
+    }
 
     /* Set credentials */
     if (acc->cred_cnt) {

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -2127,7 +2127,7 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
         pjsip_dlg_set_route_set(buddy->dlg, &acc->route_set);
     }
 
-    if (acc->cfg.shared_auth) {
+    if (acc->cfg.use_shared_auth) {
         pjsip_dlg_set_auth_sess(buddy->dlg, &acc->shared_auth_sess);
     }
 

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -281,7 +281,7 @@ void AccountSipConfig::readObject(const ContainerNode &node)
     NODE_READ_BOOL      (this_node, authInitialEmpty);
     NODE_READ_STRING    (this_node, authInitialAlgorithm);
     NODE_READ_INT       (this_node, transportId);
-    NODE_READ_BOOL      (this_node, sharedAuth);
+    NODE_READ_BOOL      (this_node, useSharedAuth);
 
     ContainerNode creds_node = this_node.readArray("authCreds");
     authCreds.resize(0);
@@ -304,7 +304,7 @@ void AccountSipConfig::writeObject(ContainerNode &node) const
     NODE_WRITE_BOOL     (this_node, authInitialEmpty);
     NODE_WRITE_STRING   (this_node, authInitialAlgorithm);
     NODE_WRITE_INT      (this_node, transportId);
-    NODE_WRITE_BOOL     (this_node, sharedAuth);
+    NODE_WRITE_BOOL     (this_node, useSharedAuth);
 
     ContainerNode creds_node = this_node.writeNewArray("authCreds");
     for (unsigned i=0; i<authCreds.size(); ++i) {
@@ -633,7 +633,7 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     ret.auth_pref.algorithm     = str2Pj(sipConfig.authInitialAlgorithm);
     ret.transport_id            = sipConfig.transportId;
     ret.ipv6_sip_use            = sipConfig.ipv6Use;
-    ret.shared_auth             = sipConfig.sharedAuth;
+    ret.use_shared_auth         = sipConfig.useSharedAuth;
 
     // AccountCallConfig
     ret.call_hold_type          = callConfig.holdType;
@@ -798,7 +798,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     sipConfig.authInitialAlgorithm = pj2Str(prm.auth_pref.algorithm);
     sipConfig.transportId       = prm.transport_id;
     sipConfig.ipv6Use           = prm.ipv6_sip_use;
-    sipConfig.sharedAuth        = PJ2BOOL(prm.shared_auth);
+    sipConfig.useSharedAuth     = PJ2BOOL(prm.use_shared_auth);
 
     // AccountCallConfig
     callConfig.holdType         = prm.call_hold_type;

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -281,6 +281,7 @@ void AccountSipConfig::readObject(const ContainerNode &node)
     NODE_READ_BOOL      (this_node, authInitialEmpty);
     NODE_READ_STRING    (this_node, authInitialAlgorithm);
     NODE_READ_INT       (this_node, transportId);
+    NODE_READ_BOOL      (this_node, sharedAuth);
 
     ContainerNode creds_node = this_node.readArray("authCreds");
     authCreds.resize(0);
@@ -303,6 +304,7 @@ void AccountSipConfig::writeObject(ContainerNode &node) const
     NODE_WRITE_BOOL     (this_node, authInitialEmpty);
     NODE_WRITE_STRING   (this_node, authInitialAlgorithm);
     NODE_WRITE_INT      (this_node, transportId);
+    NODE_WRITE_BOOL     (this_node, sharedAuth);
 
     ContainerNode creds_node = this_node.writeNewArray("authCreds");
     for (unsigned i=0; i<authCreds.size(); ++i) {
@@ -631,6 +633,7 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     ret.auth_pref.algorithm     = str2Pj(sipConfig.authInitialAlgorithm);
     ret.transport_id            = sipConfig.transportId;
     ret.ipv6_sip_use            = sipConfig.ipv6Use;
+    ret.shared_auth             = sipConfig.sharedAuth;
 
     // AccountCallConfig
     ret.call_hold_type          = callConfig.holdType;
@@ -795,6 +798,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     sipConfig.authInitialAlgorithm = pj2Str(prm.auth_pref.algorithm);
     sipConfig.transportId       = prm.transport_id;
     sipConfig.ipv6Use           = prm.ipv6_sip_use;
+    sipConfig.sharedAuth        = PJ2BOOL(prm.shared_auth);
 
     // AccountCallConfig
     callConfig.holdType         = prm.call_hold_type;


### PR DESCRIPTION
For Accounts that establish a lot of dialogs it may be beneficial to reuse a already established Authorization.
To achieve this, the account was extended to store a shared pjsip_auth_clt_sess and this is set on the relevant dialogs.

This patch adds PJSIP_SHARED_AUTH_SESSION to enable this behavior in the account and to extend the relevant api.

