### PR TITLE
Expose SIP and media ioqueue fds via pjsua2 Endpoint

### DIFF
--- a/pjlib/include/pj/ioqueue.h
+++ b/pjlib/include/pj/ioqueue.h
@@ -944,6 +944,17 @@ PJ_DECL(pj_status_t) pj_ioqueue_sendto( pj_ioqueue_key_t *key,
  */
 PJ_DECL(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue );
 
+/**
+ * Get the file descriptor associated with an ioqueue instance.
+ *
+ * @param ioqueue        The ioqueue instance.
+ *
+ * @return          The OS file descriptor associated with the instance.
+ *                  For epoll/kqueue this will be a value >= 0. For all
+ *                  other platforms, or if no handle is available, -1 will
+*                   be returned.
+ */
+PJ_DECL(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue );
 
 /**
  * @}

--- a/pjlib/src/pj/ioqueue_dummy.c
+++ b/pjlib/src/pj/ioqueue_dummy.c
@@ -202,4 +202,10 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return -1;
+}
+
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_NONE */

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -1088,4 +1088,9 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return ioqueue ? (pj_oshandle_t)&ioqueue->epfd : NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    return ioqueue ? ioqueue->epfd : -1;
+}
+
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_EPOLL */

--- a/pjlib/src/pj/ioqueue_kqueue.c
+++ b/pjlib/src/pj/ioqueue_kqueue.c
@@ -733,4 +733,9 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return ioqueue ? (pj_oshandle_t)&ioqueue->kfd : NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    return ioqueue ? ioqueue->kfd : -1;
+}
+
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_KQUEUE */

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -1148,4 +1148,10 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return -1;
+}
+
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_SELECT */

--- a/pjlib/src/pj/ioqueue_symbian.cpp
+++ b/pjlib/src/pj/ioqueue_symbian.cpp
@@ -875,4 +875,10 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return -1;
+}
+
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_SYMBIAN */

--- a/pjlib/src/pj/ioqueue_uwp.cpp
+++ b/pjlib/src/pj/ioqueue_uwp.cpp
@@ -372,4 +372,10 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return -1;
+}
+
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_UWP */

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -1699,5 +1699,10 @@ PJ_DEF(pj_oshandle_t) pj_ioqueue_get_os_handle( pj_ioqueue_t *ioqueue )
     return ioqueue ? (pj_oshandle_t)ioqueue->iocp : NULL;
 }
 
+PJ_DEF(int) pj_ioqueue_get_os_fd( pj_ioqueue_t *ioqueue )
+{
+    PJ_UNUSED_ARG(ioqueue);
+    return -1;
+}
 
 #endif /* PJ_IOQUEUE_IMP == PJ_IOQUEUE_IMP_IOCP */

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1545,6 +1545,19 @@ public:
      */
     void libDestroy(unsigned prmFlags=0) PJSUA2_THROW(Error);
 
+    /**
+     * Get the file descriptor associated with pjsua's SIP IO queue, if any.
+     * Returns an integer >= 0 if the IO queue is implemented with epoll or
+     * kqueue, otherwise returns -1.
+     */
+    int libGetSipIoQueueFd();
+
+    /**
+     * Get the file descriptor associated with pjsua's media IO queue, if any.
+     * Returns an integer >= 0 if the IO queue is implemented with epoll or
+     * kqueue, otherwise returns -1.
+     */
+    int libGetMediaIoQueueFd();
 
     /*************************************************************************
      * Utilities

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -2244,6 +2244,20 @@ void Endpoint::libDestroy(unsigned flags) PJSUA2_THROW(Error)
     PJSUA2_CHECK_RAISE_ERROR(status);
 }
 
+int Endpoint::libGetSipIoQueueFd()
+{
+    pjsip_endpoint* endp = pjsua_get_pjsip_endpt();
+    pj_ioqueue_t* ioq = pjsip_endpt_get_ioqueue(endp);
+    return pj_ioqueue_get_os_fd(ioq);
+}
+
+int Endpoint::libGetMediaIoQueueFd()
+{
+    pjmedia_endpt* endp = pjsua_get_pjmedia_endpt();
+    pj_ioqueue_t* ioq = pjmedia_endpt_get_ioqueue(endp);
+    return pj_ioqueue_get_os_fd(ioq);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 /*
  * Endpoint Utilities


### PR DESCRIPTION
This change lets python users integrate pjsua2 with their own event loops. Support is limited to platforms where the underlying PJ ioqueues are associated with a file descriptor (currently those that use epoll and kqueue).