### PR TITLE
pj_stun_sock_create: Use pj_sockaddr_has_addr instead of checking socket family directly to account for network stacks that do not support IPv6.

### DIFF
--- a/pjnath/src/pjnath/stun_sock.c
+++ b/pjnath/src/pjnath/stun_sock.c
@@ -282,11 +282,8 @@ PJ_DEF(pj_status_t) pj_stun_sock_create( pj_stun_config *stun_cfg,
     if (cfg->port_range && cfg->port_range < max_bind_retry)
         max_bind_retry = cfg->port_range;
     pj_sockaddr_init(af, &bound_addr, NULL, 0);
-    if (cfg->bound_addr.addr.sa_family == pj_AF_INET() || 
-        cfg->bound_addr.addr.sa_family == pj_AF_INET6())
-    {
+    if (pj_sockaddr_has_addr(&cfg->bound_addr.addr))
         pj_sockaddr_cp(&bound_addr, &cfg->bound_addr);
-    }
     status = pj_sock_bind_random(stun_sock->sock_fd, &bound_addr,
                                  cfg->port_range, max_bind_retry);
     if (status != PJ_SUCCESS)


### PR DESCRIPTION
On some network stacks (like [lwIP](https://github.com/lwip-tcpip/lwip/blob/4599f551dead9eac233b91c0b9ee5879f5d0620a/src/include/lwip/sockets.h#L248)), `AF_INET6` is defined as `AF_UNSPEC (0)` when IPv6 is unavailable, which causes the bound_addr to be cleared, and bind to fail with "invalid address".

The previous code would copy a zeroed address and cause bind to fail:
```C
pj_sockaddr_init(af, &bound_addr, NULL, 0);
if (cfg->bound_addr.addr.sa_family == pj_AF_INET() || 
    cfg->bound_addr.addr.sa_family == pj_AF_INET6()) // <-- sa_family == 0
{
    pj_sockaddr_cp(&bound_addr, &cfg->bound_addr); // <-- clears bound_addr to zero
}
status = pj_sock_bind_random(stun_sock->sock_fd, &bound_addr, ...); // <-- fails with "invalid address"
```

New:
```C
pj_sockaddr_init(af, &bound_addr, NULL, 0);
if (pj_sockaddr_has_addr(&cfg->bound_addr.addr))
    pj_sockaddr_cp(&bound_addr, &cfg->bound_addr);
status = pj_sock_bind_random(stun_sock->sock_fd, &bound_addr, ...);
```

p.s. There are many places in the code that assume that IPv6 is available, and should probably be wrapped with `#if PJ_HAS_IPV6`