### PR TITLE
Modify pjmedia_conf_enum_ports()'s ports parameter to be optional

### DIFF
--- a/pjmedia/include/pjmedia/conference.h
+++ b/pjmedia/include/pjmedia/conference.h
@@ -715,10 +715,12 @@ PJ_DECL(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
  * Enumerate occupied ports in the bridge.
  *
  * @param conf          The conference bridge.
- * @param ports         Array of port numbers to be filled in.
- * @param count         On input, specifies the maximum number of ports
- *                      in the array. On return, it will be filled with
- *                      the actual number of ports.
+ * @param ports         Optional array of port numbers to be filled in.
+ * @param count         If ports array is specified, on input, specifies
+ *                      the maximum number of ports in the array.
+ *                      Regardless of whether ports array is specified,
+ *                      on return, it will be filled with the actual
+ *                      number of ports.
  *
  * @return              PJ_SUCCESS on success.
  */

--- a/pjmedia/src/pjmedia/conf_switch.c
+++ b/pjmedia/src/pjmedia/conf_switch.c
@@ -856,7 +856,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
             continue;
 
         if (ports)
-             ports[count] = i;
+            ports[count] = i;
         count++;
     }
 

--- a/pjmedia/src/pjmedia/conf_switch.c
+++ b/pjmedia/src/pjmedia/conf_switch.c
@@ -844,16 +844,20 @@ PJ_DEF(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
 {
     unsigned i, count=0;
 
-    PJ_ASSERT_RETURN(conf && p_count && ports, PJ_EINVAL);
+    PJ_ASSERT_RETURN(conf && p_count, PJ_EINVAL);
 
     /* Lock mutex */
     pj_mutex_lock(conf->mutex);
 
-    for (i=0; i<conf->max_ports && count<*p_count; ++i) {
+    for (i=0; i<conf->max_ports; ++i) {
+        if (ports && count >= *p_count)
+            break;
         if (!conf->ports[i])
             continue;
 
-        ports[count++] = i;
+        if (ports)
+             ports[count] = i;
+        count++;
     }
 
     /* Unlock mutex */

--- a/pjmedia/src/pjmedia/conf_thread.c
+++ b/pjmedia/src/pjmedia/conf_thread.c
@@ -2490,16 +2490,20 @@ PJ_DEF(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
 {
     unsigned i, count=0;
 
-    PJ_ASSERT_RETURN(conf && p_count && ports, PJ_EINVAL);
+    PJ_ASSERT_RETURN(conf && p_count, PJ_EINVAL);
 
     /* Lock mutex */
     pj_mutex_lock(conf->mutex);
 
-    for (i=0; i<conf->max_ports && count<*p_count; ++i) {
+    for (i=0; i<conf->max_ports; ++i) {
+        if (ports && count >= *p_count)
+            break;
         if (!conf->ports[i])
             continue;
 
-        ports[count++] = i;
+        if (ports)
+             ports[count] = i;
+        count++;
     }
 
     /* Unlock mutex */

--- a/pjmedia/src/pjmedia/conf_thread.c
+++ b/pjmedia/src/pjmedia/conf_thread.c
@@ -2502,7 +2502,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
             continue;
 
         if (ports)
-             ports[count] = i;
+            ports[count] = i;
         count++;
     }
 

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1945,16 +1945,20 @@ PJ_DEF(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
 {
     unsigned i, count=0;
 
-    PJ_ASSERT_RETURN(conf && p_count && ports, PJ_EINVAL);
+    PJ_ASSERT_RETURN(conf && p_count, PJ_EINVAL);
 
     /* Lock mutex */
     pj_mutex_lock(conf->mutex);
 
-    for (i=0; i<conf->max_ports && count<*p_count; ++i) {
+    for (i=0; i<conf->max_ports; ++i) {
+        if (ports && count >= *p_count)
+            break;
         if (!conf->ports[i])
             continue;
 
-        ports[count++] = i;
+        if (ports)
+             ports[count] = i;
+        count++;
     }
 
     /* Unlock mutex */

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1957,7 +1957,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_enum_ports( pjmedia_conf *conf,
             continue;
 
         if (ports)
-             ports[count] = i;
+            ports[count] = i;
         count++;
     }
 


### PR DESCRIPTION
Based on #4585.
For efficiency, allow the ports parameter in the API `pjmedia_conf_enum_ports()` to be optional.

Thanks to @PesalaDeSilva for the original patch.
