### PR TITLE
AVI player API for PJSUA/PJSUA2 API

### DIFF
--- a/pjmedia/include/pjmedia.h
+++ b/pjmedia/include/pjmedia.h
@@ -24,6 +24,7 @@
  * @brief PJMEDIA main header file.
  */
 #include <pjmedia/alaw_ulaw.h>
+#include <pjmedia/avi.h>
 #include <pjmedia/avi_stream.h>
 #include <pjmedia/bidirectional.h>
 #include <pjmedia/circbuf.h>

--- a/pjmedia/include/pjmedia/avi_stream.h
+++ b/pjmedia/include/pjmedia/avi_stream.h
@@ -107,6 +107,18 @@ PJ_DECL(unsigned)
 pjmedia_avi_streams_get_num_streams(pjmedia_avi_streams *streams);
 
 /**
+ * Get the number of AVI stream with a certain media type.
+ *
+ * @param streams       The AVI streams.
+ * @param media_type    The media type of the stream.
+ *
+ * @return              The number of AVI stream.
+ */
+PJ_DECL(unsigned)
+pjmedia_avi_streams_get_num_streams_by_media(pjmedia_avi_streams *streams,
+                                             pjmedia_type media_type);
+
+/**
  * Return the idx-th stream of the AVI streams.
  *
  * @param streams       The AVI streams.

--- a/pjmedia/src/pjmedia-videodev/avi_dev.c
+++ b/pjmedia/src/pjmedia-videodev/avi_dev.c
@@ -276,7 +276,7 @@ static void reset_dev_info(struct avi_dev_info *adi)
     }
 
     if (adi->pool)
-        pj_pool_release(adi->pool);
+        pj_pool_safe_release(&adi->pool);
 
     pj_bzero(adi, sizeof(*adi));
 
@@ -671,8 +671,10 @@ static pj_status_t avi_dev_strm_destroy(pjmedia_vid_dev_stream *strm)
 
     avi_dev_strm_stop(strm);
 
-    stream->adi->strm = NULL;
-    stream->adi = NULL;
+    if (stream->adi) {
+        stream->adi->strm = NULL;
+        stream->adi = NULL;
+    }
     pj_pool_release(stream->pool);
 
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia-videodev/avi_dev.c
+++ b/pjmedia/src/pjmedia-videodev/avi_dev.c
@@ -276,7 +276,7 @@ static void reset_dev_info(struct avi_dev_info *adi)
     }
 
     if (adi->pool)
-        pj_pool_safe_release(&adi->pool);
+        pj_pool_release(adi->pool);
 
     pj_bzero(adi, sizeof(*adi));
 
@@ -671,10 +671,8 @@ static pj_status_t avi_dev_strm_destroy(pjmedia_vid_dev_stream *strm)
 
     avi_dev_strm_stop(strm);
 
-    if (stream->adi) {
-        stream->adi->strm = NULL;
-        stream->adi = NULL;
-    }
+    stream->adi->strm = NULL;
+    stream->adi = NULL;
     pj_pool_release(stream->pool);
 
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia/avi_player.c
+++ b/pjmedia/src/pjmedia/avi_player.c
@@ -557,7 +557,7 @@ pjmedia_avi_player_create_streams(pj_pool_t *pool_,
         pj_ansi_snprintf(port_name, sizeof(port_name), "%s-of-%s",
                          pjmedia_type_name(fport[i]->base.info.fmt.type),
                          get_fname(filename));
-        pj_strdup2(pool, &fport[i]->base.info.name, port_name);
+        pj_strdup2_with_null(pool, &fport[i]->base.info.name, port_name);
     }
 
     /* Done. */
@@ -653,6 +653,21 @@ pjmedia_avi_streams_get_num_streams(pjmedia_avi_streams *streams)
 {
     pj_assert(streams);
     return streams->num_streams;
+}
+
+PJ_DEF(unsigned)
+pjmedia_avi_streams_get_num_streams_by_media(pjmedia_avi_streams *streams,
+                                             pjmedia_type media_type)
+{
+    unsigned i = 0;
+    unsigned num_strm = 0;
+
+    pj_assert(streams);
+    for (; i < streams->num_streams; i++)
+        if (streams->streams[i]->info.fmt.type == media_type)
+            ++num_strm;
+
+    return num_strm;
 }
 
 PJ_DEF(pjmedia_avi_stream *)

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -153,6 +153,7 @@ typedef struct pjsua_app_config
     unsigned                avi_cnt;
     struct {
         pj_str_t                path;
+        pjsua_avi_player_id     p_id;
         pjmedia_vid_dev_index   dev_id;
         pjsua_conf_port_id      slot;
     } avi[PJSUA_APP_MAX_AVI];

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1738,6 +1738,11 @@ static void default_config()
     cfg->aud_cnt = 1;
 
     cfg->avi_def_idx = PJSUA_INVALID_ID;
+    for (i = 0; i < PJ_ARRAY_SIZE(cfg->avi); ++i) {
+        cfg->avi[i].slot = PJSUA_INVALID_ID;
+        cfg->avi[i].dev_id = PJMEDIA_VID_INVALID_DEV;
+        cfg->avi[i].p_id = PJSUA_INVALID_ID;
+    }
 
     cfg->use_cli = PJ_FALSE;
     cfg->cli_cfg.cli_fe = CLI_FE_CONSOLE;

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -273,6 +273,9 @@ typedef int pjsua_player_id;
 /** File recorder identification */
 typedef int pjsua_recorder_id;
 
+/** AVI player identification */
+typedef int pjsua_avi_player_id;
+
 /** AVI recorder identification */
 typedef int pjsua_avi_rec_id;
 
@@ -7457,6 +7460,13 @@ PJ_DECL(pj_status_t) pjsua_im_typing(pjsua_acc_id acc_id,
 #endif
 
  /**
+  * The maximum avi file player.
+  */
+#ifndef PJSUA_MAX_AVI_PLAYERS
+#   define PJSUA_MAX_AVI_PLAYERS        4
+#endif
+
+ /**
   * The maximum avi file recorder.
   */
 #ifndef PJSUA_MAX_AVI_RECORDERS
@@ -8444,6 +8454,95 @@ PJ_DECL(pj_status_t) pjsua_recorder_get_port(pjsua_recorder_id id,
  * @return              PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_DECL(pj_status_t) pjsua_recorder_destroy(pjsua_recorder_id id);
+
+
+/*****************************************************************************
+ * AVI player.
+ */
+
+ /**
+  * Create an avi file player, and automatically add this player to
+  * the audio/video conference bridge. The player will create a virtual
+  * video device and audio/video media port based on the streams contained
+  * in the file.
+  * The maximum number of stream is limited to PJSUA_MAX_AVI_NUM_STREAMS
+  * and the video stream is limited to one stream.
+  *
+  * @param filename      The filename to be played. Currently only
+  *                      AVI files are supported. The video stream is using
+  *                      YUY2/I420/RGB24 (uncompressed) format and the audio
+  *                      stream is using 16 bit PCM format.
+  *                      Filename's length must be smaller than PJ_MAXPATH.
+  * @param p_id          Pointer to receive player ID.
+  *
+  * @return              PJ_SUCCESS on success, or the appropriate error code.
+  */
+PJ_DECL(pj_status_t) pjsua_avi_player_create(const pj_str_t *filename,
+                                             pjsua_avi_player_id *id);
+
+/**
+ * Get the video device index of the avi player. Application can use this index
+ * as the video source/capture device.
+ *
+ * @param id            The player id.
+ *
+ * @return              The video device id or PJMEDIA_VID_INVALID_DEV if the
+ *                      player doesn't have a video device.
+ */
+PJ_DECL(pjmedia_vid_dev_index) pjsua_avi_player_get_vid_dev(
+                                                        pjsua_avi_player_id id);
+
+/**
+ * Get the number of streams created by the avi player.
+ *
+ * @param id            The player id.
+ * @param strm_type     The stream type.
+ *
+ * @return              The number of media stream of the avi player.
+ */
+PJ_DECL(unsigned) pjsua_avi_player_get_num_stream(pjsua_avi_player_id id,
+                                                  pjmedia_type strm_type);
+
+/**
+ * Get conference port ID associated with avi player based on the media type.
+ *
+ * @param id            The player id.
+ *
+ * @param strm_type     The stream type.
+ * @param strm_idx      The stream index.
+ *
+ * @return              The video/audio conference port id.
+ */
+PJ_DECL(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(pjsua_player_id id,
+                                                        pjmedia_type strm_type,
+                                                        unsigned strm_idx);
+
+/**
+ * Get the media port for the avi player based on the media type.
+ *
+ * @param id            The player id.
+ *
+ * @param strm_type     The stream type.
+ * @param strm_idx      The stream index.
+ * @param p_port        The media port port associated with the avi player.
+ *
+ * @return              The PJ_SUCCESS on success,or the appropriate error code.
+ *
+ */
+PJ_DECL(pj_status_t) pjsua_avi_player_get_port(pjsua_player_id id,
+                                               pjmedia_type strm_type,
+                                               unsigned strm_idx,
+                                               pjmedia_port **p_port);
+
+/**
+ * Close the avi file, remove the media streams from the bridge, and free
+ * resources associated with the avi player.
+ *
+ * @param id            The avi player ID.
+ *
+ * @return              PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsua_avi_player_destroy(pjsua_avi_player_id id);
 
 
 /*****************************************************************************

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -8536,7 +8536,11 @@ PJ_DECL(pj_status_t) pjsua_avi_player_get_port(pjsua_player_id id,
 
 /**
  * Close the avi file, remove the media streams from the bridge, and free
- * resources associated with the avi player.
+ * resources associated with the avi player. This API will try to remove the
+ * ports before freeing the resources. However, since the operation is done
+ * asynchronously, it might return PJ_EBUSY when the ports are still in use.
+ * In this case, application can retry calling this API after the port removal
+ * is done.
  *
  * @param id            The avi player ID.
  *

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -8484,7 +8484,7 @@ PJ_DECL(pj_status_t) pjsua_avi_player_create(const pj_str_t *filename,
  * Get the video device index of the avi player. Application can use this index
  * as the video source/capture device.
  *
- * @param id            The player id.
+ * @param id            The avi player id.
  *
  * @return              The video device id or PJMEDIA_VID_INVALID_DEV if the
  *                      player doesn't have a video device.
@@ -8495,7 +8495,7 @@ PJ_DECL(pjmedia_vid_dev_index) pjsua_avi_player_get_vid_dev(
 /**
  * Get the number of streams created by the avi player.
  *
- * @param id            The player id.
+ * @param id            The avi player id.
  * @param strm_type     The stream type.
  *
  * @return              The number of media stream of the avi player.
@@ -8506,21 +8506,22 @@ PJ_DECL(unsigned) pjsua_avi_player_get_num_stream(pjsua_avi_player_id id,
 /**
  * Get conference port ID associated with avi player based on the media type.
  *
- * @param id            The player id.
+ * @param id            The avi player id.
  *
  * @param strm_type     The stream type.
  * @param strm_idx      The stream index.
  *
  * @return              The video/audio conference port id.
  */
-PJ_DECL(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(pjsua_player_id id,
+PJ_DECL(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(
+                                                        pjsua_avi_player_id id,
                                                         pjmedia_type strm_type,
                                                         unsigned strm_idx);
 
 /**
  * Get the media port for the avi player based on the media type.
  *
- * @param id            The player id.
+ * @param id            The avi player id.
  *
  * @param strm_type     The stream type.
  * @param strm_idx      The stream index.
@@ -8529,7 +8530,7 @@ PJ_DECL(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(pjsua_player_id id,
  * @return              The PJ_SUCCESS on success,or the appropriate error code.
  *
  */
-PJ_DECL(pj_status_t) pjsua_avi_player_get_port(pjsua_player_id id,
+PJ_DECL(pj_status_t) pjsua_avi_player_get_port(pjsua_avi_player_id id,
                                                pjmedia_type strm_type,
                                                unsigned strm_idx,
                                                pjmedia_port **p_port);

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -123,6 +123,11 @@ struct pjsua_call_media
  */
 #define PJSUA_MAX_CALL_MEDIA            PJMEDIA_MAX_SDP_MEDIA
 
+ /**
+  * Maximum number of streams from an avi player.
+  */
+#define PJSUA_MAX_AVI_NUM_STREAMS       PJMEDIA_AVI_MAX_NUM_STREAMS
+
 /* Call answer's list. */
 typedef struct call_answer
 {
@@ -411,6 +416,22 @@ typedef struct pjsua_file_data
 } pjsua_file_data;
 
 /**
+ * AVI player data.
+ */
+typedef struct pjsua_avi_player_data
+{
+    pj_pool_t                 *pool;
+    pjmedia_avi_streams       *avi_streams;
+    unsigned                   vid_cnt;
+    unsigned                   aud_cnt;
+    pjmedia_vid_dev_index      vid_dev_id;
+    pjsua_conf_port_id         slot[PJSUA_MAX_AVI_NUM_STREAMS];
+    pjmedia_port              *port[PJSUA_MAX_AVI_NUM_STREAMS];
+    pjmedia_type               type[PJSUA_MAX_AVI_NUM_STREAMS];
+
+} pjsua_avi_player_data;
+
+/**
  * AVI recorder data.
  */
 typedef struct pjsua_avi_recorder_data
@@ -612,7 +633,13 @@ struct pjsua_data
     pjsua_file_data      recorder[PJSUA_MAX_RECORDERS];/**< Array of recs.*/
 
 #if PJSUA_HAS_VIDEO
-    /* File recorders: */
+    /* AVI file players: */
+    pjmedia_vid_dev_factory *avi_factory;      /**< AVI player factory.       */
+    unsigned                 avi_player_cnt;    /**< Number of avi players.   */
+    pjsua_avi_player_data    avi_player[PJSUA_MAX_AVI_PLAYERS];/**< Array of
+                                                                 avi players. */
+
+    /* AVI file recorders: */
     unsigned                  avi_rec_cnt;   /**< Number of avi recorders.    */
     pjsua_avi_recorder_data   avi_recorder[PJSUA_MAX_AVI_RECORDERS];/**< Array 
                                                              of avi recorders.*/
@@ -967,6 +994,11 @@ void print_call(const char *title,
                 char *buf, pj_size_t size);
 
 char *pjsua_get_basename(const char *path, unsigned len);
+
+/*
+ * Internal function to reset avi player data
+ */
+void pjsua_reset_avi_player_data(pjsua_avi_player_id id);
 
 /*
  * Internal function to reset avi recorder data

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2534,6 +2534,70 @@ private:
 };
 
 /**
+ * Video AVI Player.
+ */
+class VideoPlayer
+{
+public:
+    /**
+     * Constructor.
+     */
+    class VideoPlayer();
+
+    /**
+     * Create an avi file player, and automatically add this player to
+     * the audio/video conference bridge. The player will create a virtual
+     * video device and audio/video media port based on the streams contained
+     * in the file.
+     * The maximum number of stream is limited to PJSUA_MAX_AVI_NUM_STREAMS
+     * and the video stream is limited to one stream.
+     *
+     * @param filename      The filename to be played. Currently only
+     *                      AVI files are supported. The video stream is using
+     *                      YUY2/I420/RGB24 format and the audio stream is using
+     *                      16bit PCM format.
+     *                      Filename's length must be smaller than PJ_MAXPATH.
+     *
+     */
+    void createVideoPlayer(const string &file_name) PJSUA2_THROW(Error);
+
+    /**
+     * Enumerate all audio media port.
+     *
+     * @return          The list of audio media port.
+     */
+    AudioMediaVector2 mediaEnumPorts() PJSUA2_THROW(Error);
+
+    /**
+     * Enumerate all video media port.
+     *
+     * @return          The list of video media port.
+     */
+    VideoMediaVector mediaEnumVidPorts() PJSUA2_THROW(Error);
+
+    /**
+     * Get the video device index of the avi player. Application can use this
+     * index as the video source/capture device.
+     *
+     * @return          The video device index.
+     */
+    int getVideoDevId() PJSUA2_THROW(Error);
+
+    /**
+     * Destructor. This will unregister the audio/video port from the
+     * audio/video conference bridge.
+     */
+    virtual ~VideoPlayer();
+
+private:
+    /**
+     * Player Id.
+     */
+    int playerId;
+
+};
+
+/**
  * Video AVI Recorder.
  */
 class VideoRecorder

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2542,7 +2542,7 @@ public:
     /**
      * Constructor.
      */
-    class VideoPlayer();
+    VideoPlayer();
 
     /**
      * Create an avi file player, and automatically add this player to

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -73,6 +73,10 @@ static void init_data()
         pjsua_vid_win_reset(i);
     }
 #if PJSUA_HAS_VIDEO
+    for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_player); ++i) {
+        pjsua_reset_avi_player_data(i);
+    }
+
     for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_recorder); ++i) {
         pjsua_reset_avi_recorder_data(i);
     }

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -3111,7 +3111,7 @@ void pjsua_reset_avi_player_data(pjsua_avi_player_id id)
     for (; i < PJ_ARRAY_SIZE(pjsua_var.avi_player[id].port); ++i) {
         pjsua_var.avi_player[id].port[i] = NULL;
         pjsua_var.avi_player[id].slot[i] = PJSUA_INVALID_ID;
-        pjsua_var.avi_player[id].slot[i] = PJMEDIA_TYPE_NONE;
+        pjsua_var.avi_player[id].type[i] = PJMEDIA_TYPE_NONE;
     }
 }
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -182,7 +182,11 @@ pj_status_t pjsua_vid_subsys_destroy(void)
         pjsua_var.vid_conf = NULL;
     }
 
-    /* Destroy avi file players. */
+    /* Destroy avi file players. To safely release the resources, all ports
+     * created by the player needed to be disconnected from other ports.
+     * Disconnecting and removing the ports from the conference will
+     * be done from #pjmedia_vid_conf_destroy() above.
+     */
     for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_player); ++i) {
         if (pjsua_var.avi_player[i].avi_streams != NULL)
         {

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -3181,11 +3181,11 @@ static void add_port_to_conf(pjsua_avi_player_id avi_id,
     *num_stream = num_strm;
 }
 
-PJ_DEF(pj_status_t) pjsua_avi_player_create(const pj_str_t* filename,
-                                            pjsua_avi_player_id* id)
+PJ_DEF(pj_status_t) pjsua_avi_player_create(const pj_str_t *filename,
+                                            pjsua_avi_player_id *id)
 {
     pj_status_t status = PJ_SUCCESS;
-    pj_pool_t* pool = NULL;
+    pj_pool_t *pool = NULL;
     pjmedia_avi_dev_param avdp;
     pjmedia_vid_dev_index avid;
     unsigned avi_id;
@@ -3298,7 +3298,8 @@ PJ_DEF(unsigned) pjsua_avi_player_get_num_stream(pjsua_avi_player_id id,
 
 #define AUD_IDX(id, strm_idx)    (pjsua_var.avi_player[id].vid_cnt+strm_idx)
 
-PJ_DEF(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(pjsua_player_id id,
+PJ_DEF(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(
+                                                        pjsua_avi_player_id id,
                                                         pjmedia_type strm_type,
                                                         unsigned strm_idx)
 {
@@ -3322,7 +3323,7 @@ PJ_DEF(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(pjsua_player_id id,
     }
 }
 
-PJ_DEF(pj_status_t) pjsua_avi_player_get_port(pjsua_player_id id,
+PJ_DEF(pj_status_t) pjsua_avi_player_get_port(pjsua_avi_player_id id,
                                               pjmedia_type strm_type,
                                               unsigned strm_idx,
                                               pjmedia_port **p_port)

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -3338,12 +3338,14 @@ PJ_DEF(pj_status_t) pjsua_avi_player_get_port(pjsua_player_id id,
                          PJSUA_INVALID_ID);
 
         *p_port = pjsua_var.avi_player[id].port[AUD_IDX(id, strm_idx)];
+        break;
     case PJMEDIA_TYPE_VIDEO:
         PJ_ASSERT_RETURN(strm_idx >= 0 &&
                          strm_idx < pjsua_var.avi_player[id].vid_cnt,
                          PJSUA_INVALID_ID);
 
         *p_port = pjsua_var.avi_player[id].port[strm_idx];
+        break;
     default:
         status = PJ_ENOTFOUND;
     }
@@ -3385,6 +3387,9 @@ PJ_DECL(pj_status_t) pjsua_avi_player_destroy(pjsua_avi_player_id id)
         if (status != PJ_SUCCESS) {
             PJ_PERROR(4, (THIS_FILE, status,
                          "Fail destroying avi file player %d", id));
+
+            PJSUA_UNLOCK();
+            pj_log_pop_indent();
             return status;
         }
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -176,6 +176,19 @@ pj_status_t pjsua_vid_subsys_destroy(void)
             pjsua_var.win[i].pool = NULL;
         }
     }
+
+    /* Destroy avi file players */
+    for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_player); ++i) {
+        if (pjsua_var.avi_player[i].avi_streams != NULL)
+        {
+            PJ_LOG(2, (THIS_FILE, "Destructor for avi player id=%d "
+                       "is not called", i));
+            pjsua_avi_player_destroy(i);
+        }
+    }
+    if (pjsua_var.avi_factory)
+        pjsua_var.avi_factory = NULL;
+
     /* Destroy avi file recorders */
     for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_recorder); ++i) {
         if (pjsua_var.avi_recorder[i].avi_streams != NULL)
@@ -3082,6 +3095,303 @@ on_return:
     PJSUA_UNLOCK();
 
     return port_id;
+}
+
+/*****************************************************************************
+ * AVI player.
+ */
+void pjsua_reset_avi_player_data(pjsua_avi_player_id id)
+{
+    unsigned i = 0;
+
+    pjsua_var.avi_player[id].vid_dev_id = PJMEDIA_VID_INVALID_DEV;
+    pjsua_var.avi_player[id].vid_cnt = 0;
+    pjsua_var.avi_player[id].aud_cnt = 0;
+    pjsua_var.avi_player[id].avi_streams = NULL;
+    for (; i < PJ_ARRAY_SIZE(pjsua_var.avi_player[id].port); ++i) {
+        pjsua_var.avi_player[id].port[i] = NULL;
+        pjsua_var.avi_player[id].slot[i] = PJSUA_INVALID_ID;
+        pjsua_var.avi_player[id].slot[i] = PJMEDIA_TYPE_NONE;
+    }
+}
+
+static void add_port_to_conf(pjsua_avi_player_id avi_id,
+                             const pj_str_t *med_name,
+                             pjmedia_type med_type,
+                             unsigned start_idx,
+                             unsigned *num_stream)
+{
+    unsigned strm_cnt, strm_idx, num_strm = 0;
+    pjmedia_avi_streams *streams = pjsua_var.avi_player[avi_id].avi_streams;
+    pj_pool_t *pool = pjsua_var.avi_player[avi_id].pool;
+
+    strm_cnt = pjmedia_avi_streams_get_num_streams_by_media(streams,
+                                                            med_type);
+
+    for (strm_idx = 0; strm_idx < strm_cnt; ++strm_idx) {
+        pjmedia_port *port;
+        pjmedia_format *fmt;
+        pjsua_conf_port_id slot = 0;
+        pj_status_t status = PJ_EINVAL;
+
+        port = (pjmedia_port*)pjmedia_avi_streams_get_stream_by_media(streams,
+                                                            strm_idx, med_type);
+        fmt = &port->info.fmt;
+
+        if (med_type == PJMEDIA_TYPE_VIDEO) {
+            /* Only supports one video stream */
+            if (pjsua_var.avi_player[avi_id].vid_cnt > 0) {
+                *num_stream = num_strm;
+                return;
+            }
+
+            status = pjsua_vid_conf_add_port(pool, port,
+                                             NULL, &slot);
+        }
+        else if (med_type == PJMEDIA_TYPE_AUDIO) {
+            if (fmt->id == PJMEDIA_FORMAT_PCM) {
+                status = pjsua_conf_add_port(pool, port, &slot);
+            } else {
+                status = PJ_ENOTSUP;
+                char fmt_name[5];
+
+                pjmedia_fourcc_name(fmt->id, fmt_name);
+                PJ_PERROR(4, (THIS_FILE, status,
+                              "AVI %.*s: audio ignored, format=%s",
+                              (int)med_name->slen, med_name->ptr,
+                              fmt_name));
+            }
+        }
+        if (status == PJ_SUCCESS) {
+            PJ_LOG(4, (THIS_FILE,
+                       "AVI %.*s: %s added to slot %d",
+                       (int)med_name->slen, med_name->ptr,
+                       med_type == PJMEDIA_TYPE_VIDEO ? "video":"audio",
+                       slot));
+            pjsua_var.avi_player[avi_id].slot[start_idx + num_strm] = slot;
+            pjsua_var.avi_player[avi_id].port[start_idx + num_strm] = port;
+            pjsua_var.avi_player[avi_id].type[start_idx + num_strm] = med_type;
+            num_strm++;
+        }
+    }
+    *num_stream = num_strm;
+}
+
+PJ_DEF(pj_status_t) pjsua_avi_player_create(const pj_str_t* filename,
+                                            pjsua_avi_player_id* id)
+{
+    pj_status_t status = PJ_SUCCESS;
+    pj_pool_t* pool = NULL;
+    pjmedia_avi_dev_param avdp;
+    pjmedia_vid_dev_index avid;
+    unsigned avi_id;
+
+    if (filename->slen >= PJ_MAXPATH)
+        return PJ_ENAMETOOLONG;
+    if (filename->slen < 4)
+        return PJ_EINVALIDOP;
+
+    PJ_LOG(4, (THIS_FILE, "Creating avi file player: %.*s..",
+               (int)filename->slen, filename->ptr));
+    pj_log_push_indent();
+
+    PJSUA_LOCK();
+
+    if (pjsua_var.avi_player_cnt >= PJ_ARRAY_SIZE(pjsua_var.avi_player)) {
+        status = PJ_ETOOMANY;
+        goto on_return;
+    }
+
+    for (avi_id = 0; avi_id < PJ_ARRAY_SIZE(pjsua_var.avi_player); ++avi_id) {
+        if (pjsua_var.avi_player[avi_id].avi_streams == NULL)
+            break;
+    }
+
+    if (avi_id == PJ_ARRAY_SIZE(pjsua_var.avi_player)) {
+        /* This is unexpected */
+        pj_assert(0);
+        status = PJ_EBUG;
+        goto on_return;
+    }
+
+    pjmedia_avi_dev_param_default(&avdp);
+    avdp.path = *filename;
+
+    pool = pjsua_pool_create(pjsua_get_basename(filename->ptr,
+                             (unsigned)filename->slen), 1000, 1000);
+    if (!pool) {
+        status = PJ_ENOMEM;
+        goto on_return;
+    }
+    pjsua_var.avi_player[avi_id].pool = pool;
+
+    if (pjsua_var.avi_factory == NULL) {
+        status = pjmedia_avi_dev_create_factory(pjsua_get_pool_factory(),
+                                                PJSUA_MAX_AVI_PLAYERS,
+                                                &pjsua_var.avi_factory);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(1, (THIS_FILE, status, "Error creating AVI factory"));
+            goto on_return;
+        }
+    }
+
+    status = pjmedia_avi_dev_alloc(pjsua_var.avi_factory, &avdp, &avid);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(1, (THIS_FILE, status,
+                      "Error creating AVI player for %.*s",
+                      (int)avdp.path.slen, avdp.path.ptr));
+        goto on_return;
+    }
+    pjsua_reset_avi_player_data(avi_id);
+
+    PJ_LOG(4, (THIS_FILE, "AVI player %.*s created, id=%d, dev_id=%d",
+               (int)avdp.title.slen, avdp.title.ptr, avi_id, avid));
+
+    pjsua_var.avi_player[avi_id].vid_dev_id = avid;
+    pjsua_var.avi_player[avi_id].avi_streams = avdp.avi_streams;
+    add_port_to_conf(avi_id, &avdp.title, PJMEDIA_TYPE_VIDEO, 0,
+                     &pjsua_var.avi_player[avi_id].vid_cnt);
+    add_port_to_conf(avi_id, &avdp.title, PJMEDIA_TYPE_AUDIO,
+                     pjsua_var.avi_player[avi_id].vid_cnt,
+                     &pjsua_var.avi_player[avi_id].aud_cnt);
+
+    pjsua_var.avi_player_cnt++;
+    *id = avi_id;
+
+on_return:
+    PJSUA_UNLOCK();
+    if (pool) pj_pool_release(pool);
+    pj_log_pop_indent();
+    return status;
+}
+
+PJ_DEF(pjmedia_vid_dev_index) pjsua_avi_player_get_vid_dev(
+                                                         pjsua_avi_player_id id)
+{
+    if (id >= (int)PJ_ARRAY_SIZE(pjsua_var.avi_player))
+        return PJMEDIA_VID_INVALID_DEV;
+
+    return pjsua_var.avi_player[id].vid_dev_id;
+}
+
+PJ_DEF(unsigned) pjsua_avi_player_get_num_stream(pjsua_avi_player_id id,
+                                                 pjmedia_type strm_type)
+{
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_player),
+                     0);
+
+    switch (strm_type) {
+    case PJMEDIA_TYPE_AUDIO:
+        return pjsua_var.avi_player[id].aud_cnt;
+        break;
+    case PJMEDIA_TYPE_VIDEO:
+        return pjsua_var.avi_player[id].vid_cnt;
+        break;
+    default:
+        return 0;
+    }
+}
+
+#define AUD_IDX(id, strm_idx)    (pjsua_var.avi_player[id].vid_cnt+strm_idx)
+
+PJ_DEF(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(pjsua_player_id id,
+                                                        pjmedia_type strm_type,
+                                                        unsigned strm_idx)
+{
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_player),
+                     PJSUA_INVALID_ID);
+    PJ_ASSERT_RETURN(strm_idx >= 0, PJSUA_INVALID_ID);
+
+    switch (strm_type) {
+    case PJMEDIA_TYPE_AUDIO:
+        if (pjsua_var.avi_player[id].aud_cnt)
+            return pjsua_var.avi_player[id].slot[AUD_IDX(id, strm_idx)];
+        else
+            return PJSUA_INVALID_ID;
+    case PJMEDIA_TYPE_VIDEO:
+        if (pjsua_var.avi_player[id].vid_cnt)
+            return pjsua_var.avi_player[id].slot[strm_idx];
+        else
+            return PJSUA_INVALID_ID;
+    default:
+        return PJSUA_INVALID_ID;
+    }
+}
+
+PJ_DEF(pj_status_t) pjsua_avi_player_get_port(pjsua_player_id id,
+                                              pjmedia_type strm_type,
+                                              unsigned strm_idx,
+                                              pjmedia_port **p_port)
+{
+    pj_status_t status = PJ_SUCCESS;
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_player),
+        PJ_EINVAL);
+
+    switch (strm_type) {
+    case PJMEDIA_TYPE_AUDIO:
+        PJ_ASSERT_RETURN(strm_idx >= 0 &&
+                         strm_idx < pjsua_var.avi_player[id].aud_cnt, 
+                         PJSUA_INVALID_ID);
+
+        *p_port = pjsua_var.avi_player[id].port[AUD_IDX(id, strm_idx)];
+    case PJMEDIA_TYPE_VIDEO:
+        PJ_ASSERT_RETURN(strm_idx >= 0 &&
+                         strm_idx < pjsua_var.avi_player[id].vid_cnt,
+                         PJSUA_INVALID_ID);
+
+        *p_port = pjsua_var.avi_player[id].port[strm_idx];
+    default:
+        status = PJ_ENOTFOUND;
+    }
+    return status;
+}
+
+PJ_DECL(pj_status_t) pjsua_avi_player_destroy(pjsua_avi_player_id id)
+{
+    PJ_ASSERT_RETURN(id >= 0 && id < (int)PJ_ARRAY_SIZE(pjsua_var.avi_player),
+        PJ_EINVAL);
+
+    PJ_LOG(4, (THIS_FILE, "Destroying avi file player %d..", id));
+    pj_log_push_indent();
+
+    PJSUA_LOCK();
+
+    if (pjsua_var.avi_player[id].avi_streams != NULL) {
+        unsigned i = 0;
+        pj_status_t status;
+
+        for (; i < PJ_ARRAY_SIZE(pjsua_var.avi_player[id].port); ++i) {
+            if (pjsua_var.avi_player[id].slot[i] == PJSUA_INVALID_ID)
+                continue;
+
+            if (pjsua_var.avi_player[id].type[i] == PJMEDIA_TYPE_VIDEO) {
+                if (pjsua_var.vid_conf) {
+                    pjsua_vid_conf_remove_port(pjsua_var.avi_player[id].slot[i]);
+                    --pjsua_var.avi_player[id].vid_cnt;
+                }
+            } else if (pjsua_var.avi_player[id].type[i] == PJMEDIA_TYPE_AUDIO) {
+                if (pjsua_var.mconf) {
+                    pjsua_conf_remove_port(pjsua_var.avi_player[id].slot[i]);
+                    --pjsua_var.avi_player[id].aud_cnt;
+                }
+            }
+        }
+        // All of the video/audio ports will be destroyed here
+        status = pjmedia_avi_dev_free(pjsua_var.avi_player[id].vid_dev_id);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4, (THIS_FILE, status,
+                         "Fail destroying avi file player %d", id));
+            return status;
+        }
+
+        pjsua_reset_avi_player_data(id);
+        pjsua_var.avi_player_cnt--;
+    }
+
+    PJSUA_UNLOCK();
+    pj_log_pop_indent();
+
+    return PJ_SUCCESS;
 }
 
 /*****************************************************************************

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -177,7 +177,12 @@ pj_status_t pjsua_vid_subsys_destroy(void)
         }
     }
 
-    /* Destroy avi file players */
+    if (pjsua_var.vid_conf) {
+        pjmedia_vid_conf_destroy(pjsua_var.vid_conf);
+        pjsua_var.vid_conf = NULL;
+    }
+
+    /* Destroy avi file players. */
     for (i = 0; i < PJ_ARRAY_SIZE(pjsua_var.avi_player); ++i) {
         if (pjsua_var.avi_player[i].avi_streams != NULL)
         {
@@ -197,11 +202,6 @@ pj_status_t pjsua_vid_subsys_destroy(void)
                        "is not called", i));
             pjsua_avi_recorder_destroy(i);
         }
-    }
-
-    if (pjsua_var.vid_conf) {
-        pjmedia_vid_conf_destroy(pjsua_var.vid_conf);
-        pjsua_var.vid_conf = NULL;
     }
 
     pjmedia_vid_dev_subsys_shutdown();
@@ -3376,7 +3376,7 @@ PJ_DECL(pj_status_t) pjsua_avi_player_destroy(pjsua_avi_player_id id)
                 }
             }
         }
-        // All of the video/audio ports will be destroyed here
+        // All of the video/audio ports will be destroyed here.
         status = pjmedia_avi_dev_free(pjsua_var.avi_player[id].vid_dev_id);
         if (status != PJ_SUCCESS) {
             PJ_PERROR(4, (THIS_FILE, status,

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -2007,7 +2007,7 @@ AudioMediaVector2 VideoPlayer::mediaEnumPorts() PJSUA2_THROW(Error)
 
         pjsua_conf_port_id port_id = pjsua_avi_player_get_conf_port(playerId,
                                                          PJMEDIA_TYPE_AUDIO, i);
-        if (port_id != PJSUA_INVALID_ID)
+        if (port_id == PJSUA_INVALID_ID)
             continue;
 
         am.setPortId(port_id);
@@ -2035,7 +2035,7 @@ VideoMediaVector VideoPlayer::mediaEnumVidPorts() PJSUA2_THROW(Error)
 
         pjsua_conf_port_id port_id = pjsua_avi_player_get_conf_port(playerId,
                                                          PJMEDIA_TYPE_VIDEO, i);
-        if (port_id != PJSUA_INVALID_ID)
+        if (port_id == PJSUA_INVALID_ID)
             continue;
 
         vm.setPortId(port_id);


### PR DESCRIPTION
This patch will add AVI player API for `PJSUA/PJSUA2`.
The player will read the audio/video streams in an AVI file, create a virtual video device and create/add audio/video port based 
on the streams contained in the file.

Note:
To convert a video to the supported format (video:YUY2/I420/RGB24, audio:16bit PCM), you can use ffmpeg.
```
ffmpeg -i [input.mp4] -vf scale=320:240 -c:v rawvideo -pix_fmt yuv420p -c:a pcm_alaw -ar 16000 [output.avi]
```