### PR TITLE
Prevent race condition in Unix thread creation

### DIFF
--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -693,6 +693,9 @@ static void *thread_main(void *param)
     rec->stk_start = (char*)&rec;
 #endif
 
+    /* Store the thread. */
+    rec->thread = pthread_self();
+
     /* Set current thread id. */
     rc = pj_thread_local_set(thread_tls_id, rec);
     if (rc != PJ_SUCCESS) {
@@ -732,6 +735,7 @@ PJ_DEF(pj_status_t) pj_thread_create( pj_pool_t *pool,
 {
 #if PJ_HAS_THREADS
     pj_thread_t *rec;
+    pthread_t thread;
     pthread_attr_t thread_attr;
     void *stack_addr;
     int rc;
@@ -806,7 +810,7 @@ PJ_DEF(pj_status_t) pj_thread_create( pj_pool_t *pool,
     /* Create the thread. */
     rec->proc = proc;
     rec->arg = arg;
-    rc = pthread_create( &rec->thread, &thread_attr, &thread_main, rec);
+    rc = pthread_create( &thread, &thread_attr, &thread_main, rec);
     if (rc != 0) {
         pthread_attr_destroy(&thread_attr);
         return PJ_RETURN_OS_ERROR(rc);


### PR DESCRIPTION
To fix #4521.

According to https://man7.org/linux/man-pages/man3/pthread_create.3.html:
```
int pthread_create(pthread_t *restrict thread,
                          const pthread_attr_t *restrict attr,
                          typeof(void *(void *)) *start_routine,
                          void *restrict arg);

pthread_create() function starts a new thread in the calling process.
...
Before returning, a successful call to pthread_create() stores the
       ID of the new thread in the buffer pointed to by thread;
```

Note that there's no guarantee that the new thread ID is stored **before** starting the thread itself, so `rec->thread` can potentially be still unassigned when the thread is already running.
