### PR TITLE
Correctly escaping IPv6 address used in contact URI

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2026,7 +2026,7 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
                  PJSIP_TRANSPORT_SECURE;
         
         /* Enclose IPv6 address in square brackets */
-        if (tp->key.type & PJSIP_TRANSPORT_IPV6) {
+        if (pj_strchr(&via_addr, ':')) {
             beginquote = "[";
             endquote = "]";
         } else {
@@ -3930,7 +3930,7 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uac_contact( pj_pool_t *pool,
         return status;
 
     /* Enclose IPv6 address in square brackets */
-    if (tp_type & PJSIP_TRANSPORT_IPV6) {
+    if (pj_strchr(&addr.host, ':')) {
         beginquote = "[";
         endquote = "]";
     } else {
@@ -4143,7 +4143,7 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uas_contact( pj_pool_t *pool,
     }
 
     /* Enclose IPv6 address in square brackets */
-    if (tp_type & PJSIP_TRANSPORT_IPV6) {
+    if (pj_strchr(&local_addr, ':')) {
         beginquote = "[";
         endquote = "]";
     } else {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3689,6 +3689,10 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
     addr->host = tfla2_prm.ret_addr;
     addr->port = tfla2_prm.ret_port;
 
+    if (pj_strchr(&addr->host, ':')) {
+        tp_type |= PJSIP_TRANSPORT_IPV6;
+    }
+
     /* If we are behind NAT64, use the Contact and Via address from
      * the UDP6 transport, which should be obtained from STUN.
      */
@@ -3703,6 +3707,9 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
         if (status == PJ_SUCCESS) {
             update_addr = PJ_FALSE;
             addr->host = tfla2_prm2.ret_addr;
+            if (pj_strchr(&addr->host, ':')) {
+                tp_type |= PJSIP_TRANSPORT_IPV6;
+            }
             pj_strdup(acc->pool, &acc->via_addr.host, &addr->host);
             acc->via_addr.port = addr->port;
             acc->via_tp = (pjsip_transport *)tfla2_prm.ret_tp;
@@ -3723,6 +3730,9 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
                               &pjsua_var.tpdata[i].data.tp->local_name.host);
                     addr->port = (pj_uint16_t)
                                  pjsua_var.tpdata[i].data.tp->local_name.port;
+                    if (pj_strchr(&addr->host, ':')) {
+                        tp_type |= PJSIP_TRANSPORT_IPV6;
+                    }
                 }
                 break;
             }
@@ -3880,9 +3890,9 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
                 addr->port = tp->local_name.port;
                 tp_type = tp->key.type;
 
-                if (pj_strchr(&tp->local_name.host, ':')) {
+                 if (pj_strchr(&addr->host, ':')) {
                     tp_type |= PJSIP_TRANSPORT_IPV6;
-                }
+                 }
             }
         }
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2026,7 +2026,7 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
                  PJSIP_TRANSPORT_SECURE;
         
         /* Enclose IPv6 address in square brackets */
-        if (pj_strchr(&via_addr, ':')) {
+        if (tp->key.type & PJSIP_TRANSPORT_IPV6) {
             beginquote = "[";
             endquote = "]";
         } else {
@@ -3930,7 +3930,7 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uac_contact( pj_pool_t *pool,
         return status;
 
     /* Enclose IPv6 address in square brackets */
-    if (pj_strchr(&addr.host, ':')) {
+    if (tp_type & PJSIP_TRANSPORT_IPV6) {
         beginquote = "[";
         endquote = "]";
     } else {
@@ -4143,7 +4143,7 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uas_contact( pj_pool_t *pool,
     }
 
     /* Enclose IPv6 address in square brackets */
-    if (pj_strchr(&local_addr, ':')) {
+    if (tp_type & PJSIP_TRANSPORT_IPV6) {
         beginquote = "[";
         endquote = "]";
     } else {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3886,8 +3886,6 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
 
             if (update_addr) {
                 pj_strdup(pool, &addr->host, &tp->local_name.host);
-            
-                addr->port = tp->local_name.port;
                 tp_type = tp->key.type;
 
                  if (pj_strchr(&addr->host, ':')) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3888,10 +3888,11 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
                 pj_strdup(pool, &addr->host, &tp->local_name.host);
                 tp_type = tp->key.type;
 
-                 if (pj_strchr(&addr->host, ':')) {
+                if (pj_strchr(&addr->host, ':')) {
                     tp_type |= PJSIP_TRANSPORT_IPV6;
-                 }
+                }
             }
+            addr->port = tp->local_name.port;
         }
 
         /* Here the transport's ref counter WILL reach zero. But the

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3873,9 +3873,17 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
              * we are on NAT64 and already obtained the address
              * from STUN above.
              */
-            if (update_addr)
+
+            if (update_addr) {
                 pj_strdup(pool, &addr->host, &tp->local_name.host);
-            addr->port = tp->local_name.port;
+            
+                addr->port = tp->local_name.port;
+                tp_type = tp->key.type;
+
+                if (pj_strchr(&tp->local_name.host, ':')) {
+                    tp_type |= PJSIP_TRANSPORT_IPV6;
+                }
+            }
         }
 
         /* Here the transport's ref counter WILL reach zero. But the


### PR DESCRIPTION
If an IPv6 address is used in a contact URI it must be wrapped in square brackets. Otherwise the contact URI pjua builds is invalid. A validly escaped IPv6 address looks like this "[2001:0db8:0001:0000:0000:0ab9:C0A8:0102]:1234" where the port is added after the closing bracket. 
The existing code did not check if the address that was wrapped was an IPv6 address correctly so that during testing in an. IPv6/NAT64 network the IPv6 address was not correctly escaped. 
This resulted in pjsua being unable to register and make calls.

I also created an issue before this PR: #4586 This PR does solve that issue for me and seems to not cause issues.