### PR TITLE
Implement PJSUA/PJSUA2 API for AVI writer

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -513,7 +513,7 @@ static void on_call_audio_state(pjsua_call_info *ci, unsigned mi,
 static void on_call_video_state(pjsua_call_info *ci, unsigned mi,
                                 pj_bool_t *has_error)
 {
-    if (ci->media_status != PJSUA_CALL_MEDIA_ACTIVE)
+    if (ci->media[mi].status != PJSUA_CALL_MEDIA_ACTIVE)
         return;
 
     arrange_window(ci->media[mi].stream.vid.win_in);
@@ -1243,13 +1243,11 @@ static void hangup_timeout_callback(pj_timer_heap_t *timer_heap,
     pjsua_call_hangup_all();
 }
 
-static void avi_writer_cb(pjmedia_avi_streams *streams,
-                          void *usr_data)
+static void avi_writer_cb(pjsua_avi_rec_id id, void *user_data)
 {
-    PJ_UNUSED_ARG(streams);
-    PJ_UNUSED_ARG(usr_data);
+    PJ_UNUSED_ARG(user_data);
 
-    PJ_LOG(4, (THIS_FILE, "AVI recording has completed"));
+    PJ_LOG(4, (THIS_FILE, "AVI recorder %d, recording has completed", id));
 }
 
 /*
@@ -1714,42 +1712,24 @@ static pj_status_t app_init(void)
 
     if (app_config.avi_rec.slen) {
 #if PJMEDIA_HAS_VIDEO
-        pjmedia_format fmt[2];
-        pjmedia_avi_streams *streams;
-        pjmedia_port *aviw_port;
-
-        pjmedia_format_init_video(&fmt[0], PJMEDIA_FORMAT_I420,
-                                  320, 240, 15, 1);
-        pjmedia_format_init_audio(&fmt[1], PJMEDIA_FORMAT_PCM,
-                                  app_config.media_cfg.clock_rate,
-                                  app_config.media_cfg.channel_count,
-                                  16,
-                                  app_config.media_cfg.audio_frame_ptime*1000,
-                                  0, 0);
-        status = pjmedia_avi_writer_create_streams(app_config.pool,
-                                                   app_config.avi_rec.ptr,
-                                                   app_config.avi_rec_size,
-                                                   2, fmt, 0, &streams);
-        pj_assert(status == PJ_SUCCESS);
-
-        pjmedia_avi_streams_set_cb(streams, NULL, &avi_writer_cb);
-
-        app_config.avi_vid_port = (pjmedia_port *)
-                                  pjmedia_avi_streams_get_stream(streams, 0);
-        status = pjsua_vid_conf_add_port(app_config.pool,
-                                         app_config.avi_vid_port, NULL,
-                                         &app_config.avi_vid_slot);
-        pj_assert(status == PJ_SUCCESS);
-
-        if (app_config.avi_rec_audio) {
-            app_config.avi_aud_port = (pjmedia_port *)
-                                      pjmedia_avi_streams_get_stream(streams,
-                                                                     1);
-            status = pjsua_conf_add_port(app_config.pool,
-                                         app_config.avi_aud_port,
-                                         &app_config.avi_aud_slot);
-            pj_assert(status == PJ_SUCCESS);
+        status = pjsua_avi_recorder_create(&app_config.avi_rec,
+                                           app_config.avi_rec_size,
+                                           NULL, NULL, 0,
+                                           &app_config.avi_rec_id);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(1, (THIS_FILE, status, "Error creating AVI recorder"));
+            goto on_error;
         }
+
+        app_config.avi_vid_slot = pjsua_avi_recorder_get_conf_port(
+                                                     app_config.avi_rec_id,
+                                                     PJMEDIA_TYPE_VIDEO);
+        app_config.avi_aud_slot = pjsua_avi_recorder_get_conf_port(
+                                                     app_config.avi_rec_id,
+                                                     PJMEDIA_TYPE_AUDIO);
+
+        pjsua_avi_recorder_set_cb(app_config.avi_rec_id, NULL, 
+                                  &avi_writer_cb);
 #endif
     }
 
@@ -2262,17 +2242,11 @@ static pj_status_t app_destroy(void)
 
     /* Close avi writer */
 #if PJMEDIA_HAS_VIDEO
-    if (app_config.avi_vid_slot != PJSUA_INVALID_ID) {
-        pjsua_vid_conf_remove_port(app_config.avi_vid_slot);
-        pjmedia_port_destroy(app_config.avi_vid_port);
-        app_config.avi_vid_slot = PJSUA_INVALID_ID;
+    if (app_config.avi_rec_id != PJSUA_INVALID_ID) {
+        pjsua_avi_recorder_destroy(app_config.avi_rec_id);
+        app_config.avi_rec_id = PJSUA_INVALID_ID;
     }
 #endif
-    if (app_config.avi_aud_slot != PJSUA_INVALID_ID) {
-        pjsua_conf_remove_port(app_config.avi_aud_slot);
-        pjmedia_port_destroy(app_config.avi_aud_port);
-        app_config.avi_aud_slot = PJSUA_INVALID_ID;
-    }
 
     /* Close ringback port */
     if (app_config.ringback_port && 
@@ -2341,6 +2315,7 @@ static pj_status_t app_destroy(void)
     pj_bzero(&app_config, sizeof(app_config));
     app_config.wav_id = PJSUA_INVALID_ID;
     app_config.rec_id = PJSUA_INVALID_ID;
+    app_config.avi_rec_id = PJSUA_INVALID_ID;
     app_config.avi_vid_slot = PJSUA_INVALID_ID;
     app_config.avi_aud_slot = PJSUA_INVALID_ID;
 

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -160,14 +160,13 @@ typedef struct pjsua_app_config
     int                     avi_def_idx;
 
     /* AVI recording */
+    pjsua_avi_rec_id        avi_rec_id;
     pj_str_t                avi_rec;
     pj_uint32_t             avi_rec_size;
     pj_bool_t               avi_rec_audio;
     pj_bool_t               avi_auto_rec;
     pjsua_conf_port_id      avi_vid_slot;
-    pjmedia_port           *avi_vid_port;
     pjsua_conf_port_id      avi_aud_slot;
-    pjmedia_port           *avi_aud_port;
 
     /* CLI setting */
     pj_bool_t               use_cli;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1723,6 +1723,7 @@ static void default_config()
     cfg->playback_lat = PJMEDIA_SND_DEFAULT_PLAY_LATENCY;
     cfg->ringback_slot = PJSUA_INVALID_ID;
     cfg->ring_slot = PJSUA_INVALID_ID;
+    cfg->avi_rec_id = PJSUA_INVALID_ID;
     cfg->avi_vid_slot = PJSUA_INVALID_ID;
     cfg->avi_aud_slot = PJSUA_INVALID_ID;
 

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -145,6 +145,7 @@ using namespace pj;
 %feature("director") FindBuddyMatch;
 %feature("director") AudioMediaPlayer;
 %feature("director") AudioMediaPort;
+%feature("director") VideoRecorder;
 
 // PendingJob is only used on Python
 #ifdef SWIGPYTHON

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -273,6 +273,9 @@ typedef int pjsua_player_id;
 /** File recorder identification */
 typedef int pjsua_recorder_id;
 
+/** AVI recorder identification */
+typedef int pjsua_avi_rec_id;
+
 /** Conference port identification */
 typedef int pjsua_conf_port_id;
 
@@ -7430,12 +7433,18 @@ PJ_DECL(pj_status_t) pjsua_im_typing(pjsua_acc_id acc_id,
 
 
 /**
- * The maximum file player.
+ * The maximum file recorder.
  */
 #ifndef PJSUA_MAX_RECORDERS
 #   define PJSUA_MAX_RECORDERS          32
 #endif
 
+ /**
+  * The maximum avi file recorder.
+  */
+#ifndef PJSUA_MAX_AVI_RECORDERS
+#   define PJSUA_MAX_AVI_RECORDERS          4
+#endif
 
 /**
  * Enable/disable "c=" line in SDP session level. Set to zero to disable it.
@@ -8404,6 +8413,95 @@ PJ_DECL(pj_status_t) pjsua_recorder_get_port(pjsua_recorder_id id,
  */
 PJ_DECL(pj_status_t) pjsua_recorder_destroy(pjsua_recorder_id id);
 
+
+/*****************************************************************************
+ * AVI writer.
+ */
+
+ /**
+  * Create an avi recorder and automatically add a audio/video port
+  * the audio/video conference bridge. User can connect the audio/video port
+  * from a source port to store the uncompressed video and 16 bit PCM audio.
+  * The recorder currently supports YUY2/I420/RGB24 video format and 
+  * PCM/PCMA/PCMU audio format.
+  * 
+  * Note: Uncompressed video can lead to significant file size growth.
+  * 
+  * @param filename      The filename to be played. Currently only
+  *                      AVI files are supported. Filename's length must be
+  *                      smaller than PJ_MAXPATH.
+  *                      Filename's length must be smaller than PJ_MAXPATH.
+  * @param max_size      Maximum file size.
+  * @param vid_fmt       The video format. If this is not set (NULL), the
+                         format will be set to:
+                         - format:PJMEDIA_FORMAT_I420
+                         - size:320x240
+                         - fps:15
+  * @param aud_fmt       The audio format. If this is not set (NULL), the
+                         format will be set to:
+                         - format:PJMEDIA_FORMAT_PCM
+                         - bits_per_sample:16
+                         - clock rate/chan count/ptime:the conf bridge settings
+  * @param options       Optional options.
+  * @param id            Pointer to receive avi recorder instance.
+  *
+  * @return              PJ_SUCCESS on success, or the appropriate error code.
+  */
+PJ_DECL(pj_status_t) pjsua_avi_recorder_create(const pj_str_t *filename,
+                                               pj_ssize_t max_size,
+                                               const pjmedia_format *vid_fmt,
+                                               const pjmedia_format *aud_fmt,
+                                               unsigned options,
+                                               pjsua_avi_rec_id *id);
+
+/**
+ * Get the conference port identification associated with the recorder.
+ *
+ * @param id            The recorder id.
+ * @param strm_type     The stream type.
+ *
+ * @return              The video/audio conference port ID.
+ */
+PJ_DECL(pjsua_conf_port_id) pjsua_avi_recorder_get_conf_port(
+                                                        pjsua_avi_rec_id id,
+                                                        pjmedia_type strm_type);
+
+/**
+ * Get the media port for the avi recorder based on the media type.
+ *
+ * @param id            The recorder ID.
+ * @param strm_type     The stream type.
+ * @param p_port        The media port associated with the avi recorder.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjsua_avi_recorder_get_port(pjsua_avi_rec_id id,
+                                                 pjmedia_type strm_type,
+                                                 pjmedia_port **p_port);
+
+/**
+ * Register a callback to be called when the file size has reached the
+ * max size.
+ * 
+ * @param id            The recorder ID.
+ * @param user_data     User data to be specified in the callback, and will be
+ *                      given on the callback.
+ * @param cb            Callback to be called.
+ */
+PJ_DECL(pj_status_t) pjsua_avi_recorder_set_cb(pjsua_avi_rec_id id,
+                                            void *user_data,
+                                            void(*cb)(pjsua_avi_rec_id rec_id, 
+                                                      void *usr_data));
+
+/**
+ * Destroy the avi recorder, remove the media port from the bridge, and free
+ * resources associated with the avi recorder.
+ *
+ * @param id            The avi recorder ID.
+ *
+ * @return              PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsua_avi_recorder_destroy(pjsua_avi_rec_id id);
 
 /*****************************************************************************
  * Sound devices.

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -410,6 +410,21 @@ typedef struct pjsua_file_data
     unsigned         slot;
 } pjsua_file_data;
 
+/**
+ * AVI recorder data.
+ */
+typedef struct pjsua_avi_recoder_data
+{
+    pj_pool_t               *pool;
+    pjmedia_avi_streams     *avi_streams;
+    pjsua_conf_port_id       aud_slot;
+    pjsua_conf_port_id       vid_slot;
+    pjmedia_port            *aud_port;
+    pjmedia_port            *vid_port;
+    void                    (*cb)(pjsua_avi_rec_id id,
+                                  void *user_data);
+    void                    *user_data;
+} pjsua_avi_recorder_data;
 
 /**
  * Additional parameters for conference bridge.
@@ -595,6 +610,13 @@ struct pjsua_data
     /* File recorders: */
     unsigned             rec_cnt;   /**< Number of file recorders.      */
     pjsua_file_data      recorder[PJSUA_MAX_RECORDERS];/**< Array of recs.*/
+
+#if PJSUA_HAS_VIDEO
+    /* File recorders: */
+    unsigned                  avi_rec_cnt;   /**< Number of avi recorders.    */
+    pjsua_avi_recorder_data   avi_recorder[PJSUA_MAX_AVI_RECORDERS];/**< Array 
+                                                             of avi recorders.*/
+#endif
 
     /* Video windows */
 #if PJSUA_HAS_VIDEO
@@ -943,6 +965,13 @@ const char *good_number(char *buf, unsigned buf_size, pj_int32_t val);
 void print_call(const char *title,
                 int call_id,
                 char *buf, pj_size_t size);
+
+char *get_basename(const char *path, unsigned len);
+
+/*
+ * Internal function to reset avi recorder data
+ */
+void reset_avi_recorder_data(pjsua_avi_rec_id id);
 
 /*
  * Audio

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2487,6 +2487,84 @@ private:
     friend class Endpoint;
 };
 
+/**
+ * Video AVI Recorder.
+ */
+class VideoRecorder
+{
+public:
+    /**
+     * Constructor.
+     */
+    class VideoRecorder();
+
+    /**
+     * Create an avi recorder and automatically add a audio/video port
+     * the audio/video conference bridge. User can connect the audio/video port
+     * from a source port to store the uncompressed video and 16 bit PCM audio.
+     * The recorder currently supports YUY2/I420/RGB24 video format and
+     * PCM/PCMA/PCMU audio format.
+     *
+     * Note: Uncompressed video can lead to significant file size growth.
+     *
+     * @param filename      The filename to be played. Currently only
+     *                      AVI files are supported. Filename's length must be
+     *                      smaller than PJ_MAXPATH.
+     *                      Filename's length must be smaller than PJ_MAXPATH.
+     * @param max_size      Maximum file size.
+     * @param vid_fmt       The video format. If this is not set (NULL), the
+                            format will be set to:
+                            - format:PJMEDIA_FORMAT_I420
+                            - size:320x240
+                            - fps:15
+     * @param aud_fmt       The audio format. If this is not set (NULL), the
+                            format will be set to:
+                            - format:PJMEDIA_FORMAT_PCM
+                            - bits_per_sample:16
+                            - clock rate/chan count/ptime:the conf bridge settings
+     * @param options       Optional options.
+     */
+    void createRecorder(const string& file_name,
+                        long max_size = 0,
+                        MediaFormatVideo *vid_fmt = 0,
+                        MediaFormatAudio *aud_fmt = 0,
+                        unsigned options = 0) PJSUA2_THROW(Error);
+
+    /**
+     * Enumerate video media port.
+     *
+     * @return          The list of audio media port.
+     */
+    VideoMedia getVideoMedia() PJSUA2_THROW(Error);
+
+    /**
+     * Enumerate audio media port.
+     *
+     * @return          The list of video media port.
+     */
+    AudioMedia getAudioMedia() PJSUA2_THROW(Error);
+
+    /**
+     * Register a callback to be called when the file size has reached the
+     * max size.
+     */
+    virtual void onMaxSize()
+    {
+    }
+
+    virtual ~VideoRecorder();
+
+private:
+    /**
+     * Recorder Id.
+     */
+    int recorderId;
+
+    /**
+     *  Low level callback
+     */
+    static void max_size_cb(pjsua_recorder_id id, void *usr_data);
+};
 
 /*************************************************************************
 * Codec management

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1145,19 +1145,6 @@ PJ_DEF(pj_status_t) pjsua_conf_get_signal_level(pjsua_conf_port_id slot,
  * File player.
  */
 
-static char* get_basename(const char *path, unsigned len)
-{
-    char *p = ((char*)path) + len;
-
-    if (len==0)
-        return p;
-
-    for (--p; p!=path && *p!='/' && *p!='\\'; ) --p;
-
-    return (p==path) ? p : p+1;
-}
-
-
 /*
  * Create a file player, and automatically connect this player to
  * the conference bridge.

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -72,8 +72,13 @@ static void init_data()
     for (i=0; i<PJSUA_MAX_VID_WINS; ++i) {
         pjsua_vid_win_reset(i);
     }
-}
+#if PJSUA_HAS_VIDEO
+    for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_recorder); ++i) {
+        reset_avi_recorder_data(i);
+    }
+#endif
 
+}
 
 PJ_DEF(void) pjsua_logging_config_default(pjsua_logging_config *cfg)
 {

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -33,6 +33,18 @@
 
 static void stop_media_stream(pjsua_call *call, unsigned med_idx);
 
+char *get_basename(const char* path, unsigned len)
+{
+    char* p = ((char*)path) + len;
+
+    if (len == 0)
+        return p;
+
+    for (--p; p != path && *p != '/' && *p != '\\'; ) --p;
+
+    return (p == path) ? p : p + 1;
+}
+
 static void pjsua_media_config_dup(pj_pool_t *pool,
                                    pjsua_media_config *dst,
                                    const pjsua_media_config *src)

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -170,6 +170,15 @@ pj_status_t pjsua_vid_subsys_destroy(void)
             pjsua_var.win[i].pool = NULL;
         }
     }
+    /* Destroy avi file recorders */
+    for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_recorder); ++i) {
+        if (pjsua_var.avi_recorder[i].avi_streams != NULL)
+        {
+            PJ_LOG(2, (THIS_FILE, "Destructor for avi recorder id=%d "
+                       "is not called", i));
+            pjsua_avi_recorder_destroy(i);
+        }
+    }
 
     if (pjsua_var.vid_conf) {
         pjmedia_vid_conf_destroy(pjsua_var.vid_conf);
@@ -3065,6 +3074,243 @@ on_return:
     return port_id;
 }
 
+/*****************************************************************************
+ * AVI recordder.
+ */
+
+#define AVI_REC_FILE_MAX_SIZE   5  /* 5Mb */
+#define AVI_REC_FILE_FMT        PJMEDIA_FORMAT_I420
+#define AVI_REC_FILE_WIDTH      320
+#define AVI_REC_FILE_HEIGHT     240
+#define AVI_REC_FILE_FPS_NUM    15
+#define AVI_REC_FILE_FPS_DENUM  1
+
+static void avi_writer_cb(pjmedia_avi_streams *streams,
+                          void *usr_data)
+{
+    pjsua_avi_rec_id id;
+    PJ_UNUSED_ARG(streams);
+    id = (pjsua_avi_rec_id)(pj_ssize_t)usr_data;
+    if (id < 0 || id > PJ_ARRAY_SIZE(pjsua_var.avi_recorder))
+        return;
+
+    pj_log_push_indent();
+    if (pjsua_var.avi_recorder[id].cb) {
+        (*pjsua_var.avi_recorder[id].cb)(id, 
+                                        pjsua_var.avi_recorder[id].user_data);
+    }
+    pj_log_pop_indent();
+}
+
+void reset_avi_recorder_data(pjsua_avi_rec_id id)
+{
+    pjsua_var.avi_recorder[id].aud_port = NULL;
+    pjsua_var.avi_recorder[id].vid_port = NULL;
+    pjsua_var.avi_recorder[id].aud_slot = PJSUA_INVALID_ID;
+    pjsua_var.avi_recorder[id].vid_slot = PJSUA_INVALID_ID;
+    pjsua_var.avi_recorder[id].avi_streams = NULL;
+    pjsua_var.avi_recorder[id].cb = NULL;
+    pjsua_var.avi_recorder[id].user_data = NULL;
+}
+
+PJ_DEF(pj_status_t) pjsua_avi_recorder_create(const pj_str_t *filename,
+                                              pj_ssize_t max_size,
+                                              const pjmedia_format *vid_fmt,
+                                              const pjmedia_format *aud_fmt,
+                                              unsigned options,
+                                              pjsua_avi_rec_id *id)
+{
+    pjmedia_format fmt[2];
+    pjmedia_avi_streams *streams;
+    pj_pool_t *pool = NULL;
+    pjmedia_port *aviw_port;
+    pj_status_t status = PJ_SUCCESS;
+    unsigned avi_id;
+
+    /* Filename must present */
+    PJ_ASSERT_RETURN(filename != NULL, PJ_EINVAL);
+
+    if (filename->slen >= PJ_MAXPATH)
+        return PJ_ENAMETOOLONG;
+    if (filename->slen < 4)
+        return PJ_EINVALIDOP;
+
+    if (max_size <= 0)
+        max_size = AVI_REC_FILE_MAX_SIZE * 1000000;
+
+    PJ_LOG(4, (THIS_FILE, "Creating avi recorder %.*s..",
+               (int)filename->slen, filename->ptr));
+
+    pj_log_push_indent();
+
+    if (pjsua_var.avi_rec_cnt >= PJ_ARRAY_SIZE(pjsua_var.avi_recorder)) {
+        pj_log_pop_indent();
+        return PJ_ETOOMANY;
+    }
+
+    PJSUA_LOCK();
+
+    for (avi_id = 0; avi_id <
+         PJ_ARRAY_SIZE(pjsua_var.avi_recorder); ++avi_id)
+    {
+        if (pjsua_var.avi_recorder[avi_id].avi_streams == NULL)
+            break;
+    }
+
+    if (avi_id == PJ_ARRAY_SIZE(pjsua_var.avi_recorder)) {
+        status = PJ_ETOOMANY;
+        goto on_return;
+    }
+
+    pool = pjsua_pool_create(get_basename(filename->ptr,
+                             (unsigned)filename->slen), 1000, 1000);
+    if (!pool) {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
+    pjsua_var.avi_recorder[avi_id].pool = pool;
+
+    if (!vid_fmt) {
+        pjmedia_format_init_video(&fmt[0], AVI_REC_FILE_FMT,
+                                AVI_REC_FILE_WIDTH, AVI_REC_FILE_HEIGHT,
+                                AVI_REC_FILE_FPS_NUM, AVI_REC_FILE_FPS_DENUM);
+    } else {
+        fmt[0] = *vid_fmt;
+    }
+
+    if (!aud_fmt) {
+        pjmedia_format_init_audio(&fmt[1], PJMEDIA_FORMAT_PCM,
+                                  pjsua_var.media_cfg.clock_rate,
+                                  pjsua_var.media_cfg.channel_count,
+                                  16,
+                                  pjsua_var.media_cfg.audio_frame_ptime * 1000,
+                                  0, 0);
+    } else {
+        fmt[1] = *aud_fmt;
+    }
+    status = pjmedia_avi_writer_create_streams(pool, filename->ptr, max_size,
+                                               2, fmt, options, &streams);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+
+    aviw_port = (pjmedia_port*)pjmedia_avi_streams_get_stream(streams, 0);
+    if (aviw_port) {
+        status = pjsua_vid_conf_add_port(pjsua_var.avi_recorder[avi_id].pool,
+                                    aviw_port, NULL,
+                                    &pjsua_var.avi_recorder[avi_id].vid_slot);
+        if (status != PJ_SUCCESS)
+            goto on_return;
+
+        pjsua_var.avi_recorder[avi_id].vid_port = aviw_port;
+    }
+
+    aviw_port = (pjmedia_port*)pjmedia_avi_streams_get_stream(streams, 1);
+    if (aviw_port) {
+        status = pjsua_conf_add_port(pjsua_var.avi_recorder[avi_id].pool, aviw_port,
+                                     &pjsua_var.avi_recorder[avi_id].aud_slot);
+
+        if (status != PJ_SUCCESS)
+            goto on_return;
+
+        pjsua_var.avi_recorder[avi_id].aud_port = aviw_port;
+    }
+    pjsua_var.avi_recorder[avi_id].avi_streams = streams;
+    pjsua_var.avi_rec_cnt++;
+    *id = avi_id;
+
+    PJ_LOG(4, (THIS_FILE, "AVI Recorder created, id=%d", avi_id));
+
+on_return:
+    PJSUA_UNLOCK();
+    if (pool) pj_pool_release(pool);
+    pj_log_pop_indent();
+    return status;
+}
+
+PJ_DEF(pjsua_conf_port_id) pjsua_avi_recorder_get_conf_port(
+                                                        pjsua_avi_rec_id id,
+                                                        pjmedia_type strm_type)
+{
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_recorder),
+                     PJSUA_INVALID_ID);
+
+    switch (strm_type) {
+    case PJMEDIA_TYPE_AUDIO:
+        return pjsua_var.avi_recorder[id].aud_slot;
+    case PJMEDIA_TYPE_VIDEO:
+        return pjsua_var.avi_recorder[id].vid_slot;
+    default:
+        return PJSUA_INVALID_ID;
+    }
+}
+
+PJ_DEF(pj_status_t) pjsua_avi_recorder_get_port(pjsua_avi_rec_id id,
+                                                pjmedia_type strm_type,
+                                                pjmedia_port **p_port)
+{
+    pj_status_t status = PJ_SUCCESS;
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_recorder),
+                     PJSUA_INVALID_ID);
+
+    switch (strm_type) {
+    case PJMEDIA_TYPE_AUDIO:
+        p_port = &pjsua_var.avi_recorder[id].aud_port;
+    case PJMEDIA_TYPE_VIDEO:
+        p_port = &pjsua_var.avi_recorder[id].vid_port;
+    default:
+        status = PJ_ENOTFOUND;
+    }
+    return status;
+}
+
+PJ_DEF(pj_status_t) pjsua_avi_recorder_set_cb(pjsua_avi_rec_id id,
+                                              void *user_data,
+                                              void(*cb)(pjsua_avi_rec_id rec_id,
+                                                        void *usr_data))
+{
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_recorder),
+                     PJSUA_INVALID_ID);
+
+    if (pjsua_var.avi_recorder[id].avi_streams) {
+        pjsua_var.avi_recorder[id].cb = cb;
+        pjsua_var.avi_recorder[id].user_data = user_data;
+        pjmedia_avi_streams_set_cb(pjsua_var.avi_recorder[id].avi_streams, 
+                                   (void*)id, &avi_writer_cb);
+    }
+
+    return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_avi_recorder_destroy(pjsua_avi_rec_id id)
+{
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_recorder),
+                     PJSUA_INVALID_ID);
+
+    PJ_LOG(4, (THIS_FILE, "Destroying avi recorder %d..", id));
+    pj_log_push_indent();
+    PJSUA_LOCK();
+
+    if (pjsua_var.avi_recorder[id].avi_streams != NULL) {
+        if (pjsua_var.vid_conf)
+            pjsua_vid_conf_remove_port(pjsua_var.avi_recorder[id].vid_slot);
+
+        if (pjsua_var.avi_recorder[id].vid_port)
+            pjmedia_port_destroy(pjsua_var.avi_recorder[id].vid_port);
+
+        if (pjsua_var.mconf)
+            pjsua_conf_remove_port(pjsua_var.avi_recorder[id].aud_slot);
+
+        if (pjsua_var.avi_recorder[id].aud_port)
+            pjmedia_port_destroy(pjsua_var.avi_recorder[id].aud_port);
+
+        reset_avi_recorder_data(id);
+        pjsua_var.avi_rec_cnt--;
+    }
+    PJSUA_UNLOCK();
+    pj_log_pop_indent();
+
+    return PJ_SUCCESS;
+}
 
 #endif /* PJSUA_HAS_VIDEO */
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1963,6 +1963,103 @@ VidDevManager::~VidDevManager()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+VideoRecorder::VideoRecorder()
+: recorderId(PJSUA_INVALID_ID)
+{
+
+}
+
+VideoRecorder::~VideoRecorder()
+{
+#if PJSUA_HAS_VIDEO
+    if (recorderId != PJSUA_INVALID_ID) {
+        pjsua_avi_recorder_destroy(recorderId);
+    }
+#endif
+}
+
+void VideoRecorder::createRecorder(const string& file_name,
+                                   long max_size,
+                                   MediaFormatVideo *vid_fmt,
+                                   MediaFormatAudio *aud_fmt,
+                                   unsigned options) PJSUA2_THROW(Error)
+{
+#if PJSUA_HAS_VIDEO
+    if (recorderId != PJSUA_INVALID_ID) {
+        PJSUA2_RAISE_ERROR(PJ_EEXISTS);
+    }
+    pjmedia_format vidfmt;
+    pjmedia_format audfmt;
+
+    pj_str_t pj_name = str2Pj(file_name);
+    if (vid_fmt)
+        vidfmt = vid_fmt->toPj();
+    if (aud_fmt)
+        audfmt = aud_fmt->toPj();
+
+    PJSUA2_CHECK_EXPR(pjsua_avi_recorder_create(&pj_name, 
+                                                max_size,
+                                                vid_fmt?&vidfmt:NULL,
+                                                aud_fmt?&audfmt:NULL,
+                                                options, 
+                                                &recorderId));
+
+    pjsua_avi_recorder_set_cb(recorderId, this, &max_size_cb);
+#else
+    PJ_UNUSED_ARG(file_name);
+    PJ_UNUSED_ARG(max_size);
+    PJ_UNUSED_ARG(vid_fmt);
+    PJ_UNUSED_ARG(aud_fmt);
+    PJ_UNUSED_ARG(options);
+    PJSUA2_RAISE_ERROR(PJ_EINVALIDOP);
+#endif
+}
+
+VideoMedia VideoRecorder::getVideoMedia() PJSUA2_THROW(Error)
+{
+#if PJSUA_HAS_VIDEO
+    pjsua_conf_port_id port_id = pjsua_avi_recorder_get_conf_port(recorderId,
+                                                            PJMEDIA_TYPE_VIDEO);
+
+    if (port_id == PJSUA_INVALID_ID)
+        PJSUA2_RAISE_ERROR(PJ_ENOTFOUND);
+
+    VideoMediaHelper vm;
+    vm.setPortId(port_id);
+
+    return vm;
+#else
+    PJSUA2_RAISE_ERROR(PJ_EINVALIDOP);
+#endif
+}
+
+AudioMedia VideoRecorder::getAudioMedia() PJSUA2_THROW(Error)
+{
+#if PJSUA_HAS_VIDEO
+    pjsua_conf_port_id port_id = pjsua_avi_recorder_get_conf_port(recorderId,
+                                                            PJMEDIA_TYPE_AUDIO);
+
+    if (port_id == PJSUA_INVALID_ID)
+        PJSUA2_RAISE_ERROR(PJ_ENOTFOUND);
+
+    AudioMediaHelper vm;
+    vm.setPortId(port_id);
+
+    return vm;
+#else
+    PJSUA2_RAISE_ERROR(PJ_EINVALIDOP);
+#endif
+}
+
+void VideoRecorder::max_size_cb(pjsua_recorder_id id, void *usr_data)
+{
+    PJ_UNUSED_ARG(id);
+
+    VideoRecorder *vid_rec = (VideoRecorder*)usr_data;
+    vid_rec->onMaxSize();
+}
+
+///////////////////////////////////////////////////////////////////////////////
 
 /** 
  * Utility class for converting CodecFmtpVector to and from pjmedia_codec_fmtp. 


### PR DESCRIPTION
The PR #4385 implements AVI recorder/writer for the purpose of video end-to-end quality test.
This PR will implement the PJSUA/PJSUA2 API specifically for Android tests.

The AVI recorder will create a video and audio port which can be connected to a source port to store the content.
The recorder uses uncompressed video and 16 bit PCM audio.

Note that due to using uncompressed video, the file size can grow significantly.