### PR TITLE
Add lock to WAV player for convenient set_pos() & get_pos()

### DIFF
--- a/pjmedia/include/pjmedia/wav_port.h
+++ b/pjmedia/include/pjmedia/wav_port.h
@@ -46,7 +46,15 @@ enum pjmedia_file_player_option
      * Tell the file player to return NULL frame when the whole
      * file has been played.
      */
-    PJMEDIA_FILE_NO_LOOP = 1
+    PJMEDIA_FILE_NO_LOOP = 1,
+
+    /**
+     * Disable mutex protection for getting/setting the player's position.
+     * If the application does not access the file position, enabling this
+     * option may improve performance by avoiding unnecessary locking on
+     * each frame retrieval.
+     */
+    PJMEDIA_FILE_NO_LOCK = 2
 };
 
 
@@ -135,10 +143,12 @@ PJ_DECL(pj_ssize_t) pjmedia_wav_player_get_len(pjmedia_port *port);
 
 /**
  * Set the file play position of WAV player.
- * @b Safety: This function can only be called when the player is not running
+ *
+ * @b Safety: if the player is created with PJMEDIA_FILE_NO_LOCK option,
+ * this function can only be called when the player is not running
  * (that is: get_frame() is not being called).
  *
- * @sa pjmedia_conf_configure_port
+ * @sa PJMEDIA_FILE_NO_LOCK
  *
  * @param port          The file player port.
  * @param offset        Playback position in bytes, relative to the start of
@@ -152,10 +162,12 @@ PJ_DECL(pj_status_t) pjmedia_wav_player_port_set_pos( pjmedia_port *port,
 
 /**
  * Get the file play position of WAV player, in bytes.
- * @b Safety: This function can only be called when the player is not running
+ *
+ * @b Safety: if the player is created with PJMEDIA_FILE_NO_LOCK option,
+ * this function can only be called when the player is not running
  * (that is: get_frame() is not being called).
  *
- * @sa pjmedia_conf_configure_port
+ * @sa PJMEDIA_FILE_NO_LOCK
  *
  * @param port          The file player port.
  *

--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -57,6 +57,8 @@ struct file_reader_port
     pjmedia_port     base;
     pj_pool_t       *pool;
     unsigned         options;
+    pj_lock_t       *lock;
+
     pjmedia_wave_fmt_tag fmt_tag;
     pj_uint16_t      bytes_per_sample;
     pj_bool_t        eof;
@@ -228,7 +230,7 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool_,
     pjmedia_wave_hdr wave_hdr;
     pj_ssize_t size_read;
     pj_off_t size_to_read;
-    struct file_reader_port *fport;
+    struct file_reader_port *fport = NULL;
     pjmedia_audio_format_detail *ad;
     pj_off_t pos;
     pj_str_t name;
@@ -270,6 +272,15 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool_,
     }
     fport->pool = pool;
 
+    /* Create lock */
+    if (options & PJMEDIA_FILE_NO_LOCK) {
+        status = pj_lock_create_null_mutex(pool, "wav_play", &fport->lock);
+    } else {
+        status = pj_lock_create_simple_mutex(pool, "wav_play", &fport->lock);
+    }
+    if (status != PJ_SUCCESS) {
+        goto on_error;
+    }
 
     /* Get the file size. */
     fport->fsize = pj_file_size(filename);
@@ -505,6 +516,9 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool_,
     return PJ_SUCCESS;
 
 on_error:
+    if (fport && fport->lock)
+        pj_lock_destroy(fport->lock);
+
     if (pool)
         pj_pool_release(pool);
 
@@ -580,7 +594,7 @@ PJ_DEF(pj_ssize_t) pjmedia_wav_player_get_len(pjmedia_port *port)
 PJ_DEF(pj_status_t) pjmedia_wav_player_port_set_pos(pjmedia_port *port,
                                                     pj_uint32_t bytes )
 {
-    struct file_reader_port *fport;
+    struct file_reader_port *fport = (struct file_reader_port*) port;
     pj_status_t status;
 
     /* Sanity check */
@@ -589,24 +603,25 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_set_pos(pjmedia_port *port,
     /* Check that this is really a player port */
     PJ_ASSERT_RETURN(port->info.signature == SIGNATURE, PJ_EINVALIDOP);
 
-
-    fport = (struct file_reader_port*) port;
-
     /* Check that this offset does not pass the audio-data (in case of
      * extra chunk after audio data chunk
      */
     PJ_ASSERT_RETURN(bytes < fport->data_len, PJ_EINVAL);
 
+    pj_lock_acquire(fport->lock);
     fport->fpos = fport->start_data + bytes;
     fport->data_left = fport->data_len - bytes;
     pj_file_setpos( fport->fd, fport->fpos, PJ_SEEK_SET);
 
     fport->eof = PJ_FALSE;
     status = fill_buffer(fport);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+        pj_lock_release(fport->lock);
         return status;
+    }
 
     fport->readpos = fport->buf;
+    pj_lock_release(fport->lock);
 
     return PJ_SUCCESS;
 }
@@ -617,8 +632,8 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_set_pos(pjmedia_port *port,
  */
 PJ_DEF(pj_ssize_t) pjmedia_wav_player_port_get_pos( pjmedia_port *port )
 {
-    struct file_reader_port *fport;
-    pj_size_t payload_pos;
+    struct file_reader_port *fport = (struct file_reader_port*) port;
+    pj_size_t payload_pos, pos;
 
     /* Sanity check */
     PJ_ASSERT_RETURN(port, -PJ_EINVAL);
@@ -626,15 +641,17 @@ PJ_DEF(pj_ssize_t) pjmedia_wav_player_port_get_pos( pjmedia_port *port )
     /* Check that this is really a player port */
     PJ_ASSERT_RETURN(port->info.signature == SIGNATURE, -PJ_EINVALIDOP);
 
-    fport = (struct file_reader_port*) port;
-
+    pj_lock_acquire(fport->lock);
     payload_pos = (pj_size_t)(fport->fpos - fport->start_data);
     if (payload_pos == 0)
-        return 0;
+        pos = 0;
     else if (payload_pos >= fport->bufsize)
-        return payload_pos - fport->bufsize + (fport->readpos - fport->buf);
+        pos = payload_pos - fport->bufsize + (fport->readpos - fport->buf);
     else
-        return (fport->readpos - fport->buf) % payload_pos;
+        pos = (fport->readpos - fport->buf) % payload_pos;
+    pj_lock_release(fport->lock);
+
+    return pos;
 }
 
 
@@ -722,6 +739,8 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
     pj_assert(fport->base.info.signature == SIGNATURE);
     pj_assert(frame->size <= fport->bufsize);
 
+    pj_lock_acquire(fport->lock);
+
     /* EOF is set and readpos already passed the eofpos */
     if (fport->eof && fport->readpos >= fport->eofpos) {
         PJ_LOG(5,(THIS_FILE, "File port %.*s EOF",
@@ -761,10 +780,14 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
             frame->type = PJMEDIA_FRAME_TYPE_NONE;
             frame->size = 0;
             
+            pj_lock_release(fport->lock);
             return (no_loop? PJ_EEOF: PJ_SUCCESS);
 
         } else if (fport->cb) {
+            /* Release lock during callback to avoid deadlock */
+            pj_lock_release(fport->lock);
             status = (*fport->cb)(this_port, fport->base.port_data.pdata);
+            pj_lock_acquire(fport->lock);
         }
 
         /* If callback returns non PJ_SUCCESS or 'no loop' is specified,
@@ -775,6 +798,7 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
         {
             frame->type = PJMEDIA_FRAME_TYPE_NONE;
             frame->size = 0;
+            pj_lock_release(fport->lock);
             return PJ_EEOF;
         }
 
@@ -817,6 +841,7 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
                 frame->type = PJMEDIA_FRAME_TYPE_NONE;
                 frame->size = 0;
                 fport->readpos = fport->buf + fport->bufsize;
+                pj_lock_release(fport->lock);
                 return status;
             }
         }
@@ -845,6 +870,7 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
                           frame_size - endread);
             }
 
+            pj_lock_release(fport->lock);
             return PJ_SUCCESS;
         }
 
@@ -854,6 +880,7 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
             frame->type = PJMEDIA_FRAME_TYPE_NONE;
             frame->size = 0;
             fport->readpos = fport->buf + fport->bufsize;
+            pj_lock_release(fport->lock);
             return status;
         }
 
@@ -882,6 +909,7 @@ static pj_status_t file_get_frame(pjmedia_port *this_port,
         }
     }
 
+    pj_lock_release(fport->lock);
     return PJ_SUCCESS;
 }
 
@@ -900,6 +928,9 @@ static pj_status_t file_on_destroy(pjmedia_port *this_port)
         pjmedia_event_unsubscribe(NULL, &file_on_event, fport, fport);
         fport->subscribed = PJ_FALSE;
     }
+
+    if (fport->lock)
+        pj_lock_destroy(fport->lock);
 
     if (fport->pool)
         pj_pool_safe_release(&fport->pool);


### PR DESCRIPTION
To resolve #4431.

Currently WAV player does not use lock, so `set_pos()` & `get_pos()` are not thread-safe. Application must manage the thread safety manually, for example by simply temporarily stopping `get_frame()` using `pjmedia_conf_configure_port()` before & after `get/set_pos()`. However this simple trick is no longer working with the asynchronous conference, so adding a lock to WAV player will be handy for app.