### PR TITLE
Fix hang loop when scan a camera device with no support match v4l2_fmt_maps array

### DIFF
--- a/pjmedia/src/pjmedia-videodev/v4l2_dev.c
+++ b/pjmedia/src/pjmedia-videodev/v4l2_dev.c
@@ -205,7 +205,7 @@ static pj_status_t xioctl(int fh, int request, void *arg)
         r = v4l2_ioctl(fh, request, arg);
     } while (r==-1 && c++<RETRY && ((errno==EINTR) || (errno==EAGAIN)));
 
-    return (r == -1) ? pj_get_os_error() : PJ_SUCCESS;
+    return (r == -1) ? pj_get_os_error() : (r < 0 ? PJ_STATUS_FROM_OS(-r) : PJ_SUCCESS);
 }
 
 static vid4lin_fmt_map* get_v4l2_format_info(pjmedia_format_id id)


### PR DESCRIPTION
when I scan camera devices , I found it will hang loop when scan a camera device with no support match v4l2_fmt_maps array, like
![Screenshot from 2025-05-20 01-03-14](https://github.com/user-attachments/assets/09e0face-864f-4bcc-abc0-473b583a8b65)
