### PR TITLE
Android unit test

### DIFF
--- a/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/build.gradle
@@ -6,6 +6,8 @@ plugins {
 android {
     compileSdk 33
 
+    buildFeatures.buildConfig true
+
     defaultConfig {
         applicationId "org.pjsip.pjsua2.app_kotlin"
         minSdkVersion 23
@@ -18,6 +20,18 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    flavorDimensions "version"
+    productFlavors {
+        demo {
+            isDefault true
+            dimension "version"
+            buildConfigField "int", "SIP_PORT", "6000"
+        }
+        ciTest {
+            dimension "version"
+            buildConfigField "int", "SIP_PORT", "6677"
         }
     }
     compileOptions {
@@ -33,7 +47,7 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'     
     implementation project(path: ':pjsua2')
 }

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/java/org/pjsip/pjsua2/app_kotlin/MainActivity.kt
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/java/org/pjsip/pjsua2/app_kotlin/MainActivity.kt
@@ -5,8 +5,8 @@ import android.hardware.camera2.CameraManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Message
-import android.support.v4.app.ActivityCompat
-import android.support.v7.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.View

--- a/pjsip-apps/src/swig/java/android/app-kotlin/src/main/res/layout/activity_main.xml
+++ b/pjsip-apps/src/swig/java/android/app-kotlin/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/relativeLayout"
@@ -81,4 +81,4 @@
     </RelativeLayout>
 
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pjsip-apps/src/swig/java/android/app/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app/build.gradle
@@ -2,11 +2,14 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdk 33
+    buildFeatures.buildConfig true
+
 
     defaultConfig {
         applicationId "org.pjsip.pjsua2.app"
         minSdkVersion 23
         targetSdkVersion 33
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -15,10 +18,34 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+    flavorDimensions "version"
+    productFlavors {
+        demo {
+            isDefault true
+            dimension "version"
+            buildConfigField "int", "SIP_PORT", "6000"
+            buildConfigField "boolean", "IS_TEST", "false"
+            buildConfigField "String", "TEST_TAG", "\"demo\""
+        }
+        ciTest {
+            dimension "version"
+            buildConfigField "int", "SIP_PORT", "6677"
+            buildConfigField "boolean", "IS_TEST", "true"
+            buildConfigField "String", "TEST_TAG", "\"ciTest\""
+        }
+    }
     namespace 'org.pjsip.pjsua2.app'
 }
 
 dependencies {
     implementation project(path: ':pjsua2')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.5'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    testImplementation 'junit:junit:4.12'
 }

--- a/pjsip-apps/src/swig/java/android/app/src/androidTest/AndroidManifest.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="org.pjsip.pjsua2.app"
+        android:handleProfiling="false"
+        android:functionalTest="false" />
+
+    <application>
+        <uses-library android:name="android.test.runner" />
+    </application>
+
+</manifest>

--- a/pjsip-apps/src/swig/java/android/app/src/androidTest/java/org/pjsip/pjsua2/app/Pjsua2Test.java
+++ b/pjsip-apps/src/swig/java/android/app/src/androidTest/java/org/pjsip/pjsua2/app/Pjsua2Test.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2025 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package org.pjsip.pjsua2.app;
+
+import org.pjsip.pjsua2.*;
+import org.pjsip.pjsua2.app.BuildConfig;
+
+import java.io.File;
+import java.util.HashMap;
+
+import android.Manifest;
+import android.content.Context;
+import android.util.Log;
+import android.util.SparseBooleanArray;
+import android.widget.ListView;
+import android.os.Environment;
+
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResource;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static org.hamcrest.Matchers.anything;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+class Holder<T> {
+    T value;
+}
+
+@RunWith(AndroidJUnit4.class)
+public class Pjsua2Test {
+    final static String TAG = "PJSUA2Test";
+    final static String FILE_NAME = "pjsua2test_screenshot.png";
+
+    private UiDevice device;
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> activityScenarioRule =
+            new ActivityScenarioRule<>(MainActivity.class);
+
+    @Before
+    public void setup() {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        InstrumentationRegistry.getInstrumentation().getUiAutomation().grantRuntimePermission(
+            InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageName(),
+            "android.permission.CAMERA"
+        );
+        InstrumentationRegistry.getInstrumentation().getUiAutomation().grantRuntimePermission(
+            InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageName(),
+            "android.permission.RECORD_AUDIO"
+        );
+
+        Context appContext =
+            InstrumentationRegistry.getInstrumentation().getTargetContext();
+        assertEquals(BuildConfig.APPLICATION_ID, appContext.getPackageName());
+    }
+
+    private void takeScreenshot() throws Exception {
+        UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        File path = new File(Environment.getExternalStoragePublicDirectory(
+                             Environment.DIRECTORY_PICTURES).getAbsolutePath(),
+                       "screenshots");
+        if (!path.exists()) {
+            if (!path.mkdirs()) {
+                System.err.println("Failed to create "+ path.getAbsolutePath() +  " directory");
+                return;
+            }
+        }
+        System.out.println("Taking screenshot to : " + path.getAbsolutePath() + "//" + FILE_NAME);
+        device.takeScreenshot(new File(path, FILE_NAME));
+    }
+
+    @Test
+    public void addBuddy() {
+        String localUri = "sip:localhost";
+
+        localUri += ":" + Integer.toString(BuildConfig.SIP_PORT);
+        Log.d(TAG, "Starting addBuddy()");
+
+        activityScenarioRule.getScenario().onActivity(activity -> {
+            activity.findViewById(R.id.buttonAddBuddy).setTag(BuildConfig.TEST_TAG);
+        });
+        onView(withId(R.id.buttonAddBuddy)).perform(click());
+
+        Log.d(TAG, "Wait for the dialog to be shown");
+        try {
+            Thread.sleep(500);
+        } catch (Exception e) {
+            Log.e(TAG,  e.getMessage());
+        };
+
+        Log.d(TAG, "Change the buddy URI");
+        onView(withId(R.id.editTextUri)).perform(replaceText(localUri));
+
+        Log.d(TAG, "Click confirm");
+        onView(withText("OK")).perform(click());
+    }
+    @Test
+    public void callBuddy() {
+        ListView listView;
+        final Holder<ListView> holder = new Holder<>();
+
+        Log.d(TAG, "Starting callBuddy()");
+
+        String localUri = "sip:localhost";
+        localUri += ":" + Integer.toString(BuildConfig.SIP_PORT);
+
+        onData(anything())
+            .inAdapterView(withId(R.id.listViewBuddy))
+            .atPosition(0)
+            .perform(click());
+
+        // Retrieve the ListView and the checked item position
+        activityScenarioRule.getScenario().onActivity(activity -> {
+            holder.value = activity.findViewById(R.id.listViewBuddy);
+        });
+        listView = holder.value;
+        assert(listView != null);
+        listView.setTag(BuildConfig.TEST_TAG);
+
+        int checkedPosition = listView.getCheckedItemPosition();
+        SparseBooleanArray checkedItems = listView.getCheckedItemPositions();
+        if (checkedItems != null) {
+            for (int i=0; i<checkedItems.size(); i++) {
+                if (checkedItems.valueAt(i)) {
+                    String item = listView.getAdapter().getItem(
+                                             checkedItems.keyAt(i)). toString();
+                }
+            }
+        }
+        assertTrue("No item is checked",
+                   checkedPosition != ListView.INVALID_POSITION);
+
+        //Get the text of the checked item
+        HashMap<String, String> checkedBuddy = (HashMap<String, String>)
+                                 listView.getAdapter().getItem(checkedPosition);
+
+        String checkedURI = checkedBuddy.get("uri");
+
+        Log.d(TAG, "Selected URI is: " + checkedURI);
+        assertEquals(localUri, checkedURI);
+
+        onView(withId(R.id.buttonCall)).perform(click());
+
+        try {
+            Thread.sleep(4000);
+            takeScreenshot();
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage());
+        };
+    }
+
+}

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -32,6 +32,7 @@ import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -42,7 +43,7 @@ import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
-import android.support.v4.app.ActivityCompat;
+import androidx.core.app.ActivityCompat;
 
 import org.pjsip.PjCameraInfo2;
 import org.pjsip.pjsua2.AccountConfig;
@@ -51,11 +52,17 @@ import org.pjsip.pjsua2.AuthCredInfoVector;
 import org.pjsip.pjsua2.BuddyConfig;
 import org.pjsip.pjsua2.CallInfo;
 import org.pjsip.pjsua2.CallOpParam;
+import org.pjsip.pjsua2.IntVector;
 import org.pjsip.pjsua2.OnCallMediaEventParam;
 import org.pjsip.pjsua2.OnTimerParam;
 import org.pjsip.pjsua2.StringVector;
+import org.pjsip.pjsua2.pjmedia_dir;
 import org.pjsip.pjsua2.pjsip_inv_state;
+import org.pjsip.pjsua2.pjsip_role_e;
 import org.pjsip.pjsua2.pjsip_status_code;
+import org.pjsip.pjsua2.app.R;
+import org.pjsip.pjsua2.app.BuildConfig;
+import org.pjsip.pjsua2.pjsua_call_flag;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -66,6 +73,8 @@ public class MainActivity extends Activity
 {
     public static MyApp app = null;
     public static MyCall currentCall = null;
+    // for ciTest build only
+    public static MyCall incomingCall = null;
     public static MyAccount account = null;
     public static AccountConfig accCfg = null;
     public static MyBroadcastReceiver receiver = null;
@@ -168,7 +177,8 @@ public class MainActivity extends Activity
                 } catch (InterruptedException e) {}
             }
 
-            app.init(this, getFilesDir().getAbsolutePath());
+            app.init(this, getFilesDir().getAbsolutePath(), false,
+                     BuildConfig.SIP_PORT, BuildConfig.IS_TEST);
         }
 
         if (app.accList.size() == 0) {
@@ -177,6 +187,7 @@ public class MainActivity extends Activity
             accCfg.getNatConfig().setIceEnabled(true);
             accCfg.getVideoConfig().setAutoTransmitOutgoing(true);
             accCfg.getVideoConfig().setAutoShowIncoming(true);
+            accCfg.getVideoConfig().setDefaultCaptureDevice(app.defVidCapDev);
             account = app.addAcc(accCfg);
         } else {
             account = app.accList.get(0);
@@ -220,6 +231,15 @@ public class MainActivity extends Activity
     }
 
     @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (receiver != null) {
+            unregisterReceiver(receiver);
+            receiver = null;
+        }
+    }
+
+    @Override
     public boolean onCreateOptionsMenu(Menu menu)
     {
         // Inflate the menu; this adds items to the action bar
@@ -232,11 +252,11 @@ public class MainActivity extends Activity
     public boolean onOptionsItemSelected(MenuItem item)
     {
         switch (item.getItemId()) {
-            case R.id.action_acc_config:
+            case R.id.action_acc_config :
                 dlgAccountSetting();
                 break;
 
-            case R.id.action_quit:
+            case R.id.action_quit :
                 Message m = Message.obtain(handler, 0);
                 m.sendToTarget();
                 break;
@@ -259,10 +279,19 @@ public class MainActivity extends Activity
             android.os.Process.killProcess(android.os.Process.myPid());
 
         } else if (m.what == MSG_TYPE.CALL_STATE) {
-
+            int callId;
+            MyCall curCall;
             CallInfo ci = (CallInfo) m.obj;
-
-            if (currentCall == null || ci == null || ci.getId() != currentCall.getId()) {
+            if (!BuildConfig.IS_TEST ||
+                ci.getRole() == pjsip_role_e.PJSIP_ROLE_UAC)
+            {
+                curCall = currentCall;
+            } else {
+                curCall = incomingCall;
+            }
+            if ((!BuildConfig.IS_TEST && currentCall == null) || ci == null ||
+                ci.getId() != curCall.getId())
+            {
                 System.out.println("Call state event received, but call info is invalid");
                 return true;
             }
@@ -275,10 +304,14 @@ public class MainActivity extends Activity
 
             if (ci.getState() == pjsip_inv_state.PJSIP_INV_STATE_DISCONNECTED)
             {
-                currentCall.delete();
-                currentCall = null;
+                if (curCall == currentCall) {
+                    currentCall.delete();
+                    currentCall = null;
+                } else if (curCall == incomingCall) {
+                    incomingCall.delete();
+                    incomingCall = null;
+                }
             }
-
         } else if (m.what == MSG_TYPE.CALL_MEDIA_STATE) {
 
             /* Forward the message to CallActivity */
@@ -324,8 +357,10 @@ public class MainActivity extends Activity
             final MyCall call = (MyCall) m.obj;
             CallOpParam prm = new CallOpParam(true);
 
-            /* Only one call at anytime */
-            if (currentCall != null) {
+            /* Only one call at anytime for demo mode */
+            if ((!BuildConfig.IS_TEST && currentCall != null) ||
+               (BuildConfig.IS_TEST && currentCall == null))
+            {
                 prm.setStatusCode(pjsip_status_code.PJSIP_SC_BUSY_HERE);
                 try {
                     call.hangup(prm);
@@ -336,13 +371,21 @@ public class MainActivity extends Activity
             }
 
             /* Answer with ringing */
-            prm.setStatusCode(pjsip_status_code.PJSIP_SC_RINGING);
+            if (BuildConfig.IS_TEST) {
+                prm.setStatusCode(pjsip_status_code.PJSIP_SC_OK);
+            } else {
+                prm.setStatusCode(pjsip_status_code.PJSIP_SC_RINGING);
+            }
             try {
                 call.answer(prm);
             } catch (Exception e) {}
 
-            currentCall = call;
-            showCallActivity();
+            if (BuildConfig.IS_TEST) {
+                incomingCall = call;
+            } else {
+                currentCall = call;
+                showCallActivity();
+            }
 
         } else if (m.what == MSG_TYPE.CHANGE_NETWORK) {
             app.handleNetworkChange();
@@ -448,6 +491,13 @@ public class MainActivity extends Activity
 
     public void makeCall(View view)
     {
+       if (BuildConfig.IS_TEST) {
+           // On ciTest build, don't allow any normal input
+           if (view.getTag() == null || view.getTag().equals(BuildConfig.TEST_TAG)) {
+               return;
+           }
+       }
+
         if (buddyListSelectedIdx == -1)
             return;
 
@@ -547,6 +597,12 @@ public class MainActivity extends Activity
 
     public void addBuddy(View view)
     {
+       if (BuildConfig.IS_TEST) {
+           // On ciTest build, don't allow any normal input
+           if (view.getTag() == null || view.getTag().equals(BuildConfig.TEST_TAG)) {
+               return;
+           }
+       }
         dlgAddEditBuddy(null);
     }
 
@@ -663,6 +719,12 @@ public class MainActivity extends Activity
 
     public void notifyCallMediaEvent(MyCall call, OnCallMediaEventParam prm)
     {
+        CallInfo ci;
+        try {
+            ci = call.getInfo();
+        } catch (Exception e) {
+            return;
+        }
         /* Forward the message to CallActivity */
         if (CallActivity.handler_ != null) {
             Message m = Message.obtain(CallActivity.handler_,

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -493,7 +493,9 @@ public class MainActivity extends Activity
     {
        if (BuildConfig.IS_TEST) {
            // On ciTest build, don't allow any normal input
-           if (view.getTag() == null || view.getTag().equals(BuildConfig.TEST_TAG)) {
+           if (view.getTag() == null ||
+              !view.getTag().equals(BuildConfig.TEST_TAG))
+           {
                return;
            }
        }
@@ -599,7 +601,9 @@ public class MainActivity extends Activity
     {
        if (BuildConfig.IS_TEST) {
            // On ciTest build, don't allow any normal input
-           if (view.getTag() == null || view.getTag().equals(BuildConfig.TEST_TAG)) {
+           if (view.getTag() == null ||
+               !view.getTag().equals(BuildConfig.TEST_TAG))
+           {
                return;
            }
        }

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MyApp.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MyApp.java
@@ -99,6 +99,7 @@ class MyCall extends Call
 
         for (int i = 0; i < cmiv.size(); i++) {
             CallMediaInfo cmi = cmiv.get(i);
+
             if (cmi.getType() == pjmedia_type.PJMEDIA_TYPE_AUDIO &&
                 (cmi.getStatus() == 
                         pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE ||
@@ -120,6 +121,10 @@ class MyCall extends Call
             } else if (cmi.getType() == pjmedia_type.PJMEDIA_TYPE_VIDEO &&
                        cmi.getStatus() == pjsua_call_media_status.PJSUA_CALL_MEDIA_ACTIVE)
             {
+                if (MyApp.isTest && ci.getRole() == pjsip_role_e.PJSIP_ROLE_UAS)
+                {
+                    return;
+                }
                 /* If videoPreview was started, stop it first in case capture device has changed */
                 if (vidPrevStarted) {
                     try {
@@ -154,7 +159,15 @@ class MyCall extends Call
 
     @Override
     public void onCallMediaEvent(OnCallMediaEventParam prm) {
-        MyApp.observer.notifyCallMediaEvent(this, prm);
+        CallInfo ci;
+        try {
+            ci = getInfo();
+        } catch (Exception e) {
+            return;
+        }
+        if (!MyApp.isTest || ci.getRole() == pjsip_role_e.PJSIP_ROLE_UAC) {
+            MyApp.observer.notifyCallMediaEvent(this, prm);
+        }
     }
 }
 
@@ -327,6 +340,7 @@ class MyEndpoint extends Endpoint
 class MyApp extends pjsua2 {
     public static MyEndpoint ep = new MyEndpoint();
     public static MyAppObserver observer;
+    public static boolean isTest = false;
     public ArrayList<MyAccount> accList = new ArrayList<MyAccount>();
 
     private ArrayList<MyAccountConfig> accCfgs =
@@ -339,19 +353,32 @@ class MyApp extends pjsua2 {
     private MyLogWriter logWriter;
 
     private final String configName = "pjsua2.json";
-    private final int SIP_PORT  = 6000;
     private final int LOG_LEVEL = 4;
+    private int SIP_PORT  = 6000;
+    int defVidCapDev =pjmedia_vid_dev_std_index.PJMEDIA_VID_DEFAULT_CAPTURE_DEV;
 
     public void init(MyAppObserver obs, String app_dir)
     {
-        init(obs, app_dir, false);
+        init(obs, app_dir, false, SIP_PORT, false);
     }
 
     public void init(MyAppObserver obs, String app_dir,
                      boolean own_worker_thread)
     {
+        init(obs, app_dir, own_worker_thread, SIP_PORT, false);
+    }
+
+    public void init(MyAppObserver obs, String app_dir,
+                     boolean own_worker_thread, int sip_port, boolean is_test)
+    {
         observer = obs;
         appDir = app_dir;
+        isTest = is_test;
+
+        SIP_PORT = sip_port;
+
+        System.out.println("Initializing the library as " + (is_test?
+                           "test":"demo"));
 
         /* Create endpoint */
         try {
@@ -364,7 +391,7 @@ class MyApp extends pjsua2 {
         /* Load config */
         String configPath = appDir + "/" + configName;
         File f = new File(configPath);
-        if (f.exists()) {
+        if (f.exists() && !isTest) {
             loadConfig(configPath);
         } else {
             /* Set 'default' values */
@@ -454,6 +481,27 @@ class MyApp extends pjsua2 {
         /* Set SIP port back to default for JSON saved config */
         sipTpConfig.setPort(SIP_PORT);
 
+        if (isTest) {
+            try {
+                VideoDevInfoVector2 vidVector =
+                                            MyApp.ep.vidDevManager().enumDev2();
+                for (int i = 0; i < vidVector.size(); i++) {
+                    VideoDevInfo devInfo = vidVector.get(i);
+
+                    if (devInfo.getName().equalsIgnoreCase(
+                                        "Colorbar generator"))
+                    {
+                        defVidCapDev = i;
+                        break;
+                    }
+                }
+            } catch (Exception e) {
+                System.out.println(e);
+            }
+        }
+        System.out.println("Use vid index=" + Integer.toString(defVidCapDev) +
+                           " as default capture device");
+
         /* Create accounts. */
         for (int i = 0; i < accCfgs.size(); i++) {
             MyAccountConfig my_cfg = accCfgs.get(i);
@@ -466,7 +514,7 @@ class MyApp extends pjsua2 {
             /* Enable SRTP optional mode and without requiring SIP TLS transport */
             my_cfg.accCfg.getMediaConfig().setSrtpUse(pjmedia_srtp_use.PJMEDIA_SRTP_OPTIONAL);
             my_cfg.accCfg.getMediaConfig().setSrtpSecureSignaling(0);
-
+            my_cfg.accCfg.getVideoConfig().setDefaultCaptureDevice(defVidCapDev);
             MyAccount acc = addAcc(my_cfg.accCfg);
             if (acc == null)
                 continue;
@@ -619,8 +667,10 @@ class MyApp extends pjsua2 {
 
     public void deinit()
     {
-        String configPath = appDir + "/" + configName;
-        saveConfig(configPath);
+        if (!isTest) {
+            String configPath = appDir + "/" + configName;
+            saveConfig(configPath);
+        }
 
         /* Try force GC to avoid late destroy of PJ objects as they should be
         * deleted before lib is destroyed.

--- a/pjsip-apps/src/swig/java/android/app/src/main/res/layout/activity_main.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="1"
+        android:choiceMode="singleChoice"
     	android:listSelector="@drawable/bkg" >
     </ListView>
 
@@ -28,13 +29,15 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:onClick="makeCall"
+            android:importantForAccessibility = "no"
             android:src="@android:drawable/ic_menu_call" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_weight="1"
-			android:text="   "/>
+            android:text="   "
+            android:importantForAccessibility = "no"/>
 
         <ImageButton
             android:id="@+id/buttonAddBuddy"
@@ -42,7 +45,8 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:onClick="addBuddy"
-            android:src="@android:drawable/ic_menu_add" />
+            android:src="@android:drawable/ic_menu_add"
+            android:importantForAccessibility = "no" />
         
         <ImageButton
             android:id="@+id/buttonEditBuddy"
@@ -50,6 +54,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:onClick="editBuddy"
+            android:importantForAccessibility = "no"
             android:src="@android:drawable/ic_menu_edit" />
         
         <ImageButton
@@ -58,6 +63,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:onClick="delBuddy"
+            android:importantForAccessibility = "no"
             android:src="@android:drawable/ic_menu_delete" />
 
         </LinearLayout>

--- a/pjsip-apps/src/swig/java/android/app/src/main/res/layout/dlg_account_config.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/res/layout/dlg_account_config.xml
@@ -8,70 +8,76 @@
     <TextView
         android:id="@+id/textViewInfo"
         android:textAppearance="?android:attr/textAppearanceSmall"
-    	android:paddingBottom="20dp"
-        android:textColor="#b0b0b0" >
+        android:paddingBottom="20dp"
+        android:textColor="#b0b0b0"
+        android:importantForAccessibility = "no">
     </TextView>
     
-	<TableRow>
-        <TextView android:text="ID">
-        </TextView>  
-
-	    <EditText
-	        android:id="@+id/editTextId"
-	        android:layout_width="match_parent"
-	        android:layout_height="wrap_content"
-	        android:layout_weight="1"
-	        android:inputType="textUri|textEmailAddress" >
+   <TableRow>
+      <TextView android:text="ID">
+      </TextView>
 
-	        <requestFocus />
-	    </EditText>
-    </TableRow>
-	<TableRow>
-        <TextView android:text="Registrar">
-        </TextView>  
-	    <EditText
-	        android:id="@+id/editTextRegistrar"
-	        android:layout_width="match_parent"
-	        android:layout_height="wrap_content"
-	        android:layout_weight="1"
-	        android:inputType="textUri" >
-	    </EditText>
-    </TableRow>
-	<TableRow>
-        <TextView android:text="Proxy">
-        </TextView>  
-	    <EditText
-	        android:id="@+id/editTextProxy"
-	        android:layout_width="match_parent"
-	        android:layout_height="wrap_content"
-	        android:layout_weight="1"
-	        android:inputType="textUri" >
-	    </EditText>
-    </TableRow>
-	<TableRow>
-        <TextView android:text="Username">
-        </TextView>  
 
-	    <EditText
-	        android:id="@+id/editTextUsername"
-	        android:layout_width="match_parent"
-	        android:layout_height="wrap_content"
-	        android:layout_weight="1"
-	        android:inputType="text" >
+      <EditText
+         android:id="@+id/editTextId"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_weight="1"
+         android:importantForAccessibility="no"
+         android:inputType="textUri|textEmailAddress">
+         <requestFocus />
+      </EditText>
+   </TableRow>
+   <TableRow>
+      <TextView android:text="Registrar">
+      </TextView>
 
-	    </EditText>
-    </TableRow>
-	<TableRow>
-        <TextView android:text="Password">
-        </TextView>  
+      <EditText
+         android:id="@+id/editTextRegistrar"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_weight="1"
+         android:importantForAccessibility="no"
+         android:inputType="textUri">
+      </EditText>
+   </TableRow>
+   <TableRow>
+      <TextView android:text="Proxy">
+      </TextView>
 
-	    <EditText
-	        android:id="@+id/editTextPassword"
-	        android:layout_width="match_parent"
-	        android:layout_height="wrap_content"
-	        android:layout_weight="1"
-	        android:inputType="textPassword" >
+      <EditText
+         android:id="@+id/editTextProxy"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_weight="1"
+         android:importantForAccessibility="no"
+         android:inputType="textUri">
+      </EditText>
+   </TableRow>
+   <TableRow>
+      <TextView android:text="Username">
+      </TextView>
 
-	    </EditText>
-    </TableRow>
+      <EditText
+         android:id="@+id/editTextUsername"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_weight="1"
+         android:inputType="text"
+         android:importantForAccessibility="no">
+      </EditText>
+   </TableRow>
+   <TableRow>
+      <TextView android:text="Password">
+      </TextView>
+
+      <EditText
+         android:id="@+id/editTextPassword"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:layout_weight="1"
+         android:importantForAccessibility="no"
+         android:inputType="textPassword">
+      </EditText>
+   </TableRow>
 </TableLayout>

--- a/pjsip-apps/src/swig/java/android/app/src/main/res/layout/dlg_add_buddy.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/res/layout/dlg_add_buddy.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TableLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:padding = "20dp"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-	<TableRow>
-        <TextView android:text="Buddy URI">
-        </TextView>  
-
-	    <EditText
-	        android:id="@+id/editTextUri"
-	        android:layout_weight="1"
-	        android:inputType="textUri|textEmailAddress" >
+   xmlns:android="http://schemas.android.com/apk/res/android"
+   android:padding = "20dp"
+   android:layout_width="match_parent"
+   android:layout_height="match_parent">
 
-	        <requestFocus />
-	    </EditText>
-    </TableRow>
-	<TableRow>
-        <CheckBox
-            android:id="@+id/checkBoxSubscribe"
-            android:layout_column="1"
-            android:text="Subscribe presence" />
-    </TableRow>
+   <TableRow>
+      <TextView android:text="Buddy URI">
+      </TextView>
+
+      <EditText
+         android:id="@+id/editTextUri"
+         android:layout_weight="1"
+         android:importantForAccessibility="no"
+         android:inputType="textUri|textEmailAddress">
+         <requestFocus />
+      </EditText>
+   </TableRow>
+   <TableRow>
+      <CheckBox
+         android:id="@+id/checkBoxSubscribe"
+         android:layout_column="1"
+         android:text="Subscribe presence" />
+   </TableRow>
 </TableLayout>

--- a/pjsip-apps/src/swig/java/android/app/src/main/res/menu/call.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/res/menu/call.xml
@@ -1,9 +1,10 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
-        android:showAsAction="never"
+        app:showAsAction="never"
         android:title="@string/action_settings"/>
 
 </menu>

--- a/pjsip-apps/src/swig/java/android/app/src/main/res/menu/main.xml
+++ b/pjsip-apps/src/swig/java/android/app/src/main/res/menu/main.xml
@@ -1,14 +1,14 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/action_acc_config"
         android:icon="@android:drawable/ic_menu_manage"
-        android:showAsAction="ifRoom"
+        app:showAsAction="ifRoom"
         android:title="Account Config"/>
     <item
         android:id="@+id/action_quit"
         android:icon="@android:drawable/ic_menu_close_clear_cancel"
-        android:showAsAction="ifRoom"
+        app:showAsAction="ifRoom"
         android:title="Quit"/>
-    
 </menu>

--- a/pjsip-apps/src/swig/java/android/build.gradle
+++ b/pjsip-apps/src/swig/java/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.9.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/pjsip-apps/src/swig/java/android/gradle.properties
+++ b/pjsip-apps/src/swig/java/android/gradle.properties
@@ -1,0 +1,3 @@
+android.useAndroidX=true
+android.enableJetifier=true
+android.nonFinalResIds=false

--- a/pjsip-apps/src/swig/java/android/gradle/wrapper/gradle-wrapper.properties
+++ b/pjsip-apps/src/swig/java/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Thu Mar 13 11:32:10 WIB 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
+++ b/pjsip-apps/src/swig/java/android/pjsua2/build.gradle
@@ -19,8 +19,7 @@ android {
                 arguments "-DANDROID_STL=c++_shared"
             }
         }
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
 


### PR DESCRIPTION
This PR will add Android Unit Test using espresso for `pjsua2` app.

Changes:
- Use `androidx` instead of `android.support`. 
- Add new build flavor type (`ciTest`) specific for the instrumentation test.
- the unit test will simulate a video call to itself.

Behavior changes to pjsua2 app when build using `ciTest` flavor type:
- any call related operation is enable only from the unit test module.
- no save/load from config file when app starts/stops.

Building the unit tests from command line: (`pjsip-apps/src/swig/java/android`)
```
./gradlew assembleCiTestDebug
```

Running the unit tests from command line: (make sure you have a device/emulator running/connected)
```
./gradlew connectedCiTestDebug
```

Alternatively, you can run and build the unit test from Android Studio by choosing the correct build variant.