### PR TITLE
Fixed issue with SDP version when reoffer is rejected

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1940,15 +1940,18 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_cancel_offer(pjmedia_sdp_neg *neg)
                      neg->state == PJMEDIA_SDP_NEG_STATE_REMOTE_OFFER,
                      PJMEDIA_SDPNEG_EINSTATE);
 
-    // No longer needed after #3322.
-    if (0 && neg->state == PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER &&
+    if (neg->state == PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER &&
         neg->active_local_sdp) 
     {
         /* Increment next version number. This happens if for example
          * the reinvite offer is rejected by 488. If we don't increment
          * the version here, the next offer will have the same version.
          */
-        neg->active_local_sdp->origin.version++;
+        // No longer needed after #3322.
+        // neg->active_local_sdp->origin.version++;
+
+        /* Revert last sent SDP. */
+        neg->last_sent = neg->active_local_sdp;
     }
 
     /* Revert back initial SDP */


### PR DESCRIPTION
History:
- We #3322
- Then in #3393, the origin version is no longer incremented when the reoffer is rejected, but we need to revert the `last_sent` as well, otherwise the `last_sent` will contain the rejected reoffer.

Sipp script to test the scenario is available in `scripts-sipp/uas-reinv-after-failed-nego.xml`.
