### PR TITLE
Remove unnecessary assertion in converter and format managers

### DIFF
--- a/pjmedia/src/pjmedia/converter.c
+++ b/pjmedia/src/pjmedia/converter.c
@@ -78,7 +78,7 @@ PJ_DEF(pj_status_t) pjmedia_converter_mgr_create(pj_pool_t *pool,
 
 PJ_DEF(pjmedia_converter_mgr*) pjmedia_converter_mgr_instance(void)
 {
-    pj_assert(converter_manager_instance != NULL);
+//    pj_assert(converter_manager_instance != NULL);
     return converter_manager_instance;
 }
 

--- a/pjmedia/src/pjmedia/format.c
+++ b/pjmedia/src/pjmedia/format.c
@@ -403,7 +403,7 @@ pjmedia_register_video_format_info(pjmedia_video_format_mgr *mgr,
 
 PJ_DEF(pjmedia_video_format_mgr*) pjmedia_video_format_mgr_instance(void)
 {
-    pj_assert(video_format_mgr_instance != NULL);
+//    pj_assert(video_format_mgr_instance != NULL);
     return video_format_mgr_instance;
 }
 


### PR DESCRIPTION
When the managers are not yet created (such as during failure cases), calling `pjsua_vid_subsys_destroy()` may trigger assertions.
https://github.com/pjsip/pjproject/blob/7e1e310f277d19b00c94bca142505155faaff5b8/pjsip/src/pjsua-lib/pjsua_vid.c#L234-L241

Similar to video codec manager,
https://github.com/pjsip/pjproject/blob/7e1e310f277d19b00c94bca142505155faaff5b8/pjmedia/src/pjmedia/vid_codec.c#L179-L182
it should be unnecessary to assert when trying to get the manager instances.
