### PR TITLE
Fixed WebRTC build failure on iOS

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -11081,7 +11081,7 @@ printf "%s\n" "Checking if libwebrtc is disabled...no" >&6; }
         case $target in
             *-apple-darwin_ios*)
                 case $target in
-                    arm64*)
+                    arm64* | aarch64*)
                         ac_webrtc_instset=neon
                         ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
                     ;;
@@ -11234,7 +11234,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
             case $target in
                 *-apple-darwin_ios*)
                     case $target in
-                        arm64*)
+                        arm64* | aarch64*)
                             ac_webrtc_aec3_instset=neon
                             ac_webrtc_aec3_cflags="-DWEBRTC_ARCH_ARM64"
                         ;;

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -2717,7 +2717,7 @@ AC_ARG_ENABLE(libwebrtc,
         case $target in
             *-apple-darwin_ios*)
                 case $target in
-                    arm64*)
+                    arm64* | aarch64*)
                         ac_webrtc_instset=neon
                         ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
                     ;;
@@ -2837,7 +2837,7 @@ AC_ARG_ENABLE(libwebrtc_aec3,
             case $target in
                 *-apple-darwin_ios*)
                     case $target in
-                        arm64*)
+                        arm64* | aarch64*)
                             ac_webrtc_aec3_instset=neon
                             ac_webrtc_aec3_cflags="-DWEBRTC_ARCH_ARM64"
                         ;;


### PR DESCRIPTION
Due to configure changes in #4386, WebRTC will fail to build on iOS:
`In file included from ../../webrtc/src/webrtc//modules/audio_processing/aec/aec_core_sse2.c:15:
/Applications/Xcode-14.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.3/include/emmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"`

 This is due to the target build is now named `aarch64-apple-darwin_ios` (previously `arm64`).
