### PR TITLE
Audio and video stream refactoring

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -641,7 +641,7 @@
 #endif
 
 /**
- * Perform RTP payload type checking in the audio stream. Normally the peer
+ * Perform RTP payload type checking in the media stream. Normally the peer
  * MUST send RTP with payload type as we specified in our SDP. Certain
  * agents may not be able to follow this hence the only way to have
  * communication is to disable this check.
@@ -1706,11 +1706,17 @@
  * agents may not be able to follow this hence the only way to have
  * communication is to disable this check.
  *
- * Default: PJMEDIA_STREAM_CHECK_RTP_PT (follow audio stream's setting)
+ * Note: Since media streams now share some common implementation,
+ * the setting MUST have the same value as PJMEDIA_STREAM_CHECK_RTP_PT.
  */
-#ifndef PJMEDIA_VID_STREAM_CHECK_RTP_PT
-#   define PJMEDIA_VID_STREAM_CHECK_RTP_PT      PJMEDIA_STREAM_CHECK_RTP_PT
+#if defined(PJMEDIA_VID_STREAM_CHECK_RTP_PT) && \
+    PJMEDIA_VID_STREAM_CHECK_RTP_PT != PJMEDIA_STREAM_CHECK_RTP_PT
+#    pragma message("PJMEDIA_VID_STREAM_CHECK_RTP_PT must have the same " \
+                    "value as PJMEDIA_STREAM_CHECK_RTP_PT...")
 #endif
+
+#undef PJMEDIA_VID_STREAM_CHECK_RTP_PT
+#define PJMEDIA_VID_STREAM_CHECK_RTP_PT      PJMEDIA_STREAM_CHECK_RTP_PT
 
 /**
  * @}

--- a/pjmedia/include/pjmedia/stream.h
+++ b/pjmedia/include/pjmedia/stream.h
@@ -78,79 +78,20 @@ PJ_BEGIN_DECL
  */
 
 /**
- * Opaque declaration for media channel.
- * Media channel is unidirectional flow of media from sender to
- * receiver.
- */
-typedef struct pjmedia_channel pjmedia_channel;
-
-/**
- * This structure describes media stream information. Each media stream
+ * This structure describes audio stream information. Each audio stream
  * corresponds to one "m=" line in SDP session descriptor, and it has
  * its own RTP/RTCP socket pair.
  */
 typedef struct pjmedia_stream_info
 {
-    pjmedia_type        type;       /**< Media type (audio, video)          */
-    pjmedia_tp_proto    proto;      /**< Transport protocol (RTP/AVP, etc.) */
-    pjmedia_dir         dir;        /**< Media direction.                   */
-    pj_sockaddr         local_addr; /**< Local RTP address                  */
-    pj_sockaddr         rem_addr;   /**< Remote RTP address                 */
-    pj_sockaddr         rem_rtcp;   /**< Optional remote RTCP address. If
-                                         sin_family is zero, the RTP address
-                                         will be calculated from RTP.       */
-    pj_bool_t           rtcp_mux;   /**< Use RTP and RTCP multiplexing.     */
-#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
-    pj_bool_t           rtcp_xr_enabled;
-                                    /**< Specify whether RTCP XR is enabled.*/
-    pj_uint32_t         rtcp_xr_interval; /**< RTCP XR interval.            */
-    pj_sockaddr         rtcp_xr_dest;/**<Additional remote RTCP XR address.
-                                         This is useful for third-party (e.g:
-                                         network monitor) to monitor the 
-                                         stream. If sin_family is zero, 
-                                         this will be ignored.              */
-#endif
-    pjmedia_rtcp_fb_info loc_rtcp_fb; /**< Local RTCP-FB info.              */
-    pjmedia_rtcp_fb_info rem_rtcp_fb; /**< Remote RTCP-FB info.             */
+    PJ_DECL_STREAM_INFO_COMMON_MEMBER()
+
     pjmedia_codec_info  fmt;        /**< Incoming codec format info.        */
     pjmedia_codec_param *param;     /**< Optional codec param.              */
-    unsigned            tx_pt;      /**< Outgoing codec paylaod type.       */
-    unsigned            rx_pt;      /**< Incoming codec paylaod type.       */
+
     unsigned            tx_maxptime;/**< Outgoing codec max ptime.          */
     int                 tx_event_pt;/**< Outgoing pt for telephone-events.  */
     int                 rx_event_pt;/**< Incoming pt for telephone-events.  */
-    pj_uint32_t         ssrc;       /**< RTP SSRC.                          */
-    pj_str_t            cname;      /**< RTCP CNAME.                        */
-    pj_bool_t           has_rem_ssrc;/**<Has remote RTP SSRC?               */
-    pj_uint32_t         rem_ssrc;   /**< Remote RTP SSRC.                   */
-    pj_str_t            rem_cname;  /**< Remote RTCP CNAME.                 */
-    pj_uint32_t         rtp_ts;     /**< Initial RTP timestamp.             */
-    pj_uint16_t         rtp_seq;    /**< Initial RTP sequence number.       */
-    pj_uint8_t          rtp_seq_ts_set;
-                                    /**< Bitmask flags if initial RTP sequence 
-                                         and/or timestamp for sender are set.
-                                         bit 0/LSB : sequence flag 
-                                         bit 1     : timestamp flag         */
-    int                 jb_init;    /**< Jitter buffer init delay in msec.  
-                                         (-1 for default).                  */
-    int                 jb_min_pre; /**< Jitter buffer minimum prefetch
-                                         delay in msec (-1 for default).    */
-    int                 jb_max_pre; /**< Jitter buffer maximum prefetch
-                                         delay in msec (-1 for default).    */
-    int                 jb_max;     /**< Jitter buffer max delay in msec.   */
-    pjmedia_jb_discard_algo jb_discard_algo;
-                                    /**< Jitter buffer discard algorithm.   */
-
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
-    pj_bool_t           use_ka;     /**< Stream keep-alive and NAT hole punch
-                                         (see #PJMEDIA_STREAM_ENABLE_KA)
-                                         is enabled?                        */
-    pjmedia_stream_ka_config ka_cfg;
-                                    /**< Stream send kep-alive settings.    */
-#endif
-    pj_bool_t           rtcp_sdes_bye_disabled; 
-                                    /**< Disable automatic sending of RTCP
-                                         SDES and BYE.                      */
 } pjmedia_stream_info;
 
 /**

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -25,12 +25,152 @@
  */
 
 #include <pjmedia/codec.h>
+#include <pjmedia/jbuf.h>
 #include <pjmedia/sdp.h>
 #include <pjmedia/rtp.h>
 #include <pjmedia/rtcp.h>
+#include <pjmedia/transport.h>
 
 
 PJ_BEGIN_DECL
+
+/*****************************************************************************
+ *
+ * COMMON MEDIA STREAM
+ *
+ *****************************************************************************/
+
+/* Tracing jitter buffer operations in a stream session to a CSV file.
+ * The trace will contain JB operation timestamp, frame info, RTP info, and
+ * the JB state right after the operation.
+ */
+#define PJMEDIA_STREAM_TRACE_JB     0
+
+/* Forward declarations. */
+typedef struct pjmedia_stream_info_common pjmedia_stream_info_common;
+typedef struct pjmedia_channel pjmedia_channel;
+
+/**
+ * This structure describes media stream.
+ * A media stream is bidirectional media transmission between two endpoints.
+ * It consists of two channels, i.e. encoding and decoding channels.
+ * A media stream corresponds to a single "m=" line in a SDP session
+ * description.
+ */
+typedef struct pjmedia_stream_common
+{
+    pjmedia_endpt           *endpt;         /**< Media endpoint.            */
+    pj_grp_lock_t           *grp_lock;      /**< Group lock.                */
+    pjmedia_stream_info_common *si;         /**< Creation parameter.        */
+    pjmedia_port             port;          /**< Port interface.            */
+    pjmedia_channel         *enc;           /**< Encoding channel.          */
+    pjmedia_channel         *dec;           /**< Decoding channel.          */
+    pj_pool_t               *own_pool;      /**< Only created if not given  */
+
+    pjmedia_dir              dir;           /**< Stream direction.          */
+    void                    *user_data;     /**< User data.                 */
+    pj_str_t                 name;          /**< Stream name                */
+    pj_str_t                 cname;         /**< SDES CNAME                 */
+
+    pjmedia_transport       *transport;     /**< Stream transport.          */
+
+    pj_int16_t              *enc_buf;       /**< Encoding buffer, when enc's
+                                                 ptime is different than dec.
+                                                 Otherwise it's NULL.       */
+
+    unsigned                 frame_size;    /**< Size of encoded base frame.*/
+
+    pj_mutex_t              *jb_mutex;
+    pjmedia_jbuf            *jb;            /**< Jitter buffer.             */
+    char                     jb_last_frm;   /**< Last frame type from jb    */
+    unsigned                 jb_last_frm_cnt;/**< Last JB frame type counter*/
+
+    pjmedia_rtcp_session     rtcp;          /**< RTCP for incoming RTP.     */
+
+    pj_uint32_t              rtcp_last_tx;  /**< RTCP tx time in timestamp  */
+    pj_timestamp             rtcp_fb_last_tx;/**< Last RTCP-FB tx time.     */
+    pj_uint32_t              rtcp_interval; /**< Interval, in timestamp.    */
+    pj_bool_t                initial_rr;    /**< Initial RTCP RR sent       */
+    pj_bool_t                rtcp_sdes_bye_disabled;/**< Send RTCP SDES/BYE?*/
+    void                    *out_rtcp_pkt;  /**< Outgoing RTCP packet.      */
+    unsigned                 out_rtcp_pkt_size;
+                                            /**< Outgoing RTCP packet size. */
+
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    pj_uint32_t              rtcp_xr_last_tx;  /**< RTCP XR tx time
+                                                    in timestamp.           */
+    pj_uint32_t              rtcp_xr_interval; /**< Interval, in timestamp. */
+    pj_sockaddr              rtcp_xr_dest;     /**< Additional remote RTCP XR
+                                                    dest. If sin_family is
+                                                    zero, it will be ignored*/
+    unsigned                 rtcp_xr_dest_len; /**< Length of RTCP XR dest
+                                                    address                 */
+#endif
+
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
+    pj_bool_t                use_ka;           /**< Stream keep-alive with non-
+                                                    codec-VAD mechanism is
+                                                    enabled?                */
+    unsigned                 ka_interval;      /**< The keepalive sending
+                                                    interval                */
+    pj_time_val              last_frm_ts_sent; /**< Time of last sending
+                                                    packet                  */
+    unsigned                 start_ka_count;   /**< The number of keep-alive
+                                                    to be sent after it is
+                                                    created                 */
+    unsigned                 start_ka_interval;/**< The keepalive sending
+                                                    interval after the stream
+                                                    is created              */
+    pj_timestamp             last_start_ka_tx; /**< Timestamp of the last
+                                                    keepalive sent          */
+#endif
+
+    pj_sockaddr              rem_rtp_addr;     /**< Remote RTP address      */
+    unsigned                 rem_rtp_flag;     /**< Indicator flag about
+                                                    packet from this addr.
+                                                    0=no pkt, 1=good ssrc,
+                                                    2=bad ssrc pkts         */
+    pj_sockaddr              rtp_src_addr;     /**< Actual packet src addr.    */
+    unsigned                 rtp_src_cnt;      /**< How many pkt from
+                                                    this addr.              */
+
+#if defined(PJMEDIA_STREAM_TRACE_JB) && PJMEDIA_STREAM_TRACE_JB != 0
+    pj_oshandle_t            trace_jb_fd;      /**< Jitter tracing file handle.*/
+    char                    *trace_jb_buf;     /**< Jitter tracing buffer.     */
+#endif
+
+    pj_uint32_t              rtp_rx_last_ts;        /**< Last received RTP
+                                                         timestamp          */
+    pj_uint32_t              rtp_tx_err_cnt;        /**< The number of RTP
+                                                         send() error       */
+    pj_uint32_t              rtcp_tx_err_cnt;       /**< The number of RTCP
+                                                         send() error       */
+
+    /* RTCP Feedback */
+    pj_bool_t                send_rtcp_fb_nack;     /**< Send NACK?         */
+    int                      pending_rtcp_fb_nack;  /**< Any pending NACK?  */
+    pjmedia_rtcp_fb_nack     rtcp_fb_nack;          /**< TX NACK state.     */
+    int                      rtcp_fb_nack_cap_idx;  /**< RX NACK cap idx.   */
+} pjmedia_stream_common;
+
+
+/**
+ * Media channel.
+ * Media channel is unidirectional flow of media from sender to
+ * receiver.
+ */
+typedef struct pjmedia_channel
+{
+    pjmedia_stream_common  *stream;         /**< Parent stream.             */
+    pjmedia_dir             dir;            /**< Channel direction.         */
+    pjmedia_port            port;           /**< Port interface.            */
+    unsigned                pt;             /**< Payload type.              */
+    pj_bool_t               paused;         /**< Paused?.                   */
+    void                   *buf;            /**< Output buffer.             */
+    unsigned                buf_size;       /**< Size of output buffer.     */
+    pjmedia_rtp_session     rtp;            /**< RTP session.               */
+} pjmedia_channel;
+
 
 /**
  * This structure describes rtp/rtcp session information of the media stream.
@@ -53,6 +193,89 @@ typedef struct pjmedia_stream_rtp_sess_info
     const pjmedia_rtcp_session *rtcp;
 
 } pjmedia_stream_rtp_sess_info;
+
+
+/**
+ * Get the stream statistics. See also
+ * #pjmedia_stream_get_stat_jbuf()
+ *
+ * @param stream        The media stream.
+ * @param stat          Media stream statistics.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_common_get_stat( const pjmedia_stream_common *stream,
+                                pjmedia_rtcp_stat *stat);
+
+
+/**
+ * Reset the stream statistics.
+ *
+ * @param stream        The media stream.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_common_reset_stat(pjmedia_stream_common *stream);
+
+
+/**
+ * Send RTCP SDES for the media stream.
+ *
+ * @param stream        The media stream.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) 
+pjmedia_stream_common_send_rtcp_sdes( pjmedia_stream_common *stream );
+
+/**
+ * Send RTCP BYE for the media stream.
+ *
+ * @param stream        The media stream.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_common_send_rtcp_bye( pjmedia_stream_common *stream );
+
+
+/**
+ * Get the RTP session information of the media stream. This function can be
+ * useful for app with custom media transport to inject/filter some
+ * outgoing/incoming proprietary packets into normal audio RTP traffics.
+ * This will return the original pointer to the internal states of the stream,
+ * and generally it is not advisable for app to modify them.
+ *
+ * @param stream        The media stream.
+ *
+ * @param session_info  The stream session info.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_common_get_rtp_session_info(pjmedia_stream_common *stream,
+                                   pjmedia_stream_rtp_sess_info *session_info);
+
+
+/* Internal function. */
+
+/* Internal:  * Send RTCP SDES for the media stream. */
+pj_status_t pjmedia_stream_send_rtcp(pjmedia_stream_common *c_strm,
+                                     pj_bool_t with_sdes,
+                                     pj_bool_t with_bye,
+                                     pj_bool_t with_xr,
+                                     pj_bool_t with_fb,
+                                     pj_bool_t with_fb_nack,
+                                     pj_bool_t with_fb_pli);
+
+
+/*****************************************************************************
+ *
+ * COMMON MEDIA STREAM INFORMATION
+ *
+ *****************************************************************************/
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
 
@@ -95,7 +318,110 @@ typedef struct pjmedia_stream_ka_config
 PJ_DECL(void)
 pjmedia_stream_ka_config_default(pjmedia_stream_ka_config *cfg);
 
+#define PJ_DECL_STREAM_INFO_KA_MEMBER() \
+    pj_bool_t           use_ka;     /**< Stream keep-alive and NAT hole punch \
+                                         (see #PJMEDIA_STREAM_ENABLE_KA) \
+                                         is enabled?                        */ \
+    pjmedia_stream_ka_config ka_cfg; \
+                                    /**< Stream send kep-alive settings.    */ \
+
+#else
+
+#define PJ_DECL_STREAM_INFO_KA_MEMBER()
+
 #endif
+
+
+/**
+ * This structure describes the common media stream information.
+ */
+#define PJ_DECL_STREAM_INFO_COMMON_MEMBER() \
+    pjmedia_type        type;       /**< Media type (audio, video)          */ \
+    pjmedia_tp_proto    proto;      /**< Transport protocol (RTP/AVP, etc.) */ \
+    pjmedia_dir         dir;        /**< Media direction.                   */ \
+    pj_sockaddr         local_addr; /**< Local RTP address                  */ \
+    pj_sockaddr         rem_addr;   /**< Remote RTP address                 */ \
+    pj_sockaddr         rem_rtcp;   /**< Optional remote RTCP address. If \
+                                         sin_family is zero, the RTP address \
+                                         will be calculated from RTP.       */ \
+    pj_bool_t           rtcp_mux;   /**< Use RTP and RTCP multiplexing.     */ \
+\
+    pj_bool_t           rtcp_xr_enabled; \
+                                    /**< Specify whether RTCP XR is enabled.*/ \
+    pj_uint32_t         rtcp_xr_interval; /**< RTCP XR interval.            */ \
+    pj_sockaddr         rtcp_xr_dest;/**<Additional remote RTCP XR address. \
+                                         This is useful for third-party (e.g: \
+                                         network monitor) to monitor the \
+                                         stream. If sin_family is zero, \
+                                         this will be ignored.              */ \
+\
+    pjmedia_rtcp_fb_info loc_rtcp_fb; /**< Local RTCP-FB info.              */ \
+    pjmedia_rtcp_fb_info rem_rtcp_fb; /**< Remote RTCP-FB info.             */ \
+\
+    unsigned            tx_pt;      /**< Outgoing codec payload type.       */ \
+    unsigned            rx_pt;      /**< Incoming codec payload type.       */ \
+\
+    pj_uint32_t         ssrc;       /**< RTP SSRC.                          */ \
+    pj_str_t            cname;      /**< RTCP CNAME.                        */ \
+    pj_bool_t           has_rem_ssrc;/**<Has remote RTP SSRC?               */ \
+    pj_uint32_t         rem_ssrc;   /**< Remote RTP SSRC.                   */ \
+    pj_str_t            rem_cname;  /**< Remote RTCP CNAME.                 */ \
+    pj_uint32_t         rtp_ts;     /**< Initial RTP timestamp.             */ \
+    pj_uint16_t         rtp_seq;    /**< Initial RTP sequence number.       */ \
+    pj_uint8_t          rtp_seq_ts_set; \
+                                    /**< Bitmask flags if initial RTP sequence \
+                                         and/or timestamp for sender are set. \
+                                         bit 0/LSB : sequence flag  \
+                                         bit 1     : timestamp flag         */ \
+    int                 jb_init;    /**< Jitter buffer init delay in msec. \
+                                         (-1 for default).                  */ \
+    int                 jb_min_pre; /**< Jitter buffer minimum prefetch \
+                                         delay in msec (-1 for default).    */ \
+    int                 jb_max_pre; /**< Jitter buffer maximum prefetch \
+                                         delay in msec (-1 for default).    */ \
+    int                 jb_max;     /**< Jitter buffer max delay in msec.   */ \
+    pjmedia_jb_discard_algo jb_discard_algo; \
+                                    /**< Jitter buffer discard algorithm.   */ \
+\
+    PJ_DECL_STREAM_INFO_KA_MEMBER() \
+\
+    pj_bool_t           rtcp_sdes_bye_disabled; \
+                                    /**< Disable automatic sending of RTCP \
+                                         SDES and BYE.                      */ \
+
+
+/**
+ * This structure describes media stream information. Each media stream
+ * corresponds to one "m=" line in SDP session descriptor, and it has
+ * its own RTP/RTCP socket pair.
+ */
+typedef struct pjmedia_stream_info_common
+{
+    PJ_DECL_STREAM_INFO_COMMON_MEMBER()
+} pjmedia_stream_info_common;
+
+
+/**
+ * This function will initialize the stream info based on information
+ * in both SDP session descriptors for the specified stream index.
+ *
+ * @param si            Stream info structure to be initialized.
+ * @param pool          Pool to allocate memory.
+ * @param endpt         PJMEDIA endpoint instance.
+ * @param local         Local SDP session descriptor.
+ * @param remote        Remote SDP session descriptor.
+ * @param stream_idx    Media stream index in the session descriptor.
+ *
+ * @return              PJ_SUCCESS if stream info is successfully initialized.
+ */
+PJ_DECL(pj_status_t)
+pjmedia_stream_info_common_from_sdp(pjmedia_stream_info_common *si,
+                                    pj_pool_t *pool,
+                                    pjmedia_endpt *endpt,
+                                    const pjmedia_sdp_session *local,
+                                    const pjmedia_sdp_session *remote,
+                                    unsigned stream_idx);
+
 
 /**
  * This is internal function for parsing SDP format parameter of specific

--- a/pjmedia/include/pjmedia/stream_common.h
+++ b/pjmedia/include/pjmedia/stream_common.h
@@ -411,6 +411,8 @@ typedef struct pjmedia_stream_info_common
  * @param local         Local SDP session descriptor.
  * @param remote        Remote SDP session descriptor.
  * @param stream_idx    Media stream index in the session descriptor.
+ * @param active        Output parameter to indicate whether the stream is
+ *                      active.
  *
  * @return              PJ_SUCCESS if stream info is successfully initialized.
  */
@@ -420,7 +422,8 @@ pjmedia_stream_info_common_from_sdp(pjmedia_stream_info_common *si,
                                     pjmedia_endpt *endpt,
                                     const pjmedia_sdp_session *local,
                                     const pjmedia_sdp_session *remote,
-                                    unsigned stream_idx);
+                                    unsigned stream_idx,
+                                    pj_bool_t *active);
 
 
 /**

--- a/pjmedia/include/pjmedia/vid_stream.h
+++ b/pjmedia/include/pjmedia/vid_stream.h
@@ -148,53 +148,10 @@ typedef struct pjmedia_vid_stream_sk_config
  */
 typedef struct pjmedia_vid_stream_info
 {
-    pjmedia_type        type;       /**< Media type (audio, video)          */
-    pjmedia_tp_proto    proto;      /**< Transport protocol (RTP/AVP, etc.) */
-    pjmedia_dir         dir;        /**< Media direction.                   */
-    pj_sockaddr         local_addr; /**< Local RTP address                  */
-    pj_sockaddr         rem_addr;   /**< Remote RTP address                 */
-    pj_sockaddr         rem_rtcp;   /**< Optional remote RTCP address. If
-                                         sin_family is zero, the RTP address
-                                         will be calculated from RTP.       */
-    pj_bool_t           rtcp_mux;   /**< Use RTP and RTCP multiplexing.     */
-    pjmedia_rtcp_fb_info loc_rtcp_fb; /**< Local RTCP-FB info.              */
-    pjmedia_rtcp_fb_info rem_rtcp_fb; /**< Remote RTCP-FB info.             */
-    unsigned            tx_pt;      /**< Outgoing codec paylaod type.       */
-    unsigned            rx_pt;      /**< Incoming codec paylaod type.       */
-    pj_uint32_t         ssrc;       /**< RTP SSRC.                          */
-    pj_str_t            cname;      /**< RTCP CNAME.                        */
-    pj_bool_t           has_rem_ssrc;/**<Has remote RTP SSRC?               */
-    pj_uint32_t         rem_ssrc;   /**< Remote RTP SSRC.                   */
-    pj_str_t            rem_cname;  /**< Remote RTCP CNAME.                 */
-    pj_uint32_t         rtp_ts;     /**< Initial RTP timestamp.             */
-    pj_uint16_t         rtp_seq;    /**< Initial RTP sequence number.       */
-    pj_uint8_t          rtp_seq_ts_set;
-                                    /**< Bitmask flags if initial RTP sequence 
-                                         and/or timestamp for sender are set.
-                                         bit 0/LSB : sequence flag 
-                                         bit 1     : timestamp flag         */
-    int                 jb_init;    /**< Jitter buffer init delay in msec.  
-                                         (-1 for default).                  */
-    int                 jb_min_pre; /**< Jitter buffer minimum prefetch
-                                         delay in msec (-1 for default).    */
-    int                 jb_max_pre; /**< Jitter buffer maximum prefetch
-                                         delay in msec (-1 for default).    */
-    int                 jb_max;     /**< Jitter buffer max delay in msec.   */
-
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
-    pj_bool_t           use_ka;     /**< Stream keep-alive and NAT hole punch
-                                         (see #PJMEDIA_STREAM_ENABLE_KA)
-                                         is enabled?                        */
-    pjmedia_stream_ka_config ka_cfg;
-                                    /**< Stream send kep-alive settings.    */
-#endif
+    PJ_DECL_STREAM_INFO_COMMON_MEMBER()
 
     pjmedia_vid_codec_info   codec_info;  /**< Incoming codec format info.  */
     pjmedia_vid_codec_param *codec_param; /**< Optional codec param.        */
-
-    pj_bool_t           rtcp_sdes_bye_disabled; 
-                                    /**< Disable automatic sending of RTCP
-                                         SDES and BYE.                      */
 
     pjmedia_vid_stream_rc_config rc_cfg;
                                     /**< Stream send rate control settings. */

--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -16,9 +16,277 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
  */
 #include <pjmedia/stream_common.h>
+#include <pjmedia/errno.h>
 #include <pj/log.h>
+#include <pj/rand.h>
 
 #define THIS_FILE       "stream_common.c"
+
+#define LOGERR_(expr)                   PJ_PERROR(4,expr);
+
+/*  Number of send error before repeat the report. */
+#define SEND_ERR_COUNT_TO_REPORT        50
+
+static const pj_str_t ID_IN = { "IN", 2 };
+static const pj_str_t ID_IP4 = { "IP4", 3};
+static const pj_str_t ID_IP6 = { "IP6", 3};
+
+/*
+ * Create stream info from SDP media line.
+ */
+PJ_DEF(pj_status_t) pjmedia_stream_info_common_from_sdp(
+                                           pjmedia_stream_info_common *si,
+                                           pj_pool_t *pool,
+                                           pjmedia_endpt *endpt,
+                                           const pjmedia_sdp_session *local,
+                                           const pjmedia_sdp_session *remote,
+                                           unsigned stream_idx)
+{
+    const pj_str_t STR_INACTIVE = { "inactive", 8 };
+    const pj_str_t STR_SENDONLY = { "sendonly", 8 };
+    const pj_str_t STR_RECVONLY = { "recvonly", 8 };
+
+    const pjmedia_sdp_attr *attr;
+    const pjmedia_sdp_media *local_m;
+    const pjmedia_sdp_media *rem_m;
+    const pjmedia_sdp_conn *local_conn;
+    const pjmedia_sdp_conn *rem_conn;
+    int rem_af, local_af;
+    unsigned i;
+    pj_status_t status;
+
+
+    /* Validate arguments: */
+    PJ_ASSERT_RETURN(pool && si && local && remote, PJ_EINVAL);
+    PJ_ASSERT_RETURN(stream_idx < local->media_count, PJ_EINVAL);
+    PJ_ASSERT_RETURN(stream_idx < remote->media_count, PJ_EINVAL);
+
+    /* Keep SDP shortcuts */
+    local_m = local->media[stream_idx];
+    rem_m = remote->media[stream_idx];
+
+    local_conn = local_m->conn ? local_m->conn : local->conn;
+    if (local_conn == NULL)
+        return PJMEDIA_SDP_EMISSINGCONN;
+
+    rem_conn = rem_m->conn ? rem_m->conn : remote->conn;
+    if (rem_conn == NULL)
+        return PJMEDIA_SDP_EMISSINGCONN;
+
+    /* Reset: */
+    pj_bzero(si, sizeof(*si));
+
+#if PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR
+    /* Set default RTCP XR enabled/disabled */
+    si->rtcp_xr_enabled = PJ_TRUE;
+#endif
+
+    /* Media type: */
+    si->type = pjmedia_get_type(&local_m->desc.media);
+
+    /* Transport protocol */
+
+    /* At this point, transport type must be compatible,
+     * the transport instance will do more validation later.
+     */
+    status = pjmedia_sdp_transport_cmp(&rem_m->desc.transport,
+                                       &local_m->desc.transport);
+    if (status != PJ_SUCCESS)
+        return PJMEDIA_SDPNEG_EINVANSTP;
+
+    /* Get the transport protocol */
+    si->proto = pjmedia_sdp_transport_get_proto(&local_m->desc.transport);
+
+    /* Just return success if stream is not RTP/AVP compatible */
+    if (!PJMEDIA_TP_PROTO_HAS_FLAG(si->proto, PJMEDIA_TP_PROTO_RTP_AVP))
+        return PJ_SUCCESS;
+
+    /* Check address family in remote SDP */
+    rem_af = pj_AF_UNSPEC();
+    if (pj_stricmp(&rem_conn->net_type, &ID_IN)==0) {
+        if (pj_stricmp(&rem_conn->addr_type, &ID_IP4)==0) {
+            rem_af = pj_AF_INET();
+        } else if (pj_stricmp(&rem_conn->addr_type, &ID_IP6)==0) {
+            rem_af = pj_AF_INET6();
+        }
+    }
+
+    if (rem_af==pj_AF_UNSPEC()) {
+        /* Unsupported address family */
+        return PJ_EAFNOTSUP;
+    }
+
+    /* Set remote address: */
+    status = pj_sockaddr_init(rem_af, &si->rem_addr, &rem_conn->addr,
+                              rem_m->desc.port);
+    if (status == PJ_ERESOLVE && rem_af == pj_AF_INET()) {
+        /* Handle special case in NAT64 scenario where for some reason, server
+         * puts IPv6 (literal or FQDN) in SDP answer while indicating "IP4"
+         * in its address type, let's retry resolving using AF_INET6.
+         */
+        status = pj_sockaddr_init(pj_AF_INET6(), &si->rem_addr,
+                                  &rem_conn->addr, rem_m->desc.port);
+    }
+    if (status != PJ_SUCCESS) {
+        /* Invalid IP address. */
+        return PJMEDIA_EINVALIDIP;
+    }
+
+    /* Check address family of local info */
+    local_af = pj_AF_UNSPEC();
+    if (pj_stricmp(&local_conn->net_type, &ID_IN)==0) {
+        if (pj_stricmp(&local_conn->addr_type, &ID_IP4)==0) {
+            local_af = pj_AF_INET();
+        } else if (pj_stricmp(&local_conn->addr_type, &ID_IP6)==0) {
+            local_af = pj_AF_INET6();
+        }
+    }
+
+    if (local_af==pj_AF_UNSPEC()) {
+        /* Unsupported address family */
+        return PJ_SUCCESS;
+    }
+
+    /* Set remote address: */
+    status = pj_sockaddr_init(local_af, &si->local_addr, &local_conn->addr,
+                              local_m->desc.port);
+    if (status != PJ_SUCCESS) {
+        /* Invalid IP address. */
+        return PJMEDIA_EINVALIDIP;
+    }
+
+    /* Local and remote address family must match, except when ICE is used
+     * by both sides (see also ticket #1952).
+     */
+    if (local_af != rem_af) {
+        const pj_str_t STR_ICE_CAND = { "candidate", 9 };
+        if (pjmedia_sdp_media_find_attr(rem_m, &STR_ICE_CAND, NULL)==NULL ||
+            pjmedia_sdp_media_find_attr(local_m, &STR_ICE_CAND, NULL)==NULL)
+        {
+            return PJ_EAFNOTSUP;
+        }
+    }
+
+    /* Media direction: */
+    if (local_m->desc.port == 0 ||
+        pj_sockaddr_has_addr(&si->local_addr)==PJ_FALSE ||
+        pj_sockaddr_has_addr(&si->rem_addr)==PJ_FALSE ||
+        pjmedia_sdp_media_find_attr(local_m, &STR_INACTIVE, NULL)!=NULL)
+    {
+        /* Inactive stream. */
+
+        si->dir = PJMEDIA_DIR_NONE;
+
+    } else if (pjmedia_sdp_media_find_attr(local_m, &STR_SENDONLY, NULL)!=NULL) {
+
+        /* Send only stream. */
+
+        si->dir = PJMEDIA_DIR_ENCODING;
+
+    } else if (pjmedia_sdp_media_find_attr(local_m, &STR_RECVONLY, NULL)!=NULL) {
+
+        /* Recv only stream. */
+
+        si->dir = PJMEDIA_DIR_DECODING;
+
+    } else {
+
+        /* Send and receive stream. */
+
+        si->dir = PJMEDIA_DIR_ENCODING_DECODING;
+
+    }
+
+    /* No need to do anything else if stream is rejected */
+    if (local_m->desc.port == 0) {
+        return PJ_SUCCESS;
+    }
+
+    /* Check if "rtcp-mux" is present in the SDP. */
+    attr = pjmedia_sdp_attr_find2(rem_m->attr_count, rem_m->attr,
+                                  "rtcp-mux", NULL);
+    if (attr)
+        si->rtcp_mux = PJ_TRUE;
+
+    /* If "rtcp" attribute is present in the SDP, set the RTCP address
+     * from that attribute. Otherwise, calculate from RTP address.
+     */
+    attr = pjmedia_sdp_attr_find2(rem_m->attr_count, rem_m->attr,
+                                  "rtcp", NULL);
+    if (attr) {
+        pjmedia_sdp_rtcp_attr rtcp;
+        status = pjmedia_sdp_attr_get_rtcp(attr, &rtcp);
+        if (status == PJ_SUCCESS) {
+            if (rtcp.addr.slen) {
+                status = pj_sockaddr_init(rem_af, &si->rem_rtcp, &rtcp.addr,
+                                          (pj_uint16_t)rtcp.port);
+                if (status != PJ_SUCCESS)
+                    return PJMEDIA_EINVALIDIP;
+            } else {
+                pj_sockaddr_init(rem_af, &si->rem_rtcp, NULL,
+                                 (pj_uint16_t)rtcp.port);
+                pj_memcpy(pj_sockaddr_get_addr(&si->rem_rtcp),
+                          pj_sockaddr_get_addr(&si->rem_addr),
+                          pj_sockaddr_get_addr_len(&si->rem_addr));
+            }
+        }
+    }
+
+    if (!pj_sockaddr_has_addr(&si->rem_rtcp)) {
+        int rtcp_port;
+
+        pj_memcpy(&si->rem_rtcp, &si->rem_addr, sizeof(pj_sockaddr));
+        rtcp_port = pj_sockaddr_get_port(&si->rem_addr) + 1;
+        pj_sockaddr_set_port(&si->rem_rtcp, (pj_uint16_t)rtcp_port);
+    }
+
+    /* Check if "ssrc" attribute is present in the SDP. */
+    for (i = 0; i < rem_m->attr_count; i++) {
+        if (pj_strcmp2(&rem_m->attr[i]->name, "ssrc") == 0) {
+            pjmedia_sdp_ssrc_attr ssrc;
+
+            status = pjmedia_sdp_attr_get_ssrc(
+                        (const pjmedia_sdp_attr *)rem_m->attr[i], &ssrc);
+            if (status == PJ_SUCCESS) {
+                si->has_rem_ssrc = PJ_TRUE;
+                si->rem_ssrc = ssrc.ssrc;
+                if (ssrc.cname.slen > 0) {
+                    pj_strdup(pool, &si->rem_cname, &ssrc.cname);
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Leave SSRC to random. */
+    si->ssrc = pj_rand();
+
+    /* Set default jitter buffer parameter. */
+    si->jb_init = si->jb_max = si->jb_min_pre = si->jb_max_pre = -1;
+    si->jb_discard_algo = PJMEDIA_JB_DISCARD_PROGRESSIVE;
+
+    if (pjmedia_get_type(&local_m->desc.media) == PJMEDIA_TYPE_AUDIO ||
+        pjmedia_get_type(&local_m->desc.media) == PJMEDIA_TYPE_VIDEO)
+    {
+        /* Get local RTCP-FB info */
+        if (pjmedia_get_type(&local_m->desc.media) == PJMEDIA_TYPE_AUDIO ||
+        pjmedia_get_type(&local_m->desc.media) == PJMEDIA_TYPE_VIDEO)
+        status = pjmedia_rtcp_fb_decode_sdp2(pool, endpt, NULL, local,
+                                             stream_idx, si->rx_pt,
+                                             &si->loc_rtcp_fb);
+        if (status != PJ_SUCCESS)
+            return status;
+
+        /* Get remote RTCP-FB info */
+        status = pjmedia_rtcp_fb_decode_sdp2(pool, endpt, NULL, remote,
+                                             stream_idx, si->tx_pt,
+                                             &si->rem_rtcp_fb);
+        if (status != PJ_SUCCESS)
+            return status;
+    }
+
+    return status;
+}
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
 
@@ -149,3 +417,261 @@ PJ_DECL(pj_status_t) pjmedia_stream_info_parse_fmtp_data(pj_pool_t *pool,
     return PJ_SUCCESS;
 }
 
+/*
+ * Get stream statistics.
+ */
+PJ_DEF(pj_status_t)
+pjmedia_stream_common_get_stat( const pjmedia_stream_common *c_strm,
+                                pjmedia_rtcp_stat *stat)
+{
+    PJ_ASSERT_RETURN(c_strm && stat, PJ_EINVAL);
+
+    pj_memcpy(stat, &c_strm->rtcp.stat, sizeof(pjmedia_rtcp_stat));
+    return PJ_SUCCESS;
+}
+
+/*
+ * Reset the stream statistics in the middle of a stream session.
+ */
+PJ_DEF(pj_status_t)
+pjmedia_stream_common_reset_stat(pjmedia_stream_common *c_strm)
+{
+    PJ_ASSERT_RETURN(c_strm, PJ_EINVAL);
+
+    pjmedia_rtcp_init_stat(&c_strm->rtcp.stat);
+
+    return PJ_SUCCESS;
+}
+
+/*
+ * Send RTCP SDES.
+ */
+PJ_DEF(pj_status_t)
+pjmedia_stream_common_send_rtcp_sdes( pjmedia_stream_common *stream )
+{
+    PJ_ASSERT_RETURN(stream, PJ_EINVAL);
+
+    return pjmedia_stream_send_rtcp(stream, PJ_TRUE, PJ_FALSE, PJ_FALSE,
+                                    PJ_FALSE, PJ_FALSE, PJ_FALSE);
+}
+
+/*
+ * Send RTCP BYE.
+ */
+PJ_DEF(pj_status_t)
+pjmedia_stream_common_send_rtcp_bye( pjmedia_stream_common *c_strm )
+{
+    PJ_ASSERT_RETURN(c_strm, PJ_EINVAL);
+
+    if (c_strm->enc && c_strm->transport) {
+        return pjmedia_stream_send_rtcp(c_strm, PJ_TRUE, PJ_TRUE, PJ_FALSE,
+                                        PJ_FALSE, PJ_FALSE, PJ_FALSE);
+    }
+
+    return PJ_SUCCESS;
+}
+
+/**
+ * Get RTP session information from stream.
+ */
+PJ_DEF(pj_status_t)
+pjmedia_stream_common_get_rtp_session_info(pjmedia_stream_common *c_strm,
+                                pjmedia_stream_rtp_sess_info *session_info)
+{
+    session_info->rx_rtp = &c_strm->dec->rtp;
+    session_info->tx_rtp = &c_strm->enc->rtp;
+    session_info->rtcp = &c_strm->rtcp;
+    return PJ_SUCCESS;
+}
+
+static pj_status_t build_rtcp_fb(pjmedia_stream_common *c_strm, void *buf,
+                                 pj_size_t *length)
+{
+    pj_status_t status;
+
+    /* Generic NACK */
+    if (c_strm->send_rtcp_fb_nack && c_strm->rtcp_fb_nack.pid >= 0)
+    {
+        status = pjmedia_rtcp_fb_build_nack(&c_strm->rtcp, buf, length, 1,
+                                            &c_strm->rtcp_fb_nack);
+        if (status != PJ_SUCCESS)
+            return status;
+
+        /* Reset Packet ID */
+        c_strm->rtcp_fb_nack.pid = -1;
+    }
+
+    return PJ_SUCCESS;
+}
+
+pj_status_t pjmedia_stream_send_rtcp(pjmedia_stream_common *c_strm,
+                                     pj_bool_t with_sdes,
+                                     pj_bool_t with_bye,
+                                     pj_bool_t with_xr,
+                                     pj_bool_t with_fb,
+                                     pj_bool_t with_fb_nack,
+                                     pj_bool_t with_fb_pli)
+{
+    void *sr_rr_pkt;
+    pj_uint8_t *pkt;
+    int len, max_len;
+    pj_status_t status;
+
+    /* We need to prevent data race since there is only a single instance
+     * of rtcp packet buffer. And to avoid deadlock with media transport,
+     * we use the transport's group lock.
+     */
+    if (c_strm->transport->grp_lock)
+        pj_grp_lock_acquire(c_strm->transport->grp_lock);
+
+    /* Build RTCP RR/SR packet */
+    pjmedia_rtcp_build_rtcp(&c_strm->rtcp, &sr_rr_pkt, &len);
+
+#if !defined(PJMEDIA_HAS_RTCP_XR) || (PJMEDIA_HAS_RTCP_XR == 0)
+    with_xr = PJ_FALSE;
+#endif
+
+    if (with_sdes || with_bye || with_xr || with_fb || with_fb_nack ||
+        with_fb_pli)
+    {
+        pkt = (pj_uint8_t*) c_strm->out_rtcp_pkt;
+        pj_memcpy(pkt, sr_rr_pkt, len);
+        max_len = c_strm->out_rtcp_pkt_size;
+    } else {
+        pkt = (pj_uint8_t*)sr_rr_pkt;
+        max_len = len;
+    }
+
+    /* Build RTCP SDES packet, forced if also send RTCP-FB */
+    with_sdes = with_sdes || with_fb_pli || with_fb_nack;
+
+    /* Build RTCP SDES packet */
+    if (with_sdes) {
+        pjmedia_rtcp_sdes sdes;
+        pj_size_t sdes_len;
+
+        pj_bzero(&sdes, sizeof(sdes));
+        sdes.cname = c_strm->cname;
+        sdes_len = max_len - len;
+        status = pjmedia_rtcp_build_rtcp_sdes(&c_strm->rtcp, pkt+len,
+                                              &sdes_len, &sdes);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                                     "Error generating RTCP SDES"));
+        } else {
+            len += (int)sdes_len;
+        }
+    }
+
+    if (with_fb) {
+        pj_size_t fb_len = max_len - len;
+        status = build_rtcp_fb(c_strm, pkt+len, &fb_len);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                                     "Error generating RTCP FB"));
+        } else {
+            len += (int)fb_len;
+        }
+    }
+
+    /* Build RTCP XR packet */
+#if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
+    if (with_xr) {
+        int i;
+        pjmedia_jb_state jb_state;
+        void *xr_pkt;
+        int xr_len;
+
+        /* Update RTCP XR with current JB states */
+        pjmedia_jbuf_get_state(c_strm->jb, &jb_state);
+
+        i = jb_state.avg_delay;
+        status = pjmedia_rtcp_xr_update_info(&c_strm->rtcp.xr_session,
+                                             PJMEDIA_RTCP_XR_INFO_JB_NOM, i);
+        pj_assert(status == PJ_SUCCESS);
+
+        i = jb_state.max_delay;
+        status = pjmedia_rtcp_xr_update_info(&c_strm->rtcp.xr_session,
+                                             PJMEDIA_RTCP_XR_INFO_JB_MAX, i);
+        pj_assert(status == PJ_SUCCESS);
+
+        pjmedia_rtcp_build_rtcp_xr(&c_strm->rtcp.xr_session, 0,
+                                   &xr_pkt, &xr_len);
+
+        if (xr_len + len <= max_len) {
+            pj_memcpy(pkt+len, xr_pkt, xr_len);
+            len += xr_len;
+
+            /* Send the RTCP XR to third-party destination if specified */
+            if (c_strm->rtcp_xr_dest_len) {
+                pjmedia_transport_send_rtcp2(c_strm->transport,
+                                             &c_strm->rtcp_xr_dest,
+                                             c_strm->rtcp_xr_dest_len,
+                                             xr_pkt, xr_len);
+            }
+
+        } else {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, PJ_ETOOBIG,
+                         "Error generating RTCP-XR"));
+        }
+    }
+#endif
+
+    /* Build RTCP BYE packet */
+    if (with_bye) {
+        pj_size_t bye_len;
+
+        bye_len = max_len - len;
+        status = pjmedia_rtcp_build_rtcp_bye(&c_strm->rtcp, pkt+len,
+                                             &bye_len, NULL);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                                     "Error generating RTCP BYE"));
+        } else {
+            len += (int)bye_len;
+        }
+    }
+
+    /* Build RTCP-FB generic NACK packet */
+    if (with_fb_nack && c_strm->rtcp_fb_nack.pid >= 0) {
+        pj_size_t fb_len = max_len - len;
+        status = pjmedia_rtcp_fb_build_nack(&c_strm->rtcp, pkt+len, &fb_len,
+                                            1, &c_strm->rtcp_fb_nack);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                                     "Error generating RTCP-FB NACK"));
+        } else {
+            len += (int)fb_len;
+        }
+    }
+
+    /* Build RTCP-FB PLI packet */
+    if (with_fb_pli) {
+        pj_size_t fb_len = max_len - len;
+        status = pjmedia_rtcp_fb_build_pli(&c_strm->rtcp, pkt+len, &fb_len);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                                     "Error generating RTCP-FB PLI"));
+        } else {
+            len += (int)fb_len;
+            PJ_LOG(5,(c_strm->name.ptr, "Sending RTCP-FB PLI packet"));
+        }
+    }
+
+    /* Send! */
+    status = pjmedia_transport_send_rtcp(c_strm->transport, pkt, len);
+    if (status != PJ_SUCCESS) {
+        if (c_strm->rtcp_tx_err_cnt++ == 0) {
+            LOGERR_((c_strm->port.info.name.ptr, status,
+                     "Error sending RTCP"));
+        }
+        if (c_strm->rtcp_tx_err_cnt > SEND_ERR_COUNT_TO_REPORT) {
+            c_strm->rtcp_tx_err_cnt = 0;
+        }
+    }
+
+    if (c_strm->transport->grp_lock)
+        pj_grp_lock_release(c_strm->transport->grp_lock);
+
+    return status;
+}

--- a/pjmedia/src/pjmedia/stream_common.c
+++ b/pjmedia/src/pjmedia/stream_common.c
@@ -40,7 +40,8 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_common_from_sdp(
                                            pjmedia_endpt *endpt,
                                            const pjmedia_sdp_session *local,
                                            const pjmedia_sdp_session *remote,
-                                           unsigned stream_idx)
+                                           unsigned stream_idx,
+                                           pj_bool_t *active)
 {
     const pj_str_t STR_INACTIVE = { "inactive", 8 };
     const pj_str_t STR_SENDONLY = { "sendonly", 8 };
@@ -55,6 +56,8 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_common_from_sdp(
     unsigned i;
     pj_status_t status;
 
+    /* Init */
+    *active = PJ_FALSE;
 
     /* Validate arguments: */
     PJ_ASSERT_RETURN(pool && si && local && remote, PJ_EINVAL);
@@ -285,6 +288,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_common_from_sdp(
             return status;
     }
 
+    *active = PJ_TRUE;
     return status;
 }
 

--- a/pjmedia/src/pjmedia/stream_imp_common.c
+++ b/pjmedia/src/pjmedia/stream_imp_common.c
@@ -1,0 +1,599 @@
+/* 
+ * Copyright (C) 2025 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+ */
+
+/* Prototypes. */
+/* Specific stream implementation's RX RTP handler. */
+static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
+                                    const pjmedia_rtp_hdr *hdr,
+                                    const void *payload,
+                                    unsigned payloadlen,
+                                    pjmedia_rtp_status seq_st,
+                                    pj_bool_t *pkt_discarded);
+
+/* Specific stream implementation's destroy handler. */
+static void on_stream_destroy(void *arg);
+
+#if TRACE_JB
+
+#include <pj/file_io.h>
+
+#define TRACE_JB_INVALID_FD          ((pj_oshandle_t)-1)
+#define TRACE_JB_OPENED(s)           (s->trace_jb_fd != TRACE_JB_INVALID_FD)
+
+PJ_INLINE(int) trace_jb_print_timestamp(char **buf, pj_ssize_t len)
+{
+    pj_time_val now;
+    pj_parsed_time ptime;
+    char *p = *buf;
+
+    if (len < 14)
+        return -1;
+
+    pj_gettimeofday(&now);
+    pj_time_decode(&now, &ptime);
+    p += pj_utoa_pad(ptime.hour, p, 2, '0');
+    *p++ = ':';
+    p += pj_utoa_pad(ptime.min, p, 2, '0');
+    *p++ = ':';
+    p += pj_utoa_pad(ptime.sec, p, 2, '0');
+    *p++ = '.';
+    p += pj_utoa_pad(ptime.msec, p, 3, '0');
+    *p++ = ',';
+
+    *buf = p;
+
+    return 0;
+}
+
+PJ_INLINE(int) trace_jb_print_state(pjmedia_stream_common *c_strm,
+                                    char **buf, pj_ssize_t len)
+{
+    char *p = *buf;
+    char *endp = *buf + len;
+    pjmedia_jb_state state;
+
+    pjmedia_jbuf_get_state(c_strm->jb, &state);
+
+    len = pj_ansi_snprintf(p, endp-p, "%d, %d, %d",
+                           state.size, state.burst, state.prefetch);
+    if ((len < 0) || (len >= endp-p))
+        return -1;
+
+    p += len;
+    *buf = p;
+    return 0;
+}
+
+static void trace_jb_get(pjmedia_stream_common *c_strm, pjmedia_jb_frame_type ft,
+                         pj_size_t fsize)
+{
+    char *p = c_strm->trace_jb_buf;
+    char *endp = c_strm->trace_jb_buf + PJ_LOG_MAX_SIZE;
+    pj_ssize_t len = 0;
+    const char* ft_st;
+
+    if (!TRACE_JB_OPENED(c_strm))
+        return;
+
+    /* Print timestamp. */
+    if (trace_jb_print_timestamp(&p, endp-p))
+        goto on_insuff_buffer;
+
+    /* Print frame type and size */
+    switch(ft) {
+        case PJMEDIA_JB_MISSING_FRAME:
+            ft_st = "missing";
+            break;
+        case PJMEDIA_JB_NORMAL_FRAME:
+            ft_st = "normal";
+            break;
+        case PJMEDIA_JB_ZERO_PREFETCH_FRAME:
+            ft_st = "prefetch";
+            break;
+        case PJMEDIA_JB_ZERO_EMPTY_FRAME:
+            ft_st = "empty";
+            break;
+        default:
+            ft_st = "unknown";
+            break;
+    }
+
+    /* Print operation, size, frame count, frame type */
+    len = pj_ansi_snprintf(p, endp-p, "GET,%zu,1,%s,,,,", fsize, ft_st);
+    if ((len < 0) || (len >= endp-p))
+        goto on_insuff_buffer;
+    p += len;
+
+    /* Print JB state */
+    if (trace_jb_print_state(c_strm, &p, endp-p))
+        goto on_insuff_buffer;
+
+    /* Print end of line */
+    if (endp-p < 2)
+        goto on_insuff_buffer;
+    *p++ = '\n';
+
+    /* Write and flush */
+    len = p - c_strm->trace_jb_buf;
+    pj_file_write(c_strm->trace_jb_fd, c_strm->trace_jb_buf, &len);
+    pj_file_flush(c_strm->trace_jb_fd);
+    return;
+
+on_insuff_buffer:
+    pj_assert(!"Trace buffer too small, check PJ_LOG_MAX_SIZE!");
+}
+
+static void trace_jb_put(pjmedia_stream_common *c_strm,
+                         const pjmedia_rtp_hdr *hdr,
+                         unsigned payloadlen, unsigned frame_cnt)
+{
+    char *p = c_strm->trace_jb_buf;
+    char *endp = c_strm->trace_jb_buf + PJ_LOG_MAX_SIZE;
+    pj_ssize_t len = 0;
+
+    if (!TRACE_JB_OPENED(c_strm))
+        return;
+
+    /* Print timestamp. */
+    if (trace_jb_print_timestamp(&p, endp-p))
+        goto on_insuff_buffer;
+
+    /* Print operation, size, frame count, RTP info */
+    len = pj_ansi_snprintf(p, endp-p,
+                           "PUT,%d,%d,,%d,%d,%d,",
+                           payloadlen, frame_cnt,
+                           pj_ntohs(hdr->seq), pj_ntohl(hdr->ts), hdr->m);
+    if ((len < 0) || (len >= endp-p))
+        goto on_insuff_buffer;
+    p += len;
+
+    /* Print JB state */
+    if (trace_jb_print_state(c_strm, &p, endp-p))
+        goto on_insuff_buffer;
+
+    /* Print end of line */
+    if (endp-p < 2)
+        goto on_insuff_buffer;
+    *p++ = '\n';
+
+    /* Write and flush */
+    len = p - c_strm->trace_jb_buf;
+    pj_file_write(c_strm->trace_jb_fd, c_strm->trace_jb_buf, &len);
+    pj_file_flush(c_strm->trace_jb_fd);
+    return;
+
+on_insuff_buffer:
+    pj_assert(!"Trace buffer too small, check PJ_LOG_MAX_SIZE!");
+}
+
+#endif /* TRACE_JB */
+
+
+static pj_status_t send_rtcp(pjmedia_stream_common *c_strm,
+                             pj_bool_t with_sdes,
+                             pj_bool_t with_bye,
+                             pj_bool_t with_xr,
+                             pj_bool_t with_fb,
+                             pj_bool_t with_fb_nack,
+                             pj_bool_t with_fb_pli)
+{
+    return pjmedia_stream_send_rtcp(c_strm, with_sdes, with_bye,
+                                    with_xr, with_fb, with_fb_nack,
+                                    with_fb_pli);
+}
+
+
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
+/*
+ * Send keep-alive packet using non-codec frame.
+ */
+static void send_keep_alive_packet(pjmedia_stream_common *c_strm)
+{
+#if PJMEDIA_STREAM_ENABLE_KA == PJMEDIA_STREAM_KA_EMPTY_RTP
+
+    /* Keep-alive packet is empty RTP */
+    pj_status_t status;
+    void *pkt;
+    int pkt_len;
+
+    if (!c_strm->transport)
+        return;
+
+    TRC_((c_strm->port.info.name.ptr,
+          "Sending keep-alive (RTCP and empty RTP)"));
+
+    /* Send RTP */
+    status = pjmedia_rtp_encode_rtp( &c_strm->enc->rtp,
+                                     c_strm->enc->pt, 0,
+                                     1,
+                                     0,
+                                     (const void**)&pkt,
+                                     &pkt_len);
+    pj_assert(status == PJ_SUCCESS);
+
+    pj_memcpy(c_strm->enc->buf, pkt, pkt_len);
+    pjmedia_transport_send_rtp(c_strm->transport, c_strm->enc->buf,
+                               pkt_len);
+
+    /* Send RTCP */
+    send_rtcp(c_strm, PJ_TRUE, PJ_FALSE, PJ_FALSE, PJ_FALSE,
+              PJ_FALSE, PJ_FALSE);
+
+    /* Update stats in case the stream is paused */
+    c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(c_strm->enc->rtp.out_hdr.seq);
+
+#elif PJMEDIA_STREAM_ENABLE_KA == PJMEDIA_STREAM_KA_USER
+
+    /* Keep-alive packet is defined in PJMEDIA_STREAM_KA_USER_PKT */
+    pjmedia_channel *channel = c_strm->enc;
+    int pkt_len;
+    const pj_str_t str_ka = PJMEDIA_STREAM_KA_USER_PKT;
+
+    TRC_((c_strm->port.info.name.ptr,
+          "Sending keep-alive (custom RTP/RTCP packets)"));
+
+    /* Send to RTP port */
+    pj_memcpy(c_strm->enc->buf, str_ka.ptr, str_ka.slen);
+    pkt_len = str_ka.slen;
+    pjmedia_transport_send_rtp(c_strm->transport, c_strm->enc->buf,
+                               pkt_len);
+
+    /* Send to RTCP port */
+    pjmedia_transport_send_rtcp(c_strm->transport, c_strm->enc->buf,
+                                pkt_len);
+
+#else
+
+    PJ_UNUSED_ARG(stream);
+
+#endif
+}
+#endif  /* defined(PJMEDIA_STREAM_ENABLE_KA) */
+
+/**
+ * Publish transport error event.
+ */
+static void publish_tp_event(pjmedia_event_type event_type,
+                             pj_status_t status,
+                             pj_bool_t is_rtp,
+                             pjmedia_dir dir,
+                             pjmedia_stream_common *stream)
+{
+    pjmedia_event ev;
+    pj_timestamp ts_now;
+
+    pj_get_timestamp(&ts_now);
+    pj_bzero(&ev.data.med_tp_err, sizeof(ev.data.med_tp_err));
+
+    /* Publish event. */
+    pjmedia_event_init(&ev, event_type,
+                       &ts_now, stream);
+    ev.data.med_tp_err.type = stream->si->type;
+    ev.data.med_tp_err.is_rtp = is_rtp;
+    ev.data.med_tp_err.dir = dir;
+    ev.data.med_tp_err.status = status;
+
+    pjmedia_event_publish(NULL, stream, &ev, 0);
+}
+
+/*
+ * This callback is called by stream transport on receipt of packets
+ * in the RTCP socket.
+ */
+static void on_rx_rtcp( void *data,
+                        void *pkt,
+                        pj_ssize_t bytes_read)
+{
+    pjmedia_stream_common *c_strm = (pjmedia_stream_common *)data;
+    pj_status_t status;
+
+    /* Check for errors */
+    if (bytes_read < 0) {
+        status = (pj_status_t)-bytes_read;
+        if (status == PJ_STATUS_FROM_OS(OSERR_EWOULDBLOCK)) {
+            return;
+        }
+        LOGERR_((c_strm->port.info.name.ptr, status,
+                         "Unable to receive RTCP packet"));
+
+        if (status == PJ_ESOCKETSTOP) {
+            /* Publish receive error event. */
+            publish_tp_event(PJMEDIA_EVENT_MEDIA_TP_ERR, status, PJ_FALSE,
+                             PJMEDIA_DIR_DECODING, c_strm);
+        }
+        return;
+    }
+
+    pjmedia_rtcp_rx_rtcp(&c_strm->rtcp, pkt, bytes_read);
+}
+
+/*
+ * This callback is called by stream transport on receipt of packets
+ * in the RTP socket.
+ */
+static void on_rx_rtp( pjmedia_tp_cb_param *param)
+{
+#ifdef AUDIO_STREAM
+    pjmedia_stream *stream = (pjmedia_stream*) param->user_data;
+#endif
+    pjmedia_stream_common *c_strm = (pjmedia_stream_common *)
+                                    param->user_data;
+    void *pkt = param->pkt;
+    pj_ssize_t bytes_read = param->size;
+    pjmedia_channel *channel = c_strm->dec;
+    const pjmedia_rtp_hdr *hdr;
+    const void *payload;
+    unsigned payloadlen;
+    pjmedia_rtp_status seq_st;
+    pj_bool_t check_pt;
+    pj_status_t status;
+    pj_bool_t pkt_discarded = PJ_FALSE;
+
+    /* Check for errors */
+    if (bytes_read < 0) {
+        status = (pj_status_t)-bytes_read;
+        if (status == PJ_STATUS_FROM_OS(OSERR_EWOULDBLOCK)) {
+            return;
+        }
+
+        LOGERR_((c_strm->port.info.name.ptr, status,
+                 "Unable to receive RTP packet"));
+
+        if (status == PJ_ESOCKETSTOP) {
+            /* Publish receive error event. */
+            publish_tp_event(PJMEDIA_EVENT_MEDIA_TP_ERR, status, PJ_TRUE,
+                             PJMEDIA_DIR_DECODING, c_strm);
+        }
+        return;
+    }
+
+    /* Ignore non-RTP keep-alive packets */
+    if (bytes_read < (pj_ssize_t) sizeof(pjmedia_rtp_hdr))
+        return;
+
+    /* Update RTP and RTCP session. */
+    status = pjmedia_rtp_decode_rtp(&channel->rtp, pkt, (int)bytes_read,
+                                    &hdr, &payload, &payloadlen);
+    if (status != PJ_SUCCESS) {
+        LOGERR_((c_strm->port.info.name.ptr, status, "RTP decode error"));
+        c_strm->rtcp.stat.rx.discard++;
+        return;
+    }
+
+    /* Check if multiplexing is allowed and the payload indicates RTCP. */
+    if (c_strm->si->rtcp_mux && hdr->pt >= 64 && hdr->pt <= 95) {
+        on_rx_rtcp(c_strm, pkt, bytes_read);
+        return;
+    }
+
+    /* See if source address of RTP packet is different than the
+     * configured address, and check if we need to tell the
+     * media transport to switch RTP remote address.
+     */
+    if (param->src_addr) {
+        pj_uint32_t peer_ssrc = channel->rtp.peer_ssrc;
+        pj_bool_t badssrc = PJ_FALSE;
+
+        /* Check SSRC. */
+        if (!channel->rtp.has_peer_ssrc && peer_ssrc == 0)
+            peer_ssrc = pj_ntohl(hdr->ssrc);
+
+        if ((c_strm->si->has_rem_ssrc) && (pj_ntohl(hdr->ssrc) != peer_ssrc)) {
+            badssrc = PJ_TRUE;
+        }
+
+        if (pj_sockaddr_cmp(&c_strm->rem_rtp_addr, param->src_addr) == 0) {
+            /* We're still receiving from rem_rtp_addr. */
+            c_strm->rtp_src_cnt = 0;
+            c_strm->rem_rtp_flag = badssrc? 2: 1;
+        } else {
+            c_strm->rtp_src_cnt++;
+
+            if (c_strm->rtp_src_cnt < PJMEDIA_RTP_NAT_PROBATION_CNT) {
+                if (c_strm->rem_rtp_flag == 1 ||
+                    (c_strm->rem_rtp_flag == 2 && badssrc))
+                {
+                    /* Only discard if:
+                     * - we have ever received packet with good ssrc from
+                     *   remote address (rem_rtp_addr), or
+                     * - we have ever received packet with bad ssrc from
+                     *   remote address and this packet also has bad ssrc.
+                     */
+                    return;                 
+                }
+                if (!badssrc && c_strm->rem_rtp_flag != 1)
+                {
+                    /* Immediately switch if we receive packet with the
+                     * correct ssrc AND we never receive packets with
+                     * good ssrc from rem_rtp_addr.
+                     */
+                    param->rem_switch = PJ_TRUE;
+                }
+            } else {
+                /* Switch. We no longer receive packets from rem_rtp_addr. */
+                param->rem_switch = PJ_TRUE;
+            }
+
+            if (param->rem_switch) {
+                /* Set remote RTP address to source address */
+                pj_sockaddr_cp(&c_strm->rem_rtp_addr, param->src_addr);
+
+                /* Reset counter and flag */
+                c_strm->rtp_src_cnt = 0;
+                c_strm->rem_rtp_flag = badssrc? 2: 1;
+
+                /* Update RTCP peer ssrc */
+                c_strm->rtcp.peer_ssrc = pj_ntohl(hdr->ssrc);
+            }
+        }
+    }
+
+    /* Add ref counter to avoid premature destroy from callbacks */
+    pj_grp_lock_add_ref(c_strm->grp_lock);
+
+    /* Ignore the packet if decoder is paused */
+    if (channel->paused)
+        goto on_return;
+
+    /* Update RTP session (also checks if RTP session can accept
+     * the incoming packet.
+     */
+    pj_bzero(&seq_st, sizeof(seq_st));
+    check_pt = PJMEDIA_STREAM_CHECK_RTP_PT;
+#ifdef AUDIO_STREAM
+    check_pt = check_pt && hdr->pt != stream->rx_event_pt;
+#endif
+    pjmedia_rtp_session_update2(&channel->rtp, hdr, &seq_st, check_pt);
+#if !PJMEDIA_STREAM_CHECK_RTP_PT
+    if (!check_pt && hdr->pt != channel->rtp.out_pt) {
+#ifdef AUDIO_STREAM
+        if (hdr->pt != stream->rx_event_pt)
+#endif
+        seq_st.status.flag.badpt = -1;
+    }
+#endif
+    if (seq_st.status.value) {
+        TRC_  ((c_strm->port.info.name.ptr,
+                "RTP status: badpt=%d, badssrc=%d, dup=%d, "
+                "outorder=%d, probation=%d, restart=%d",
+                seq_st.status.flag.badpt,
+                seq_st.status.flag.badssrc,
+                seq_st.status.flag.dup,
+                seq_st.status.flag.outorder,
+                seq_st.status.flag.probation,
+                seq_st.status.flag.restart));
+
+        if (seq_st.status.flag.badpt) {
+            PJ_LOG(4,(c_strm->port.info.name.ptr,
+                      "Bad RTP pt %d (expecting %d)",
+                      hdr->pt, channel->rtp.out_pt));
+        }
+
+        if (!c_strm->si->has_rem_ssrc && seq_st.status.flag.badssrc) {
+            PJ_LOG(4,(c_strm->port.info.name.ptr,
+                      "Changed RTP peer SSRC %d (previously %d)",
+                      channel->rtp.peer_ssrc, c_strm->rtcp.peer_ssrc));
+            c_strm->rtcp.peer_ssrc = channel->rtp.peer_ssrc;
+        }
+
+
+    }
+
+    /* Skip bad RTP packet */
+    if (seq_st.status.flag.bad) {
+        pkt_discarded = PJ_TRUE;
+        goto on_return;
+    }
+
+    /* Ignore if payloadlen is zero */
+    if (payloadlen == 0) {
+        pkt_discarded = PJ_TRUE;
+        goto on_return;
+    }
+
+    /* Pass it to specific stream for further processing. */
+    on_stream_rx_rtp(c_strm, hdr, payload, payloadlen, seq_st,
+                     &pkt_discarded);
+
+on_return:
+    /* Update RTCP session */
+    if (c_strm->rtcp.peer_ssrc == 0)
+        c_strm->rtcp.peer_ssrc = channel->rtp.peer_ssrc;
+
+    pjmedia_rtcp_rx_rtp2(&c_strm->rtcp, pj_ntohs(hdr->seq),
+                         pj_ntohl(hdr->ts), payloadlen, pkt_discarded);
+
+    /* RTCP-FB generic NACK */
+    if (c_strm->rtcp.received >= 10 && seq_st.diff > 1 &&
+        c_strm->send_rtcp_fb_nack && pj_ntohs(hdr->seq) >= seq_st.diff)
+    {
+        pj_uint16_t nlost, first_seq;
+
+        /* Report only one NACK (last 17 losts) */
+        nlost = PJ_MIN(seq_st.diff - 1, 17);
+        first_seq = pj_ntohs(hdr->seq) - nlost;
+
+        pj_bzero(&c_strm->rtcp_fb_nack, sizeof(c_strm->rtcp_fb_nack));
+        c_strm->rtcp_fb_nack.pid = first_seq;
+        while (--nlost) {
+            c_strm->rtcp_fb_nack.blp <<= 1;
+            c_strm->rtcp_fb_nack.blp |= 1;
+        }
+
+        /* Send it immediately */
+        status = send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled,
+                           PJ_FALSE, PJ_FALSE, PJ_TRUE, PJ_FALSE, PJ_FALSE);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                      "Error sending RTCP FB generic NACK"));
+        } else {
+            c_strm->initial_rr = PJ_TRUE;
+        }
+    }
+
+    /* Send RTCP RR and SDES after we receive some RTP packets */
+    if (c_strm->rtcp.received >= 10 && !c_strm->initial_rr) {
+        status = send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled,
+                           PJ_FALSE, PJ_FALSE, PJ_FALSE, PJ_FALSE, PJ_FALSE);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(c_strm->port.info.name.ptr, status,
+                     "Error sending initial RTCP RR"));
+        } else {
+            c_strm->initial_rr = PJ_TRUE;
+        }
+    }
+
+    pj_grp_lock_dec_ref(c_strm->grp_lock);
+}
+
+/* Common stream destroy handler. */
+static void on_destroy(void *arg)
+{
+    pjmedia_stream_common *c_strm = (pjmedia_stream_common *)arg;
+
+    /* This function may be called when stream is partly initialized. */
+
+    /* Call specific stream destroy handler. */
+    on_stream_destroy(arg);
+
+    /* Release ref to transport */
+    if (c_strm->transport && c_strm->transport->grp_lock)
+        pj_grp_lock_dec_ref(c_strm->transport->grp_lock);
+
+    /* Free mutex */
+    if (c_strm->jb_mutex) {
+        pj_mutex_destroy(c_strm->jb_mutex);
+        c_strm->jb_mutex = NULL;
+    }
+
+    /* Destroy jitter buffer */
+    if (c_strm->jb) {
+        pjmedia_jbuf_destroy(c_strm->jb);
+        c_strm->jb = NULL;
+    }
+
+#if TRACE_JB
+    if (TRACE_JB_OPENED(c_strm)) {
+        pj_file_close(c_strm->trace_jb_fd);
+        c_strm->trace_jb_fd = TRACE_JB_INVALID_FD;
+    }
+#endif
+
+    PJ_LOG(4,(c_strm->port.info.name.ptr, "Stream destroyed"));
+    pj_pool_safe_release(&c_strm->own_pool);
+}

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -22,10 +22,6 @@
 #include <pj/ctype.h>
 #include <pj/rand.h>
 
-static const pj_str_t ID_IN = { "IN", 2 };
-static const pj_str_t ID_IP4 = { "IP4", 3};
-static const pj_str_t ID_IP6 = { "IP6", 3};
-//static const pj_str_t ID_SDP_NAME = { "pjmedia", 7 };
 static const pj_str_t ID_RTPMAP = { "rtpmap", 6 };
 static const pj_str_t ID_TELEPHONE_EVENT = { "telephone-event", 15 };
 
@@ -357,37 +353,20 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
                                            const pjmedia_sdp_session *remote,
                                            unsigned stream_idx)
 {
-    const pj_str_t STR_INACTIVE = { "inactive", 8 };
-    const pj_str_t STR_SENDONLY = { "sendonly", 8 };
-    const pj_str_t STR_RECVONLY = { "recvonly", 8 };
-
+    pjmedia_stream_info_common *csi = (pjmedia_stream_info_common *)si;
     pjmedia_codec_mgr *mgr;
-    const pjmedia_sdp_attr *attr;
     const pjmedia_sdp_media *local_m;
     const pjmedia_sdp_media *rem_m;
-    const pjmedia_sdp_conn *local_conn;
-    const pjmedia_sdp_conn *rem_conn;
-    int rem_af, local_af;
-    unsigned i;
     pj_status_t status;
 
-
-    /* Validate arguments: */
-    PJ_ASSERT_RETURN(pool && si && local && remote, PJ_EINVAL);
-    PJ_ASSERT_RETURN(stream_idx < local->media_count, PJ_EINVAL);
-    PJ_ASSERT_RETURN(stream_idx < remote->media_count, PJ_EINVAL);
+    status = pjmedia_stream_info_common_from_sdp(csi, pool, endpt, local,
+                                                 remote, stream_idx);
+    if (status != PJ_SUCCESS)
+        return status;
 
     /* Keep SDP shortcuts */
     local_m = local->media[stream_idx];
     rem_m = remote->media[stream_idx];
-
-    local_conn = local_m->conn ? local_m->conn : local->conn;
-    if (local_conn == NULL)
-        return PJMEDIA_SDP_EMISSINGCONN;
-
-    rem_conn = rem_m->conn ? rem_m->conn : remote->conn;
-    if (rem_conn == NULL)
-        return PJMEDIA_SDP_EMISSINGCONN;
 
     /* Media type must be audio */
     if (pjmedia_get_type(&local_m->desc.media) != PJMEDIA_TYPE_AUDIO)
@@ -395,193 +374,6 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
 
     /* Get codec manager. */
     mgr = pjmedia_endpt_get_codec_mgr(endpt);
-
-    /* Reset: */
-
-    pj_bzero(si, sizeof(*si));
-
-#if PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR
-    /* Set default RTCP XR enabled/disabled */
-    si->rtcp_xr_enabled = PJ_TRUE;
-#endif
-
-    /* Media type: */
-    si->type = PJMEDIA_TYPE_AUDIO;
-
-    /* Transport protocol */
-
-    /* At this point, transport type must be compatible,
-     * the transport instance will do more validation later.
-     */
-    status = pjmedia_sdp_transport_cmp(&rem_m->desc.transport,
-                                       &local_m->desc.transport);
-    if (status != PJ_SUCCESS)
-        return PJMEDIA_SDPNEG_EINVANSTP;
-
-    /* Get the transport protocol */
-    si->proto = pjmedia_sdp_transport_get_proto(&local_m->desc.transport);
-
-    /* Just return success if stream is not RTP/AVP compatible */
-    if (!PJMEDIA_TP_PROTO_HAS_FLAG(si->proto, PJMEDIA_TP_PROTO_RTP_AVP))
-        return PJ_SUCCESS;
-
-    /* Check address family in remote SDP */
-    rem_af = pj_AF_UNSPEC();
-    if (pj_stricmp(&rem_conn->net_type, &ID_IN)==0) {
-        if (pj_stricmp(&rem_conn->addr_type, &ID_IP4)==0) {
-            rem_af = pj_AF_INET();
-        } else if (pj_stricmp(&rem_conn->addr_type, &ID_IP6)==0) {
-            rem_af = pj_AF_INET6();
-        }
-    }
-
-    if (rem_af==pj_AF_UNSPEC()) {
-        /* Unsupported address family */
-        return PJ_EAFNOTSUP;
-    }
-
-    /* Set remote address: */
-    status = pj_sockaddr_init(rem_af, &si->rem_addr, &rem_conn->addr,
-                              rem_m->desc.port);
-    if (status == PJ_ERESOLVE && rem_af == pj_AF_INET()) {
-        /* Handle special case in NAT64 scenario where for some reason, server
-         * puts IPv6 (literal or FQDN) in SDP answer while indicating "IP4"
-         * in its address type, let's retry resolving using AF_INET6.
-         */
-        status = pj_sockaddr_init(pj_AF_INET6(), &si->rem_addr,
-                                  &rem_conn->addr, rem_m->desc.port);
-    }
-    if (status != PJ_SUCCESS) {
-        /* Invalid IP address. */
-        return PJMEDIA_EINVALIDIP;
-    }
-
-    /* Check address family of local info */
-    local_af = pj_AF_UNSPEC();
-    if (pj_stricmp(&local_conn->net_type, &ID_IN)==0) {
-        if (pj_stricmp(&local_conn->addr_type, &ID_IP4)==0) {
-            local_af = pj_AF_INET();
-        } else if (pj_stricmp(&local_conn->addr_type, &ID_IP6)==0) {
-            local_af = pj_AF_INET6();
-        }
-    }
-
-    if (local_af==pj_AF_UNSPEC()) {
-        /* Unsupported address family */
-        return PJ_SUCCESS;
-    }
-
-    /* Set remote address: */
-    status = pj_sockaddr_init(local_af, &si->local_addr, &local_conn->addr,
-                              local_m->desc.port);
-    if (status != PJ_SUCCESS) {
-        /* Invalid IP address. */
-        return PJMEDIA_EINVALIDIP;
-    }
-
-    /* Local and remote address family must match, except when ICE is used
-     * by both sides (see also ticket #1952).
-     */
-    if (local_af != rem_af) {
-        const pj_str_t STR_ICE_CAND = { "candidate", 9 };
-        if (pjmedia_sdp_media_find_attr(rem_m, &STR_ICE_CAND, NULL)==NULL ||
-            pjmedia_sdp_media_find_attr(local_m, &STR_ICE_CAND, NULL)==NULL)
-        {
-            return PJ_EAFNOTSUP;
-        }
-    }
-
-    /* Media direction: */
-
-    if (local_m->desc.port == 0 ||
-        pj_sockaddr_has_addr(&si->local_addr)==PJ_FALSE ||
-        pj_sockaddr_has_addr(&si->rem_addr)==PJ_FALSE ||
-        pjmedia_sdp_media_find_attr(local_m, &STR_INACTIVE, NULL)!=NULL)
-    {
-        /* Inactive stream. */
-
-        si->dir = PJMEDIA_DIR_NONE;
-
-    } else if (pjmedia_sdp_media_find_attr(local_m, &STR_SENDONLY, NULL)!=NULL) {
-
-        /* Send only stream. */
-
-        si->dir = PJMEDIA_DIR_ENCODING;
-
-    } else if (pjmedia_sdp_media_find_attr(local_m, &STR_RECVONLY, NULL)!=NULL) {
-
-        /* Recv only stream. */
-
-        si->dir = PJMEDIA_DIR_DECODING;
-
-    } else {
-
-        /* Send and receive stream. */
-
-        si->dir = PJMEDIA_DIR_ENCODING_DECODING;
-
-    }
-
-    /* No need to do anything else if stream is rejected */
-    if (local_m->desc.port == 0) {
-        return PJ_SUCCESS;
-    }
-
-    /* Check if "rtcp-mux" is present in the SDP. */
-    attr = pjmedia_sdp_attr_find2(rem_m->attr_count, rem_m->attr,
-                                  "rtcp-mux", NULL);
-    if (attr)
-        si->rtcp_mux = PJ_TRUE;
-
-    /* If "rtcp" attribute is present in the SDP, set the RTCP address
-     * from that attribute. Otherwise, calculate from RTP address.
-     */
-    attr = pjmedia_sdp_attr_find2(rem_m->attr_count, rem_m->attr,
-                                  "rtcp", NULL);
-    if (attr) {
-        pjmedia_sdp_rtcp_attr rtcp;
-        status = pjmedia_sdp_attr_get_rtcp(attr, &rtcp);
-        if (status == PJ_SUCCESS) {
-            if (rtcp.addr.slen) {
-                status = pj_sockaddr_init(rem_af, &si->rem_rtcp, &rtcp.addr,
-                                          (pj_uint16_t)rtcp.port);
-                if (status != PJ_SUCCESS)
-                    return PJMEDIA_EINVALIDIP;
-            } else {
-                pj_sockaddr_init(rem_af, &si->rem_rtcp, NULL,
-                                 (pj_uint16_t)rtcp.port);
-                pj_memcpy(pj_sockaddr_get_addr(&si->rem_rtcp),
-                          pj_sockaddr_get_addr(&si->rem_addr),
-                          pj_sockaddr_get_addr_len(&si->rem_addr));
-            }
-        }
-    }
-
-    if (!pj_sockaddr_has_addr(&si->rem_rtcp)) {
-        int rtcp_port;
-
-        pj_memcpy(&si->rem_rtcp, &si->rem_addr, sizeof(pj_sockaddr));
-        rtcp_port = pj_sockaddr_get_port(&si->rem_addr) + 1;
-        pj_sockaddr_set_port(&si->rem_rtcp, (pj_uint16_t)rtcp_port);
-    }
-
-    /* Check if "ssrc" attribute is present in the SDP. */
-    for (i = 0; i < rem_m->attr_count; i++) {
-        if (pj_strcmp2(&rem_m->attr[i]->name, "ssrc") == 0) {
-            pjmedia_sdp_ssrc_attr ssrc;
-
-            status = pjmedia_sdp_attr_get_ssrc(
-                        (const pjmedia_sdp_attr *)rem_m->attr[i], &ssrc);
-            if (status == PJ_SUCCESS) {
-                si->has_rem_ssrc = PJ_TRUE;
-                si->rem_ssrc = ssrc.ssrc;
-                if (ssrc.cname.slen > 0) {
-                    pj_strdup(pool, &si->rem_cname, &ssrc.cname);
-                    break;
-                }
-            }
-        }
-    }
 
     /* Get the payload number for receive channel. */
     /*
@@ -605,27 +397,6 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
 
     /* Get codec info and param */
     status = get_audio_codec_info_param(si, pool, mgr, local_m, rem_m);
-    if (status != PJ_SUCCESS)
-        return status;
-
-    /* Leave SSRC to random. */
-    si->ssrc = pj_rand();
-
-    /* Set default jitter buffer parameter. */
-    si->jb_init = si->jb_max = si->jb_min_pre = si->jb_max_pre = -1;
-    si->jb_discard_algo = PJMEDIA_JB_DISCARD_PROGRESSIVE;
-
-    /* Get local RTCP-FB info */
-    status = pjmedia_rtcp_fb_decode_sdp2(pool, endpt, NULL, local, stream_idx,
-                                         si->rx_pt, &si->loc_rtcp_fb);
-    if (status != PJ_SUCCESS)
-        return status;
-
-    /* Get remote RTCP-FB info */
-    status = pjmedia_rtcp_fb_decode_sdp2(pool, endpt, NULL, remote, stream_idx,
-                                         si->tx_pt, &si->rem_rtcp_fb);
-    if (status != PJ_SUCCESS)
-        return status;
 
     return status;
 }

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -360,6 +360,9 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
     pj_bool_t active;
     pj_status_t status;
 
+    PJ_ASSERT_RETURN(si, PJ_EINVAL);
+    pj_bzero(si, sizeof(*si));
+
     status = pjmedia_stream_info_common_from_sdp(csi, pool, endpt, local,
                                                  remote, stream_idx, &active);
     if (status != PJ_SUCCESS || !active)

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -357,11 +357,12 @@ PJ_DEF(pj_status_t) pjmedia_stream_info_from_sdp(
     pjmedia_codec_mgr *mgr;
     const pjmedia_sdp_media *local_m;
     const pjmedia_sdp_media *rem_m;
+    pj_bool_t active;
     pj_status_t status;
 
     status = pjmedia_stream_info_common_from_sdp(csi, pool, endpt, local,
-                                                 remote, stream_idx);
-    if (status != PJ_SUCCESS)
+                                                 remote, stream_idx, &active);
+    if (status != PJ_SUCCESS || !active)
         return status;
 
     /* Keep SDP shortcuts */

--- a/pjmedia/src/pjmedia/vid_stream_info.c
+++ b/pjmedia/src/pjmedia/vid_stream_info.c
@@ -182,6 +182,9 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_info_from_sdp(
     pj_bool_t active;
     pj_status_t status;
 
+    PJ_ASSERT_RETURN(si, PJ_EINVAL);
+    pj_bzero(si, sizeof(*si));
+
     status = pjmedia_stream_info_common_from_sdp(csi, pool, endpt, local,
                                                  remote, stream_idx, &active);
     if (status != PJ_SUCCESS || !active)

--- a/pjmedia/src/pjmedia/vid_stream_info.c
+++ b/pjmedia/src/pjmedia/vid_stream_info.c
@@ -179,11 +179,12 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_info_from_sdp(
     pjmedia_stream_info_common *csi = (pjmedia_stream_info_common *)si;
     const pjmedia_sdp_media *local_m;
     const pjmedia_sdp_media *rem_m;
+    pj_bool_t active;
     pj_status_t status;
 
     status = pjmedia_stream_info_common_from_sdp(csi, pool, endpt, local,
-                                                 remote, stream_idx);
-    if (status != PJ_SUCCESS)
+                                                 remote, stream_idx, &active);
+    if (status != PJ_SUCCESS || !active)
         return status;
 
     /* Keep SDP shortcuts */

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3938,7 +3938,7 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
 #endif
     pjmedia_stream_info_common *si;
     pjsua_stream_info stream_info;
-                               pj_str_t *enc_name;
+    pj_str_t *enc_name = NULL;
 
     if (call_med->type == PJMEDIA_TYPE_AUDIO) {
         si = (pjmedia_stream_info_common *)&asi;
@@ -4228,8 +4228,8 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
         }
         len = pj_ansi_snprintf( info+info_len, sizeof(info)-info_len,
                                ", stream #%d: %.*s (%s)", mi,
-                               (int)enc_name->slen,
-                               enc_name->ptr,
+                               (enc_name? (int)enc_name->slen: 0),
+                               (enc_name? enc_name->ptr: info),
                                dir);
         if (len > 0)
             info_len += len;


### PR DESCRIPTION
In order to support additional media, it would be better to refactor the current implementation of audio and video stream since they contains a lot of duplications, which make code maintenance tedious and more prone to bug (such as if you only fix one stream and do not apply to others).

Scope:
- a new structure `pjmedia_stream_common` is created as a parent of `pjmedia_stream` and `pjmedia_vid_stream`
- a new structure `pjmedia_stream_info_common`  which contains members that exist in both`pjmedia_stream_info` and `pjmedia_vid_stream_info`. Note that unlike the streams (`pjmedia_stream` and `pjmedia_vid_stream`) which are opaque, the  stream info definition is public, so we cannot modify its internal structure.
- common callbacks for RTP and RTCP handling, `on_rx_rtp()` and `on_rx_rtcp()`, which will call its specific stream implementation: `on_stream_rx_rtp()` (currently no specific stream's RTCP handling).
- common group lock handler `on_destroy()` which will call its specific stream's handler `on_stream_destroy()`.

Notes:
- https://github.com/pjsip/pjproject/pull/2713. The PR was only applied to audio stream, but not video stream. Now both will have the same behavior.
- With this refactoring, the setting `PJMEDIA_VID_STREAM_CHECK_RTP_PT` now MUST have the same value as `PJMEDIA_STREAM_CHECK_RTP_PT`. If not, we will print a warning message during compilation and automatically set it to be equal.

