### PR TITLE
Improve performance of pj_get_timestamp on Darwin

### DIFF
--- a/pjlib/src/pj/os_timestamp_posix.c
+++ b/pjlib/src/pj/os_timestamp_posix.c
@@ -121,75 +121,18 @@ PJ_DEF(pj_status_t) pj_get_timestamp_freq(pj_timestamp *freq)
 
 #elif defined(PJ_DARWINOS) && PJ_DARWINOS != 0
 
-/* SYSTEM_CLOCK will stop when the device is in deep sleep, so we use
- * KERN_BOOTTIME instead. 
- * See ticket #2140 for more details.
- */
-#define USE_KERN_BOOTTIME 1
+#include <mach/mach.h>
+#include <mach/mach_time.h>
 
-#if USE_KERN_BOOTTIME
-#   include <sys/sysctl.h>
-#else
-#   include <mach/mach.h>
-#   include <mach/clock.h>
-#   include <errno.h>
-#endif
-
-#ifndef NSEC_PER_SEC
-#       define NSEC_PER_SEC     1000000000
-#endif
-
-#if USE_KERN_BOOTTIME
-static int64_t get_boottime()
-{
-    struct timeval boottime;
-    int mib[2] = {CTL_KERN, KERN_BOOTTIME};
-    size_t size = sizeof(boottime);
-    int rc;
-
-    rc = sysctl(mib, 2, &boottime, &size, NULL, 0);
-    if (rc != 0)
-      return 0;
-
-    return (int64_t)boottime.tv_sec * 1000000 + (int64_t)boottime.tv_usec;
-}
-#endif
+static mach_timebase_info_data_t timebase;
 
 PJ_DEF(pj_status_t) pj_get_timestamp(pj_timestamp *ts)
 {
-#if USE_KERN_BOOTTIME
-    int64_t before_now, after_now;
-    struct timeval now;
-
-    after_now = get_boottime();
-    do {
-        before_now = after_now;
-        gettimeofday(&now, NULL);
-        after_now = get_boottime();
-    } while (after_now != before_now);
-
-    ts->u64 = (int64_t)now.tv_sec * 1000000 + (int64_t)now.tv_usec;
-    ts->u64 -= before_now;
-    ts->u64 *= 1000;
-#else
-    mach_timespec_t tp;
-    int ret;
-    clock_serv_t serv;
-
-    ret = host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &serv);
-    if (ret != KERN_SUCCESS) {
-        return PJ_RETURN_OS_ERROR(EINVAL);
+    if (!timebase.denom) {
+        mach_timebase_info(&timebase);
     }
 
-    ret = clock_get_time(serv, &tp);
-    if (ret != KERN_SUCCESS) {
-        return PJ_RETURN_OS_ERROR(EINVAL);
-    }
-
-    ts->u64 = tp.tv_sec;
-    ts->u64 *= NSEC_PER_SEC;
-    ts->u64 += tp.tv_nsec;
-#endif
+    ts->u64 = mach_continuous_time() * timebase.numer / timebase.denom;
 
     return PJ_SUCCESS;
 }


### PR DESCRIPTION
Using match functions is faster than the syscall alternative. This is the implementation used on libuv (the Nodejs platform layer) amongst others.