### PR TITLE
[pjlib] fix invalid use of pj_sock_getsockname() in the BSD QoS backend

### DIFF
--- a/pjlib/src/pj/sock_qos_bsd.c
+++ b/pjlib/src/pj/sock_qos_bsd.c
@@ -42,7 +42,7 @@ PJ_DEF(pj_status_t) pj_sock_set_qos_params(pj_sock_t sock,
     if (param->flags & PJ_QOS_PARAM_HAS_DSCP) {
         /* We need to know if the socket is IPv4 or IPv6 */
         pj_sockaddr sa;
-        int salen = sizeof(salen);
+        int salen = sizeof(sa);
 
         /* Value is dscp_val << 2 */
         int val = (param->dscp_val << 2);
@@ -104,7 +104,7 @@ PJ_DEF(pj_status_t) pj_sock_get_qos_params(pj_sock_t sock,
     pj_status_t last_err = PJ_ENOTSUP;
     int val = 0, optlen;
     pj_sockaddr sa;
-    int salen = sizeof(salen);
+    int salen = sizeof(sa);
     pj_status_t status;
 
     pj_bzero(p_param, sizeof(*p_param));


### PR DESCRIPTION
In the QoS backend for BSD sockets the two functions `pj_sock_set_qos_params()` and `pj_sock_get_qos_params()`
use `pj_sock_getsockname()` with a wrong _namelen_ parameter. Instead of providing the size of the provided sockaddr struct, they're providing the size of _namelen_ itself.

I found this while investigating error messages on Windows,
because I keep getting errors when trying to set QoS related params.
There is another issue on Windows: Some socket options can only be set **after** a socket has been bound.
But this needs further investigation; if anything comes out of that it'll be another PR.