### PR TITLE
Port dlg event subscription

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -2085,6 +2085,10 @@ private:
                                      pjsip_evsub *sub,
                                      pjsip_event *event);
     static void on_buddy_dlg_event_state(pjsua_buddy_id buddy_id);
+    static void on_buddy_evsub_dlg_event_state(pjsua_buddy_id buddy_id,
+                                               pjsip_evsub *sub,
+                                               pjsip_event *event);
+
     // Call callbacks
     static void on_call_state(pjsua_call_id call_id, pjsip_event *e);
     static void on_call_tsx_state(pjsua_call_id call_id,

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -2084,6 +2084,7 @@ private:
     static void on_buddy_evsub_state(pjsua_buddy_id buddy_id,
                                      pjsip_evsub *sub,
                                      pjsip_event *event);
+    static void on_buddy_dlg_event_state(pjsua_buddy_id buddy_id);
     // Call callbacks
     static void on_call_state(pjsua_call_id call_id, pjsip_event *e);
     static void on_call_tsx_state(pjsua_call_id call_id,

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -311,6 +311,21 @@ public:
      void updatePresence(void) PJSUA2_THROW(Error);
      
     /**
+     * Enable/disable buddy's dialog event monitoring. Once buddy's dialog event
+     * is subscribed, application will be informed about buddy's dialog info
+     * status change via \a on_buddy_dlg_event_state() callback.
+     *
+     * Note that only one subscription (presence or dialog event) can be active
+     * at any time.
+     *
+     * @param subscribe     Specify non-zero to activate dialog event subscription
+     *                      to the specified buddy.
+     *
+     * @return              PJ_SUCCESS on success, or the appropriate error code.
+     */
+    void subscribeDlgEvent(bool subscribe) PJSUA2_THROW(Error);
+
+    /**
      * Send instant messaging outside dialog, using this buddy's specified
      * account for route set and authentication.
      *

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -93,6 +93,14 @@ struct BuddyConfig : public PersistentObject
      */
     bool                 subscribe;
 
+    /**
+     * Specify whether we should immediately subscribe to the buddy's
+     * dialog event, such as for Busy Lamp Field (BLF) feature.
+     * Note that only one subscription (presence or dialog event)
+     * can be active at any time.
+     */
+    bool                 subscribe_dlg_event;
+
 public:
     /**
      * Read this object from a container node.

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -338,6 +338,12 @@ public:
      */
     virtual void onBuddyState()
     {}
+    /**
+     * Notify application when the buddy dialog state has changed.
+     * Application may then query the buddy into to get the details.
+     */
+    virtual void onBuddyDlgEventState()
+    {}
 
     /**
      * Notify application when the state of client subscription session

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -313,7 +313,7 @@ public:
     /**
      * Enable/disable buddy's dialog event monitoring. Once buddy's dialog event
      * is subscribed, application will be informed about buddy's dialog info
-     * status change via \a on_buddy_dlg_event_state() callback.
+     * status change via \a onBuddyDlgEventState() callback.
      *
      * Note that only one subscription (presence or dialog event) can be active
      * at any time.
@@ -334,13 +334,13 @@ public:
      *
      * Note that the buddy's dialog event subscription will only be initiated
      * if dialog event monitoring is enabled for the buddy. See
-     * #pjsua_buddy_subscribe_dlg_event() for more info. Also if dialog event
+     * subscribeDlgEvent() for more info. Also if dialog event
      * subscription for the buddy is already active, this function will not do
      * anything.
      *
      * Once the dialog event subscription is activated successfully for the buddy,
      * application will be notified about the buddy's dialog info status in the
-     * on_buddy_dlg_event_state() callback.
+     * onBuddyDlgEventState() callback.
      */
     void updateDlgEvent(void) PJSUA2_THROW(Error);
 

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -355,7 +355,14 @@ public:
      */
     virtual void onBuddyEvSubState(OnBuddyEvSubStateParam &prm)
     { PJ_UNUSED_ARG(prm); }
-     
+    /**
+     * Notify application when the state of client subscription session
+     * associated with a buddy dialog state has changed. Application
+     * may use this callback to retrieve more detailed information about the
+     * state changed event.
+     */
+    virtual void onBuddyEvSubDlgEventState(OnBuddyEvSubStateParam &prm)
+    { PJ_UNUSED_ARG(prm); }
 private:
      /**
       * Buddy ID.

--- a/pjsip/include/pjsua2/presence.hpp
+++ b/pjsip/include/pjsua2/presence.hpp
@@ -326,6 +326,25 @@ public:
     void subscribeDlgEvent(bool subscribe) PJSUA2_THROW(Error);
 
     /**
+     * Update the dialog event information for the buddy. Although the library
+     * periodically refreshes the dialog event subscription for all buddies, some
+     * application may want to refresh the buddy's dialog event subscription
+     * immediately, and in this case it can use this function to accomplish
+     * this.
+     *
+     * Note that the buddy's dialog event subscription will only be initiated
+     * if dialog event monitoring is enabled for the buddy. See
+     * #pjsua_buddy_subscribe_dlg_event() for more info. Also if dialog event
+     * subscription for the buddy is already active, this function will not do
+     * anything.
+     *
+     * Once the dialog event subscription is activated successfully for the buddy,
+     * application will be notified about the buddy's dialog info status in the
+     * on_buddy_dlg_event_state() callback.
+     */
+    void updateDlgEvent(void) PJSUA2_THROW(Error);
+
+    /**
      * Send instant messaging outside dialog, using this buddy's specified
      * account for route set and authentication.
      *

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -675,6 +675,10 @@ PJ_DEF(pj_status_t) pjsua_buddy_subscribe_pres( pjsua_buddy_id buddy_id,
     return PJ_SUCCESS;
 }
 
+/*
+ * Enable/disable buddy's dialog event monitoring.
+ */
+
 PJ_DEF(pj_status_t) pjsua_buddy_subscribe_dlg_event(pjsua_buddy_id buddy_id,
                                                     pj_bool_t subscribe)
 {

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1132,6 +1132,18 @@ void Endpoint::on_buddy_state(pjsua_buddy_id buddy_id)
     buddy->onBuddyState();
 }
 
+void Endpoint::on_buddy_dlg_event_state(pjsua_buddy_id buddy_id)
+{
+    Buddy b(buddy_id);
+    Buddy *buddy = b.getOriginalInstance();
+    if (!buddy || !buddy->isValid()) {
+        /* Ignored */
+        return;
+    }
+
+    buddy->onBuddyDlgEventState();
+}
+
 void Endpoint::on_buddy_evsub_state(pjsua_buddy_id buddy_id,
                                     pjsip_evsub *sub,
                                     pjsip_event *event)

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1163,6 +1163,25 @@ void Endpoint::on_buddy_evsub_state(pjsua_buddy_id buddy_id,
     buddy->onBuddyEvSubState(prm);
 }
 
+void Endpoint::on_buddy_evsub_dlg_event_state(pjsua_buddy_id buddy_id,
+                                              pjsip_evsub *sub,
+                                              pjsip_event *event)
+{
+    PJ_UNUSED_ARG(sub);
+
+    Buddy b(buddy_id);
+    Buddy *buddy = b.getOriginalInstance();
+    if (!buddy || !buddy->isValid()) {
+        /* Ignored */
+        return;
+    }
+
+    OnBuddyEvSubStateParam prm;
+    prm.e.fromPj(*event);
+
+    buddy->onBuddyEvSubDlgEventState(prm);
+}
+
 // Call callbacks
 void Endpoint::on_call_state(pjsua_call_id call_id, pjsip_event *e)
 {

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -41,6 +41,7 @@ void BuddyConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
 
     NODE_READ_STRING   ( this_node, uri);
     NODE_READ_BOOL     ( this_node, subscribe);
+    NODE_READ_BOOL     ( this_node, subscribe_dlg_event);
 }
 
 void BuddyConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
@@ -49,6 +50,7 @@ void BuddyConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
 
     NODE_WRITE_STRING  ( this_node, uri);
     NODE_WRITE_BOOL    ( this_node, subscribe);
+    NODE_WRITE_BOOL     ( this_node, subscribe_dlg_event);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -142,6 +144,7 @@ void Buddy::create(Account &account, const BuddyConfig &cfg)
 
     pj_cfg.uri = str2Pj(cfg.uri);
     pj_cfg.subscribe = cfg.subscribe;
+    pj_cfg.subscribe_dlg_event = cfg.subscribe_dlg_event;
     pj_cfg.user_data = (void*)bud;
     pj_cfg.acc_id = account.getId();
     PJSUA2_CHECK_EXPR( pjsua_buddy_add(&pj_cfg, &id) );

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -201,7 +201,15 @@ void Buddy::updatePresence(void) PJSUA2_THROW(Error)
 {
     PJSUA2_CHECK_EXPR( pjsua_buddy_update_pres(id) );
 }
-     
+
+/*
+ * Update the dialog event information for the buddy.
+ */
+void Buddy::updateDlgEvent(void) PJSUA2_THROW(Error)
+{
+    PJSUA2_CHECK_EXPR( pjsua_buddy_update_dlg_event(id) );
+}
+
 /*
  * Send instant messaging outside dialog.
  */

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -186,7 +186,14 @@ void Buddy::subscribePresence(bool subscribe) PJSUA2_THROW(Error)
     PJSUA2_CHECK_EXPR( pjsua_buddy_subscribe_pres(id, subscribe) );
 }
 
-    
+/*
+ * Enable/disable buddy's dialog event monitoring.
+ */
+void Buddy::subscribeDlgEvent(bool subscribe) PJSUA2_THROW(Error)
+{
+    PJSUA2_CHECK_EXPR( pjsua_buddy_subscribe_dlg_event(id, subscribe) );
+}
+
 /*
  * Update the presence information for the buddy.
  */


### PR DESCRIPTION
Hi all, following up the PR #3754 for implementing the Dialog Event subscription (client only) which is working fine and present in 2.15.1.

But there is no porting to the applications to use the feature (python3 in my case).

So please preview this PR as I'm currently having it working with my setup.

I'm not sure how to setup automated unit tests (if there is any) in opening this PR, so feel free to correct me then.

Thank you.
