### PR TITLE
Use configured public address for SIP transport TCP and TLS

### DIFF
--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -856,6 +856,7 @@ struct pjsip_transport
 
     int                     addr_len;       /**< Length of addresses.       */
     pj_sockaddr             local_addr;     /**< Bound address.             */
+    pj_bool_t               has_addr_name;  /**< Has config published name? */
     pjsip_host_port         local_name;     /**< Published name (eg. STUN). */
     pjsip_host_port         remote_name;    /**< Remote address name.       */
     pjsip_transport_dir     dir;            /**< Connection direction.      */
@@ -1082,6 +1083,7 @@ struct pjsip_tpfactory
     char                   *info;           /**< Transport info/description.*/
 
     pj_sockaddr             local_addr;     /**< Bound address.         */
+    pj_bool_t               has_addr_name;  /**< Has published name?    */
     pjsip_host_port         addr_name;      /**< Published name.        */
 
     /**

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -402,6 +402,7 @@ static pj_status_t update_factory_addr(struct tls_listener *listener,
         }
 
         /* Copy the address */
+        listener->factory.has_addr_name = PJ_TRUE;
         listener->factory.addr_name = *addr_name;
         pj_strdup(listener->factory.pool, &listener->factory.addr_name.host,
                   &addr_name->host);
@@ -922,7 +923,10 @@ static pj_status_t tls_create( struct tls_listener *listener,
         pj_sockaddr_cp(&tls->base.local_addr, local);
     }
     
-    sockaddr_to_host_port(pool, &tls->base.local_name, &tls->base.local_addr);
+    /* Use listener's published address, if any. */
+    tls->base.has_addr_name = listener->factory.has_addr_name;
+    tls->base.local_name = listener->factory.addr_name;
+
     if (tls->remote_name.slen) {
         tls->base.remote_name.host = tls->remote_name;
         tls->base.remote_name.port = pj_sockaddr_get_port(remote);
@@ -1366,8 +1370,15 @@ static pj_status_t lis_create_transport(pjsip_tpfactory *factory,
                                      new_port);
             }
 
-            sockaddr_to_host_port(tls->base.pool, &tls->base.local_name,
-                                  &tls->base.local_addr);
+            /* Only update published address if not specified, otherwise
+             * only update the port.
+             */
+            if (!tls->base.has_addr_name) {
+                sockaddr_to_host_port(tls->base.pool, &tls->base.local_name,
+                                      &tls->base.local_addr);
+            } else {
+                tls->base.local_name.port = new_port;
+            }
         }
 
         PJ_LOG(4,(tls->base.obj_name, 


### PR DESCRIPTION
To close #4393.

Note that for UDP, we already have https://github.com/pjsip/pjproject/pull/3595.
