### PR TITLE
Set default timeout for TURN TLS

### DIFF
--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -230,10 +230,10 @@
 /**
  * Default timeout value (in seconds) for TURN TLS connection.
  *
- * Default: 5 seconds
+ * Default: 10 seconds
  */
 #ifndef PJ_TURN_TLS_DEFAULT_TIMEOUT
-#   define PJ_TURN_TLS_DEFAULT_TIMEOUT              5
+#   define PJ_TURN_TLS_DEFAULT_TIMEOUT              10
 #endif
 
 /* **************************************************************************

--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -227,6 +227,15 @@
 #   define PJ_TURN_MAX_TCP_CONN_CNT                 8
 #endif
 
+/**
+ * Default timeout value (in seconds) for TURN TLS connection.
+ *
+ * Default: 5 seconds
+ */
+#ifndef PJ_TURN_TLS_DEFAULT_TIMEOUT
+#   define PJ_TURN_TLS_DEFAULT_TIMEOUT              5
+#endif
+
 /* **************************************************************************
  * ICE CONFIGURATION
  */

--- a/pjnath/include/pjnath/config.h
+++ b/pjnath/include/pjnath/config.h
@@ -228,12 +228,13 @@
 #endif
 
 /**
- * Default timeout value (in seconds) for TURN TLS connection.
+ * Specify default value of TURN TLS socket connection timeout in contacting
+ * TURN server.
  *
  * Default: 10 seconds
  */
-#ifndef PJ_TURN_TLS_DEFAULT_TIMEOUT
-#   define PJ_TURN_TLS_DEFAULT_TIMEOUT              10
+#ifndef PJ_TURN_SSL_SOCK_DEFAULT_TIMEOUT
+#   define PJ_TURN_SSL_SOCK_DEFAULT_TIMEOUT         10
 #endif
 
 /* **************************************************************************

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -217,7 +217,7 @@ PJ_DEF(void) pj_turn_sock_tls_cfg_default(pj_turn_sock_tls_cfg *tls_cfg)
     pj_bzero(tls_cfg, sizeof(*tls_cfg));
     pj_ssl_sock_param_default(&tls_cfg->ssock_param);
     tls_cfg->ssock_param.proto = PJ_TURN_TLS_DEFAULT_PROTO;
-    tls_cfg->ssock_param.timeout.sec = PJ_TURN_TLS_DEFAULT_TIMEOUT;
+    tls_cfg->ssock_param.timeout.sec = PJ_TURN_SSL_SOCK_DEFAULT_TIMEOUT;
 }
 
 PJ_DEF(void) pj_turn_sock_tls_cfg_dup(pj_pool_t *pool,

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -217,6 +217,7 @@ PJ_DEF(void) pj_turn_sock_tls_cfg_default(pj_turn_sock_tls_cfg *tls_cfg)
     pj_bzero(tls_cfg, sizeof(*tls_cfg));
     pj_ssl_sock_param_default(&tls_cfg->ssock_param);
     tls_cfg->ssock_param.proto = PJ_TURN_TLS_DEFAULT_PROTO;
+    tls_cfg->ssock_param.timeout.sec = PJ_TURN_TLS_DEFAULT_TIMEOUT;
 }
 
 PJ_DEF(void) pj_turn_sock_tls_cfg_dup(pj_pool_t *pool,


### PR DESCRIPTION
Currently the timeout value in TURN TLS config is left unset (zero), and this may cause ICE to appear stalled for a long time when waiting for TURN TLS connection (in my local test, by default it times out only after 60 seconds).
