### PR TITLE
Update some AEC flags docs

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -735,11 +735,24 @@
 
 
 /**
- * WebRtc Acoustic Echo Cancellation (AEC).
+ * WebRTC Acoustic Echo Cancellation (AEC).
+ * Please check https://github.com/pjsip/pjproject/issues/1888 for more info.
+ *
  * By default is disabled.
  */
 #ifndef PJMEDIA_HAS_WEBRTC_AEC
 #   define PJMEDIA_HAS_WEBRTC_AEC               0
+#endif
+
+/**
+ * WebRTC Acoustic Echo Cancellation 3 (WebRTC AEC3).
+ * Please check https://github.com/pjsip/pjproject/pull/2722 and
+ * https://github.com/pjsip/pjproject/pull/2775 for more info.
+ *
+ * By default is disabled.
+ */
+#ifndef PJMEDIA_HAS_WEBRTC_AEC3
+#   define PJMEDIA_HAS_WEBRTC_AEC3              0
 #endif
 
 /**

--- a/pjmedia/include/pjmedia/echo.h
+++ b/pjmedia/include/pjmedia/echo.h
@@ -115,12 +115,16 @@ typedef enum pjmedia_echo_flag
     /**
      * If PJMEDIA_ECHO_USE_NOISE_SUPPRESSOR flag is specified, the echo
      * canceller will also apply noise suppressor method to reduce noise.
+     *
+     * Currently this is only effective on WebRTC AEC & WebRTC AEC3 backends.
      */
     PJMEDIA_ECHO_USE_NOISE_SUPPRESSOR = 128,
 
     /**
      * If PJMEDIA_ECHO_USE_GAIN_CONTROLLER flag is specified, the echo
      * canceller will also apply automatic gain control.
+     *
+     * Currently this is only effective on WebRTC AEC3 backend.
      */
     PJMEDIA_ECHO_USE_GAIN_CONTROLLER = 256,
     
@@ -135,6 +139,8 @@ typedef enum pjmedia_echo_flag
      * Use conservative aggressiveness setting for the echo canceller
      * algorithm. This setting is mutually exclusive with the other
      * aggressiveness settings.
+     *
+     * Currently this is only effective on WebRTC AEC backend.
      */
     PJMEDIA_ECHO_AGGRESSIVENESS_CONSERVATIVE = 0x1000,
     
@@ -142,6 +148,8 @@ typedef enum pjmedia_echo_flag
      * Use moderate aggressiveness setting for the echo canceller algorithm. 
      * This setting is mutually exclusive with the other aggressiveness
      * settings.
+     *
+     * Currently this is only effective on WebRTC AEC backend.
      */
     PJMEDIA_ECHO_AGGRESSIVENESS_MODERATE = 0x2000,
     
@@ -149,6 +157,8 @@ typedef enum pjmedia_echo_flag
      * Use aggressive aggressiveness setting for the echo canceller
      * algorithm. This setting is mutually exclusive with the other
      * aggressiveness settings.
+     *
+     * Currently this is only effective on WebRTC AEC backend.
      */
     PJMEDIA_ECHO_AGGRESSIVENESS_AGGRESSIVE = 0x3000,
     


### PR DESCRIPTION
To clarify that some AEC flags are only applicable for some specific backends.
Also added `PJMEDIA_HAS_WEBRTC_AEC3` to `pjmedia/config.h` so it can be found in PJSIP docs.