### PR TITLE
Fixed pjsip test build failure

### DIFF
--- a/pjsip/build/Makefile
+++ b/pjsip/build/Makefile
@@ -192,8 +192,8 @@ export TEST_LDFLAGS += $(PJSIP_LDLIB) \
 		       $(PJMEDIA_VIDEODEV_LDLIB) \
 		       $(PJMEDIA_LDLIB) \
 		       $(PJMEDIA_AUDIODEV_LDLIB) \
-		       $(PJLIB_UTIL_LDLIB) \
 		       $(PJNATH_LDLIB) \
+		       $(PJLIB_UTIL_LDLIB) \
 		       $(PJLIB_LDLIB) \
 		       $(_LDFLAGS)
 ifeq ($(EXCLUDE_APP),0)


### PR DESCRIPTION
On Ubuntu CI, pjsip test will fail to build due to incorrect dependency order.
pjnath should depend on pjlib-util.

Log:
```
2025-03-19T09:16:26.1716545Z g++ -o ../bin/pjsip-test-x86_64-unknown-linux-gnu \
2025-03-19T09:16:26.1730825Z      output/pjsip-test-x86_64-unknown-linux-gnu/main.o  output/pjsip-test-x86_64-unknown-linux-gnu/dlg_core_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/dns_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/msg_err_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/msg_logger.o  output/pjsip-test-x86_64-unknown-linux-gnu/msg_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/multipart_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/regc_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/test.o  output/pjsip-test-x86_64-unknown-linux-gnu/transport_loop_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/transport_tcp_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/transport_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/transport_udp_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/tsx_basic_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/tsx_bench.o  output/pjsip-test-x86_64-unknown-linux-gnu/tsx_uac_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/tsx_uas_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/txdata_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/uri_test.o  output/pjsip-test-x86_64-unknown-linux-gnu/inv_offer_answer_test.o -lpjsip-x86_64-unknown-linux-gnu -lpjsip-ua-x86_64-unknown-linux-gnu -lpjsip-simple-x86_64-unknown-linux-gnu  -lpjmedia-codec-x86_64-unknown-linux-gnu -lpjmedia-videodev-x86_64-unknown-linux-gnu -lpjmedia-x86_64-unknown-linux-gnu -lpjmedia-audiodev-x86_64-unknown-linux-gnu -lpjlib-util-x86_64-unknown-linux-gnu -lpjnath-x86_64-unknown-linux-gnu -lpj-x86_64-unknown-linux-gnu -lsrtp-x86_64-unknown-linux-gnu -lresample-x86_64-unknown-linux-gnu -lgsmcodec-x86_64-unknown-linux-gnu -lspeex-x86_64-unknown-linux-gnu -lilbccodec-x86_64-unknown-linux-gnu -lg7221codec-x86_64-unknown-linux-gnu -lyuv-x86_64-unknown-linux-gnu -lwebrtc-x86_64-unknown-linux-gnu   -rdynamic -lssl -lcrypto -lm -lrt -lpthread    -lopencore-amrnb   -L/home/runner/work/pjproject/pjproject/pjlib/lib -L/home/runner/work/pjproject/pjproject/pjlib-util/lib -L/home/runner/work/pjproject/pjproject/pjnath/lib -L/home/runner/work/pjproject/pjproject/pjmedia/lib -L/home/runner/work/pjproject/pjproject/pjsip/lib -L/home/runner/work/pjproject/pjproject/third_party/lib             -rdynamic  

2025-03-19T09:16:26.2810085Z /usr/bin/ld: /home/runner/work/pjproject/pjproject/pjnath/lib/libpjnath-x86_64-unknown-linux-gnu.a(stun_auth.o): in function `calc_md5_key':
2025-03-19T09:16:26.2812506Z /home/runner/work/pjproject/pjproject/pjnath/build/../src/pjnath/stun_auth.c:90:(.text+0x27f): undefined reference to `pj_md5_init'
2025-03-19T09:16:26.2814577Z /usr/bin/ld: /home/runner/work/pjproject/pjproject/pjnath/build/../src/pjnath/stun_auth.c:100:(.text+0x305): undefined reference to `pj_md5_update'
2025-03-19T09:16:26.2825650Z /usr/bin/ld: /home/runner/work/pjproject/pjproject/pjnath/build/../src/pjnath/stun_auth.c:119:(.text+0x3f7): undefined reference to `pj_md5_final'
2025-03-19T09:16:26.2829033Z /usr/bin/ld: /home/runner/work/pjproject/pjproject/pjnath/lib/libpjnath-x86_64-unknown-linux-gnu.a(stun_auth.o): in function `pj_stun_authenticate_request':
2025-03-19T09:16:26.2830953Z /home/runner/work/pjproject/pjproject/pjnath/build/../src/pjnath/stun_auth.c:448:(.text+0x107f): undefined reference to `pj_hmac_sha1_init'
2025-03-19T09:16:26.2832910Z /usr/bin/ld: /home/runner/work/pjproject/pjproject/pjnath/build/../src/pjnath/stun_auth.c:463:(.text+0x10db): undefined reference to `pj_hmac_sha1_update'
2025-03-19T09:16:26.2838764Z /usr/bin/ld: /home/runner/work/pjproject/pjproject/pjnath/build/../src/pjnath/stun_auth.c:479:(.text+0x1134): undefined reference to `pj_hmac_sha1_final'
...
```
