### PR TITLE
Added support for updated RFC7866 content-type sub type with XML extension

### DIFF
--- a/pjsip/include/pjsip-ua/sip_siprec.h
+++ b/pjsip/include/pjsip-ua/sip_siprec.h
@@ -102,8 +102,25 @@ PJ_DECL(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
                                                 pjsip_endpoint *endpt,
                                                 pjsip_tx_data **p_tdata);
 
-PJ_END_DECL
 
+/**
+ * Find siprec metadata information from the message body
+ * with "rs-metadata" Content-Type.
+ *
+ * @param pool               Pool to allocate memory.
+ * @param body               The message body.
+ * @param metadata           If metadata is found, this variable will be
+ *                           populated with the extracted data.
+ *
+ * @return                   Return PJ_SUCCESS if metadata is found,
+ *                           otherwise return PJ_ENOTFOUND.
+ */
+PJ_DECL(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
+                                                pjsip_msg_body *body,
+                                                pj_str_t* metadata);
+
+
+PJ_END_DECL
 
 /**
  * @}

--- a/pjsip/include/pjsip-ua/sip_siprec.h
+++ b/pjsip/include/pjsip-ua/sip_siprec.h
@@ -102,24 +102,6 @@ PJ_DECL(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
                                                 pjsip_endpoint *endpt,
                                                 pjsip_tx_data **p_tdata);
 
-
-/**
- * Find siprec metadata information from the message body
- * with "rs-metadata" Content-Type.
- *
- * @param pool               Pool to allocate memory.
- * @param body               The message body.
- * @param metadata           If metadata is found, this variable will be
- *                           populated with the extracted data.
- *
- * @return                   Return PJ_SUCCESS if metadata is found,
- *                           otherwise return PJ_ENOTFOUND.
- */
-PJ_DECL(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
-                                                pjsip_msg_body *body,
-                                                pj_str_t* metadata);
-
-
 PJ_END_DECL
 
 

--- a/pjsip/include/pjsip-ua/sip_siprec.h
+++ b/pjsip/include/pjsip-ua/sip_siprec.h
@@ -122,6 +122,7 @@ PJ_DECL(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
 
 PJ_END_DECL
 
+
 /**
  * @}
  */

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -194,13 +194,18 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
         }
     }
 
-    /* Try rs-metadata extension first */
+    /* 
+    * Updated to support RFC base content type extension
+    * https://datatracker.ietf.org/doc/html/draft-sipcore-siprec-fix-mediatype-00
+    */
+
+    /* Try rs-metadata first */
     pjsip_media_type_init2(&media_type, "application", "rs-metadata");
     
     metadata_part = pjsip_multipart_find_part(rdata->msg_info.msg->body,
                                          &media_type, NULL);
 
-    /* Fallback to rs-metadata+xml if needed - RFC7865 updates RFC7866*/
+    /* Fallback to XML extension rs-metadata+xml if needed */
     if (!metadata_part) {
         pjsip_media_type_init2(&media_type, "application", "rs-metadata+xml");
                               

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -142,9 +142,6 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
     const char *warn_text = NULL;
     pjsip_hdr res_hdr_list;
     unsigned mi;
-    pjsip_media_type media_type;
-    pjsip_multipart_part *metadata_part = NULL;
-
 
     /* Init return arguments. */
     if (p_tdata) *p_tdata = NULL;
@@ -194,36 +191,14 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
         }
     }
 
-    /* 
-    * Updated to support RFC base content type extension
-    * https://datatracker.ietf.org/doc/html/draft-sipcore-siprec-fix-mediatype-00
-    */
-
-    /* Try rs-metadata first */
-    pjsip_media_type_init2(&media_type, "application", "rs-metadata");
+    status = pjsip_siprec_get_metadata(rdata->tp_info.pool,
+                                        rdata->msg_info.msg->body,
+                                        metadata);
     
-    metadata_part = pjsip_multipart_find_part(rdata->msg_info.msg->body,
-                                         &media_type, NULL);
-
-    /* Fallback to XML extension rs-metadata+xml if needed */
-    if (!metadata_part) {
-        pjsip_media_type_init2(&media_type, "application", "rs-metadata+xml");
-                              
-        metadata_part = pjsip_multipart_find_part(rdata->msg_info.msg->body, 
-                                             &media_type, NULL);
-    }
-
-    /* Check if the metadata part exists */
-    if (!metadata_part) {
+    if(status != PJ_SUCCESS) {
         code = PJSIP_SC_BAD_REQUEST;
         warn_text = "SIPREC INVITE must have a content-type of 'rs-metadata' or with XML extension 'rs-metadata+xml'";
         goto on_return;
-    }
-
-    /* Get the metadata content */
-    if (metadata) {
-        metadata->ptr = (char*)metadata_part->body->data;
-        metadata->slen = metadata_part->body->len;
     }
 
     *options |= PJSIP_INV_REQUIRE_SIPREC;
@@ -283,4 +258,48 @@ on_return:
     }
 
     return status;
+}
+
+    /**
+ * Find siprec metadata from the message body
+ */
+PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
+                                            pjsip_msg_body *body,
+                                            pj_str_t* metadata)
+{
+    pjsip_media_type application_metadata;
+    pjsip_multipart_part *metadata_part = NULL;
+
+    /* 
+    * Updated to support RFC base content type extension
+    * https://datatracker.ietf.org/doc/html/draft-sipcore-siprec-fix-mediatype-00
+    */
+
+    metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL); 
+
+    /* Try rs-metadata first */
+    pjsip_media_type_init2(&application_metadata, "application", "rs-metadata");
+
+    metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
+
+    /* Fallback to XML extension rs-metadata+xml if needed */
+    if (!metadata_part) {
+        pjsip_media_type_init2(&application_metadata, "application", "rs-metadata+xml");
+                              
+        metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
+    }
+
+    /* Get the metadata content */
+    if (metadata) {
+        metadata->ptr = (char*)metadata_part->body->data;
+        metadata->slen = metadata_part->body->len;
+    }
+
+    if(!metadata_part)
+        return PJ_ENOTFOUND;
+
+    metadata->ptr = (char*)metadata_part->body->data;
+    metadata->slen = metadata_part->body->len;
+    
+    return PJ_SUCCESS;
 }

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -260,7 +260,7 @@ on_return:
     return status;
 }
 
-    /**
+/**
  * Find siprec metadata from the message body
  */
 PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
@@ -274,18 +274,15 @@ PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
     * Updated to support RFC base content type extension
     * https://datatracker.ietf.org/doc/html/draft-sipcore-siprec-fix-mediatype-00
     */
-
-    metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL); 
+    metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
 
     /* Try rs-metadata first */
     pjsip_media_type_init2(&application_metadata, "application", "rs-metadata");
-
     metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
 
     /* Fallback to XML extension rs-metadata+xml if needed */
     if (!metadata_part) {
         pjsip_media_type_init2(&application_metadata, "application", "rs-metadata+xml");
-                              
         metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
     }
 

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -194,7 +194,7 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
     status = pjsip_siprec_get_metadata(rdata->tp_info.pool,
                                         rdata->msg_info.msg->body,
                                         metadata);
-    
+
     if(status != PJ_SUCCESS) {
         code = PJSIP_SC_BAD_REQUEST;
         warn_text = "SIPREC INVITE must have a content-type of 'rs-metadata' or with XML extension 'rs-metadata+xml'";
@@ -260,6 +260,7 @@ on_return:
     return status;
 }
 
+
 /**
  * Find siprec metadata from the message body
  */
@@ -274,8 +275,6 @@ PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
     * Updated to support RFC base content type extension
     * https://datatracker.ietf.org/doc/html/draft-sipcore-siprec-fix-mediatype-00
     */
-    metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
-
     /* Try rs-metadata first */
     pjsip_media_type_init2(&application_metadata, "application", "rs-metadata");
     metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
@@ -289,8 +288,8 @@ PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
     if(!metadata_part)
         return PJ_ENOTFOUND;
 
-    metadata->ptr = (char*)metadata_part->body->data;
+    metadata->ptr  = (char*)metadata_part->body->data;
     metadata->slen = metadata_part->body->len;
-    
+
     return PJ_SUCCESS;
 }

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -142,6 +142,9 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
     const char *warn_text = NULL;
     pjsip_hdr res_hdr_list;
     unsigned mi;
+    pjsip_media_type media_type;
+    pjsip_multipart_part *metadata_part = NULL;
+
 
     /* Init return arguments. */
     if (p_tdata) *p_tdata = NULL;
@@ -191,14 +194,31 @@ PJ_DEF(pj_status_t) pjsip_siprec_verify_request(pjsip_rx_data *rdata,
         }
     }
 
-    status = pjsip_siprec_get_metadata(rdata->tp_info.pool,
-                                        rdata->msg_info.msg->body,
-                                        metadata);
+    /* Try rs-metadata extension first */
+    pjsip_media_type_init2(&media_type, "application", "rs-metadata");
     
-    if(status != PJ_SUCCESS) {
+    metadata_part = pjsip_multipart_find_part(rdata->msg_info.msg->body,
+                                         &media_type, NULL);
+
+    /* Fallback to rs-metadata+xml if needed - RFC7865 updates RFC7866*/
+    if (!metadata_part) {
+        pjsip_media_type_init2(&media_type, "application", "rs-metadata+xml");
+                              
+        metadata_part = pjsip_multipart_find_part(rdata->msg_info.msg->body, 
+                                             &media_type, NULL);
+    }
+
+    /* Check if the metadata part exists */
+    if (!metadata_part) {
         code = PJSIP_SC_BAD_REQUEST;
-        warn_text = "SIPREC INVITE must have a 'rs-metadata' Content-Type";
+        warn_text = "SIPREC INVITE must have a content-type of 'rs-metadata' or with XML extension 'rs-metadata+xml'";
         goto on_return;
+    }
+
+    /* Get the metadata content */
+    if (metadata) {
+        metadata->ptr = (char*)metadata_part->body->data;
+        metadata->slen = metadata_part->body->len;
     }
 
     *options |= PJSIP_INV_REQUIRE_SIPREC;
@@ -258,28 +278,4 @@ on_return:
     }
 
     return status;
-}
-
-
-/**
- * Find siprec metadata from the message body
- */
-PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
-                                              pjsip_msg_body *body,
-                                              pj_str_t* metadata)
-{
-    pjsip_media_type app_metadata;
-    pjsip_multipart_part *metadata_part;
-
-    PJ_UNUSED_ARG(pool);
-    pjsip_media_type_init2(&app_metadata, "application", "rs-metadata");
-    metadata_part = pjsip_multipart_find_part(body, &app_metadata, NULL);
-
-    if(!metadata_part)
-        return PJ_ENOTFOUND;
-
-    metadata->ptr  = (char*)metadata_part->body->data;
-    metadata->slen = metadata_part->body->len;
-    
-    return PJ_SUCCESS;
 }

--- a/pjsip/src/pjsip-ua/sip_siprec.c
+++ b/pjsip/src/pjsip-ua/sip_siprec.c
@@ -289,12 +289,6 @@ PJ_DEF(pj_status_t) pjsip_siprec_get_metadata(pj_pool_t *pool,
         metadata_part = pjsip_multipart_find_part(body, &application_metadata, NULL);
     }
 
-    /* Get the metadata content */
-    if (metadata) {
-        metadata->ptr = (char*)metadata_part->body->data;
-        metadata->slen = metadata_part->body->len;
-    }
-
     if(!metadata_part)
         return PJ_ENOTFOUND;
 


### PR DESCRIPTION
Updated to support RFC7866 base content type XML extension per https://datatracker.ietf.org/doc/html/draft-sipcore-siprec-fix-mediatype-00
    