### PR TITLE
Fix version string for Python setup

### DIFF
--- a/version.mak
+++ b/version.mak
@@ -2,7 +2,7 @@
 export PJ_VERSION_MAJOR  := 2
 export PJ_VERSION_MINOR  := 15
 export PJ_VERSION_REV    :=
-export PJ_VERSION_SUFFIX := -dev
+export PJ_VERSION_SUFFIX := dev
 
 export PJ_VERSION := $(PJ_VERSION_MAJOR).$(PJ_VERSION_MINOR)
 


### PR DESCRIPTION
To fix https://github.com/pjsip/pjproject/issues/3969.

Our version suffix convention already includes '-' (such as "-svn" back when we still used SVN, or "-dev" for now), so we don't need the extra '-'.

"-" comes from another part of the code and causes version became "pjsua2.15--dev" instead of "pjsua2.15-dev" and fails to python build.