### PR TITLE
Avoid 100rel retransmit if invite transaction no longer exists

### DIFF
--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -978,6 +978,10 @@ PJ_DEF(void*) pj_thread_local_get(long index)
     //Can't check stack because this function is called
     //by PJ_CHECK_STACK() itself!!!
     //PJ_CHECK_STACK();
+    if (index == -1)
+    {
+        return 0;
+    }
 #if defined(PJ_WIN32_WINPHONE8) && PJ_WIN32_WINPHONE8
     return TlsGetValueRT(index);
 #else

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -978,10 +978,7 @@ PJ_DEF(void*) pj_thread_local_get(long index)
     //Can't check stack because this function is called
     //by PJ_CHECK_STACK() itself!!!
     //PJ_CHECK_STACK();
-    if (index == -1)
-    {
-        return 0;
-    }
+    PJ_ASSERT_RETURN(index >= 0, NULL);
 #if defined(PJ_WIN32_WINPHONE8) && PJ_WIN32_WINPHONE8
     return TlsGetValueRT(index);
 #else

--- a/pjmedia/include/pjmedia/circbuf.h
+++ b/pjmedia/include/pjmedia/circbuf.h
@@ -84,9 +84,14 @@ PJ_INLINE(pj_status_t) pjmedia_circ_buf_create(pj_pool_t *pool,
 {
     pjmedia_circ_buf *cbuf;
 
+    *p_cb = NULL;
+
     cbuf = PJ_POOL_ZALLOC_T(pool, pjmedia_circ_buf);
-    cbuf->buf = (pj_int16_t*) pj_pool_calloc(pool, capacity, 
-                                             sizeof(pj_int16_t));
+    if (!cbuf)
+        return PJ_ENOMEM;
+    cbuf->buf = (pj_int16_t*) pj_pool_calloc(pool, capacity, sizeof(pj_int16_t));
+    if (!cbuf->buf)
+        return PJ_ENOMEM;
     cbuf->capacity = capacity;
     cbuf->start = cbuf->buf;
     cbuf->len = 0;

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -581,7 +581,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
         /* Clear all pending responses */
         clear_all_responses(dd);
 
-        /* Send 500 response */
+        /* Send 504 (Server Time-out) response */
         status = pjsip_inv_end_session(dd->inv, 504, &reason, &tdata);
         if (status == PJ_SUCCESS && tdata) {
             pjsip_dlg_send_response(dd->inv->dlg, 

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -582,7 +582,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
         clear_all_responses(dd);
 
         /* Send 500 response */
-        status = pjsip_inv_end_session(dd->inv, 500, &reason, &tdata);
+        status = pjsip_inv_end_session(dd->inv, 504, &reason, &tdata);
         if (status == PJ_SUCCESS && tdata) {
             pjsip_dlg_send_response(dd->inv->dlg, 
                                     dd->inv->invite_tsx,
@@ -608,7 +608,10 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
             return;
         }
     } else {
-        pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
+        if (dd->inv->invite_tsx)
+            pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
+        else
+            pjsip_tx_data_dec_ref(tdata);
     }
 
     if (final) {

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -592,7 +592,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
         status = pjsip_inv_end_session(dd->inv, 504, &reason, &tdata);
         if (status == PJ_SUCCESS && tdata) {
             pjsip_dlg_send_response(dd->inv->dlg, 
-                                    dd->inv->invite_tsx,
+                                    invite_tsx,
                                     tdata);
         }
         return;
@@ -608,14 +608,14 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
     if (dd->uas_state->retransmit_count == 1) {
         pj_status_t status;
         
-        status = pjsip_tsx_send_msg(dd->inv->invite_tsx, tdata);
+        status = pjsip_tsx_send_msg(invite_tsx, tdata);
         if (status != PJ_SUCCESS) {
             PJ_PERROR(3, (THIS_FILE, status,
                          "Failed to send message"));
             return;
         }
     } else {
-        pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
+        pjsip_tsx_retransmit_no_state(invite_tsx, tdata);
     }
 
     if (final) {

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -557,6 +557,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
                           struct pj_timer_entry *entry)
 {
     dlg_data *dd;
+    pjsip_transaction* invite_tsx;
     tx_data_list_t *tl;
     pjsip_tx_data *tdata;
     pj_bool_t final;
@@ -567,6 +568,12 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
     dd = (dlg_data*) entry->user_data;
 
     entry->id = PJ_FALSE;
+
+    invite_tsx = dd->inv->invite_tsx;
+    if (!invite_tsx) {
+        clear_all_responses(dd);
+        return;
+    }
 
     ++dd->uas_state->retransmit_count;
     if (dd->uas_state->retransmit_count >= 7) {
@@ -608,10 +615,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
             return;
         }
     } else {
-        if (dd->inv->invite_tsx)
             pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
-        else
-            pjsip_tx_data_dec_ref(tdata);
     }
 
     if (final) {

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -615,7 +615,7 @@ static void on_retransmit(pj_timer_heap_t *timer_heap,
             return;
         }
     } else {
-            pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
+        pjsip_tsx_retransmit_no_state(dd->inv->invite_tsx, tdata);
     }
 
     if (final) {


### PR DESCRIPTION
Also a couple of misc fixes included in this PR:
- Add assertion in os_core_win32 `pj_thread_local_get()` if the thread index is invalid.
- Add memory allocation check in pjmedia circular buffer.
