### PR TITLE
Handle SSRC change after SRTP restart

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1233,6 +1233,17 @@
 #endif
 
 
+ /**
+  * Specify whether SRTP needs to handle condition that remote/local
+  * may change SSRC when SRTP is restarted.
+  *
+  * Default: enabled.
+  */
+#ifndef PJMEDIA_SRTP_CHECK_SSRC_ON_RESTART
+#   define PJMEDIA_SRTP_CHECK_SSRC_ON_RESTART        1
+#endif
+
+
 /**
  * Let the library handle libsrtp initialization and deinitialization.
  * Application may want to disable this and manually perform libsrtp


### PR DESCRIPTION
In the case SRTP restart (e.g.: reinitialize media due to IP change), error might raise:
```
srtp0x115f47400  Failed to unprotect SRTP, pkt size=23, err=no appropriate context found
``` 
which is caused by SSRC change.
This PR will handle this by using the new SSRC sent/received..