### PR TITLE
Check if ice strans is valid before using it to send

### DIFF
--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -2458,7 +2458,11 @@ static pj_status_t transport_send_rtp(pjmedia_transport *tp,
                                       pj_size_t size)
 {
     struct transport_ice *tp_ice = (struct transport_ice*)tp;
+    pj_ice_strans *ice_st = tp_ice->ice_st;
     pj_status_t status;
+
+    if (!ice_st)
+        return PJ_SUCCESS;
 
     /* Simulate packet lost on TX direction */
     if (tp_ice->tx_drop_pct) {
@@ -2470,7 +2474,7 @@ static pj_status_t transport_send_rtp(pjmedia_transport *tp,
         }
     }
 
-    status = pj_ice_strans_sendto2(tp_ice->ice_st, 1, 
+    status = pj_ice_strans_sendto2(ice_st, 1, 
                                    pkt, size, &tp_ice->remote_rtp,
                                    tp_ice->addr_len);
     if (status == PJ_EPENDING)
@@ -2494,6 +2498,10 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
                                         pj_size_t size)
 {
     struct transport_ice *tp_ice = (struct transport_ice*)tp;
+    pj_ice_strans *ice_st = tp_ice->ice_st;
+
+    if (!ice_st)
+        return PJ_SUCCESS;
 
     if (tp_ice->comp_cnt > 1 || tp_ice->use_rtcp_mux) {
         pj_status_t status;
@@ -2504,7 +2512,7 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
             addr_len = pj_sockaddr_get_len(addr);
         }         
 
-        status = pj_ice_strans_sendto2(tp_ice->ice_st, comp_id, pkt, size,
+        status = pj_ice_strans_sendto2(ice_st, comp_id, pkt, size,
                                        addr, addr_len);
         if (status == PJ_EPENDING)
             status = PJ_SUCCESS;


### PR DESCRIPTION
Consider the information from the log before crash:
```
13:48:20.814           conference.c  ....Remove port 1 queued
13:48:20.814 strm0xb400007b87cce8c8  ...Stream destroying
13:48:20.814          pjsua_media.c  ...Media stream call00:0 is destroyed
...
13:48:20.814                icetp00  ..Stopping ICE, reason=media stop requested
13:48:20.814 srtp0xb400007bb7cdeb40  ..Destroying SRTP transport
13:48:20.814                icetp00  ..Destroying ICE transport
13:48:20.862 srtp0xb400007bb7ce2350  SRTP transport destroyed
13:48:20.898               playdbuf !Underflow, buf_cnt=0, will generate 1 frame
13:48:20.898               playdbuf  Underflow, buf_cnt=0, will generate 1 frame
```

The stack trace:
```
pj_ice_strans_sendto2+44
transport_send_rtp+184
pjmedia_transport_send_rtp+48
...
```

When ICE transport is being destroyed:
https://github.com/pjsip/pjproject/blob/fdd4041f126de8b6b1f69c5bcbe35821011acd76/pjmedia/src/pjmedia/transport_ice.c#L2761-L2765

And the crash:
https://github.com/pjsip/pjproject/blob/fdd4041f126de8b6b1f69c5bcbe35821011acd76/pjnath/src/pjnath/ice_strans.c#L1985-L1987

Note that there's already #4281 to avoid the crash