### PR TITLE
Suppresses compiler warnings in pjlib math

### DIFF
--- a/pjlib/include/pj/math.h
+++ b/pjlib/include/pj/math.h
@@ -144,13 +144,13 @@ PJ_INLINE(void) pj_math_stat_update(pj_math_stat *stat, int val)
     }
 
 #if PJ_HAS_FLOATING_POINT
-    delta = val - stat->fmean_;
-    stat->fmean_ += delta/stat->n;
+    delta = (float)val - stat->fmean_;
+    stat->fmean_ += delta/(float)stat->n;
     
     /* Return mean value with 'rounding' */
     stat->mean = (int) (stat->fmean_ + 0.5);
 
-    stat->m2_ += (int)(delta * (val-stat->fmean_));
+    stat->m2_ += (int)(delta * ((float)val-stat->fmean_));
 #else
     delta = val - stat->mean;
     stat->mean += delta/stat->n;


### PR DESCRIPTION
Fixes compiler warnings:
`warning: implicit conversion loses integer precision: 'int' to 'float'`

Thank you to Ingo Proetel for the patch.
