### PR TITLE
Fix potential overflow in `platform_strerror`

### DIFF
--- a/pjlib/src/pj/os_error_symbian.cpp
+++ b/pjlib/src/pj/os_error_symbian.cpp
@@ -134,7 +134,9 @@ PJ_DEF(int) platform_strerror( pj_os_err_type os_errcode,
     int len = 0;
 
     pj_assert(buf != NULL);
-    pj_assert(bufsize >= 0);
+
+    if (bufsize == 0)
+        return 0;
 
     /*
      * MUST NOT check stack here.

--- a/pjlib/src/pj/os_error_unix.c
+++ b/pjlib/src/pj/os_error_unix.c
@@ -55,8 +55,14 @@ PJ_END_DECL
 int platform_strerror( pj_os_err_type os_errcode, 
                        char *buf, pj_size_t bufsize)
 {
-    const char *syserr = strerror(os_errcode);
-    pj_size_t len = syserr ? strlen(syserr) : 0;
+    const char *syserr;
+    pj_size_t len;
+
+    if (bufsize == 0)
+        return 0;
+
+    syserr = strerror(os_errcode);
+    len = syserr ? strlen(syserr) : 0;
 
     if (len >= bufsize) len = bufsize - 1;
     if (len > 0)
@@ -64,5 +70,3 @@ int platform_strerror( pj_os_err_type os_errcode,
     buf[len] = '\0';
     return len;
 }
-
-

--- a/pjlib/src/pj/os_error_win32.c
+++ b/pjlib/src/pj/os_error_win32.c
@@ -145,7 +145,9 @@ int platform_strerror( pj_os_err_type os_errcode,
     PJ_DECL_UNICODE_TEMP_BUF(wbuf,128);
 
     pj_assert(buf != NULL);
-    pj_assert(bufsize >= 0);
+
+    if (bufsize == 0)
+        return 0;
 
     /*
      * MUST NOT check stack here.


### PR DESCRIPTION
Length calculation does not handle the case when the value of `bufsize` being zero, which may lead to the result value to wrap.

```c
    const char *syserr = strerror(os_errcode);
    pj_size_t len = syserr ? strlen(syserr) : 0;

    if (len >= bufsize) len = bufsize - 1; /* <- `len` is `SIZE_MAX` if `bufsize` is 0 */

```