### PR TITLE
Prevent data race between SSL handshake and data read

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1174,9 +1174,16 @@ static pj_bool_t ssock_on_accept_complete (pj_ssl_sock_t *ssock_parent,
     }
 
     /* Start SSL handshake */
+    /* Prevent data race with on_data_read() until ssl_do_handshake()
+     * completes.
+     */
+    if (ssock->circ_buf_input_mutex)
+        pj_lock_acquire(ssock->circ_buf_input_mutex);
     ssock->ssl_state = SSL_STATE_HANDSHAKING;
     ssl_set_state(ssock, PJ_TRUE);
     status = ssl_do_handshake(ssock);
+    if (ssock->circ_buf_input_mutex)
+        pj_lock_release(ssock->circ_buf_input_mutex);
 
 on_return:
     if (ssock && status != PJ_EPENDING) {

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1508,8 +1508,8 @@ PJ_DEF(pj_status_t) pj_ssl_sock_create (pj_pool_t *pool,
         return status;
 
     /* Create input circular buffer mutex */
-    status = pj_lock_create_simple_mutex(pool, pool->obj_name,
-                                         &ssock->circ_buf_input_mutex);
+    status = pj_lock_create_recursive_mutex(pool, pool->obj_name,
+                                            &ssock->circ_buf_input_mutex);
     if (status != PJ_SUCCESS)
         return status;
 


### PR DESCRIPTION
It is reported that a data race between SSL handshake and data read can cause handshake failure.

```
29-04 08:54:01,736 (7f6f3effd700)(1) [DEBUG] sip.cpp        :83   :LOC : ssock_on_accept_complete (nil) 1
29-04 08:54:01,738 (7f6f3effd700)(1) [WARN ]              SSL-TRACE  SSL - Create 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3effd700)(1) [WARN ]              SSL-TRACE  SSL - On_Data_Accept 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3effd700)(1) [WARN ]              SSL-TRACE  SSL - HS-Start 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3e7fc700)(7) [DEBUG] sip.cpp        :83   :LOC : ssock_on_data_read 0x7f6f05a6d320 2
29-04 08:54:01,738 (7f6f3e7fc700)(7) [WARN ]              SSL-TRACE !SSL - On_Data_Read-1 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3effd700)(1) [WARN ]              SSL-TRACE  SSL - HS-End 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3effd700)(1) [WARN ]              SSL-TRACE !SSL - HS-Error 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3effd700)(1) [NOTE ]                    SSL  BIO error, SSL_ERROR_SYSCALL (Handshake): errno: <0> <Success> len: 0
29-04 08:54:01,738 (7f6f3e7fc700)(7) [WARN ]              SSL-TRACE !SSL - HS-Start 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,738 (7f6f3effd700)(1) [WARN ]      ssl0x7f6f05a51190 !Handshake failed on [...:5061](http://...:5061/) in accepting [...:60137](http://...:60137/): DH lib
29-04 08:54:01,741 (7f6f3e7fc700)(7) [WARN ]              SSL-TRACE !SSL - HS-End 0x7f6f05a6d320 0x7f6f05a50290 )
29-04 08:54:01,741 (7f6f3e7fc700)(7) [DEBUG] sip.cpp        :89   :ULOC: ssock_on_data_read 0x7f6f05a6d320 1
29-04 08:54:01,741 (7f6f3effd700)(1) [DEBUG] sip.cpp        :89   :ULOC: ssock_on_accept_complete 0x7f6f05a6d320 0
```

Note that although the issue is only reported on OpenSSL, the fix is done in the common SSL implementation. But this should be fine since the additional locking proposed in this patch is quite cheap (in other words, there's not much performance penalty since it only happens once at the start of the handshake).
