### PR TITLE
Add options to set `op` and `amf` for aka auth in pjsua cli tool

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_common.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.c
@@ -64,6 +64,31 @@ int my_atoi2(const pj_str_t *str)
     }
 }
 
+int my_hex_string_to_octet_array(const char *hex, int len, char octet[])
+{
+     int i;
+     for (i = 0; i < len; i+=2) {
+         int tmp;
+         if (i+1 >= len || !pj_isxdigit(hex[i]) || !pj_isxdigit(hex[i+1]))
+             return i;
+         tmp  = pj_hex_digit_to_val((unsigned char)hex[i]) << 4;
+         tmp |= pj_hex_digit_to_val((unsigned char)hex[i+1]);
+         octet[i/2] = (char)(tmp & 0xFF);
+     }
+     return len;
+}
+
+void my_octet_array_to_hex_string(const char octet[], int len, char hex[])
+{
+     int i;
+     char *p = hex;
+     for (i = 0; i<len; ++i) {
+         pj_val_to_hex_digit(octet[i], p);
+         p += 2;
+     }
+}
+
+
 /*
  * Find next call when current call is disconnected or when user
  * press ']'

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -171,6 +171,8 @@ extern pj_bool_t            app_running;
 
 int my_atoi(const char *cs);
 int my_atoi2(const pj_str_t *s);
+int my_hex_string_to_octet_array(const char *hex, int len, char octet[]);
+void my_octet_array_to_hex_string(const char octet[], int len, char hex[]);
 pj_bool_t find_next_call(void);
 pj_bool_t find_prev_call(void);
 void send_request(char *cstr_method, const pj_str_t *dst_uri);

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -55,6 +55,12 @@ static void usage(void)
     puts  ("  --realm=string      Set realm");
     puts  ("  --username=string   Set authentication username");
     puts  ("  --password=string   Set authentication password");
+
+#if PJSIP_HAS_DIGEST_AKA_AUTH
+    puts  ("  --op=string         Set OP value to use in Digest AKA authentication");
+    puts  ("  --amf=string        Set AMF value to use in Digest AKA authentication");
+#endif
+
     puts  ("  --contact=url       Optionally override the Contact information");
     puts  ("  --contact-params=S  Append the specified parameters S in Contact header");
     puts  ("  --contact-uri-params=S  Append the specified parameters S in Contact URI");
@@ -367,7 +373,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_LOCAL_PORT, OPT_IP_ADDR, OPT_PROXY, OPT_OUTBOUND_PROXY,
            OPT_REGISTRAR, OPT_REG_TIMEOUT, OPT_PUBLISH, OPT_ID, OPT_CONTACT,
            OPT_BOUND_ADDR, OPT_CONTACT_PARAMS, OPT_CONTACT_URI_PARAMS,
-           OPT_100REL, OPT_USE_IMS, OPT_REALM, OPT_USERNAME, OPT_PASSWORD,
+           OPT_100REL, OPT_USE_IMS, OPT_REALM, OPT_USERNAME, OPT_PASSWORD, OPT_OP, OPT_AMF,
            OPT_REG_RETRY_INTERVAL, OPT_REG_USE_PROXY,
            OPT_MWI, OPT_NAMESERVER, OPT_STUN_SRV, OPT_UPNP, OPT_OUTB_RID,
            OPT_ADD_BUDDY, OPT_OFFER_X_MS_MSG, OPT_NO_PRESENCE,
@@ -446,6 +452,10 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "realm",      1, 0, OPT_REALM},
         { "username",   1, 0, OPT_USERNAME},
         { "password",   1, 0, OPT_PASSWORD},
+#if PJSIP_HAS_DIGEST_AKA_AUTH
+        { "op",   1, 0, OPT_OP},
+        { "amf",   1, 0, OPT_AMF},
+#endif
         { "rereg-delay",1, 0, OPT_REG_RETRY_INTERVAL},
         { "reg-use-proxy", 1, 0, OPT_REG_USE_PROXY},
         { "nameserver", 1, 0, OPT_NAMESERVER},
@@ -908,6 +918,14 @@ static pj_status_t parse_args(int argc, char *argv[],
             cur_acc->cred_info[cur_acc->cred_count].data_type |= PJSIP_CRED_DATA_EXT_AKA;
             cur_acc->cred_info[cur_acc->cred_count].ext.aka.k = pj_str(pj_optarg);
             cur_acc->cred_info[cur_acc->cred_count].ext.aka.cb = &pjsip_auth_create_aka_response;
+            break;
+
+        case OPT_OP:        /* aka op */
+            cur_acc->cred_info[cur_acc->cred_count].ext.aka.op = pj_str(pj_optarg);
+            break;
+
+        case OPT_AMF:       /* aka amf */
+            cur_acc->cred_info[cur_acc->cred_count].ext.aka.amf = pj_str(pj_optarg);
 #endif
             break;
 

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1831,6 +1831,22 @@ static void write_account_settings(int acc_index, pj_str_t *result)
             pj_strcat2(result, line);
         }
 
+#if PJSIP_HAS_DIGEST_AKA_AUTH
+        if (acc_cfg->cred_info[i].ext.aka.op.slen) {
+            pj_ansi_snprintf(line, sizeof(line), "--op %.*s\n",
+                                  (int)acc_cfg->cred_info[i].ext.aka.op.slen,
+                                  acc_cfg->cred_info[i].ext.aka.op.ptr);
+            pj_strcat2(result, line);
+        }
+
+        if (acc_cfg->cred_info[i].ext.aka.amf.slen) {
+            pj_ansi_snprintf(line, sizeof(line), "--amf %.*s\n",
+                                  (int)acc_cfg->cred_info[i].ext.aka.amf.slen,
+                                  acc_cfg->cred_info[i].ext.aka.amf.ptr);
+            pj_strcat2(result, line);
+        }
+#endif
+
         if (i != acc_cfg->cred_count - 1)
             pj_strcat2(result, "--next-cred\n");
     }

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -57,8 +57,8 @@ static void usage(void)
     puts  ("  --password=string   Set authentication password");
 
 #if PJSIP_HAS_DIGEST_AKA_AUTH
-    puts  ("  --op=string         Set OP value to use in Digest AKA authentication");
-    puts  ("  --amf=string        Set AMF value to use in Digest AKA authentication");
+    puts  ("  --aka-op=string     Set OP value to use in Digest AKA authentication");
+    puts  ("  --aka-amf=string    Set AMF value to use in Digest AKA authentication");
 #endif
 
     puts  ("  --contact=url       Optionally override the Contact information");
@@ -373,7 +373,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_LOCAL_PORT, OPT_IP_ADDR, OPT_PROXY, OPT_OUTBOUND_PROXY,
            OPT_REGISTRAR, OPT_REG_TIMEOUT, OPT_PUBLISH, OPT_ID, OPT_CONTACT,
            OPT_BOUND_ADDR, OPT_CONTACT_PARAMS, OPT_CONTACT_URI_PARAMS,
-           OPT_100REL, OPT_USE_IMS, OPT_REALM, OPT_USERNAME, OPT_PASSWORD, OPT_OP, OPT_AMF,
+           OPT_100REL, OPT_USE_IMS, OPT_REALM, OPT_USERNAME, OPT_PASSWORD, OPT_AKA_OP, OPT_AKA_AMF,
            OPT_REG_RETRY_INTERVAL, OPT_REG_USE_PROXY,
            OPT_MWI, OPT_NAMESERVER, OPT_STUN_SRV, OPT_UPNP, OPT_OUTB_RID,
            OPT_ADD_BUDDY, OPT_OFFER_X_MS_MSG, OPT_NO_PRESENCE,
@@ -453,8 +453,8 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "username",   1, 0, OPT_USERNAME},
         { "password",   1, 0, OPT_PASSWORD},
 #if PJSIP_HAS_DIGEST_AKA_AUTH
-        { "op",   1, 0, OPT_OP},
-        { "amf",   1, 0, OPT_AMF},
+        { "aka-op",   1, 0, OPT_AKA_OP},
+        { "aka-amf",   1, 0, OPT_AKA_AMF},
 #endif
         { "rereg-delay",1, 0, OPT_REG_RETRY_INTERVAL},
         { "reg-use-proxy", 1, 0, OPT_REG_USE_PROXY},
@@ -920,11 +920,11 @@ static pj_status_t parse_args(int argc, char *argv[],
             cur_acc->cred_info[cur_acc->cred_count].ext.aka.cb = &pjsip_auth_create_aka_response;
             break;
 
-        case OPT_OP:        /* aka op */
+        case OPT_AKA_OP:    /* aka op */
             cur_acc->cred_info[cur_acc->cred_count].ext.aka.op = pj_str(pj_optarg);
             break;
 
-        case OPT_AMF:       /* aka amf */
+        case OPT_AKA_AMF:   /* aka amf */
             cur_acc->cred_info[cur_acc->cred_count].ext.aka.amf = pj_str(pj_optarg);
 #endif
             break;
@@ -1833,14 +1833,14 @@ static void write_account_settings(int acc_index, pj_str_t *result)
 
 #if PJSIP_HAS_DIGEST_AKA_AUTH
         if (acc_cfg->cred_info[i].ext.aka.op.slen) {
-            pj_ansi_snprintf(line, sizeof(line), "--op %.*s\n",
+            pj_ansi_snprintf(line, sizeof(line), "--aka-op %.*s\n",
                                   (int)acc_cfg->cred_info[i].ext.aka.op.slen,
                                   acc_cfg->cred_info[i].ext.aka.op.ptr);
             pj_strcat2(result, line);
         }
 
         if (acc_cfg->cred_info[i].ext.aka.amf.slen) {
-            pj_ansi_snprintf(line, sizeof(line), "--amf %.*s\n",
+            pj_ansi_snprintf(line, sizeof(line), "--aka-amf %.*s\n",
                                   (int)acc_cfg->cred_info[i].ext.aka.amf.slen,
                                   acc_cfg->cred_info[i].ext.aka.amf.ptr);
             pj_strcat2(result, line);


### PR DESCRIPTION
[The documentation](https://docs.pjsip.org/en/latest/api/generated/pjsip/group/group__PJSIP__AUTH__AKA__API.html#group__PJSIP__AUTH__AKA__API_1gaafe9da8c3964f2dff4441854d7be7a1f) specifies that if pjsip is compiled with Digest AKA Authentication support then:

> Optionally application may set ext.aka.op and ext.aka.amf in the credential to specify AKA Operator variant key and AKA Authentication Management Field information.

This PR adds some options to pjsua cli interface in order to set them on app launch if needed.

> [!TIP]
> As of https://github.com/pjsip/pjproject/issues/1728, manually linking of **milenage** third-party library is required. Easiest way I found of doing this was to simply run a `git revert` on 7a302f27edb85c74c9a171383bfb561f9992291a