### PR TITLE
Fix compile error with ffmpeg upstream master branch

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1967,8 +1967,14 @@ static pj_status_t ffmpeg_codec_decode_whole(pjmedia_vid_codec *codec,
         /* Check decoding result, e.g: see if the format got changed,
          * keyframe found/missing.
          */
+#if LIBAVUTIL_VER_AT_LEAST(58,7)
         status = check_decode_result(codec, &input->timestamp,
-                                     avframe.key_frame);
+                !!(avframe.flags & AV_FRAME_FLAG_KEY));
+#else
+        status = check_decode_result(codec, &input->timestamp,
+                avframe.key_frame);
+#endif
+                                     /* avframe.key_frame); */
         if (status != PJ_SUCCESS) {
             ffmpeg_frame_unref(&avframe);
             return status;

--- a/pjmedia/src/pjmedia-videodev/ffmpeg_dev.c
+++ b/pjmedia/src/pjmedia-videodev/ffmpeg_dev.c
@@ -411,7 +411,11 @@ static pj_status_t ffmpeg_factory_refresh(pjmedia_vid_dev_factory *f)
         unsigned dev_cnt = MAX_DEV_CNT;
         unsigned dev_idx;
 
+#if LIBAVFORMAT_VER_AT_LEAST(60, 21)
+        if ((p->flags & AVFMT_NOFILE)==0) {
+#else
         if ((p->flags & AVFMT_NOFILE)==0 || p->read_probe) {
+#endif
             goto next_format;
         }
 

--- a/pjmedia/src/pjmedia/ffmpeg_util.h
+++ b/pjmedia/src/pjmedia/ffmpeg_util.h
@@ -49,6 +49,18 @@
                                                (LIBAVCODEC_VERSION_MAJOR == major && \
                                                 LIBAVCODEC_VERSION_MINOR >= minor))
 
+#define LIBAVFORMAT_VER_AT_LEAST(major,minor)  (LIBAVFORMAT_VERSION_MAJOR > major || \
+                                                (LIBAVFORMAT_VERSION_MAJOR == major && \
+                                                 LIBAVFORMAT_VERSION_MINOR >= minor))
+
+#define LIBAVUTIL_VER_AT_LEAST(major,minor)  (LIBAVUTIL_VERSION_MAJOR > major || \
+                                              (LIBAVUTIL_VERSION_MAJOR == major && \
+                                               LIBAVUTIL_VERSION_MINOR >= minor))
+
+#if LIBAVCODEC_VER_AT_LEAST(60,39)
+#   define avcodec_close(x)     ((void)0)
+#endif
+
 void pjmedia_ffmpeg_add_ref();
 void pjmedia_ffmpeg_dec_ref();
 


### PR DESCRIPTION
Fix compile error when link [ffmpeg library master branch](https://git.ffmpeg.org/ffmpeg.git ) as below:
``` bash
../src/pjmedia-videodev/ffmpeg_dev.c: In function ‘ffmpeg_capture_open’:
../src/pjmedia-videodev/ffmpeg_dev.c:187:34: warning: variable ‘vfd’ set but not used [-Wunused-but-set-variable]
  187 |     pjmedia_video_format_detail *vfd;
      |                                  ^~~
../src/pjmedia-videodev/ffmpeg_dev.c:182:10: warning: unused variable ‘buf’ [-Wunused-variable]
  182 |     char buf[128];
      |          ^~~
../src/pjmedia-videodev/ffmpeg_dev.c: In function ‘ffmpeg_factory_refresh’:
../src/pjmedia-videodev/ffmpeg_dev.c:408:7: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  408 |     p = av_input_video_device_next(NULL);
      |       ^
../src/pjmedia-videodev/ffmpeg_dev.c:414:46: error: ‘AVInputFormat’ has no member named ‘read_probe’
  414 |         if ((p->flags & AVFMT_NOFILE)==0 || p->read_probe) {
      |                                              ^~
../src/pjmedia-videodev/ffmpeg_dev.c:454:27: warning: assignment to ‘AVCodecContext *’ from incompatible pointer type ‘AVCodecParameters *’ [-Wincompatible-pointer-types]
  454 |                     codec = ctx->streams[i]->codecpar;
      |                           ^
../src/pjmedia-videodev/ffmpeg_dev.c:502:11: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  502 |         p = av_input_video_device_next(p);

...

../src/pjmedia-codec/ffmpeg_vid_codecs.c: In function ‘ffmpeg_codec_decode_whole’:
../src/pjmedia-codec/ffmpeg_vid_codecs.c:1900:5: warning: ‘av_init_packet’ is deprecated [-Wdeprecated-declarations]
 1900 |     av_init_packet(&avpacket);
      |     ^~~~~~~~~~~~~~
/usr/local/include/libavcodec/packet.h:666:6: note: declared here
  666 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
../src/pjmedia-codec/ffmpeg_vid_codecs.c:1971:45: error: ‘AVFrame’ has no member named ‘key_frame’
 1971 |                                      avframe.key_frame);
      |                                             ^
```