### PR TITLE
Check return value when setting ALSA format

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -704,6 +704,7 @@ static pj_status_t open_playback (struct alsa_stream* stream,
             "playback device '%s', err: %s", format,
             stream->af->devs[param->rec_id].name, snd_strerror(result)));
 
+        snd_pcm_close (stream->pb_pcm);
         return PJMEDIA_EAUD_SYSERR;
     }    
 
@@ -849,6 +850,7 @@ static pj_status_t open_capture (struct alsa_stream* stream,
             "capture device '%s', err: %s", format,
             stream->af->devs[param->rec_id].name, snd_strerror(result)));
 
+        snd_pcm_close (stream->ca_pcm);
         return PJMEDIA_EAUD_SYSERR;
     }
 

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -698,7 +698,14 @@ static pj_status_t open_playback (struct alsa_stream* stream,
         format = SND_PCM_FORMAT_S16_LE;
         break;
     }
-    snd_pcm_hw_params_set_format (stream->pb_pcm, params, format);
+    result = snd_pcm_hw_params_set_format (stream->pb_pcm, params, format);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set format %d for "
+            "playback device '%s', err: %s", format,
+            stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        return PJMEDIA_EAUD_SYSERR;
+    }    
 
     /* Set number of channels */
     TRACE_((THIS_FILE, "open_playback: set channels: %d",
@@ -836,7 +843,14 @@ static pj_status_t open_capture (struct alsa_stream* stream,
         format = SND_PCM_FORMAT_S16_LE;
         break;
     }
-    snd_pcm_hw_params_set_format (stream->ca_pcm, params, format);
+    result = snd_pcm_hw_params_set_format (stream->ca_pcm, params, format);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set format %d for "
+            "capture device '%s', err: %s", format,
+            stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        return PJMEDIA_EAUD_SYSERR;
+    }
 
     /* Set number of channels */
     TRACE_((THIS_FILE, "open_capture: set channels: %d",
@@ -1098,7 +1112,7 @@ static pj_status_t alsa_stream_start (pjmedia_aud_stream *s)
 
     if (stream->param.dir & PJMEDIA_DIR_CAPTURE) {
         status = pj_thread_create (stream->pool,
-                                   "alsasound_playback",
+                                   "alsasound_capture",
                                    ca_thread_func,
                                    stream,
                                    0, //ZERO,

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -788,7 +788,7 @@ static pj_status_t open_playback (struct alsa_stream* stream,
     snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
                                             &tmp_buf_size);
     if (result < 0) {
-        PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
+        PJ_LOG (3,(THIS_FILE, "Warning: unable to set period size: %d for "
                   "playback device '%s', err: %s", (int)tmp_buf_size,
                   stream->af->devs[param->play_id].name, snd_strerror(result)));
     }
@@ -980,7 +980,7 @@ static pj_status_t open_capture (struct alsa_stream* stream,
     result = snd_pcm_hw_params_set_buffer_size_near (stream->ca_pcm, params,
                                                      &tmp_buf_size);
     if (result < 0) {
-        PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
+        PJ_LOG (3,(THIS_FILE, "Warning: unable to set period size: %d for "
                    "capture device '%s', err: %s", (int)tmp_buf_size,
                    stream->af->devs[param->rec_id].name, snd_strerror(result)));
     }

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -785,14 +785,12 @@ static pj_status_t open_playback (struct alsa_stream* stream,
         tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_PLAY_LATENCY;
     if (tmp_buf_size < tmp_period_size * 2)
         tmp_buf_size = tmp_period_size * 2;
-    result = snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
-                                                     &tmp_buf_size);
+    snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
+                                            &tmp_buf_size);
     if (result < 0) {
         PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
                   "playback device '%s', err: %s", (int)tmp_buf_size,
                   stream->af->devs[param->play_id].name, snd_strerror(result)));
-
-        goto on_error;
     }
 
     stream->param.output_latency_ms = tmp_buf_size / (rate / 1000);
@@ -985,8 +983,6 @@ static pj_status_t open_capture (struct alsa_stream* stream,
         PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
                    "capture device '%s', err: %s", (int)tmp_buf_size,
                    stream->af->devs[param->rec_id].name, snd_strerror(result)));
-
-        goto on_error;
     }
 
     stream->param.input_latency_ms = tmp_buf_size / (rate / 1000);

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -662,18 +662,36 @@ static pj_status_t open_playback (struct alsa_stream* stream,
                            stream->af->devs[param->play_id].name,
                            SND_PCM_STREAM_PLAYBACK,
                            0);
-    if (result < 0)
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to open playback device '%s', err: %s",
+                  stream->af->devs[param->play_id].name, snd_strerror(result)));
+
         return PJMEDIA_EAUD_SYSERR;
+    }
 
     /* Allocate a hardware parameters object. */
     snd_pcm_hw_params_alloca (&params);
 
     /* Fill it in with default values. */
-    snd_pcm_hw_params_any (stream->pb_pcm, params);
+    result = snd_pcm_hw_params_any (stream->pb_pcm, params);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to get configuration for "
+            "playback device '%s', err: %s",
+            stream->af->devs[param->play_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
 
     /* Set interleaved mode */
-    snd_pcm_hw_params_set_access (stream->pb_pcm, params,
-                                  SND_PCM_ACCESS_RW_INTERLEAVED);
+    result = snd_pcm_hw_params_set_access (stream->pb_pcm, params,
+                                           SND_PCM_ACCESS_RW_INTERLEAVED);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set interleaved mode for "
+                  "playback device '%s', err: %s",
+                  stream->af->devs[param->play_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
 
     /* Set format */
     switch (param->bits_per_sample) {
@@ -702,11 +720,10 @@ static pj_status_t open_playback (struct alsa_stream* stream,
     if (result < 0) {
         PJ_LOG (3,(THIS_FILE, "Unable to set format %d for "
             "playback device '%s', err: %s", format,
-            stream->af->devs[param->rec_id].name, snd_strerror(result)));
+            stream->af->devs[param->play_id].name, snd_strerror(result)));
 
-        snd_pcm_close (stream->pb_pcm);
-        return PJMEDIA_EAUD_SYSERR;
-    }    
+        goto on_error;
+    }
 
     /* Set number of channels */
     TRACE_((THIS_FILE, "open_playback: set channels: %d",
@@ -715,16 +732,26 @@ static pj_status_t open_playback (struct alsa_stream* stream,
                                              param->channel_count);
     if (result < 0) {
         PJ_LOG (3,(THIS_FILE, "Unable to set a channel count of %d for "
-                   "playback device '%s'", param->channel_count,
-                   stream->af->devs[param->play_id].name));
-        snd_pcm_close (stream->pb_pcm);
-        return PJMEDIA_EAUD_SYSERR;
+                   "playback device '%s', err: %s", param->channel_count,
+                   stream->af->devs[param->play_id].name,snd_strerror(result)));
+
+        goto on_error;
     }
 
     /* Set clock rate */
     rate = param->clock_rate;
     TRACE_((THIS_FILE, "open_playback: set clock rate: %d", rate));
-    snd_pcm_hw_params_set_rate_near (stream->pb_pcm, params, &rate, NULL);
+    result = snd_pcm_hw_params_set_rate_near (stream->pb_pcm, params,
+                                              &rate, NULL);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set clock rate: %d for "
+                    "playback device '%s', err: %s", param->clock_rate,
+                    stream->af->devs[param->play_id].name,
+                    snd_strerror(result)));
+
+        goto on_error;
+    }
+
     TRACE_((THIS_FILE, "open_playback: clock rate set to: %d", rate));
 
     /* Set period size to samples_per_frame frames. */
@@ -733,13 +760,21 @@ static pj_status_t open_playback (struct alsa_stream* stream,
     TRACE_((THIS_FILE, "open_playback: set period size: %d",
             stream->pb_frames));
     tmp_period_size = stream->pb_frames;
-    snd_pcm_hw_params_set_period_size_near (stream->pb_pcm, params,
-                                            &tmp_period_size, NULL);
+    result = snd_pcm_hw_params_set_period_size_near (stream->pb_pcm, params,
+                                                     &tmp_period_size, NULL);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
+                  "playback device '%s', err: %s", (int)stream->pb_frames,
+                  stream->af->devs[param->play_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
+
     /* Commenting this as it may cause the number of samples per frame
      * to be incorrest.
-     */  
+     */
     // stream->pb_frames = tmp_period_size > stream->pb_frames ?
-    //                  tmp_period_size : stream->pb_frames;                                                                                
+    //                  tmp_period_size : stream->pb_frames;
     TRACE_((THIS_FILE, "open_playback: period size set to: %d",
             tmp_period_size));
 
@@ -750,8 +785,16 @@ static pj_status_t open_playback (struct alsa_stream* stream,
         tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_PLAY_LATENCY;
     if (tmp_buf_size < tmp_period_size * 2)
         tmp_buf_size = tmp_period_size * 2;
-    snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
-                                            &tmp_buf_size);
+    result = snd_pcm_hw_params_set_buffer_size_near (stream->pb_pcm, params,
+                                                     &tmp_buf_size);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
+                  "playback device '%s', err: %s", (int)tmp_buf_size,
+                  stream->af->devs[param->play_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
+
     stream->param.output_latency_ms = tmp_buf_size / (rate / 1000);
 
     /* Set our buffer */
@@ -767,8 +810,11 @@ static pj_status_t open_playback (struct alsa_stream* stream,
     /* Activate the parameters */
     result = snd_pcm_hw_params (stream->pb_pcm, params);
     if (result < 0) {
-        snd_pcm_close (stream->pb_pcm);
-        return PJMEDIA_EAUD_SYSERR;
+        PJ_LOG (3,(THIS_FILE, "Unable to activate the param for "
+                  "playback device '%s', err: %s",
+                  stream->af->devs[param->play_id].name, snd_strerror(result)));
+
+        goto on_error;
     }
 
     if (param->flags & PJMEDIA_AUD_DEV_CAP_OUTPUT_VOLUME_SETTING) {
@@ -785,6 +831,10 @@ static pj_status_t open_playback (struct alsa_stream* stream,
                (int)stream->param.output_latency_ms));
 
     return PJ_SUCCESS;
+
+on_error:
+    snd_pcm_close (stream->pb_pcm);
+    return PJMEDIA_EAUD_SYSERR;
 }
 
 
@@ -805,21 +855,39 @@ static pj_status_t open_capture (struct alsa_stream* stream,
     PJ_LOG (5,(THIS_FILE, "open_capture: Open capture device '%s'",
                stream->af->devs[param->rec_id].name));
     result = snd_pcm_open (&stream->ca_pcm,
-                            stream->af->devs[param->rec_id].name,
+                           stream->af->devs[param->rec_id].name,
                            SND_PCM_STREAM_CAPTURE,
                            0);
-    if (result < 0)
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to open capture device '%s', err: %s",
+                   stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
         return PJMEDIA_EAUD_SYSERR;
+    }
 
     /* Allocate a hardware parameters object. */
     snd_pcm_hw_params_alloca (&params);
 
     /* Fill it in with default values. */
-    snd_pcm_hw_params_any (stream->ca_pcm, params);
+    result = snd_pcm_hw_params_any (stream->ca_pcm, params);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to get configuration for "
+            "capture device '%s', err: %s",
+            stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
 
     /* Set interleaved mode */
-    snd_pcm_hw_params_set_access (stream->ca_pcm, params,
-                                  SND_PCM_ACCESS_RW_INTERLEAVED);
+    result = snd_pcm_hw_params_set_access (stream->ca_pcm, params,
+                                           SND_PCM_ACCESS_RW_INTERLEAVED);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set interleaved mode for "
+                  "capture device '%s', err: %s",
+                   stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
 
     /* Set format */
     switch (param->bits_per_sample) {
@@ -850,8 +918,7 @@ static pj_status_t open_capture (struct alsa_stream* stream,
             "capture device '%s', err: %s", format,
             stream->af->devs[param->rec_id].name, snd_strerror(result)));
 
-        snd_pcm_close (stream->ca_pcm);
-        return PJMEDIA_EAUD_SYSERR;
+        goto on_error;
     }
 
     /* Set number of channels */
@@ -861,16 +928,25 @@ static pj_status_t open_capture (struct alsa_stream* stream,
                                              param->channel_count);
     if (result < 0) {
         PJ_LOG (3,(THIS_FILE, "Unable to set a channel count of %d for "
-                   "capture device '%s'", param->channel_count,
-                   stream->af->devs[param->rec_id].name));
-        snd_pcm_close (stream->ca_pcm);
-        return PJMEDIA_EAUD_SYSERR;
-    }
+                    "capture device '%s', err: %s", param->channel_count,
+                    stream->af->devs[param->rec_id].name,snd_strerror(result)));
 
+        goto on_error;
+    }
     /* Set clock rate */
     rate = param->clock_rate;
     TRACE_((THIS_FILE, "open_capture: set clock rate: %d", rate));
-    snd_pcm_hw_params_set_rate_near (stream->ca_pcm, params, &rate, NULL);
+    result = snd_pcm_hw_params_set_rate_near (stream->ca_pcm, params, &rate,
+                                              NULL);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set clock rate: %d for "
+                    "capture device '%s', err: %s", param->clock_rate,
+                    stream->af->devs[param->rec_id].name,
+                    snd_strerror(result)));
+
+        goto on_error;
+    }
+
     TRACE_((THIS_FILE, "open_capture: clock rate set to: %d", rate));
 
     /* Set period size to samples_per_frame frames. */
@@ -879,8 +955,15 @@ static pj_status_t open_capture (struct alsa_stream* stream,
     TRACE_((THIS_FILE, "open_capture: set period size: %d",
             stream->ca_frames));
     tmp_period_size = stream->ca_frames;
-    snd_pcm_hw_params_set_period_size_near (stream->ca_pcm, params,
-                                            &tmp_period_size, NULL);
+    result = snd_pcm_hw_params_set_period_size_near (stream->ca_pcm, params,
+                                                     &tmp_period_size, NULL);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
+                   "capture device '%s', err: %s", (int)stream->ca_frames,
+                   stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
     /* Commenting this as it may cause the number of samples per frame
      * to be incorrest.
      */
@@ -896,8 +979,16 @@ static pj_status_t open_capture (struct alsa_stream* stream,
         tmp_buf_size = (rate / 1000) * PJMEDIA_SND_DEFAULT_REC_LATENCY;
     if (tmp_buf_size < tmp_period_size * 2)
         tmp_buf_size = tmp_period_size * 2;
-    snd_pcm_hw_params_set_buffer_size_near (stream->ca_pcm, params,
-                                            &tmp_buf_size);
+    result = snd_pcm_hw_params_set_buffer_size_near (stream->ca_pcm, params,
+                                                     &tmp_buf_size);
+    if (result < 0) {
+        PJ_LOG (3,(THIS_FILE, "Unable to set period size: %d for "
+                   "capture device '%s', err: %s", (int)tmp_buf_size,
+                   stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        goto on_error;
+    }
+
     stream->param.input_latency_ms = tmp_buf_size / (rate / 1000);
 
     /* Set our buffer */
@@ -913,8 +1004,11 @@ static pj_status_t open_capture (struct alsa_stream* stream,
     /* Activate the parameters */
     result = snd_pcm_hw_params (stream->ca_pcm, params);
     if (result < 0) {
-        snd_pcm_close (stream->ca_pcm);
-        return PJMEDIA_EAUD_SYSERR;
+        PJ_LOG (3,(THIS_FILE, "Unable to activate the param for "
+                   "capture device '%s', err: %s",
+                   stream->af->devs[param->rec_id].name, snd_strerror(result)));
+
+        goto on_error;
     }
 
     if (param->flags & PJMEDIA_AUD_DEV_CAP_INPUT_VOLUME_SETTING) {
@@ -931,6 +1025,10 @@ static pj_status_t open_capture (struct alsa_stream* stream,
                (int)stream->param.input_latency_ms));
 
     return PJ_SUCCESS;
+
+on_error:
+    snd_pcm_close (stream->ca_pcm);
+    return PJMEDIA_EAUD_SYSERR;
 }
 
 


### PR DESCRIPTION
Currently, the library only supports 16 `bits_per_sample` when opening the sound device. 
When the sound device only supports 32 bits per sample (`S32_LE` e.g.: dsnoop), the method will crash here. https://github.com/pjsip/pjproject/blob/f80984b79b7a45f136304bba83bb7aa929efac11/pjmedia/src/pjmedia-audiodev/alsa_dev.c#L615

To avoid the crash, it is better to return an error when setting the format failed.

Note:
For devices that only uses 32 bits per sample config or multiple channel, you can use a `plug:` plugin and create an alias.
This way ALSA will provide the required conversion and allow the device to be opened with other configuration.
```
pcm.tmp_dsnoop {
    type plug
    slave {
        pcm "dsnoop:CARD=PCH,DEV=0"
    }
}
```
This way, ALSA will create a `tmp_dsnoop` alias and use it as the sound device instead.

