### PR TITLE
Best effort avoid crash when media transport adapter not using group lock

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -3168,6 +3168,12 @@ PJ_DEF(pj_status_t) pjmedia_stream_destroy( pjmedia_stream *stream )
 
     PJ_LOG(4,(stream->port.info.name.ptr, "Stream destroying"));
 
+    /* Stop the streaming */
+    if (stream->enc)
+        stream->port.put_frame = NULL;
+    if (stream->dec)
+        stream->port.get_frame = NULL;
+
     /* Send RTCP BYE (also SDES & XR) */
     if (stream->transport && !stream->rtcp_sdes_bye_disabled) {
 #if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)


### PR DESCRIPTION
Due to asynchronous conference (#3928), port may still be accessed after removed from bridge. A media transport adapter may be destroyed immediately after port removal and when it is still being accessed after that, crash will occur. Or as the stream is "disconnected" from the underlying transport by the adapter, the stream cannot sync the destroy timing with the transport (i.e: cannot add/dec ref to the transport). This PR tries to maintain link of the stream to the underlying transport of a media transport adapter.

Also in this PR, try to stop streaming when stream destroy is invoked (for audio stream, video stream has already done it).