### PR TITLE
Make the use of LowLatency as  oboe performance mode configurable

### DIFF
--- a/pjmedia/include/pjmedia-audiodev/config.h
+++ b/pjmedia/include/pjmedia-audiodev/config.h
@@ -98,6 +98,14 @@ PJ_BEGIN_DECL
 #endif
 
 /**
+ * Specify wheather LowLatency is used for Oboe as performance mode.
+ * Default: 1
+ */
+#ifndef PJMEDIA_OBOE_USE_LOWLATENCY
+#   define PJMEDIA_OBOE_USE_LOWLATENCY  1
+#endif
+
+/**
  * This setting controls whether BlackBerry 10 (BB10) audio support
  * should be included.
  */

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -176,13 +176,6 @@
 #   endif
 #endif
 
-/**
- * Specify wheather LowLatency is used for Oboe as performance mode.
- * Default: 1
- */
-#ifndef PJMEDIA_OBOE_USE_LOWLATENCY
-#   define PJMEDIA_OBOE_USE_LOWLATENCY  1
-#endif
 
 /*
  * Types of WSOLA backend algorithm.

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -176,6 +176,13 @@
 #   endif
 #endif
 
+/**
+ * Specify wheather LowLatency is used for Oboe as performance mode.
+ * Default: 1
+ */
+#ifndef PJMEDIA_OBOE_USE_LOWLATENCY
+#   define PJMEDIA_OBOE_USE_LOWLATENCY  1
+#endif
 
 /*
  * Types of WSOLA backend algorithm.

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -553,6 +553,7 @@ public:
         }
 
         int dev_id = 0;
+        oboe::PerformanceMode performance_mode;
         oboe::AudioStreamBuilder sb;
 
         pj_mutex_lock(mutex);
@@ -577,10 +578,17 @@ public:
                 dev_id = stream->f->dev_info[stream->param.play_id].id;
             }
         }
+
+        if(PJMEDIA_OBOE_USE_LOWLATENCY){
+            performance_mode= oboe::PerformanceMode::LowLatency;
+        }else{
+            performance_mode = oboe::PerformanceMode::None;
+        }
+        
         sb.setDeviceId(dev_id);
         sb.setSampleRate(stream->param.clock_rate);
         sb.setChannelCount(stream->param.channel_count);
-        sb.setPerformanceMode(oboe::PerformanceMode::LowLatency);
+        sb.setPerformanceMode(performance_mode);
         sb.setFormat(oboe::AudioFormat::I16);
         sb.setUsage(oboe::Usage::VoiceCommunication);
         sb.setInputPreset(oboe::InputPreset::VoiceCommunication);

--- a/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
+++ b/pjmedia/src/pjmedia-audiodev/oboe_dev.cpp
@@ -579,9 +579,9 @@ public:
             }
         }
 
-        if(PJMEDIA_OBOE_USE_LOWLATENCY){
+        if (PJMEDIA_OBOE_USE_LOWLATENCY) {
             performance_mode= oboe::PerformanceMode::LowLatency;
-        }else{
+        } else {
             performance_mode = oboe::PerformanceMode::None;
         }
         


### PR DESCRIPTION
On a car  hardware, it is not possible to have hardware echo cancellation in case PerformanceMode::LowLatency be used as performance mode, however it works fine with PerformanceMode::None.

Not sure, but I think, using LowLatency on a audio device that doesn't support MMAP will cause this issue.


PJMEDIA_OBOE_USE_LOWLATENCY has been defined for this purpose,
by default the value is 1 and PerformanceMode::LowLatency is used. By changing it to 0 , PerformanceMode::None will be used.
 
 