### PR TITLE
fix: the issue of out-of-order data sent by TLS connection (#4533)

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -138,6 +138,7 @@ struct pj_ssl_sock_t
                                              * data is queuing in wbio.     */
     write_data_t          send_pending; /* list of pending write to network */
     pj_lock_t            *write_mutex;  /* protect write BIO and send_buf   */
+    pj_lock_t            *asock_send_mutex; /* protect send order */
 
     circ_buf_t            circ_buf_input;
     pj_lock_t            *circ_buf_input_mutex;


### PR DESCRIPTION
In the case of frequent data transmission over a TLS connection, data out-of-order issues may arise. The `SSL_Write` method ensures the order of encryption, but the `pj_activesock_send` method cannot guarantee this; hence, I have added a lock to it.

A more detailed description of the problem: [#4533](https://github.com/pjsip/pjproject/issues/4533).