### PR TITLE
Fix sip auth if OpenSSL MD5 is unavailable

### DIFF
--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -78,6 +78,35 @@
 #define EVP_MD_CTX_free(mdctx)
 #endif
 
+/*
+ * When building with OpenSSL, MD5 may not be available (e.g., FIPS-only
+ * configurations). Detect MD5 availability once and, if missing, fall back
+ * to pjlib's internal MD5 implementation for MD5-based digests.
+ */
+#if defined(PJ_HAS_SSL_SOCK) && PJ_HAS_SSL_SOCK != 0 && \
+    PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+static int g_md5_evp_supported = -1; /* -1=unknown, 0=no, 1=yes */
+static pj_bool_t md5_evp_is_supported(void)
+{
+    if (g_md5_evp_supported == -1) {
+        const EVP_MD *md = EVP_get_digestbyname("MD5");
+        if (!md) {
+            g_md5_evp_supported = 0;
+        } else {
+            EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+            if (!ctx) {
+                g_md5_evp_supported = 0;
+            } else {
+                /* EVP_DigestInit_ex will fail in strict FIPS environments */
+                g_md5_evp_supported = (EVP_DigestInit_ex(ctx, md, NULL) == 1) ? 1 : 0;
+                EVP_MD_CTX_free(ctx);
+            }
+        }
+    }
+    return g_md5_evp_supported ? PJ_TRUE : PJ_FALSE;
+}
+#endif
+
 const pjsip_auth_algorithm pjsip_auth_algorithms[] = {
 /*    TYPE                             IANA name            OpenSSL name */
 /*      Raw digest byte length  Hex representation length                */
@@ -232,6 +261,7 @@ PJ_DEF(pj_status_t) pjsip_auth_create_digest2( pj_str_t *result,
     unsigned dig_len = 0;
     const EVP_MD* md;
     DEFINE_HASH_CONTEXT;
+    pj_bool_t use_builtin_md5 = PJ_FALSE;
 
     PJ_ASSERT_RETURN(result && nonce && uri && realm && cred_info && method, PJ_EINVAL);
     pj_bzero(result->ptr, result->slen);
@@ -294,8 +324,15 @@ PJ_DEF(pj_status_t) pjsip_auth_create_digest2( pj_str_t *result,
     }
 
     md = EVP_get_digestbyname(algorithm->openssl_name);
-    if (md == NULL) {
-        /* Shouldn't happen since it was checked above */
+    /* For MD5, if OpenSSL doesn't provide/allow it, we'll fallback. */
+#if defined(PJ_HAS_SSL_SOCK) && PJ_HAS_SSL_SOCK != 0 && \
+    PJ_SSL_SOCK_IMP==PJ_SSL_SOCK_IMP_OPENSSL
+    if (algorithm->algorithm_type == PJSIP_AUTH_ALGORITHM_MD5 && !md5_evp_is_supported()) {
+        use_builtin_md5 = PJ_TRUE;
+    }
+#endif
+    if (md == NULL && !use_builtin_md5) {
+        /* Shouldn't happen since it was checked above, unless provider disabled; */
         return PJ_ENOTSUP;
     }
 
@@ -309,17 +346,27 @@ PJ_DEF(pj_status_t) pjsip_auth_create_digest2( pj_str_t *result,
         /***
          *** ha1 = (digest)(username ":" realm ":" password)
          ***/
-        mdctx = EVP_MD_CTX_new();
-
-        EVP_DigestInit_ex(mdctx, md, NULL);
-        EVP_DigestUpdate(mdctx, cred_info->username.ptr, cred_info->username.slen);
-        EVP_DigestUpdate(mdctx, ":", 1);
-        EVP_DigestUpdate(mdctx, realm->ptr, realm->slen);
-        EVP_DigestUpdate(mdctx, ":", 1);
-        EVP_DigestUpdate(mdctx, cred_info->data.ptr, cred_info->data.slen);
-
-        EVP_DigestFinal_ex(mdctx, digest, &dig_len);
-        EVP_MD_CTX_free(mdctx);
+        if (use_builtin_md5) {
+            pj_md5_context ctx;
+            pj_md5_init(&ctx);
+            pj_md5_update(&ctx, (const pj_uint8_t*)cred_info->username.ptr, (unsigned)cred_info->username.slen);
+            pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+            pj_md5_update(&ctx, (const pj_uint8_t*)realm->ptr, (unsigned)realm->slen);
+            pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+            pj_md5_update(&ctx, (const pj_uint8_t*)cred_info->data.ptr, (unsigned)cred_info->data.slen);
+            pj_md5_final(&ctx, digest);
+            dig_len = digest_len;
+        } else {
+            mdctx = EVP_MD_CTX_new();
+            EVP_DigestInit_ex(mdctx, md, NULL);
+            EVP_DigestUpdate(mdctx, cred_info->username.ptr, cred_info->username.slen);
+            EVP_DigestUpdate(mdctx, ":", 1);
+            EVP_DigestUpdate(mdctx, realm->ptr, realm->slen);
+            EVP_DigestUpdate(mdctx, ":", 1);
+            EVP_DigestUpdate(mdctx, cred_info->data.ptr, cred_info->data.slen);
+            EVP_DigestFinal_ex(mdctx, digest, &dig_len);
+            EVP_MD_CTX_free(mdctx);
+        }
         digestNtoStr(digest, dig_len, ha1);
 
     } else {
@@ -333,13 +380,23 @@ PJ_DEF(pj_status_t) pjsip_auth_create_digest2( pj_str_t *result,
     /***
      *** ha2 = (digest)(method ":" req_uri)
      ***/
-    mdctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(mdctx, md, NULL);
-    EVP_DigestUpdate(mdctx, method->ptr, method->slen);
-    EVP_DigestUpdate(mdctx, ":", 1);
-    EVP_DigestUpdate(mdctx, uri->ptr, uri->slen);
-    EVP_DigestFinal_ex(mdctx, digest, &dig_len);
-    EVP_MD_CTX_free(mdctx);
+    if (use_builtin_md5) {
+        pj_md5_context ctx;
+        pj_md5_init(&ctx);
+        pj_md5_update(&ctx, (const pj_uint8_t*)method->ptr, (unsigned)method->slen);
+        pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+        pj_md5_update(&ctx, (const pj_uint8_t*)uri->ptr, (unsigned)uri->slen);
+        pj_md5_final(&ctx, digest);
+        dig_len = digest_len;
+    } else {
+        mdctx = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(mdctx, md, NULL);
+        EVP_DigestUpdate(mdctx, method->ptr, method->slen);
+        EVP_DigestUpdate(mdctx, ":", 1);
+        EVP_DigestUpdate(mdctx, uri->ptr, uri->slen);
+        EVP_DigestFinal_ex(mdctx, digest, &dig_len);
+        EVP_MD_CTX_free(mdctx);
+    }
     digestNtoStr(digest, dig_len, ha2);
 
     AUTH_TRACE_((THIS_FILE, " ha2=%.*s", algorithm->digest_str_length, ha2));
@@ -351,24 +408,43 @@ PJ_DEF(pj_status_t) pjsip_auth_create_digest2( pj_str_t *result,
      *** When qop=auth is used:
      ***   response = (digest)(ha1 ":" nonce ":" nc ":" cnonce ":" qop ":" ha2)
      ***/
-    mdctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(mdctx, md, NULL);
-    EVP_DigestUpdate(mdctx, ha1, digest_strlen);
-    EVP_DigestUpdate(mdctx, ":", 1);
-    EVP_DigestUpdate(mdctx, nonce->ptr, nonce->slen);
-    if (qop && qop->slen != 0) {
+    if (use_builtin_md5) {
+        pj_md5_context ctx;
+        pj_md5_init(&ctx);
+        pj_md5_update(&ctx, (const pj_uint8_t*)ha1, (unsigned)digest_strlen);
+        pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+        pj_md5_update(&ctx, (const pj_uint8_t*)nonce->ptr, (unsigned)nonce->slen);
+        if (qop && qop->slen != 0) {
+            pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+            pj_md5_update(&ctx, (const pj_uint8_t*)nc->ptr, (unsigned)nc->slen);
+            pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+            pj_md5_update(&ctx, (const pj_uint8_t*)cnonce->ptr, (unsigned)cnonce->slen);
+            pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+            pj_md5_update(&ctx, (const pj_uint8_t*)qop->ptr, (unsigned)qop->slen);
+        }
+        pj_md5_update(&ctx, (const pj_uint8_t*)":", 1);
+        pj_md5_update(&ctx, (const pj_uint8_t*)ha2, (unsigned)digest_strlen);
+        pj_md5_final(&ctx, digest);
+        dig_len = digest_len;
+    } else {
+        mdctx = EVP_MD_CTX_new();
+        EVP_DigestInit_ex(mdctx, md, NULL);
+        EVP_DigestUpdate(mdctx, ha1, digest_strlen);
         EVP_DigestUpdate(mdctx, ":", 1);
-        EVP_DigestUpdate(mdctx, nc->ptr, nc->slen);
+        EVP_DigestUpdate(mdctx, nonce->ptr, nonce->slen);
+        if (qop && qop->slen != 0) {
+            EVP_DigestUpdate(mdctx, ":", 1);
+            EVP_DigestUpdate(mdctx, nc->ptr, nc->slen);
+            EVP_DigestUpdate(mdctx, ":", 1);
+            EVP_DigestUpdate(mdctx, cnonce->ptr, cnonce->slen);
+            EVP_DigestUpdate(mdctx, ":", 1);
+            EVP_DigestUpdate(mdctx, qop->ptr, qop->slen);
+        }
         EVP_DigestUpdate(mdctx, ":", 1);
-        EVP_DigestUpdate(mdctx, cnonce->ptr, cnonce->slen);
-        EVP_DigestUpdate(mdctx, ":", 1);
-        EVP_DigestUpdate(mdctx, qop->ptr, qop->slen);
+        EVP_DigestUpdate(mdctx, ha2, digest_strlen);
+        EVP_DigestFinal_ex(mdctx, digest, &dig_len);
+        EVP_MD_CTX_free(mdctx);
     }
-    EVP_DigestUpdate(mdctx, ":", 1);
-    EVP_DigestUpdate(mdctx, ha2, digest_strlen);
-
-    EVP_DigestFinal_ex(mdctx, digest, &dig_len);
-    EVP_MD_CTX_free(mdctx);
 
     /* Convert digest to string and store in chal->response. */
     result->slen = digest_strlen;
@@ -488,7 +564,10 @@ PJ_DEF(pj_bool_t) pjsip_auth_is_algorithm_supported(
 #ifdef HAVE_NO_OPENSSL
     return (algorithm_type == PJSIP_AUTH_ALGORITHM_MD5);
 #else
-    {
+    /* For MD5, allow support even if OpenSSL disables it; we'll fallback. */
+    if (algorithm_type == PJSIP_AUTH_ALGORITHM_MD5) {
+        return PJ_TRUE;
+    } else {
         const EVP_MD* md;
         md = EVP_get_digestbyname(algorithm->openssl_name);
         if (md == NULL) {
@@ -1762,4 +1841,3 @@ PJ_DEF(pj_status_t) pjsip_auth_clt_reinit_req(  pjsip_auth_clt_sess *sess,
     return PJ_SUCCESS;
 
 }
-


### PR DESCRIPTION
This is identical to #4597, but against the master branch.
