### PR TITLE
File make with j option problem

### DIFF
--- a/build/rules.mak
+++ b/build/rules.mak
@@ -154,32 +154,32 @@ $(OBJDIR)/$(app).ko: $(OBJDIR)/$(app).o | $(OBJDIRS)
 ../lib/$(app).ko: $(LIB) $(OBJDIR)/$(app).ko
 	cp $(OBJDIR)/$(app).ko ../lib
 
-$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.m | $(OBJDIRS)
+$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.m | $(@D)
 	$(CC) $($(APP)_CFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<) 
 
-$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.c | $(OBJDIRS)
+$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.c | $(@D)
 	$(CC) $($(APP)_CFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<) 
 
-$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.S | $(OBJDIRS)
+$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.S | $(@D)
 	$(CC) $($(APP)_CFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<) 
 
-$(OBJDIR)/dshowclasses.o: $(SRCDIR)/dshowclasses.cpp | $(OBJDIRS)
+$(OBJDIR)/dshowclasses.o: $(SRCDIR)/dshowclasses.cpp | $(@D)
 	$(CXX) $($(APP)_CXXFLAGS) -I$(SRCDIR)/../../../third_party/BaseClasses -fpermissive \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<)
 
-$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.cpp | $(OBJDIRS)
+$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.cpp | $(@D)
 	$(CXX) $($(APP)_CXXFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<)
 
-$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.cc | $(OBJDIRS)
+$(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.cc | $(@D)
 	$(CXX) $($(APP)_CXXFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<)


### PR DESCRIPTION
Fixed an issue where running make with the -j option would occasionally result in errors.
It seems that the ar command was sometimes executed before all .o files had been generated.
```
make[1]: *** No rule to make target `output/pjmedia-codec-aarch64-apple-darwin24.4.0/passthrough.o', needed by `../lib/libpjmedia-codec-aarch64-apple-darwin24.4.0.a'.  Stop.
make[1]: *** Waiting for unfinished jobs....
make: *** [libpjmedia-codec-aarch64-apple-darwin24.4.0.a] Error 2
```