### PR TITLE
Add dedicated-thread method for video sending rate control to improve video latency

### DIFF
--- a/pjmedia/include/pjmedia/vid_stream.h
+++ b/pjmedia/include/pjmedia/vid_stream.h
@@ -91,7 +91,17 @@ typedef enum pjmedia_vid_stream_rc_method
      * invoking the video stream put_frame(), e.g: video capture device thread,
      * will be blocked whenever transmission delay takes place.
      */
-    PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING   = 1
+    PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING   = 1,
+
+    /**
+     * Using a dedicated sending thread. Outgoing RTP packets will be queued
+     * to be sent by a dedicated sending thread to avoid peak bandwidth that
+     * is much higher than specified. Unlike simple blocking, the thread
+     * invoking the video stream put_frame() will not be blocked. This will
+     * generally provide better video latency than the simple blocking method
+     * because of more accurate bitrate calculation.
+     */
+    PJMEDIA_VID_STREAM_RC_SEND_THREAD       = 2
 
 } pjmedia_vid_stream_rc_method;
 
@@ -104,7 +114,7 @@ typedef struct pjmedia_vid_stream_rc_config
     /**
      * Rate control method.
      *
-     * Default: PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING.
+     * Default: PJMEDIA_VID_STREAM_RC_SEND_THREAD.
      */
     pjmedia_vid_stream_rc_method    method;
 


### PR DESCRIPTION
Currently, by default, video RTP sending rate control is using simple blocking method or `PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING`. This method seems to introduce significant latency compared to `PJMEDIA_VID_STREAM_RC_NONE`. So this PR implements an alternative method to avoid the latency impact while still applying the sending rate control by using a dedicated-thread for sending video RTP packets. Moreover, this alternative method will not block the stream's `put_frame()` invoker. Currently, each video stream will have a dedicated thread.

In #4325, we try to measure the delay between audio & video playbacks (audio is usually played first). When making video call to self using pjsua app, the delay with `PJMEDIA_VID_STREAM_RC_NONE` method is about 200-400ms while with `PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING` method is 500-1000ms. With `PJMEDIA_VID_STREAM_RC_SEND_THREAD` the delay seems to be similar to `PJMEDIA_VID_STREAM_RC_NONE`. So I think it is a good idea to make this the default rate control method.

Also in this PR, move the copying stream info to before media transport attach, as when testing this patch, I saw occasional crash in `on_rx_rtp()` due to accessing uninitialized stream info.

