### PR TITLE
Add missing OnTimerParam import in Android Example

### DIFF
--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -52,6 +52,7 @@ import org.pjsip.pjsua2.BuddyConfig;
 import org.pjsip.pjsua2.CallInfo;
 import org.pjsip.pjsua2.CallOpParam;
 import org.pjsip.pjsua2.OnCallMediaEventParam;
+import org.pjsip.pjsua2.OnTimerParam;
 import org.pjsip.pjsua2.StringVector;
 import org.pjsip.pjsua2.pjsip_inv_state;
 import org.pjsip.pjsua2.pjsip_status_code;


### PR DESCRIPTION
When following the example and trying to compile the project I noticed that it is missing an import statement. This PR is simply adding the import.