### PR TITLE
Deprecate pkgconfig.py

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -5395,7 +5395,7 @@ then :
 
 fi
 
-for ac_prog in $host_cpu-$host_os-pkg-config $host-pkg-config pkg-config "python pkgconfig.py"
+for ac_prog in $host_cpu-$host_os-pkg-config $host-pkg-config pkg-config
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -115,7 +115,7 @@ AC_CHECK_LIB(winmm,puts)
 AC_CHECK_LIB(socket,puts)
 AC_CHECK_LIB(rt,puts)
 AC_CHECK_LIB(m,sin)
-AC_CHECK_PROGS(PKG_CONFIG,$host_cpu-$host_os-pkg-config $host-pkg-config pkg-config "python pkgconfig.py",none)
+AC_CHECK_PROGS(PKG_CONFIG,$host_cpu-$host_os-pkg-config $host-pkg-config pkg-config,none)
 
 dnl
 dnl libuuid


### PR DESCRIPTION
Our own `pkgconfig.py` doesn't seem to be used for a while. It doesn't work on Python 3 and even when tested with Python 2, it doesn't seem to give the correct result.

To close #4380.
