### PR TITLE
Fix build errors and warnings

### DIFF
--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -250,29 +250,23 @@ void OnAudioMediaOpCompletedParam::fromPj(const pjmedia_conf_op_info &info)
     status = info.status;
     switch (opType) {
     case PJMEDIA_CONF_OP_ADD_PORT:
-    {
         opParam.addInfo.mediaId = info.op_param.add_port.port;
-    }
-    break;
+        break;
     case PJMEDIA_CONF_OP_REMOVE_PORT:
-    {
         opParam.removeInfo.mediaId = info.op_param.remove_port.port;
-    }
-    break;
+        break;
     case PJMEDIA_CONF_OP_CONNECT_PORTS:
-    {
         opParam.connectInfo.mediaId = info.op_param.connect_ports.src;
         opParam.connectInfo.targetMediaId = info.op_param.connect_ports.sink;
         opParam.connectInfo.adjLevel = info.op_param.connect_ports.adj_level;
-    }
-    break;
+        break;
     case PJMEDIA_CONF_OP_DISCONNECT_PORTS:
-    {
         opParam.disconnectInfo.mediaId = info.op_param.disconnect_ports.src;
         opParam.disconnectInfo.targetMediaId = 
-                                            info.op_param.disconnect_ports.sink;
-    }
-    break;
+                                         info.op_param.disconnect_ports.sink;
+        break;
+    default:
+        break;
     }
 }
 
@@ -282,33 +276,25 @@ void OnVideoMediaOpCompletedParam::fromPj(const pjmedia_vid_conf_op_info &info)
     status = info.status;
     switch (opType) {
     case PJMEDIA_VID_CONF_OP_ADD_PORT:
-    {
         opParam.addInfo.mediaId = info.op_param.add_port.port;
-    }
-    break;
+        break;
     case PJMEDIA_VID_CONF_OP_REMOVE_PORT:
-    {
         opParam.removeInfo.mediaId = info.op_param.remove_port.port;
-    }
-    break;
+        break;
     case PJMEDIA_VID_CONF_OP_CONNECT_PORTS:
-    {
         opParam.connectInfo.mediaId = info.op_param.connect_ports.src;
         opParam.connectInfo.targetMediaId = info.op_param.connect_ports.sink;
-    }
-    break;
+        break;
     case PJMEDIA_VID_CONF_OP_DISCONNECT_PORTS:
-    {
         opParam.disconnectInfo.mediaId = info.op_param.disconnect_ports.src;
         opParam.disconnectInfo.targetMediaId =
-                                            info.op_param.disconnect_ports.sink;
-    }
-    break;
+                                         info.op_param.disconnect_ports.sink;
+        break;
     case PJMEDIA_VID_CONF_OP_UPDATE_PORT:
-    {
         opParam.updateInfo.mediaId = info.op_param.update_port.port;
-    }
-    break;
+        break;
+    default:
+        break;
     }
 }
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -140,7 +140,7 @@ AudioMediaTransmitParam::AudioMediaTransmitParam()
 }
 
 AudioMedia::AudioMedia() 
-: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaCachingPool{},
+: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaCachingPool({{{0}}}),
   mediaPool(NULL)
 {
 }

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -140,8 +140,8 @@ AudioMediaTransmitParam::AudioMediaTransmitParam()
 }
 
 AudioMedia::AudioMedia() 
-: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaPool(NULL),
-  mediaCachingPool({0})
+: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaCachingPool({{{0}}}),
+  mediaPool(NULL)
 {
 }
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -140,7 +140,7 @@ AudioMediaTransmitParam::AudioMediaTransmitParam()
 }
 
 AudioMedia::AudioMedia() 
-: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaCachingPool({{{0}}}),
+: Media(PJMEDIA_TYPE_AUDIO), id(PJSUA_INVALID_ID), mediaCachingPool{},
   mediaPool(NULL)
 {
 }


### PR DESCRIPTION
Error in Bitrise CI iOS build:
```
		../src/pjsua2/media.cpp
../src/pjsua2/media.cpp:144:20: error: expected expression
  mediaCachingPool({0})
                   ^
1 error generated.
```

Warnings:
```
../src/pjsua2/endpoint.cpp:251:13: warning: enumeration value 'PJMEDIA_CONF_OP_UNKNOWN' not handled in switch [-Wswitch]
../src/pjsua2/endpoint.cpp:283:13: warning: enumeration value 'PJMEDIA_VID_CONF_OP_UNKNOWN' not handled in switch [-Wswitch]
../src/pjsua2/media.cpp:143:52: warning: field 'mediaPool' will be initialized after field 'mediaCachingPool' [-Wreorder-ctor]
```
