### PR TITLE
pool_i.h: Fix to warning for signed/unsigned mismatch.

### DIFF
--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -57,7 +57,7 @@ PJ_IDEF(void*) pj_pool_alloc_from_block( pj_pool_block *block, pj_size_t alignme
     //}
     ptr = PJ_POOL_ALIGN_PTR(block->cur, alignment);
     if (block->cur <= ptr && /* check pointer overflow */
-        block->end - ptr >= size) /* check available size */
+        (pj_size_t)(block->end - ptr) >= size) /* check available size */
     {
         block->cur = ptr + size;
         return ptr;


### PR DESCRIPTION
Fixes new warning added by #4382 