### PR TITLE
Add logging information when incoming message is ignored caused by unchecked source address

### DIFF
--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -3320,9 +3320,7 @@ static void handle_incoming_check(pj_ice_sess *ice,
     pj_ice_sess_cand *rcand;
     unsigned i;
 
-    /* Check if ICE has been completed. We still need to check if remote 
-     * candidate is valid when check_src_addr is set.
-     */
+    /* Check if ICE has been completed */
     if (ice->is_complete) {
         LOG4((ice->obj_name,
               "Ignored incoming check after ICE nego has been completed!"));

--- a/pjnath/src/pjnath/ice_session.c
+++ b/pjnath/src/pjnath/ice_session.c
@@ -3745,6 +3745,11 @@ PJ_DEF(pj_status_t) pj_ice_sess_on_rx_pkt(pj_ice_sess *ice,
 
             if (!pj_sockaddr_has_addr(raddr)) {
                 for (i = 0; i < ice->rcand_cnt; ++i) {
+                    /* Make sure that the source address is part of the remote
+                     * candidate and it is a valid (already checked). 
+                     * Note that the candidate will not be set to valid if the 
+                     * incoming check is received after the ICE is completed.
+                     */
                     if (ice->rcand[i].comp_id == comp_id &&
                         ice->rcand[i].checked &&
                         pj_sockaddr_cmp(src_addr, &ice->rcand[i].addr) == 0)


### PR DESCRIPTION
PR #4261 will add the option to check the valid source address.
On ICE, the valid source address is valid for the remote address that has received the connectivity check or has
the connectivity check successful.
Currently, any incoming check will be ignored once ICE is completed. In this case the remote address will not 
set as valid although receiving the connectivity check.
```
2025-02-21T02:14:00.1964594Z caller: 02:13:39.694                icetp00  ICE negotiation failed after 0s:000: All ICE checklists failed (PJNATH_EICEFAILED)
2025-02-21T02:14:00.1965169Z caller: 02:13:39.694          pjsua_media.c  .Call 0: ICE trickle stopped trickling as ICE nego completed
2025-02-21T02:14:00.1965673Z caller: 02:13:39.694                icetp00  .Ignored incoming check after ICE nego has been completed!
2025-02-21T02:14:00.1969105Z caller: 02:13:39.700                icetp00  Ignoring incoming message for component [1] because source addr 10.10.10.155:4008 unrecognized
2025-02-21T02:14:00.1974879Z caller: 02:13:39.720                icetp00  Ignoring incoming message for component [1] because source addr 10.10.10.155:4008 unrecognized
```
This PR will add logging information that incoming message might be ignored when source address is not checked.