### PR TITLE
Avoid calling `pj_log_get_level` when `level` is greater than `PJ_LOG_MAX_LEVEL`

### DIFF
--- a/pjlib/include/pj/log.h
+++ b/pjlib/include/pj/log.h
@@ -104,7 +104,7 @@ enum pj_log_decoration
  * @hideinitializer
  */
 #define PJ_LOG(level,arg)       do { \
-                                    if (level <= pj_log_get_level()) { \
+                                    if (level <= PJ_LOG_MAX_LEVEL && level <= pj_log_get_level()) { \
                                         pj_log_wrapper_##level(arg); \
                                     } \
                                 } while (0)


### PR DESCRIPTION
`PJ_LOG` macro is never used with a runtime value as the first argument, so adding a check against `PJ_LOG_MAX_LEVEL` will ensure that the compiler always optimizes away the code generated by it.

In addition to eliminating unneeded calls to `pj_log_get_level`, this will also reduce the size of generated binaries when `level` is greater than `PJ_LOG_MAX_LEVEL`.