### PR TITLE
Fix audio stream conf slot info in call info when the stream is inactive

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2569,6 +2569,10 @@ PJ_DEF(pj_status_t) pjsua_call_get_info( pjsua_call_id call_id,
         info->media_status = call->media[call->audio_idx].state;
         info->media_dir = call->media[call->audio_idx].dir;
         info->conf_slot = call->media[call->audio_idx].strm.a.conf_slot;
+    } else {
+        info->media_status = PJSUA_CALL_MEDIA_NONE;
+        info->media_dir = PJMEDIA_DIR_NONE;
+        info->conf_slot = PJSUA_INVALID_ID;
     }
 
     /* Build array of provisional media info */

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4123,7 +4123,7 @@ static pj_status_t apply_med_update(pjsua_call_media *call_med,
         }
 
         if (call->audio_idx==-1 && status==PJ_SUCCESS &&
-            si->dir != PJMEDIA_DIR_NONE)
+            call_med->tp && local_sdp->media[mi]->desc.port != 0)
         {
             call->audio_idx = mi;
         }


### PR DESCRIPTION
When an audio stream is created as inactive (i.e: SDP `a=inactive` & `port != 0`), the `conf_slot` field in call info is set to 0 which is ambiguous (port 0 is sound device port in conf bridge), it should be `-1/PJSUA_INVALID_ID`.