### PR TITLE
Various fixes/updates in pjsua2 C# sample app SimplePjsua2CS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ pjsip-apps/src/swig/java/android/app/src/main/jniLibs/
 
 # SWIG CSharp/Xamarin stuff
 pjsip-apps/src/swig/csharp/pjsua2xamarin/
+pjsip-apps/src/swig/csharp/sample/SimplePjsua2CS/pjsua2
+pjsip-apps/src/swig/csharp/sample/SimplePjsua2CS/obj
+pjsip-apps/src/swig/csharp/sample/SimplePjsua2CS/*.user
 
 # SWIG Python stuff
 pjsip-apps/src/swig/python/build/


### PR DESCRIPTION
- Fix compile error due to removal of `VideoPreviewOpParam.window.handle.setWindow()` in #4273.
- Fix truncated captured video by matching video renderer's format size to the video renderer size.
- Minor updates such as: use default video capture device (was colorbar/2), optional logging to file, add incoming call handling, indentations.
- Update gitignore for intermediate files of this project.