### PR TITLE
Defer response for incoming SIP MESSAGE requests

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4782,6 +4782,21 @@ typedef struct pjsua_acc_config
      */
     pj_bool_t        use_shared_auth;
 
+    /**
+    * Specify how to process incoming SIP MESSAGE requests.
+    *
+    * When set to PJ_TRUE (asynchronous processing), incoming MESSAGE requests
+    * will create UAS transactions and defer response sending. Applications
+    * must use pjsua_im_respond_message() to send responses manually.
+    *
+    * When set to PJ_FALSE (immediate processing), incoming MESSAGE requests
+    * will be responded to immediately with SIP 200 OK (legacy behavior).
+    *
+    * Default: PJ_FALSE (immediate response for backward compatibility)
+    */
+    pj_bool_t        process_sip_message_async;
+
+
 } pjsua_acc_config;
 
 
@@ -7283,6 +7298,26 @@ PJ_DECL(pj_status_t) pjsua_im_typing(pjsua_acc_id acc_id,
                                      pj_bool_t is_typing,
                                      const pjsua_msg_data *msg_data);
 
+/**
+ * Send response to incoming MESSAGE request using the UAS transaction.
+ * This function should be used when the application wants to send a deferred
+ * response to an incoming MESSAGE request that was processed by a UAS transaction.
+ *
+ * @param rdata         The incoming MESSAGE request data (from on_pager2 callback).
+ * @param st_code       Status code to be sent (e.g., 200 for OK, 400 for
+ *                      Bad Request, etc.).
+ * @param st_text       Optional status text. If NULL, default status text
+ *                      for the status code will be used.
+ * @param hdr_list      Optional list of headers to be added to the response.
+ * @param body          Optional message body for the response.
+ *
+ * @return              PJ_SUCCESS on success, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsua_im_respond_message(pjsip_rx_data *rdata,
+                                              pjsip_transaction *tsx,
+                                              int st_code,
+                                              const pj_str_t *st_text,
+                                              const pjsip_hdr *hdr_list);
 
 
 /**

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -311,6 +311,17 @@ struct AccountSipConfig : public PersistentObject
      */
     bool        useSharedAuth;
 
+    /**
+     * Configure SIP MESSAGE processing behavior for this account.
+     * When set to true, incoming SIP MESSAGE requests will create UAS 
+     * transactions allowing for deferred responses. When set to false,
+     * incoming SIP MESSAGE requests will be responded to immediately
+     * with a 200 OK response (legacy behavior).
+     *
+     * Default: false (immediate response for backward compatibility)
+     */
+    bool        processSipMessageAsync;
+
 public:
     /**
      * Read this object from a container node.

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -398,6 +398,8 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
                                         PJSUA_CALL_UPDATE_VIA;
     cfg->enable_rtcp_xr = (PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR);
     cfg->use_shared_auth = PJ_FALSE;
+
+    cfg->process_sip_message_async = PJ_FALSE;
 }
 
 PJ_DEF(void) pjsua_buddy_config_default(pjsua_buddy_config *cfg)

--- a/pjsip/src/pjsua-lib/pjsua_im.c
+++ b/pjsip/src/pjsua-lib/pjsua_im.c
@@ -146,6 +146,21 @@ pj_bool_t pjsua_im_accept_pager(pjsip_rx_data *rdata,
     return PJ_TRUE;
 }
 
+static pj_bool_t is_typing_indication(pjsip_rx_data *rdata)
+{
+    PJ_ASSERT_RETURN(rdata, PJ_FALSE);
+    PJ_ASSERT_RETURN(rdata->msg_info.msg, PJ_FALSE);
+
+    pjsip_msg_body *body = rdata->msg_info.msg->body;
+
+    if (body && pj_stricmp(&body->content_type.type, &STR_MIME_APP)==0 &&
+        pj_stricmp(&body->content_type.subtype, &STR_MIME_ISCOMPOSING)==0)
+    {
+        return PJ_TRUE;
+    }
+    return PJ_FALSE;
+}
+
 /**
  * Private: process pager message.
  *          This may trigger pjsua_ui_on_pager() or pjsua_ui_on_typing().
@@ -178,8 +193,7 @@ void pjsua_im_process_pager(int call_id, const pj_str_t *from,
         contact.slen = 0;
     }
 
-    if (body && pj_stricmp(&body->content_type.type, &STR_MIME_APP)==0 &&
-        pj_stricmp(&body->content_type.subtype, &STR_MIME_ISCOMPOSING)==0)
+    if (is_typing_indication(rdata) == PJ_TRUE)
     {
         /* Expecting typing indication */
         pj_status_t status;
@@ -273,6 +287,7 @@ void pjsua_im_process_pager(int call_id, const pj_str_t *from,
  */
 static pj_bool_t im_on_rx_request(pjsip_rx_data *rdata)
 {
+    pjsua_acc_id acc_id = PJSUA_INVALID_ID;
     pj_str_t from, to;
     pjsip_accept_hdr *accept_hdr;
     pjsip_msg *msg;
@@ -304,13 +319,30 @@ static pj_bool_t im_on_rx_request(pjsip_rx_data *rdata)
         return PJ_TRUE;
     }
     
-    /* Respond with 200 first, so that remote doesn't retransmit in case
-     * the UI takes too long to process the message. 
-     */
-    pjsip_endpt_respond( pjsua_var.endpt, NULL, rdata, 200, NULL,
-                         NULL, NULL, NULL);
+    acc_id = pjsua_acc_find_for_incoming(rdata);
+    
+    if (acc_id != PJSUA_INVALID_ID && pjsua_var.acc[acc_id].cfg.process_sip_message_async == PJ_TRUE
+            && is_typing_indication(rdata) == PJ_FALSE) {
+        pjsip_transaction *tsx;
+        pj_status_t status;
 
-    /* For the source URI, we use Contact header if present, since
+        status = pjsip_tsx_create_uas(&mod_pjsua_im, rdata, &tsx);
+        if (status != PJ_SUCCESS) {
+            /* Fall back to immediate response if UAS creation fails */
+            pjsip_endpt_respond(pjsua_var.endpt, NULL, rdata, 500, NULL,
+                               NULL, NULL, NULL);
+            return PJ_TRUE;
+        }
+
+        pjsip_tsx_recv_msg(tsx, rdata);
+    }
+    else
+    {
+        /* Respond with 200 OK */
+        pjsip_endpt_respond( pjsua_var.endpt, NULL, rdata, 200, NULL,
+                             NULL, NULL, NULL);
+    }
+     /* For the source URI, we use Contact header if present, since
      * Contact header contains the port number information. If this is
      * not available, then use From header.
      */
@@ -331,7 +363,7 @@ static pj_bool_t im_on_rx_request(pjsip_rx_data *rdata)
         to = pj_str("<--URI is too long-->");
 
     /* Process pager. */
-    pjsua_im_process_pager(-1, &from, &to, rdata);
+    pjsua_im_process_pager(PJSUA_INVALID_ID, &from, &to, rdata);
 
     /* Done. */
     return PJ_TRUE;
@@ -744,6 +776,54 @@ PJ_DEF(pj_status_t) pjsua_im_typing( pjsua_acc_id acc_id,
                                        im_data, &typing_callback);
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Unable to send request", status);
+        return status;
+    }
+
+    return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_im_respond_message(pjsip_rx_data *rdata,
+                                             pjsip_transaction *tsx,
+                                             int st_code,
+                                             const pj_str_t *st_text,
+                                             const pjsip_hdr *hdr_list)
+{
+    pjsip_tx_data *tdata = NULL;
+    pj_status_t status;
+
+    PJ_ASSERT_RETURN(rdata != NULL, PJ_EINVAL);
+    PJ_ASSERT_RETURN(st_code >= 200 && st_code < 700, PJ_EINVAL);
+
+    if (!tsx) {
+        PJ_LOG(1,(THIS_FILE, "UAS transaction not found for MESSAGE response"));
+        return PJ_ENOTFOUND;
+    }
+
+    PJ_ASSERT_RETURN(tsx->role == PJSIP_ROLE_UAS, PJ_EINVAL);
+    PJ_ASSERT_RETURN(pjsip_method_cmp(&tsx->method, &pjsip_message_method) == 0,
+                     PJ_EINVAL);
+
+    status = pjsip_endpt_create_response(pjsua_var.endpt, rdata,
+                                        st_code, st_text, &tdata);
+    if (status != PJ_SUCCESS) {
+        pjsua_perror(THIS_FILE, "Unable to create response", status);
+        return status;
+    }
+
+    if (hdr_list) {
+        const pjsip_hdr *hdr = hdr_list;
+        while (hdr) {
+            pjsip_hdr *cloned_hdr = (pjsip_hdr*) pjsip_hdr_clone(tdata->pool, hdr);
+            pjsip_msg_add_hdr(tdata->msg, cloned_hdr);
+            hdr = hdr->next;
+            if (hdr == hdr_list) break;
+        }
+    }
+
+    status = pjsip_tsx_send_msg(tsx, tdata);
+    if (status != PJ_SUCCESS) {
+        pjsua_perror(THIS_FILE, "Unable to send response", status);
+        pjsip_tx_data_dec_ref(tdata);
         return status;
     }
 

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -282,6 +282,7 @@ void AccountSipConfig::readObject(const ContainerNode &node)
     NODE_READ_STRING    (this_node, authInitialAlgorithm);
     NODE_READ_INT       (this_node, transportId);
     NODE_READ_BOOL      (this_node, useSharedAuth);
+    NODE_READ_BOOL      (this_node, processSipMessageAsync);
 
     ContainerNode creds_node = this_node.readArray("authCreds");
     authCreds.resize(0);
@@ -305,6 +306,7 @@ void AccountSipConfig::writeObject(ContainerNode &node) const
     NODE_WRITE_STRING   (this_node, authInitialAlgorithm);
     NODE_WRITE_INT      (this_node, transportId);
     NODE_WRITE_BOOL     (this_node, useSharedAuth);
+    NODE_WRITE_BOOL     (this_node, processSipMessageAsync);
 
     ContainerNode creds_node = this_node.writeNewArray("authCreds");
     for (unsigned i=0; i<authCreds.size(); ++i) {
@@ -645,14 +647,15 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     for (i=0; i<sipConfig.proxies.size(); ++i) {
         ret.proxy[ret.proxy_cnt++] = str2Pj(sipConfig.proxies[i]);
     }
-    ret.force_contact           = str2Pj(sipConfig.contactForced);
-    ret.contact_params          = str2Pj(sipConfig.contactParams);
-    ret.contact_uri_params      = str2Pj(sipConfig.contactUriParams);
-    ret.auth_pref.initial_auth  = sipConfig.authInitialEmpty;
-    ret.auth_pref.algorithm     = str2Pj(sipConfig.authInitialAlgorithm);
-    ret.transport_id            = sipConfig.transportId;
-    ret.ipv6_sip_use            = sipConfig.ipv6Use;
-    ret.use_shared_auth         = sipConfig.useSharedAuth;
+    ret.force_contact             = str2Pj(sipConfig.contactForced);
+    ret.contact_params            = str2Pj(sipConfig.contactParams);
+    ret.contact_uri_params        = str2Pj(sipConfig.contactUriParams);
+    ret.auth_pref.initial_auth    = sipConfig.authInitialEmpty;
+    ret.auth_pref.algorithm       = str2Pj(sipConfig.authInitialAlgorithm);
+    ret.transport_id              = sipConfig.transportId;
+    ret.ipv6_sip_use              = sipConfig.ipv6Use;
+    ret.use_shared_auth           = sipConfig.useSharedAuth;
+    ret.process_sip_message_async = sipConfig.processSipMessageAsync;
 
     // AccountCallConfig
     ret.call_hold_type          = callConfig.holdType;
@@ -814,14 +817,15 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     for (i=0; i<prm.proxy_cnt; ++i) {
         sipConfig.proxies.push_back(pj2Str(prm.proxy[i]));
     }
-    sipConfig.contactForced     = pj2Str(prm.force_contact);
-    sipConfig.contactParams     = pj2Str(prm.contact_params);
-    sipConfig.contactUriParams  = pj2Str(prm.contact_uri_params);
-    sipConfig.authInitialEmpty  = PJ2BOOL(prm.auth_pref.initial_auth);
-    sipConfig.authInitialAlgorithm = pj2Str(prm.auth_pref.algorithm);
-    sipConfig.transportId       = prm.transport_id;
-    sipConfig.ipv6Use           = prm.ipv6_sip_use;
-    sipConfig.useSharedAuth     = PJ2BOOL(prm.use_shared_auth);
+    sipConfig.contactForced          = pj2Str(prm.force_contact);
+    sipConfig.contactParams          = pj2Str(prm.contact_params);
+    sipConfig.contactUriParams       = pj2Str(prm.contact_uri_params);
+    sipConfig.authInitialEmpty       = PJ2BOOL(prm.auth_pref.initial_auth);
+    sipConfig.authInitialAlgorithm   = pj2Str(prm.auth_pref.algorithm);
+    sipConfig.transportId            = prm.transport_id;
+    sipConfig.ipv6Use                = prm.ipv6_sip_use;
+    sipConfig.useSharedAuth          = PJ2BOOL(prm.use_shared_auth);
+    sipConfig.processSipMessageAsync = PJ2BOOL(prm.process_sip_message_async);
 
     // AccountCallConfig
     callConfig.holdType         = prm.call_hold_type;


### PR DESCRIPTION
For an incoming SIP MESSAGE request, the response is sent immediately. This is a backward-compatible minimal approach for processing incoming SIP MESSAGE transactions asynchronously (see #4589) by deferring the response.

A new account configuration disables immediately response, whereas a new function (PJSUA) can be used for send a response.

It is now possible to respond with a status code != 200.

Even with PJSUA2, deferring a response is possible:
```cpp
void onInstantMessage(pj::OnInstantMessageParam& parameter) override
     {
     pjsip_rx_data* received_data_clone = nullptr;
     // Life-time of msg_info ends at the end of this scope. Copies only msg_info deeply.
     pjsip_rx_data_clone(static_cast<pjsip_rx_data*>(parameter.rdata.pjRxData), 0,
                         &received_data_clone);
     // Life-time ends when PJSIP transaction ends, i.e. after calling pjsua_im_respond_messag(...).
     auto* tsx{pjsip_rdata_get_tsx(static_cast<pjsip_rx_data*>(parameter.rdata.pjRxData))};
     
    //...
     }

// Most probably called from the main thread.
void sendResponse(pjsip_rx_data *received_data_clone, pjsip_transaction *tsx)
    {
    auto text{to_pj_string("OK")};
    pjsua_im_respond_message(&received_data_clone, tsx, 200, &text, nullptr);
    // Life-time of tsx ends very soon.
    }
```

