### PR TITLE
Do not erase decoded video frame in on_rx_rtp

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -967,9 +967,10 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
             }
 
             if (can_decode) {
+                pj_size_t old_size = stream->dec_frame.size;
                 stream->dec_frame.size = stream->dec_max_size;
                 if (decode_frame(stream, &stream->dec_frame) != PJ_SUCCESS) {
-                    stream->dec_frame.size = 0;
+                    stream->dec_frame.size = old_size;
                 }
             }
         }


### PR DESCRIPTION
Stream can try to decode another on due to ts_diff greater than `stream->dec_max_delay,` but it can be unsucsessful because of `frm_cnt < stream->dec_delay_cnt`, so it should restore already decoded frame