### PR TITLE
Surround the AMediaCodec_setAsyncNotifyCallback (API 28+) with availability check

### DIFF
--- a/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
@@ -1093,8 +1093,12 @@ static pj_status_t and_media_codec_open(pjmedia_codec *codec,
                    s->dec_setting.octet_aligned, s->dec_setting.reorder));
     }
 #endif
-    AMediaCodec_setAsyncNotifyCallback(codec_data->enc, async_cb, codec_data);
-    AMediaCodec_setAsyncNotifyCallback(codec_data->dec, async_cb, codec_data);
+    if (__builtin_available(android 28, *)) {
+        AMediaCodec_setAsyncNotifyCallback(codec_data->enc,
+                                           async_cb, codec_data);
+        AMediaCodec_setAsyncNotifyCallback(codec_data->dec,
+                                           async_cb, codec_data);
+    }
 
     status = configure_codec(codec_data, PJ_TRUE);
     if (status != PJ_SUCCESS) {

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1062,10 +1062,12 @@ static pj_status_t and_media_codec_open(pjmedia_vid_codec *codec,
         if (status != PJ_SUCCESS)
             return status;
     }
-    AMediaCodec_setAsyncNotifyCallback(and_media_data->enc, async_cb,
-                                       and_media_data);
-    AMediaCodec_setAsyncNotifyCallback(and_media_data->dec, async_cb,
-                                       and_media_data);
+    if (__builtin_available(android 28, *)) {
+        AMediaCodec_setAsyncNotifyCallback(and_media_data->enc, async_cb,
+                                           and_media_data);
+        AMediaCodec_setAsyncNotifyCallback(and_media_data->dec, async_cb,
+                                           and_media_data);
+    }
 
     and_media_data->whole = (param->packing == PJMEDIA_VID_PACKING_WHOLE);
     status = configure_encoder(and_media_data);


### PR DESCRIPTION
Surround the AMediaCodec_setAsyncNotifyCallback (API 28+) with availability check This is needed in order to allow the library to compile when targeting old Android SDK (21 for example). Otherwise, the library can only compile with the minimum API of 28