### PR TITLE
pool_i.h: Check available size instead of pointer wrap-around to avoid autological-compare.

### DIFF
--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -56,9 +56,9 @@ PJ_IDEF(void*) pj_pool_alloc_from_block( pj_pool_block *block, pj_size_t alignme
     //    size = (size + alignment) & ~(alignment -1);
     //}
     ptr = PJ_POOL_ALIGN_PTR(block->cur, alignment);
-    if (ptr + size <= block->end &&
-        /* here we check pointer overflow */
-        block->cur <= ptr && ptr <= ptr + size) {
+    if (block->cur <= ptr && /* check pointer overflow */
+        block->end - ptr >= size) /* check available size */
+    {
         block->cur = ptr + size;
         return ptr;
     }


### PR DESCRIPTION
Fixes Clang v20.1.1 generating autological warning (as error):

```
pjsip/pjproject/pjlib/include/pj/pool_i.h:61:34: error: pointer comparison always evaluates to true [-Werror,-Wtautological-compare]
   61 |         block->cur <= ptr && ptr <= ptr + size) {
      |                                  ^
1 error generated.
```

I also believe that you shouldn't need the `block->cur <= ptr` portion since `PJ_POOL_ALIGN_PTR` should always align forwards. Perhaps that should instead be an assert to validate the correctness of the macro. Or tested in a unit test.

i.e. this should be enough?
```
ptr = PJ_POOL_ALIGN_PTR(block->cur, alignment);
if (ptr + size <= block->end) {
    block->cur = ptr + size;
    return ptr;
}
```

CC: @LeonidGoltsblat