### PR TITLE
Set VoiceCommunication as InputPreset for Oboe stream builder

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -583,6 +583,7 @@ public:
         sb.setPerformanceMode(oboe::PerformanceMode::LowLatency);
         sb.setFormat(oboe::AudioFormat::I16);
         sb.setUsage(oboe::Usage::VoiceCommunication);
+        sb.setInputPreset(oboe::InputPreset::VoiceCommunication);
         sb.setContentType(oboe::ContentType::Speech);
         sb.setDataCallback(this);
         sb.setErrorCallback(this);


### PR DESCRIPTION
Some hardwares need proper InputPreset to activate microphone properly with hardware echo cancellation.
Also in oboe doc it's recommended to use InputPreset::VoiceCommunication for telephony or voice messaging.

https://github.com/google/oboe/blob/a7485b90236c5c987e962f597d22a4705ef5e757/include/oboe/Definitions.h#L489C9-L489C27