### PR TITLE
Use group lock for keep alive timer in SIP transport TCP and TLS

### DIFF
--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1204,10 +1204,10 @@ static pj_bool_t on_accept_complete(pj_activesock_t *asock,
         if (pjsip_cfg()->tcp.keep_alive_interval) {
             pj_time_val delay = { 0 };
             delay.sec = pjsip_cfg()->tcp.keep_alive_interval;
-            pjsip_endpt_schedule_timer(listener->endpt,
-                                       &tcp->ka_timer,
-                                       &delay);
-            tcp->ka_timer.id = PJ_TRUE;
+            pjsip_endpt_schedule_timer_w_grp_lock(tcp->base.endpt,
+                                                  &tcp->ka_timer,
+                                                  &delay, PJ_TRUE,
+                                                  tcp->grp_lock);
             pj_gettimeofday(&tcp->last_activity);
         }
 
@@ -1571,9 +1571,8 @@ static pj_bool_t on_connect_complete(pj_activesock_t *asock,
     if (pjsip_cfg()->tcp.keep_alive_interval) {
         pj_time_val delay = { 0 };
         delay.sec = pjsip_cfg()->tcp.keep_alive_interval;
-        pjsip_endpt_schedule_timer(tcp->base.endpt, &tcp->ka_timer, 
-                                   &delay);
-        tcp->ka_timer.id = PJ_TRUE;
+        pjsip_endpt_schedule_timer_w_grp_lock(tcp->base.endpt, &tcp->ka_timer,
+                                              &delay, PJ_TRUE, tcp->grp_lock);
         pj_gettimeofday(&tcp->last_activity);
     }
 
@@ -1602,9 +1601,8 @@ static void tcp_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
         delay.sec = pjsip_cfg()->tcp.keep_alive_interval - now.sec;
         delay.msec = 0;
 
-        pjsip_endpt_schedule_timer(tcp->base.endpt, &tcp->ka_timer, 
-                                   &delay);
-        tcp->ka_timer.id = PJ_TRUE;
+        pjsip_endpt_schedule_timer_w_grp_lock(tcp->base.endpt, &tcp->ka_timer,
+                                              &delay, PJ_TRUE, tcp->grp_lock);
         return;
     }
 
@@ -1630,9 +1628,8 @@ static void tcp_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
     delay.sec = pjsip_cfg()->tcp.keep_alive_interval;
     delay.msec = 0;
 
-    pjsip_endpt_schedule_timer(tcp->base.endpt, &tcp->ka_timer, 
-                               &delay);
-    tcp->ka_timer.id = PJ_TRUE;
+    pjsip_endpt_schedule_timer_w_grp_lock(tcp->base.endpt, &tcp->ka_timer,
+                                          &delay, PJ_TRUE, tcp->grp_lock);
 }
 
 

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -1579,10 +1579,8 @@ static pj_bool_t on_accept_complete2(pj_ssl_sock_t *ssock,
     if (pjsip_cfg()->tls.keep_alive_interval) {
         pj_time_val delay = {0};
         delay.sec = pjsip_cfg()->tls.keep_alive_interval;
-        pjsip_endpt_schedule_timer(listener->endpt,
-                                   &tls->ka_timer,
-                                   &delay);
-        tls->ka_timer.id = PJ_TRUE;
+        pjsip_endpt_schedule_timer_w_grp_lock(tls->base.endpt, &tls->ka_timer,
+                                              &delay, PJ_TRUE, tls->grp_lock);
         pj_gettimeofday(&tls->last_activity);
     }
 
@@ -2113,9 +2111,8 @@ static pj_bool_t on_connect_complete(pj_ssl_sock_t *ssock,
     if (pjsip_cfg()->tls.keep_alive_interval) {
         pj_time_val delay = {0};            
         delay.sec = pjsip_cfg()->tls.keep_alive_interval;
-        pjsip_endpt_schedule_timer(tls->base.endpt, &tls->ka_timer, 
-                                   &delay);
-        tls->ka_timer.id = PJ_TRUE;
+        pjsip_endpt_schedule_timer_w_grp_lock(tls->base.endpt, &tls->ka_timer,
+                                              &delay, PJ_TRUE, tls->grp_lock);
         pj_gettimeofday(&tls->last_activity);
     }
 
@@ -2150,9 +2147,8 @@ static void tls_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
         delay.sec = pjsip_cfg()->tls.keep_alive_interval - now.sec;
         delay.msec = 0;
 
-        pjsip_endpt_schedule_timer(tls->base.endpt, &tls->ka_timer, 
-                                   &delay);
-        tls->ka_timer.id = PJ_TRUE;
+        pjsip_endpt_schedule_timer_w_grp_lock(tls->base.endpt, &tls->ka_timer,
+                                              &delay, PJ_TRUE, tls->grp_lock);
         return;
     }
 
@@ -2180,9 +2176,8 @@ static void tls_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
     delay.sec = pjsip_cfg()->tls.keep_alive_interval;
     delay.msec = 0;
 
-    pjsip_endpt_schedule_timer(tls->base.endpt, &tls->ka_timer, 
-                               &delay);
-    tls->ka_timer.id = PJ_TRUE;
+    pjsip_endpt_schedule_timer_w_grp_lock(tls->base.endpt, &tls->ka_timer,
+                                          &delay, PJ_TRUE, tls->grp_lock);
 }
 
 


### PR DESCRIPTION
To prevent race condition between TCP/TLS keep alive timer and the transport destroy, we should use group lock when scheduling the timer.

Example stack trace:
```
   #00  ... (pj_atomic_inc_and_get+20)
   #01  ... (pjsip_transport_add_ref+140)
   #02  ... (tls_init_shutdown)
   #03  ... (tls_keep_alive_timer)
   #04  ... (pj_timer_heap_poll+592)
```
