### PR TITLE
Fix PJ_PERROR message mismatch when call pjsua_vid_channel_update

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4045,9 +4045,10 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
 
         if (call->opt.flag & PJSUA_CALL_SET_MEDIA_DIR) {
             call_med->def_dir = call->opt.media_dir[mi];
-            PJ_LOG(4,(THIS_FILE, "Call %d: setting audio media "
+            PJ_LOG(4,(THIS_FILE, "Call %d: setting %s media "
                                  "direction #%d to %d.",
-                                 call_id, mi, call_med->def_dir));
+                                 call_id, pjmedia_type_name(call_med->type), mi,
+                                 call_med->def_dir));
         }
 
         /* If the default direction specifies we do not wish
@@ -4189,7 +4190,7 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
         if (status != PJ_SUCCESS) {
             PJ_PERROR(1,(THIS_FILE, status,
                          "pjmedia_transport_media_start() failed "
-                             "for call_id %d media %d",
+                         "for call_id %d media %d",
                          call_id, mi));
             return status;
         }
@@ -4221,8 +4222,9 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
             }
             if (status != PJ_SUCCESS) {
                 PJ_PERROR(1,(THIS_FILE, status,
-                             "pjsua_aud_channel_update() failed "
-                                 "for call_id %d media %d",
+                             "%s channel_update failed "
+                             "for call_id %d media %d",
+                             pjmedia_type_name(call_med->type),
                              call_id, mi));
                 return status;
             }


### PR DESCRIPTION
when I debug with vidgui demo with video support, I found some message like below
![image](https://github.com/user-attachments/assets/cfdb9bd1-a806-4d13-be4c-ece0034bc57c)

But the real error is when call function ``pjsua_vid_channel_update``, the debug message is mismatch , so I pull this pr.
Besides I format some code format.