### PR TITLE
Fixed warnings in sip auth client

### DIFF
--- a/pjsip/include/pjsip/sip_auth.h
+++ b/pjsip/include/pjsip/sip_auth.h
@@ -618,7 +618,7 @@ PJ_DECL(pj_status_t) pjsip_auth_srv_init( pj_pool_t *pool,
  * @return              PJ_SUCCESS on success.
  */
 PJ_DECL(pj_status_t) pjsip_auth_clt_set_parent(pjsip_auth_clt_sess *sess,
-                                               const pjsip_auth_clt_sess *p);
+                                               pjsip_auth_clt_sess *p);
 
 /**
  * This structure describes initialization settings of server authorization


### PR DESCRIPTION
Fix Coverity and build warnings in sip_auth_client:
```
../src/pjsip/sip_auth_client.c:730:15: warning: unused variable 'with_parent' [-Wunused-variable]
  730 |     pj_bool_t with_parent = PJ_FALSE;
../src/pjsip/sip_auth_client.c:763:15: warning: unused variable 'with_parent' [-Wunused-variable]
  763 |     pj_bool_t with_parent = PJ_FALSE;
../src/pjsip/sip_auth_client.c:849:18: warning: assigning to 'struct pjsip_auth_clt_sess *' from 'const pjsip_auth_clt_sess *' (aka 'const struct pjsip_auth_clt_sess *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  849 |     sess->parent = parent;
../src/pjsip/sip_auth_client.c:910:9: warning: variable 'status' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
../src/pjsip/sip_auth_client.c:920:9: note: uninitialized use occurs here
  920 |     if (status != PJ_SUCCESS) {
```

Coverity warning:
- Unchecked return value of `pj_lock_create_simple_mutex()`
- Uninitialized `status` (same as above).
