### PR TITLE
Order route set based on dialogs role

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1984,7 +1984,11 @@ static void dlg_update_routeset(pjsip_dialog *dlg, const pjsip_rx_data *rdata)
             pjsip_route_hdr *r;
             r = (pjsip_route_hdr*) pjsip_hdr_clone(dlg->pool, hdr);
             pjsip_routing_hdr_set_route(r);
-            pj_list_push_back(&dlg->route_set, r);
+            if (dlg->role == PJSIP_ROLE_UAC) {
+                pj_list_push_back(&dlg->route_set, r);
+            } else {
+                pj_list_push_front(&dlg->route_set, r);
+            }
         }
     }
 


### PR DESCRIPTION
RFC 3261 specifies, that:

>  The route set MUST be set to the list of URIs in the Record-Route
>  header field from the request, taken in order and preserving all URI
>  parameters.

-- section 12.1.1 UAS behavior

also:

>  The route set MUST be set to the list of URIs in the Record-Route
>  header field from the response, taken in reverse order and preserving
>  all URI parameters.

-- section 12.1.2 UAC behavior

Currently, just the UAC behavior was taken into account backward iterating the list.

While still continuing to iterate backwards, the route is appended in front if the role is UAS.