### PR TITLE
Prevent call hangup retry if call already terminated

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -3074,7 +3074,9 @@ on_return:
      * pjsua_call_on_state_changed() to be called and call to be reset,
      * so we need to check for call->inv as well.
      */
-    if (status != PJ_SUCCESS && call->inv) {
+    if (status != PJ_SUCCESS && status != PJSIP_ESESSIONTERMINATED &&
+        call->inv)
+    {
         pj_time_val delay;
 
         /* Schedule a retry */


### PR DESCRIPTION
To fix #4416.

If call is already disconnected (`PJSIP_ESESSIONTERMINATED`), we shouldn't retry the hangup attempt.
