### PR TITLE
Fix crash due to accessing deleted authentication session parent

### DIFF
--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1222,6 +1222,9 @@ static void regc_tsx_callback(void *token, pjsip_event *event)
             }
         }
 
+        if (regc->_delete_flag != 0) {
+            regc->auth_sess.parent = NULL;
+        }
         status = pjsip_auth_clt_reinit_req( &regc->auth_sess,
                                             rdata, 
                                             tsx->last_tx,  

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -96,7 +96,6 @@ struct pjsip_regc
 
     /* Authorization sessions. */
     pjsip_auth_clt_sess          auth_sess;
-    pjsip_auth_clt_sess         *ext_auth_sess; /**< User defined auth session.     */
 
     /* Auto refresh registration. */
     pj_bool_t                    auto_reg;
@@ -1223,7 +1222,7 @@ static void regc_tsx_callback(void *token, pjsip_event *event)
         }
 
         if (regc->_delete_flag != 0) {
-            regc->auth_sess.parent = NULL;
+            pjsip_auth_clt_set_parent(&regc->auth_sess, NULL);
         }
         status = pjsip_auth_clt_reinit_req( &regc->auth_sess,
                                             rdata, 

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -907,17 +907,17 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_clone( pj_pool_t *pool,
         }
     }
 
-    if (sess->parent) {
+    if (rhs->parent) {
         pj_status_t status;
 
-        pj_lock_acquire(sess->parent->lock);
+        pj_lock_acquire(rhs->parent->lock);
         sess->parent = PJ_POOL_ZALLOC_T(pool, pjsip_auth_clt_sess);
         if (sess->parent == NULL) {
             status = PJ_ENOMEM;
         } else {
             status = pjsip_auth_clt_clone(pool, sess->parent, rhs->parent);
         }
-        pj_lock_release(sess->parent->lock);
+        pj_lock_release(rhs->parent->lock);
 
         if (status != PJ_SUCCESS)
             return status;

--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -838,8 +838,8 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_init(  pjsip_auth_clt_sess *sess,
 PJ_DEF(pj_status_t) pjsip_auth_clt_set_parent(pjsip_auth_clt_sess *sess,
                                               pjsip_auth_clt_sess *parent)
 {
-    PJ_ASSERT_RETURN(sess && parent, PJ_EINVAL);
-    if (parent->lock == NULL) {
+    PJ_ASSERT_RETURN(sess, PJ_EINVAL);
+    if (parent != NULL && parent->lock == NULL) {
         pj_status_t status;
         status = pj_lock_create_simple_mutex( parent->pool,
                                               "auth_clt_parent_lock",


### PR DESCRIPTION
that occurs when the app comes to the foreground and the IP connections were closed before, for example because the power saving mode was activated on the iPhone. The reason was that the client authentication sessions of the regc object still pointed to a parent client authentication session that had already been deleted from the account.