### PR TITLE
Fix build error when PJ_LOG_MAX_LEVEL is zero

### DIFF
--- a/pjlib/include/pj/log.h
+++ b/pjlib/include/pj/log.h
@@ -274,6 +274,13 @@ pj_status_t pj_log_init(void);
 #  define pj_log_set_log_func(func)
 
 /**
+ * Get the current log output function that is used to write log messages.
+ *
+ * @return          Current log output function.
+ */
+#  define pj_log_get_log_func() NULL
+
+/**
  * Write to log.
  *
  * @param sender    Source of the message.

--- a/pjlib/src/pj/unittest.c
+++ b/pjlib/src/pj/unittest.c
@@ -31,6 +31,9 @@ static long tls_id = INVALID_TLS_ID;
 /* When basic runner is used, current test is saved in this global var */
 static pj_test_case *tc_main_thread;
 
+/* Is unit test running */
+static pj_bool_t is_under_test;
+
 /* Forward decls. */
 static void unittest_log_callback(int level, const char *data, int len);
 static int get_completion_line( const pj_test_case *tc, const char *end_line,
@@ -227,9 +230,11 @@ PJ_DEF(void) pj_test_run(pj_test_runner *runner, pj_test_suite *suite)
     }
 
     /* Call the run method to perform runner specific loop */
+    is_under_test = PJ_TRUE;
     pj_get_timestamp(&suite->start_time);
     runner->main(runner);
     pj_get_timestamp(&suite->end_time);
+    is_under_test = PJ_FALSE;
 
     /* Restore logging */
     pj_log_set_log_func(runner->orig_log_writer);
@@ -238,7 +243,10 @@ PJ_DEF(void) pj_test_run(pj_test_runner *runner, pj_test_suite *suite)
 /* Check if we are under test */
 PJ_DEF(pj_bool_t) pj_test_is_under_test(void)
 {
-    return pj_log_get_log_func()==&unittest_log_callback;
+    // Cannot use pj_log_get_log_func() when PJ_LOG_MAX_LEVEL is 0.
+    //return pj_log_get_log_func()==&unittest_log_callback;
+
+    return is_under_test;
 }
 
 /* Calculate statistics */


### PR DESCRIPTION
The `pj_log_get_log_func()` is not defined when `PJ_LOG_MAX_LEVEL` is set to zero.

Thanks to Giorgio Alfarano for the report.