### PR TITLE
[pjmedia/pjsua] expose pjmedia_conf_configure_port() to PJSUA

### DIFF
--- a/pjmedia/include/pjmedia/wav_port.h
+++ b/pjmedia/include/pjmedia/wav_port.h
@@ -128,6 +128,10 @@ PJ_DECL(pj_ssize_t) pjmedia_wav_player_get_len(pjmedia_port *port);
 
 /**
  * Set the file play position of WAV player.
+ * @b Safety: This function can only be called when the player is stopped
+ * (that is: get_frame() is not being called).
+ *
+ * @sa pjmedia_conf_configure_port
  *
  * @param port          The file player port.
  * @param offset        Playback position in bytes, relative to the start of
@@ -141,6 +145,10 @@ PJ_DECL(pj_status_t) pjmedia_wav_player_port_set_pos( pjmedia_port *port,
 
 /**
  * Get the file play position of WAV player, in bytes.
+ * @b Safety: This function can only be called when the player is stopped
+ * (that is: get_frame() is not being called).
+ *
+ * @sa pjmedia_conf_configure_port
  *
  * @param port          The file player port.
  *

--- a/pjmedia/include/pjmedia/wav_port.h
+++ b/pjmedia/include/pjmedia/wav_port.h
@@ -128,7 +128,7 @@ PJ_DECL(pj_ssize_t) pjmedia_wav_player_get_len(pjmedia_port *port);
 
 /**
  * Set the file play position of WAV player.
- * @b Safety: This function can only be called when the player is stopped
+ * @b Safety: This function can only be called when the player is not running
  * (that is: get_frame() is not being called).
  *
  * @sa pjmedia_conf_configure_port
@@ -145,7 +145,7 @@ PJ_DECL(pj_status_t) pjmedia_wav_player_port_set_pos( pjmedia_port *port,
 
 /**
  * Get the file play position of WAV player, in bytes.
- * @b Safety: This function can only be called when the player is stopped
+ * @b Safety: This function can only be called when the player is not running
  * (that is: get_frame() is not being called).
  *
  * @sa pjmedia_conf_configure_port

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -8165,6 +8165,18 @@ PJ_DECL(pj_status_t) pjsua_conf_connect2(pjsua_conf_port_id source,
 PJ_DECL(pj_status_t) pjsua_conf_disconnect(pjsua_conf_port_id source,
                                            pjsua_conf_port_id sink);
 
+/**
+ * Change TX and RX settings for the port.
+ *
+ * @param slot         Port number/slot in the conference bridge.
+ * @param tx           Settings for the transmission TO this port.
+ * @param rx           Settings for the receipt FROM this port.
+ *
+ * @return             PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsua_conf_configure_port(pjsua_conf_port_id slot,
+                                               pjmedia_port_op tx,
+                                               pjmedia_port_op rx);
 
 /**
  * Adjust the signal level to be transmitted from the bridge to the 

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1089,6 +1089,17 @@ PJ_DEF(pj_status_t) pjsua_conf_disconnect( pjsua_conf_port_id source,
     return status;
 }
 
+/*
+ * Change TX and RX settings for the port.
+ */
+PJ_DEF(pj_status_t) pjsua_conf_configure_port( pjsua_conf_port_id slot,
+                                               pjmedia_port_op tx,
+                                               pjmedia_port_op rx)
+{
+    PJ_ASSERT_RETURN(slot >= 0, PJ_EINVAL);
+
+    return pjmedia_conf_configure_port(pjsua_var.mconf, slot, tx, rx);
+}
 
 /*
  * Adjust the signal level to be transmitted from the bridge to the


### PR DESCRIPTION
This PR adds `pjsua_conf_configure_port()` to PJSUA as a thin wrapper for `pjmedia_conf_configure_port()`
and updates the documentation for the WAV player port functions `pjmedia_wav_player_port_set_pos()` and `pjmedia_wav_player_port_get_pos()`.

Both WAV player functions access the underlying port without synchronization which means a race condition will occur when the port is being serviced (i.e. `put_frame()` is being called by the conference bridge).

One can go around this problem by telling the confbridge to stop reading from the port via `pjmedia_conf_configure_port()` then get or set the position and then call `pjmedia_conf_configure_port()` again,
this time instructing the confbridge to continue reading from the port.
This works because port configuration happens synchronously.

Care must still be taken when an EOF callback has been specified.
My personal advise would be to try and avoid calling `get_pos()` `set_pos()` in the EOF callback.

Resolves #4431 