### PR TITLE
Issue #4400: pjsip_dialog not set in pjsip_tx_data clone

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2772,6 +2772,9 @@ PJ_DEF(pj_status_t) pjsip_inv_answer(   pjsip_inv_session *inv,
     if (status != PJ_SUCCESS)
         goto on_return;
 
+    /* Put the dialog of the session in tdata's mod_data */
+    last_res->mod_data[inv->dlg->ua->id] = inv->dlg;
+
     /* Modify last response. */
     status = pjsip_dlg_modify_response(inv->dlg, last_res, st_code, st_text);
     if (status != PJ_SUCCESS) {


### PR DESCRIPTION
A pjsip_tx_data cloned by pjsip_inv_answer() does not have a reference to the pjsip_dialog of the source pjsip_tx_data.