### PR TITLE
Update configure-android to use 'grep' if 'jq' is not available

### DIFF
--- a/configure-android
+++ b/configure-android
@@ -47,7 +47,11 @@ if test "x$APP_PLATFORM" = "x"; then
   if test -d ${ANDROID_NDK_ROOT}/platforms; then
     APP_PLATFORM=`ls ${ANDROID_NDK_ROOT}/platforms/ | sed 's/android-//' | sort -gr | head -1`
   elif test -f ${ANDROID_NDK_ROOT}/meta/platforms.json; then
-    APP_PLATFORM=`cat ${ANDROID_NDK_ROOT}/meta/platforms.json  | jq -r ".min"`
+    if ! [ -x "$(command -v jq)" ]; then
+      APP_PLATFORM=`cat ${ANDROID_NDK_ROOT}/meta/platforms.json  | grep -o '"min":[[:space:]]*[[:digit:]]*' | head -1 | grep -o '[[:digit:]]*' `
+    else
+      APP_PLATFORM=`cat ${ANDROID_NDK_ROOT}/meta/platforms.json  | jq -r ".min"`
+    fi
   fi
   if test "x$APP_PLATFORM" != "x"; then
     APP_PLATFORM="android-${APP_PLATFORM}"


### PR DESCRIPTION
When `jq` is not available (e.g: in MSYS2 default package), `configure-android` prints error and uses latest API level:
```
./configure-android: line 50: jq: command not found
configure-android: APP_PLATFORM not specified, using latest
```

This PR detects `jq` and fallback to using `grep` when `jq` is not available.