### PR TITLE
Add conference test with call simulation to MIPS test

### DIFF
--- a/pjmedia/src/test/mips_test.c
+++ b/pjmedia/src/test/mips_test.c
@@ -2757,11 +2757,15 @@ int mips_test(void)
         { "conference bridge with 4 ports", OP_GET_PUT, K8|K16, &conf4_test_init},
         { "conference bridge with 8 ports", OP_GET_PUT, K8|K16, &conf8_test_init},
         { "conference bridge with 16 ports", OP_GET_PUT, K8|K16, &conf16_test_init},
+#if PJMEDIA_HAS_G711_CODEC
         { "conf bridge 100 calls - PCMU", OP_PUT_GET, K8, &conf100_pcmu_test_init},
         { "conf bridge 100 calls - PCMU, no parallel", OP_PUT_GET, K8, &conf100_pcmu_noparallel_test_init},
-        { "conf bridge 100 calls - PCMU, resample (small)", OP_PUT_GET, K16, &conf100_pcmu_test_init},
-        { "conf bridge 100 calls - Speex", OP_PUT_GET, K16, &conf100_speex_test_init},
         { "conf bridge 100 calls - PCMU, SRTP 80bit+auth", OP_PUT_GET, K8, &conf100_pcmu_srtp80auth_test_init},
+        { "conf bridge 100 calls - PCMU, resample (small)", OP_PUT_GET, K16, &conf100_pcmu_test_init},
+#endif
+#if PJMEDIA_HAS_SPEEX_CODEC
+        { "conf bridge 100 calls - Speex", OP_PUT_GET, K16, &conf100_speex_test_init},
+#endif
         { "upsample+downsample - linear", OP_GET, K8|K16, &linear_resample},
         { "upsample+downsample - small filter", OP_GET, K8|K16, &small_filt_resample},
         { "upsample+downsample - large filter", OP_GET, K8|K16, &large_filt_resample},


### PR DESCRIPTION
Following the introduction of the parallel conference bridge (#4241), hopefully, with the added tests we can:
- compare the performances of parallel vs serial conference bridges, for example:
  ```
  Clock  Item                                                        Time       CPU    MIPS
   Rate                                                             (usec)      (%)
  -----------------------------------------------------------------------------------------
   8KHz conf bridge 100 calls - PCMU                                  8856    0.886   71.75
   8KHz conf bridge 100 calls - PCMU, no parallel                    12444    1.244  100.82
  ```
- help estimate a server's capacity for handling concurrent calls
  
  For example, here is the MIPS test output from my machine:
  ```
  Clock  Item                                                        Time       CPU    MIPS
   Rate                                                             (usec)      (%)
  -----------------------------------------------------------------------------------------
   8KHz conf bridge 100 calls - PCMU, SRTP 80bit+auth                27381    2.738  221.84
  ```
  Based on the data above, the machine requires approximately 28 ms to process 1 second of audio of 100 calls. Assuming linear scalability with respect to the number of calls, this suggests a theoretical maximum of approximately 1000 / 28 * 100 ≈ 3571 concurrent calls when using the PCMU codec with SRTP enabled. For a more accurate estimate, further testing can be performed by modifying the test code directly, for example, increasing the number of simulated calls from 100 to 3500, and ensuring that the processing time does not exceed 1 second. Note that this only measures the media processing task.