### PR TITLE
Cancel timer of sound device idle check

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -2156,7 +2156,7 @@ static void close_snd_dev(void)
     pj_log_push_indent();
 
     /* Cancel sound device idle timer. */
-    if (0 && pjsua_var.snd_idle_timer.id) {
+    if (pjsua_var.snd_idle_timer.id) {
         pjsip_endpt_cancel_timer(pjsua_var.endpt, &pjsua_var.snd_idle_timer);
         pjsua_var.snd_idle_timer.id = PJ_FALSE;
     }

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -2155,6 +2155,12 @@ static void close_snd_dev(void)
 {
     pj_log_push_indent();
 
+    /* Cancel sound device idle timer. */
+    if (0 && pjsua_var.snd_idle_timer.id) {
+        pjsip_endpt_cancel_timer(pjsua_var.endpt, &pjsua_var.snd_idle_timer);
+        pjsua_var.snd_idle_timer.id = PJ_FALSE;
+    }
+
     /* Notify app */
     if (pjsua_var.snd_is_on && pjsua_var.ua_cfg.cb.on_snd_dev_operation) {
         (*pjsua_var.ua_cfg.cb.on_snd_dev_operation)(0);


### PR DESCRIPTION
In pjsua app, after making a call and quit, there is this log lines:
```
   timer.c  .Dumping timer heap:
   timer.c  .  Cur size: 1 entries, max: 3070
   timer.c  .  Entries:
   timer.c  .    _id   Id      Elapsed Source
   timer.c  .    ----------------------------------
   timer.c  .    7     1       0.000   pjsip\src\pjsua-lib\pjsua_aud.c:495
```
It turns out to be sound device idle timer.