### PR TITLE
pjsua_media: Fix to apply_med_update when PJMEDIA_HAS_VIDEO is disabled.

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3940,11 +3940,6 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
     pjsua_stream_info stream_info;
     pj_str_t *enc_name = NULL;
 
-    /* Sanity check. */
-    PJ_ASSERT_RETURN(call_med->type == PJMEDIA_TYPE_AUDIO ||
-                     call_med->type == PJMEDIA_TYPE_VIDEO,
-                     PJ_EINVAL);
-
     if (call_med->type == PJMEDIA_TYPE_AUDIO) {
         si = (pjmedia_stream_info_common *)&asi;
         status = pjmedia_stream_info_from_sdp(
@@ -3962,6 +3957,9 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
         stream_info.info.vid = vsi;
         enc_name = &vsi.codec_info.encoding_name;
 #endif
+    }
+    else {
+        status = PJMEDIA_EUNSUPMEDIATYPE;
     }
 
     if (status != PJ_SUCCESS) {


### PR DESCRIPTION
When video is disabled, the code will fall through to attempt to use uninitialized `si`:
```
pjsip/pjproject/pjsip/src/pjsua-lib/pjsua_media.c:3983:11: warning: 'si' may be used uninitialized [-Wmaybe-uninitialized]
 3983 |     if (si->rtcp_mux && !call_med->enable_rtcp_mux) {
      |         ~~^~~~~~~~~~
```