### PR TITLE
Add dual-octet vp8 pictureId to vp8 payload descriptor

### DIFF
--- a/pjmedia/src/pjmedia-codec/vpx.c
+++ b/pjmedia/src/pjmedia-codec/vpx.c
@@ -660,7 +660,9 @@ static pj_status_t vpx_codec_encode_more(pjmedia_vid_codec *codec,
     vpx_data = (vpx_codec_data*) codec->codec_data;
     
     if (vpx_data->enc_processed < vpx_data->enc_frame_size) {
-        unsigned payload_desc_size = 4;
+        /* For VP8, use 4 bytes payload desc, see #4515 for more info */
+        unsigned payload_desc_size = (vpx_data->prm->enc_fmt.id==PJMEDIA_FORMAT_VP8)? 4 : 1;
+        
         pj_size_t payload_len = out_size;
         pj_uint8_t *p = (pj_uint8_t *)output->buf;
 

--- a/pjmedia/src/pjmedia-codec/vpx_packetizer.c
+++ b/pjmedia/src/pjmedia-codec/vpx_packetizer.c
@@ -101,6 +101,7 @@ PJ_DEF(pj_status_t) pjmedia_vpx_packetize(const pjmedia_vpx_packetizer *pktz,
     /* Set payload header */
     bits[0] = 0;
     if (pktz->cfg.fmt_id == PJMEDIA_FORMAT_VP8) {
+        /* For VP8, use 4 bytes payload desc, see #4515 for more info */
         bits[0] = 0x80;
 
         /* Set S: Start of VP8 partition. */


### PR DESCRIPTION
This pull request modifies the vp8 packetization method to add the dual-octet picture id to the payload descriptor header. In our usage of vp8, certain systems required this to correctly decode our vp8 media. 

We are not sure if this will be of use to other PJSIP users, and we have not tested the changes with the vp9 codec, which might be affected by them, but we wanted to upstream our changes in case this was useful to the community. 

This code fixed our issue for recipients of our vp8 traffic, but we're unsure of it's general usefulness. Nevertheless, we wanted to upstream it to the community in case anyone finds it useful or so it can serve as the basis for future work. 

## Summary of changes:
- We added a picture_id field to the pjmedia_vpx_packetizer struct.
- We increased the size of the vp8 payload descriptor to 4 bytes.
- We increment the picture_id when the S-bit is present
- We set the ILTK Extended Control Bits 
- We added the picture id to the two pictureID octets

See https://datatracker.ietf.org/doc/rfc7741/

```
4.2.  VP8 Payload Descriptor

   The first octets after the RTP header are the VP8 payload descriptor,
   with the following structure.  The single-octet version of the
   PictureID is illustrated to the left (M bit set to 0), while the
   dual-octet version (M bit set to 1) is shown to the right.

         0 1 2 3 4 5 6 7                      0 1 2 3 4 5 6 7
        +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
        |X|R|N|S|R| PID | (REQUIRED)        |X|R|N|S|R| PID | (REQUIRED)
        +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
   X:   |I|L|T|K| RSV   | (OPTIONAL)   X:   |I|L|T|K| RSV   | (OPTIONAL)
        +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
   I:   |M| PictureID   | (OPTIONAL)   I:   |M| PictureID   | (OPTIONAL)
        +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
   L:   |   TL0PICIDX   | (OPTIONAL)        |   PictureID   |
        +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
   T/K: |TID|Y| KEYIDX  | (OPTIONAL)   L:   |   TL0PICIDX   | (OPTIONAL)
        +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
                                       T/K: |TID|Y| KEYIDX  | (OPTIONAL)
                                            +-+-+-+-+-+-+-+-+
```

The structure modified is shown in the right-hand bit diagram above.

## Caveats and limitations
- We have not tested these changes with vp9 and are unsure of the effects.
- We did not implmenet the single-octet picture_id format

### Contributors: 
Zurab Tutberidze (optime.dev)
Tornike Kutchukhidze (optime.dev)
Sergii Lovygin (Trembit)
Jonathan Knowles (Equiti Health) 