### PR TITLE
Fixed incorrect call count upon message sending failure when making call

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -573,11 +573,15 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
     if (status != PJ_SUCCESS) {
         cb_called = PJ_TRUE;
 
-        /* Upon failure to send first request, the invite
-         * session would have been cleared.
+        /* If call inv hasn't been cleared from on_call_state(DISCONNECTED),
+         * we clear it here.
          */
-        call->inv = NULL;
-        --pjsua_var.call_cnt;
+        if (call->inv) {
+            pjsip_inv_terminate(inv, PJSIP_SC_OK, PJ_FALSE);
+            --pjsua_var.call_cnt;
+        }
+
+        call->inv = inv = NULL;
         goto on_error;
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -576,7 +576,8 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
         /* Upon failure to send first request, the invite
          * session would have been cleared.
          */
-        call->inv = inv = NULL;
+        call->inv = NULL;
+        --pjsua_var.call_cnt;
         goto on_error;
     }
 


### PR DESCRIPTION
To fix #4384.

If `pjsip_inv_send_msg()` fails, the call count is not reverted.
```
/* Must increment call counter now */
++pjsua_var.call_cnt;

/* Send initial INVITE: */
status = pjsip_inv_send_msg(inv, tdata);
if (status != PJ_SUCCESS) {
    cb_called = PJ_TRUE;

    /* Upon failure to send first request, the invite
     * session would have been cleared.
     */
    call->inv = inv = NULL;
    goto on_error;
}
```
