### PR TITLE
fix pj_time_decode for 64 bit time_t and 32 bit long int, (time_t*) casting was wrong

### DIFF
--- a/pjlib/src/pj/os_time_common.c
+++ b/pjlib/src/pj/os_time_common.c
@@ -28,14 +28,15 @@
 PJ_DEF(pj_status_t) pj_time_decode(const pj_time_val *tv, pj_parsed_time *pt)
 {
     struct tm local_time;
+    time_t sec = tv->sec; // time_t might be 64 bit even when long int is 32 bit, (time_t*) dangerous
 
     PJ_CHECK_STACK();
 
 #if defined(PJ_HAS_LOCALTIME_R) && PJ_HAS_LOCALTIME_R != 0
-    localtime_r((time_t*)&tv->sec, &local_time);
+    localtime_r(&sec, &local_time);
 #else
     /* localtime() is NOT thread-safe. */
-    local_time = *localtime((time_t*)&tv->sec);
+    local_time = *localtime(&sec);
 #endif
 
     pt->year = local_time.tm_year+1900;


### PR DESCRIPTION
Using pjproject pjsua in Xilinx Zynq-7000 (ARM cortexa9t2hf-neon-xilinx-linux-gnueabi, yocto PetaLinux-2024.2) which is 32 bit little endian I have seen seemingly random times reported:

09:56:11.515 strm0xb4c06cac  Start talksprut..
12:53:15.534 strm0xb4c06cac  Starting silence
08:54:20.118   silencedet.c  Re-adjust threshold (in silence)to 0
14:25:02.308 strm0xb4c06cac  Frame lost, recovered!

glibc 2.39
gcc 13.3.0
it seems that it has **64 bit time_t and 32 bit long int** which causes using pj_time_val.**msec as higher 32 bit of time_t**
localtime((time_t*)&tv->sec)
that means (time_t*) (64 bit) fetches both tv->sec and tv->msec (as higher 32 bits)

Another solution could be for year 2038 making pj_time_val.sec time_t instead of long. But it requires thorough checking of pjproject time handling, I am not qualified to do it.

My solution is very localized and low impact.

