### PR TITLE
Add video capability to pcaputil sample app

### DIFF
--- a/pjsip-apps/src/samples/pcaputil.c
+++ b/pjsip-apps/src/samples/pcaputil.c
@@ -499,9 +499,18 @@ static pj_status_t event_cb(pjmedia_event *event, void *user_data)
         /* This is codec event */
         switch (event->type) {
         case PJMEDIA_EVENT_FMT_CHANGED:
-            app.vfmt = event->data.fmt_changed.new_fmt;
-            return PJ_SUCCESS;
+        {
+            pjmedia_format *fmt = &event->data.fmt_changed.new_fmt;
 
+            /* The event may only provide width & height, re-initialize format
+             * with fps, bps, etc.
+             */
+            pjmedia_format_init_video(&app.vfmt,
+                                      fmt->id,
+                                      fmt->det.vid.size.w,
+                                      fmt->det.vid.size.h,
+                                      25, 1);
+        }
         default:
             break;
         }
@@ -598,8 +607,6 @@ static void pcap2avi(const struct args *args)
             if (!avi_streams && app.vfmt.id == PJMEDIA_FORMAT_I420) {
                 /* Open AVI file */
                 if (pj_stristr(&args->wav_filename, &AVI)) {
-                    app.vfmt.det.vid.fps.num = 25;
-                    app.vfmt.det.vid.fps.denum = 1;
                     T( pjmedia_avi_writer_create_streams(app.pool,
                                                          args->wav_filename.ptr,
                                                          1000 * 1024 * 1024, /* max file size */

--- a/pjsip-apps/src/samples/pcaputil.c
+++ b/pjsip-apps/src/samples/pcaputil.c
@@ -491,6 +491,7 @@ static void pcap2wav(const struct args *args)
 }
 
 
+#if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
 static pj_status_t event_cb(pjmedia_event *event, void *user_data)
 {
     PJ_UNUSED_ARG(user_data);
@@ -518,6 +519,7 @@ static pj_status_t event_cb(pjmedia_event *event, void *user_data)
 
     return PJ_SUCCESS;
 }
+#endif
 
 
 static void pcap2avi(const struct args *args)

--- a/pjsip-apps/src/samples/pcaputil.c
+++ b/pjsip-apps/src/samples/pcaputil.c
@@ -500,18 +500,19 @@ static pj_status_t event_cb(pjmedia_event *event, void *user_data)
         /* This is codec event */
         switch (event->type) {
         case PJMEDIA_EVENT_FMT_CHANGED:
-        {
-            pjmedia_format *fmt = &event->data.fmt_changed.new_fmt;
+            {
+                pjmedia_format *fmt = &event->data.fmt_changed.new_fmt;
 
-            /* The event may only provide width & height, re-initialize format
-             * with fps, bps, etc.
-             */
-            pjmedia_format_init_video(&app.vfmt,
-                                      fmt->id,
-                                      fmt->det.vid.size.w,
-                                      fmt->det.vid.size.h,
-                                      25, 1);
-        }
+                /* The event may only provide width & height, re-initialize
+                 * format with fps, bps, etc.
+                 */
+                pjmedia_format_init_video(&app.vfmt,
+                                          fmt->id,
+                                          fmt->det.vid.size.w,
+                                          fmt->det.vid.size.h,
+                                          25, 1);
+            }
+            break;
         default:
             break;
         }
@@ -599,7 +600,7 @@ static void pcap2avi(const struct args *args)
         out_frame.buf = buf;
         out_frame.size = MAX_BUF_SIZE;
 
-        /* Decode and write to WAV file */
+        /* Decode and write to AVI file */
         pj_bzero(&frame, sizeof(frame));
         frame.buf = pkt0.payload;
         frame.size = pkt0.payload_len;


### PR DESCRIPTION
Added param `--video`. Sample command:
```
pcaputil input.pcap output.avi --video --codec H264 --dst-ip ... --dst-port ...
```
Note:
- The output is in raw video format such as I420 so the size can be very large.
- Some common video players, such as Windows Media Player or VLC, may not support the output format. You can use ffmpeg or the sample application `aviplay` to play the output AVI file.
