### PR TITLE
prevent infinite loop on reading of invalide wav/avi file

### DIFF
--- a/pjmedia/src/pjmedia/avi_player.c
+++ b/pjmedia/src/pjmedia/avi_player.c
@@ -838,20 +838,21 @@ static pj_status_t skip_forward(pjmedia_port *this_port, pj_size_t frames)
             pj_off_t pos;
             pj_file_getpos(fport->fd, &pos);
             if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+            {
                 PJ_LOG(2, (THIS_FILE,
                            "%.*s. Zero length chunk of type %s found at offset=%lu (skip_forward)",
                            (int)fport->base.info.name.slen,
                            fport->base.info.name.ptr,
                            pjmedia_fourcc_name(ch.id, fourcc_name),
                            (unsigned long)pos));
-
-            else 
+            } else {
                 PJ_LOG(2, (THIS_FILE,
                            "%.*s. Invalid chunk of type=0x%08X with length=%u found at offset=%lu (skip_forward)",
                            (int)fport->base.info.name.slen,
                            fport->base.info.name.ptr,
                            ch.id, ch.len,
                            (unsigned long)pos));
+            }
 
             return PJMEDIA_ENOTVALIDWAVE;
         }
@@ -1131,22 +1132,23 @@ static pj_status_t avi_get_frame(pjmedia_port *this_port,
                 char fourcc_name[5];
                 pj_uint32_t sig = ch.id;
                 if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+                {
                     PJ_LOG(2, (THIS_FILE,
                                "%.*s. Zero length chunk of type %s found at offset=%lu (avi_get_frame)",
                                (int)fport->base.info.name.slen,
                                fport->base.info.name.ptr,
                                pjmedia_fourcc_name(ch.id, fourcc_name),
                                (unsigned long)pos));
-
-                else 
+                } else {
                     PJ_LOG(2, (THIS_FILE,
                                "%.*s. Invalid chunk of type=0x%08X with length=%u found at offset=%lu (avi_get_frame)",
                                (int)fport->base.info.name.slen,
                                fport->base.info.name.ptr,
                                ch.id, ch.len,
                                (unsigned long)pos));
-
-                return PJMEDIA_ENOTVALIDWAVE;
+                }
+                status = PJMEDIA_ENOTVALIDWAVE;
+                goto on_error2;
             }
 
             PJ_CHECK_OVERFLOW_UINT32_TO_LONG(ch.len, 

--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -212,21 +212,21 @@ static pj_status_t read_wav_until(struct file_reader_port *fport,
             pj_off_t fpos;
             pj_file_getpos(fport->fd, &fpos);
             if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+            {
                 PJ_LOG(2, (THIS_FILE,
                            "%.*s. Zero length chunk of type %s found at offset=%lu (read_wav_until)",
                            (int)fport->base.info.name.slen,
                            fport->base.info.name.ptr,
                            pjmedia_fourcc_name(subchunk.id, fourcc_name),
                            (unsigned long)fpos));
-
-            else 
+            } else {
                 PJ_LOG(2, (THIS_FILE,
                            "%.*s. Invalid chunk of type=0x%08X with length=%u found at offset=%lu (read_wav_until)",
                            (int)fport->base.info.name.slen,
                            fport->base.info.name.ptr,
                            subchunk.id, subchunk.len,
                            (unsigned long)fpos));
-
+            }
             return PJMEDIA_ENOTVALIDWAVE;
         }
 

--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -204,6 +204,32 @@ static pj_status_t read_wav_until(struct file_reader_port *fport,
             break;
         }
 
+        if (!subchunk.len ||    /* prevent infinite loop */
+            !subchunk.id)       /* highly likely that the file is invalid */
+        {
+            char fourcc_name[5];
+            pj_uint32_t sig = subchunk.id;
+            pj_off_t fpos;
+            pj_file_getpos(fport->fd, &fpos);
+            if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+                PJ_LOG(2, (THIS_FILE,
+                           "%.*s. Zero length chunk of type %s found at offset=%lu (read_wav_until)",
+                           (int)fport->base.info.name.slen,
+                           fport->base.info.name.ptr,
+                           pjmedia_fourcc_name(subchunk.id, fourcc_name),
+                           (unsigned long)fpos));
+
+            else 
+                PJ_LOG(2, (THIS_FILE,
+                           "%.*s. Invalid chunk of type=0x%08X with length=%u found at offset=%lu (read_wav_until)",
+                           (int)fport->base.info.name.slen,
+                           fport->base.info.name.ptr,
+                           subchunk.id, subchunk.len,
+                           (unsigned long)fpos));
+
+            return PJMEDIA_ENOTVALIDWAVE;
+        }
+
         /* Otherwise skip the chunk contents */
         PJ_CHECK_OVERFLOW_UINT32_TO_LONG(subchunk.len,
                                          return PJMEDIA_ENOTVALIDWAVE;);

--- a/pjmedia/src/pjmedia/wav_playlist.c
+++ b/pjmedia/src/pjmedia/wav_playlist.c
@@ -547,21 +547,24 @@ PJ_DEF(pj_status_t) pjmedia_wav_playlist_create(pj_pool_t *pool_,
                 pj_off_t fpos;
                 pj_file_getpos(fport->fd_list[index], &fpos);
                 if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+                {
                     PJ_LOG(2, (THIS_FILE,
                                "%.*s. Zero length chunk of type %s found at offset=%lu",
                                (int)file_list[index].slen,
                                file_list[index].ptr,
                                pjmedia_fourcc_name(subchunk.id, fourcc_name),
                                (unsigned long)fpos));
-                else 
+                } else {
                     PJ_LOG(2, (THIS_FILE,
                                "%.*s. Invalid chunk of type=0x%08X with length=%u found at offset=%lu",
                                (int)file_list[index].slen,
                                file_list[index].ptr,
                                subchunk.id, subchunk.len,
                                (unsigned long)fpos));
+                }
+                status = PJMEDIA_ENOTVALIDWAVE;
+                goto on_error;
 
-                return PJMEDIA_ENOTVALIDWAVE;
             }
 
             /* Otherwise skip the chunk contents */

--- a/pjmedia/src/pjmedia/wav_playlist.c
+++ b/pjmedia/src/pjmedia/wav_playlist.c
@@ -539,6 +539,31 @@ PJ_DEF(pj_status_t) pjmedia_wav_playlist_create(pj_pool_t *pool_,
                 break;
             }
             
+            if (!subchunk.len ||    /* prevent infinite loop */
+                !subchunk.id)       /* highly likely that the file is invalid */
+            {
+                char fourcc_name[5];
+                pj_uint32_t sig = subchunk.id;
+                pj_off_t fpos;
+                pj_file_getpos(fport->fd_list[index], &fpos);
+                if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+                    PJ_LOG(2, (THIS_FILE,
+                               "%.*s. Zero length chunk of type %s found at offset=%lu",
+                               (int)file_list[index].slen,
+                               file_list[index].ptr,
+                               pjmedia_fourcc_name(subchunk.id, fourcc_name),
+                               (unsigned long)fpos));
+                else 
+                    PJ_LOG(2, (THIS_FILE,
+                               "%.*s. Invalid chunk of type=0x%08X with length=%u found at offset=%lu",
+                               (int)file_list[index].slen,
+                               file_list[index].ptr,
+                               subchunk.id, subchunk.len,
+                               (unsigned long)fpos));
+
+                return PJMEDIA_ENOTVALIDWAVE;
+            }
+
             /* Otherwise skip the chunk contents */
             PJ_CHECK_OVERFLOW_UINT32_TO_LONG(subchunk.len, 
                                status = PJMEDIA_ENOTVALIDWAVE; goto on_error;);


### PR DESCRIPTION
pjmedia fix

The program goes into an infinite loop when iterating over a wav or avi file, if the length field of the readed chunck header is zero.
Now this situation is tracked in the log, the loop is interrupted, and the function returns with the status code PJMEDIA_ENOTVALIDWAVE.
A similar reaction has been added for the zero chunck.id field.