### PR TITLE
Add compile-time option to specify if DNS resolver should discard truncated answer

### DIFF
--- a/pjlib-util/include/pjlib-util/config.h
+++ b/pjlib-util/include/pjlib-util/config.h
@@ -195,6 +195,16 @@
 #endif
 
 
+/**
+ * Specifies whether DNS resolver should discard truncated answer.
+ *
+ * Default: 1 (yes)
+ */
+#ifndef PJ_DNS_RESOLVER_DISCARD_TRUNCATED_ANSWER
+#   define PJ_DNS_RESOLVER_DISCARD_TRUNCATED_ANSWER     1
+#endif
+
+
 /* **************************************************************************
  * SCANNER CONFIGURATION
  */

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -590,7 +590,9 @@ static void dns_callback(void *user_data,
         query_job->q_srv = NULL;
 
         if (status == PJ_SUCCESS) {
-            if (PJ_DNS_GET_TC(pkt->hdr.flags)) {
+            if (PJ_DNS_RESOLVER_DISCARD_TRUNCATED_ANSWER &&
+                PJ_DNS_GET_TC(pkt->hdr.flags))
+            {
                 /* Got truncated answer, the standard recommends to follow up
                  * the query using TCP. Since we currently don't support it,
                  * just return error.


### PR DESCRIPTION
To fix #4319 .

In #2200, we opted to discard DNS truncated answer.
But some users may want to use it. As the RFC stated:
https://datatracker.ietf.org/doc/html/rfc1123#section-6.1.3.2
`Whether it is possible to use a truncated answer depends on the application.`

So, here we provide a compile-time option to specify whether we should discard such answer.
