### PR TITLE
Support latest 3GPP TS 33102

### DIFF
--- a/pjsip/include/pjsip/sip_auth_aka.h
+++ b/pjsip/include/pjsip/sip_auth_aka.h
@@ -129,7 +129,7 @@ PJ_BEGIN_DECL
 /**
  * Length of permanent/subscriber Key (K) in bytes.
  */
-#define PJSIP_AKA_KLEN          16
+#define PJSIP_AKA_KLEN          32
 
 /**
  * Length of AKA authentication code in bytes.

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2767,7 +2767,12 @@ static pj_status_t pjsua_regc_init(int acc_id)
     /* Set credentials
      */
     if (acc->cred_cnt) {
-        pjsip_regc_set_credentials( acc->regc, acc->cred_cnt, acc->cred);
+        status = pjsip_regc_set_credentials( acc->regc, acc->cred_cnt, acc->cred);
+        if (status != PJ_SUCCESS) {
+            pjsua_perror(THIS_FILE,
+                         "Cannot set credentials for registration",
+                         status);
+        }
     }
 
     /* Set delay before registration refresh */


### PR DESCRIPTION
The length of the authentication key (K) has changed since the implementation of Digest Authentication.

Issue: #4413