### PR TITLE
Fix compile error with ffmpeg enable on linux

### DIFF
--- a/pjsip-apps/src/vidgui/vidwin.h
+++ b/pjsip-apps/src/vidgui/vidwin.h
@@ -29,7 +29,7 @@ class VidWin : public QWidget
 public:
     VidWin(const pjmedia_vid_dev_hwnd *hwnd,
            QWidget* parent = 0,
-           Qt::WindowFlags f = 0);
+           Qt::WindowFlags f = (Qt::WindowFlags)0);
     virtual ~VidWin();
     QSize sizeHint() const { return size_hint; }
 


### PR DESCRIPTION
I try to build pjsip on fedora 38 os with ffmpeg 6.0.1 。And I do configure with command:
``./confugre CFLAGS=-I/usr/include/ffmpeg``。But when I do make command, I will get errors as below:

![Screenshot from 2025-05-08 02-53-00](https://github.com/user-attachments/assets/5c3fcf25-2846-4895-b57f-5390dcd63970)
 
and something like ``undefined refrence to av_free_packet``。After I debug then I get these modifies to make success.