### PR TITLE
Fix various coverity reports

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -3584,10 +3584,10 @@ PJ_DEF(pj_status_t) pjsua_avi_recorder_get_port(pjsua_avi_rec_id id,
 
     switch (strm_type) {
     case PJMEDIA_TYPE_AUDIO:
-        p_port = &pjsua_var.avi_recorder[id].aud_port;
+        *p_port = pjsua_var.avi_recorder[id].aud_port;
         break;
     case PJMEDIA_TYPE_VIDEO:
-        p_port = &pjsua_var.avi_recorder[id].vid_port;
+        *p_port = pjsua_var.avi_recorder[id].vid_port;
         break;
     default:
         *p_port = NULL;

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -140,7 +140,8 @@ AudioMediaTransmitParam::AudioMediaTransmitParam()
 }
 
 AudioMedia::AudioMedia() 
-: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaPool(NULL)
+: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaPool(NULL),
+  mediaCachingPool({0})
 {
 }
 


### PR DESCRIPTION
Fixed issues:
- Greater-than-or-equal-to-zero comparison of an unsigned value is always true.
- Using uninitialized value mediaCachingPool when calling AudioMedia.
- Missing break in switch.

Also fixed an issue reported by Copilot:
- Set the caller’s parameter instead of reassigning the local pointer.