### PR TITLE
Avoid deadlock in SIP transport shutdown in IP change scenario

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1466,11 +1466,14 @@ PJ_DEF(pj_status_t) pjsip_transport_shutdown2(pjsip_transport *tp,
     pj_lock_acquire(tp->lock);
 
     mgr = tp->tpmgr;
-    pj_lock_acquire(mgr->lock);
+
+    // Acquiring manager lock after transport lock may cause deadlock.
+    // And it does not seem necessary as well.
+    //pj_lock_acquire(mgr->lock);
 
     /* Do nothing if transport is being shutdown/destroyed already */
     if (tp->is_shutdown || tp->is_destroying) {
-        pj_lock_release(mgr->lock);
+        //pj_lock_release(mgr->lock);
         pj_lock_release(tp->lock);
         return PJ_SUCCESS;
     }
@@ -1501,7 +1504,7 @@ PJ_DEF(pj_status_t) pjsip_transport_shutdown2(pjsip_transport *tp,
         pjsip_transport_dec_ref(tp);
     }
 
-    pj_lock_release(mgr->lock);
+    //pj_lock_release(mgr->lock);
     pj_lock_release(tp->lock);
 
     return status;


### PR DESCRIPTION
There has been a report of deadlock in IP change, PJSIP log:
```
16:14:11:011:             pjsua_acc.c  Disconnected notification for transport tcpc0x133d82228
16:14:11:011:         sip_transport.c  .Transport tcpc0x133d82228 shutting down, force=0
16:14:11:011:            pjsua_core.c !Start handling IP address change
16:14:11:011:            pjsua_core.c  IP change shutting down transports..
16:14:11:011:         sip_transport.c  Shutting down all transports
16:14:11:011:         sip_transport.c  Transport tcpc0x133d82228 shutting down, force=1
```
Thanks to Alexey Nikitin for the report.

After investigation, there may be a race condition between a transport shutdown and all transport shutdown which may trigger non-uniform lock order:
- **A transport** shutdown occurs after transport disconnection event (by pjsua-lib or by transport implementation itself), it will acquire locks in this order: **transport lock -> transport manager lock**.
- **All transports** shutdown initiated by IP change procedure, it will acquire locks in this order: **transport manager lock -> transport lock**.

This PR removes the transport manager lock in `pjsip_transport_shutdown2()`.


