### PR TITLE
Fixed buffer overflow in Android video codec

### DIFF
--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1386,7 +1386,7 @@ static pj_status_t and_media_decode(pjmedia_vid_codec *codec,
 {
     pj_status_t status = PJ_SUCCESS;
     pj_size_t output_size;
-    int len;
+    int len = 0;
     media_status_t am_status;
     and_med_buf_info buf_info;
     pj_uint8_t *output_buf;
@@ -1490,12 +1490,16 @@ static pj_status_t and_media_decode(pjmedia_vid_codec *codec,
         PJ_LOG(4,(THIS_FILE, "Decoder getOutputBuffer failed"));
         return status;
     }
-    len = write_yuv((pj_uint8_t *)output->buf,
-                    output->size,
-                    output_buf,
-                    and_media_data->dec_stride_len,
-                    and_media_data->prm->dec_fmt.det.vid.size.w,
-                    and_media_data->prm->dec_fmt.det.vid.size.h);
+    if (output->size >= and_media_data->prm->dec_fmt.det.vid.size.w *
+        and_media_data->prm->dec_fmt.det.vid.size.h * 3 / 2)
+    {
+        len = write_yuv((pj_uint8_t *)output->buf,
+                        output->size,
+                        output_buf,
+                        and_media_data->dec_stride_len,
+                        and_media_data->prm->dec_fmt.det.vid.size.w,
+                        and_media_data->prm->dec_fmt.det.vid.size.h);
+    }
 
     am_status = AMediaCodec_releaseOutputBuffer(and_media_data->dec,
                                                 buf_info.index, 0);


### PR DESCRIPTION
To fix #4404.

As reported in https://github.com/pjsip/pjproject/issues/4404, PJSIP will crash when using Android video mediacodec and remote sends a video with resolution higher than supported.

Although the issue was caused by the remote sending video with resolution higher than signalled, PJSIP shouldn't crash. The crash is caused due to lack of checking of the frame buffer size that's supposed to hold the decoded frame.
