### PR TITLE
Aligned memory allocation

### DIFF
--- a/pjlib/include/pj/pool.h
+++ b/pjlib/include/pj/pool.h
@@ -333,7 +333,7 @@ struct pj_pool_t
 
     /** The default alignment of memory block allocated from this pool
      *  (must be power of 2).                                                 */
-    size_t          alignment;
+    pj_size_t          alignment;
 
 };
 
@@ -405,6 +405,9 @@ PJ_IDECL(pj_pool_t*) pj_pool_create(pj_pool_factory *factory,
  *                          administrative info.
  * @param alignment         the default alignment of memory block allocated 
  *                          from this pool (must be power of 2).
+ *                          The actual allocation alignment will be at least equal
+ *                          to the alignment argument of the function, 
+ *                          but not less than PJ_POOL_ALIGNMENT. 
  *                          Value of 0 means use PJ_POOL_ALIGNMENT.
  * @param callback          Callback to be called when error occurs in the pool.
  *                          If this value is NULL, then the callback from pool
@@ -513,6 +516,10 @@ PJ_IDECL(void*) pj_pool_alloc( pj_pool_t *pool, pj_size_t size);
  *
  * @param pool      the pool.
  * @param alignment the requested alignment of the allocation.
+ *                  The actual alignment of the allocation will be at least 
+ *                  equal to the alignment argument of the function, 
+ *                  but not less than the default pool alignment specified 
+ *                  when the pool was created.
  *                  Value of 0 means use the default alignment of this pool.
  * @param size      the requested size.
  *

--- a/pjlib/include/pj/pool.h
+++ b/pjlib/include/pj/pool.h
@@ -331,6 +331,10 @@ struct pj_pool_t
     /** The callback to be called when the pool is unable to allocate memory. */
     pj_pool_callback *callback;
 
+    /** The default alignment of memory block allocated from this pool
+     *  (must be power of 2).                                                 */
+    size_t          alignment;
+
 };
 
 
@@ -347,8 +351,9 @@ struct pj_pool_t
 #endif
 
 /**
- * Create a new pool from the pool factory. This wrapper will call create_pool
- * member of the pool factory.
+ * Create a new pool from the pool factory. This wrapper will call 
+ * pj_pool_aligned_create() with alignment parameter set to 0
+ * which means use the default alignment (PJ_POOL_ALIGNMENT).
  *
  * @param factory           The pool factory.
  * @param name              The name to be assigned to the pool. The name should 
@@ -378,6 +383,44 @@ PJ_IDECL(pj_pool_t*) pj_pool_create(pj_pool_factory *factory,
                                     pj_size_t initial_size, 
                                     pj_size_t increment_size,
                                     pj_pool_callback *callback);
+
+
+/**
+ * Create a new pool from the pool factory. This wrapper will call create_pool
+ * member of the pool factory.
+ *
+ * @param factory           The pool factory.
+ * @param name              The name to be assigned to the pool. The name should
+ *                          not be longer than PJ_MAX_OBJ_NAME (32 chars), or
+ *                          otherwise it will be truncated.
+ * @param initial_size      The size of initial memory blocks taken by the pool.
+ *                          Note that the pool will take 68+20 bytes for
+ *                          administrative area from this block.
+ * @param increment_size    the size of each additional blocks to be allocated
+ *                          when the pool is running out of memory. If user
+ *                          requests memory which is larger than this size, then
+ *                          an error occurs.
+ *                          Note that each time a pool allocates additional block,
+ *                          it needs PJ_POOL_SIZE more to store some
+ *                          administrative info.
+ * @param alignment         the default alignment of memory block allocated 
+ *                          from this pool (must be power of 2).
+ *                          Value of 0 means use PJ_POOL_ALIGNMENT.
+ * @param callback          Callback to be called when error occurs in the pool.
+ *                          If this value is NULL, then the callback from pool
+ *                          factory policy will be used.
+ *                          Note that when an error occurs during pool creation,
+ *                          the callback itself is not called. Instead, NULL
+ *                          will be returned.
+ *
+ * @return                  The memory pool, or NULL.
+ */
+PJ_IDECL(pj_pool_t*) pj_pool_aligned_create(pj_pool_factory *factory,
+                                            const char *name,
+                                            pj_size_t initial_size,
+                                            pj_size_t increment_size,
+                                            pj_size_t alignment,
+                                            pj_pool_callback *callback);
 
 /**
  * Release the pool back to pool factory.
@@ -448,8 +491,10 @@ PJ_IDECL(pj_size_t) pj_pool_get_used_size( pj_pool_t *pool );
 
 /**
  * Allocate storage with the specified size from the pool.
+ * The allocation will be aligned to the default alignment of the pool.
  * If there's no storage available in the pool, then the pool can allocate more
  * blocks if the increment size is larger than the requested size.
+ * This function will call pj_pool_aligned_alloc() with alignment set to 0.
  *
  * @param pool      the pool.
  * @param size      the requested size.
@@ -459,6 +504,24 @@ PJ_IDECL(pj_size_t) pj_pool_get_used_size( pj_pool_t *pool );
  * @see PJ_POOL_ALLOC_T
  */
 PJ_IDECL(void*) pj_pool_alloc( pj_pool_t *pool, pj_size_t size);
+
+
+/**
+ * Allocate storage with the specified size and alignment from the pool.
+ * If there's no storage available in the pool, then the pool can allocate more
+ * blocks if the increment size is larger than the requested size.
+ *
+ * @param pool      the pool.
+ * @param alignment the requested alignment of the allocation.
+ *                  Value of 0 means use the default alignment of this pool.
+ * @param size      the requested size.
+ *
+ * @return pointer to the allocated memory.
+ *
+ * @see PJ_POOL_ALLOC_T
+ */
+PJ_IDECL(void *) pj_pool_aligned_alloc(pj_pool_t *pool, pj_size_t alignment,
+                                       pj_size_t size);
 
 /**
  * Allocate storage  from the pool, and initialize it to zero.
@@ -523,9 +586,11 @@ PJ_INLINE(void*) pj_pool_zalloc(pj_pool_t *pool, pj_size_t size)
  * Internal functions
  */
 /** Internal function */
-PJ_IDECL(void*) pj_pool_alloc_from_block(pj_pool_block *block, pj_size_t size);
+PJ_IDECL(void*) pj_pool_alloc_from_block(pj_pool_block *block, pj_size_t alignment,
+                                         pj_size_t size);
 /** Internal function */
-PJ_DECL(void*) pj_pool_allocate_find(pj_pool_t *pool, pj_size_t size);
+PJ_DECL(void*) pj_pool_allocate_find(pj_pool_t *pool, pj_size_t alignment,
+                                     pj_size_t size);
 
 
         
@@ -687,7 +752,11 @@ struct pj_pool_factory
     *                   Note that each time a pool allocates additional block, 
     *                   it needs 20 bytes (equal to sizeof(pj_pool_block)) to 
     *                   store some administrative info.
-    * @param callback   Cllback to be called when error occurs in the pool.
+    * @param alignment  the default alignment of memory block allocated
+    *                   from this pool (must be power of 2).
+    *                   A value of 0 should result in the pool being created 
+    *                   with alignment equal to PJ_POOL_ALIGNMENT.
+    * @param callback   Callback to be called when error occurs in the pool.
     *                   Note that when an error occurs during pool creation, 
     *                   the callback itself is not called. Instead, NULL 
     *                   will be returned.
@@ -698,6 +767,7 @@ struct pj_pool_factory
                                 const char *name,
                                 pj_size_t initial_size, 
                                 pj_size_t increment_size,
+                                pj_size_t alignment,
                                 pj_pool_callback *callback);
 
     /**
@@ -748,6 +818,7 @@ struct pj_pool_factory
  * @param name              Pool name.
  * @param initial_size      Initial size.
  * @param increment_size    Increment size.
+ * @param alignment         Pool alignment.
  * @param callback          Callback.
  * @return                  The pool object, or NULL.
  */
@@ -755,6 +826,7 @@ PJ_DECL(pj_pool_t*) pj_pool_create_int( pj_pool_factory *factory,
                                         const char *name,
                                         pj_size_t initial_size, 
                                         pj_size_t increment_size,
+                                        pj_size_t alignment,
                                         pj_pool_callback *callback);
 
 /**
@@ -762,11 +834,13 @@ PJ_DECL(pj_pool_t*) pj_pool_create_int( pj_pool_factory *factory,
  * @param pool              The pool.
  * @param name              Pool name.
  * @param increment_size    Increment size.
+ * @param alignment         Pool alignment.
  * @param callback          Callback function.
  */
 PJ_DECL(void) pj_pool_init_int( pj_pool_t *pool, 
                                 const char *name,
                                 pj_size_t increment_size,
+                                pj_size_t alignment,
                                 pj_pool_callback *callback);
 
 /**

--- a/pjlib/include/pj/pool_alt.h
+++ b/pjlib/include/pj/pool_alt.h
@@ -46,7 +46,7 @@ struct pj_pool_t
     char                obj_name[32];
     pj_size_t           used_size;
     pj_pool_callback   *cb;
-    size_t              alignment;
+    pj_size_t           alignment;
 };
 
 

--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -123,7 +123,7 @@ PJ_IDECL(pj_pool_t *) pj_pool_aligned_create(pj_pool_factory *f,
                                              const char *name,
                                              pj_size_t initial_size,
                                              pj_size_t increment_size,
-                                             size_t alignment,
+                                             pj_size_t alignment,
                                              pj_pool_callback *callback)
 {
     return (*f->create_pool)(f, name, initial_size, increment_size, alignment, callback);

--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -20,6 +20,8 @@
 
 #include <pj/string.h>
 
+#define ALIGN_PTR(PTR,ALIGNMENT)    (PTR + (-(pj_ssize_t)(PTR) & (ALIGNMENT-1)))
+
 
 PJ_IDEF(pj_size_t) pj_pool_get_capacity( pj_pool_t *pool )
 {
@@ -37,18 +39,19 @@ PJ_IDEF(pj_size_t) pj_pool_get_used_size( pj_pool_t *pool )
     return used_size;
 }
 
-PJ_IDEF(void*) pj_pool_alloc_from_block( pj_pool_block *block, pj_size_t size )
+PJ_IDEF(void*) pj_pool_alloc_from_block( pj_pool_block *block, pj_size_t alignment,
+                                         pj_size_t size )
 {
     /* The operation below is valid for size==0. 
      * When size==0, the function will return the pointer to the pool
      * memory address, but no memory will be allocated.
      */
-    if (size & (PJ_POOL_ALIGNMENT-1)) {
-        size = (size + PJ_POOL_ALIGNMENT) & ~(PJ_POOL_ALIGNMENT-1);
+    if (size & (alignment -1)) {
+        size = (size + alignment) & ~(alignment -1);
     }
-    if ((pj_size_t)(block->end - block->cur) >= size) {
-        void *ptr = block->cur;
-        block->cur += size;
+    unsigned char *ptr = ALIGN_PTR(block->cur, alignment);
+    if (ptr < block->end && (pj_size_t)(block->end - ptr) >= size) {
+        block->cur = ptr + size;
         return ptr;
     }
     return NULL;
@@ -56,9 +59,18 @@ PJ_IDEF(void*) pj_pool_alloc_from_block( pj_pool_block *block, pj_size_t size )
 
 PJ_IDEF(void*) pj_pool_alloc( pj_pool_t *pool, pj_size_t size)
 {
-    void *ptr = pj_pool_alloc_from_block(pool->block_list.next, size);
+    return pj_pool_aligned_alloc(pool, 0, size);
+}
+
+PJ_IDECL(void *) pj_pool_aligned_alloc(pj_pool_t *pool, pj_size_t alignment,
+                                       pj_size_t size)
+{
+    if (alignment < pool->alignment)
+        alignment = pool->alignment;
+    void *ptr = pj_pool_alloc_from_block(pool->block_list.next, 
+                                         alignment, size);
     if (!ptr)
-        ptr = pj_pool_allocate_find(pool, size);
+        ptr = pj_pool_allocate_find(pool, alignment, size);
     return ptr;
 }
 
@@ -82,7 +94,17 @@ PJ_IDEF(pj_pool_t*) pj_pool_create( pj_pool_factory *f,
                                     pj_size_t increment_size,
                                     pj_pool_callback *callback)
 {
-    return (*f->create_pool)(f, name, initial_size, increment_size, callback);
+    return pj_pool_aligned_create(f, name, initial_size, increment_size, 0, callback);
+}
+
+PJ_IDECL(pj_pool_t *) pj_pool_aligned_create(pj_pool_factory *f,
+                                             const char *name,
+                                             pj_size_t initial_size,
+                                             pj_size_t increment_size,
+                                             size_t alignment,
+                                             pj_pool_callback *callback)
+{
+    return (*f->create_pool)(f, name, initial_size, increment_size, alignment, callback);
 }
 
 PJ_IDEF(void) pj_pool_release( pj_pool_t *pool )

--- a/pjlib/src/pj/pool_buf.c
+++ b/pjlib/src/pj/pool_buf.c
@@ -105,6 +105,7 @@ PJ_DEF(pj_pool_t*) pj_pool_create_on_buf(const char *name,
     pj_thread_local_set(tls, &param);
 
     return pj_pool_create_int(&stack_based_factory, name, size, 0, 
+                              PJ_POOL_ALIGNMENT,
                               pj_pool_factory_default_policy.callback);
 #else
     PJ_UNUSED_ARG(buf);

--- a/pjlib/src/pj/pool_caching.c
+++ b/pjlib/src/pj/pool_caching.c
@@ -31,6 +31,7 @@ static pj_pool_t* cpool_create_pool(pj_pool_factory *pf,
                                     const char *name,
                                     pj_size_t initial_size, 
                                     pj_size_t increment_sz,
+                                    pj_size_t alignment,
                                     pj_pool_callback *callback);
 static void cpool_release_pool(pj_pool_factory *pf, pj_pool_t *pool);
 static void cpool_dump_status(pj_pool_factory *factory, pj_bool_t detail );
@@ -127,16 +128,18 @@ PJ_DEF(void) pj_caching_pool_destroy( pj_caching_pool *cp )
 }
 
 static pj_pool_t* cpool_create_pool(pj_pool_factory *pf, 
-                                              const char *name, 
-                                              pj_size_t initial_size, 
-                                              pj_size_t increment_sz, 
-                                              pj_pool_callback *callback)
+                                    const char *name, 
+                                    pj_size_t initial_size, 
+                                    pj_size_t increment_sz,
+                                    pj_size_t alignment,
+                                    pj_pool_callback *callback)
 {
     pj_caching_pool *cp = (pj_caching_pool*)pf;
     pj_pool_t *pool;
     int idx;
 
     PJ_CHECK_STACK();
+    PJ_UNUSED_ARG(alignment);
 
     pj_lock_acquire(cp->lock);
 
@@ -173,7 +176,7 @@ static pj_pool_t* cpool_create_pool(pj_pool_factory *pf,
 
         /* Create new pool */
         pool = pj_pool_create_int(&cp->factory, name, initial_size, 
-                                  increment_sz, callback);
+                                  increment_sz, alignment, callback);
         if (!pool) {
             pj_lock_release(cp->lock);
             return NULL;
@@ -185,7 +188,7 @@ static pj_pool_t* cpool_create_pool(pj_pool_factory *pf,
         pj_list_erase(pool);
 
         /* Initialize the pool. */
-        pj_pool_init_int(pool, name, increment_sz, callback);
+        pj_pool_init_int(pool, name, increment_sz, alignment, callback);
 
         /* Update pool manager's free capacity. */
         if (cp->capacity > pj_pool_get_capacity(pool)) {

--- a/pjlib/src/pj/pool_caching.c
+++ b/pjlib/src/pj/pool_caching.c
@@ -139,7 +139,6 @@ static pj_pool_t* cpool_create_pool(pj_pool_factory *pf,
     int idx;
 
     PJ_CHECK_STACK();
-    PJ_UNUSED_ARG(alignment);
 
     pj_lock_acquire(cp->lock);
 

--- a/pjlib/src/pjlib-test/pool.c
+++ b/pjlib/src/pjlib-test/pool.c
@@ -23,6 +23,8 @@
 #include <pj/except.h>
 #include "test.h"
 
+#define THIS_FILE "pool.c" 
+
 /**
  * \page page_pjlib_pool_test Test: Pool
  *
@@ -85,6 +87,7 @@ static int pool_alignment_test(void)
     void *ptr;
     enum { MEMSIZE = 64, LOOP = 100, POOL_ALIGNMENT_TEST = 4*PJ_POOL_ALIGNMENT };
     unsigned i;
+    int rc = 0;
 
     PJ_LOG(3,("test", "...alignment test"));
 
@@ -105,98 +108,44 @@ static int pool_alignment_test(void)
 
     for (i=0; i<LOOP; ++i) {
         /* Test first allocation */
-        if (i % 2)
-        {
+        if (i % 2) {
             ptr = pj_pool_aligned_alloc(pool, POOL_ALIGNMENT_TEST, 1);
-            if (!IS_ALIGNED2(ptr))
-            {
-                pj_pool_release(pool);
-                pj_pool_release(pool2);
-                return -312;
-            }
+            PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -310; goto on_return; });
+
             ptr = pj_pool_aligned_alloc(pool2, PJ_POOL_ALIGNMENT, 1);
-            if (!IS_ALIGNED2(ptr))
-            {
-                pj_pool_release(pool);
-                pj_pool_release(pool2);
-                return -313;
-            }
-        }
-        else
-        {
+            PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -312; goto on_return;});
+        } else {
             ptr = pj_pool_alloc(pool, 1);
-            if (!IS_ALIGNED(ptr))
-            {
-                pj_pool_release(pool);
-                pj_pool_release(pool2);
-                return -310;
-            }
+            PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, {rc = -314; goto on_return;});
             ptr = pj_pool_alloc(pool2, 1);
-            if (!IS_ALIGNED2(ptr))
-            {
-                pj_pool_release(pool);
-                pj_pool_release(pool2);
-                return -312;
-            }
+            PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -316; goto on_return; });
         }
 
         /* Test subsequent allocation */
         ptr = pj_pool_alloc(pool, 1);
-        if (!IS_ALIGNED(ptr)) {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -320;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, {rc = -320; goto on_return; });
+
         ptr = pj_pool_aligned_alloc(pool, POOL_ALIGNMENT_TEST, 1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -321;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -322; goto on_return;});
+
         ptr = pj_pool_alloc(pool2, 1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -322;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -324; goto on_return; });
+
         ptr = pj_pool_aligned_alloc(pool2, PJ_POOL_ALIGNMENT, 1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -323;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -328; goto on_return;});
 
         /* Test allocation after new block is created */
         ptr = pj_pool_alloc(pool, MEMSIZE*2+1);
-        if (!IS_ALIGNED(ptr)) {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -330;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, {rc = -330; goto on_return;});
+
         ptr = pj_pool_aligned_alloc(pool, POOL_ALIGNMENT_TEST, MEMSIZE*2+1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -331;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -332; goto on_return; });
+
         ptr = pj_pool_alloc(pool2, MEMSIZE*2+1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -332;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -334; goto on_return;});
+
         ptr = pj_pool_aligned_alloc(pool2, PJ_POOL_ALIGNMENT, MEMSIZE*2+1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            pj_pool_release(pool2);
-            return -333;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -336; goto on_return; });
 
         /* Reset the pool */
         pj_pool_reset(pool);
@@ -205,10 +154,11 @@ static int pool_alignment_test(void)
     }
 
     /* Done */
+on_return:
     pj_pool_release(pool);
     pj_pool_release(pool2);
+    return rc;
 
-    return 0;
 }
 
 /* Test that the alignment works for pool on buf. */
@@ -219,6 +169,7 @@ static int pool_buf_alignment_test(void)
     void *ptr;
     enum { LOOP = 100, POOL_ALIGNMENT_TEST = 4*PJ_POOL_ALIGNMENT};
     unsigned i;
+    int rc = 0;
 
     PJ_LOG(3,("test", "...pool_buf alignment test"));
 
@@ -228,44 +179,29 @@ static int pool_buf_alignment_test(void)
 
     for (i=0; i<LOOP; ++i) {
         /* Test first allocation */
-        if (i % 2)
-        {
+        if (i % 2) {
             ptr = pj_pool_aligned_alloc(pool, POOL_ALIGNMENT_TEST, 1);
-            if (!IS_ALIGNED2(ptr))
-            {
-                pj_pool_release(pool);
-                return -411;
-            }
-        }
-        else
-        {
+            PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -410; goto on_return; });
+        } else {
             ptr = pj_pool_alloc(pool, 1);
-            if (!IS_ALIGNED(ptr))
-            {
-                pj_pool_release(pool);
-                return -410;
-            }
+            PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, {rc = -415; goto on_return;});
         }
 
         /* Test subsequent allocation */
         ptr = pj_pool_alloc(pool, 1);
-        if (!IS_ALIGNED(ptr)) {
-            pj_pool_release(pool);
-            return -420;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, {rc = -420; goto on_return; });
+
         ptr = pj_pool_aligned_alloc(pool, POOL_ALIGNMENT_TEST, 1);
-        if (!IS_ALIGNED2(ptr))
-        {
-            pj_pool_release(pool);
-            return -421;
-        }
+        PJ_TEST_TRUE(IS_ALIGNED2(ptr), NULL, {rc = -425; goto on_return;});
 
         /* Reset the pool */
         pj_pool_reset(pool);
     }
 
     /* Done */
-    return 0;
+on_return:
+    pj_pool_release(pool);
+    return rc;
 }
 
 /* Test function to drain the pool's space. 
@@ -386,6 +322,18 @@ int pool_test(void)
     enum { LOOP = 2 };
     int loop;
     int rc;
+
+    int init_size = 50 + sizeof(pj_pool_t) + sizeof(pj_pool_block);
+    int pool_alignment = 4;
+    int huge_alignment = 256;
+    int inc_size = 50;
+    void *ptr;
+
+    pj_pool_t *pool = pj_pool_aligned_create(mem, NULL, init_size, inc_size, pool_alignment,
+                                             &null_callback);
+    ptr = pj_pool_aligned_alloc(pool, huge_alignment, 1);
+    pj_pool_release(pool);
+    PJ_TEST_NOT_NULL(ptr, NULL, return -220);
 
     rc = capacity_test();
     if (rc) return rc;

--- a/pjlib/src/pjlib-test/pool.c
+++ b/pjlib/src/pjlib-test/pool.c
@@ -305,11 +305,12 @@ static int pool_buf_test(void)
 int pool_test(void)
 {
     enum { LOOP = 2 };
-    int loop;
     int rc;
 
+#if PJ_HAS_POOL_ALT_API == 0
     rc = capacity_test();
     if (rc) return rc;
+#endif  //PJ_HAS_POOL_ALT_API == 0
 
     rc = pool_alignment_test();
     if (rc) return rc;
@@ -317,6 +318,8 @@ int pool_test(void)
     rc = pool_buf_alignment_test();
     if (rc) return rc;
 
+#if PJ_HAS_POOL_ALT_API == 0
+    int loop;
     for (loop=0; loop<LOOP; ++loop) {
         /* Test that the pool should grow automaticly. */
         rc = drain_test(SIZE, SIZE);
@@ -332,6 +335,7 @@ int pool_test(void)
     rc = pool_buf_test();
     if (rc != 0)
         return rc;
+#endif  //PJ_HAS_POOL_ALT_API == 0
 
 
     return 0;


### PR DESCRIPTION
Currently pjsip library supports only global (library level) memory allocation alignment control.
This PR introduce more granular control of this process. 
```c
PJ_IDECL(pj_pool_t*) pj_pool_aligned_create(pj_pool_factory *factory,
                                            const char *name,
                                            pj_size_t initial_size,
                                            pj_size_t increment_size,
                                            pj_size_t alignment,
                                            pj_pool_callback *callback);

``` 
This feature allows to set the default alignment for all subsequent allocations from the pool created here. 
The actual allocation alignment will be at least equal to the alignment argument of the function, but not less than PJ_POOL_ALIGNMENT. (Pool created by pj_pool_create() has the default alignment equal to  PJ_POOL_ALIGNMENT.)

The second API allow to control the alignment of memory allocated by the current allocation request:
```c
PJ_IDECL(void *) pj_pool_aligned_alloc(pj_pool_t *pool, pj_size_t alignment,
                                       pj_size_t size);
``` 
The actual alignment of the allocation will be at least equal to the alignment argument of the function, but not less than the default pool alignment specified when the pool was created.