### PR TITLE
Fix keyframe detection with libavcodec 58.137 and later

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1662,13 +1662,21 @@ static pj_status_t ffmpeg_codec_encode_whole(pjmedia_vid_codec *codec,
                     break;
                 }
                 if (err >= 0) {
-                    pj_memcpy(bits_out, pkt->data, pkt->size);
-                    bits_out += pkt->size;
                     out_size += pkt->size;
+                    if (out_size <= output_buf_len) {
+                        pj_memcpy(bits_out, pkt->data, pkt->size);
+                        bits_out += pkt->size;
+                    }
                     av_packet_unref(pkt);
                 }
             }
             av_packet_free(&pkt);
+            if (out_size > output_buf_len) {
+                PJ_LOG(2, (THIS_FILE,
+                    "Output frame size (%u) exceeds buffer size (%u)",
+                     out_size, output_buf_len));
+                return PJ_ETOOSMALL;
+            }
         }
     }
 

--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1665,7 +1665,7 @@ static pj_status_t ffmpeg_codec_encode_whole(pjmedia_vid_codec *codec,
                     pj_memcpy(bits_out, pkt->data, pkt->size);
                     bits_out += pkt->size;
                     out_size += pkt->size;
-                    av_packet_unref(&avpacket);
+                    av_packet_unref(pkt);
                 }
             }
             av_packet_free(&pkt);


### PR DESCRIPTION
Outgoing keyframes are not correctly detected when encoded with contemporary libavcodec versions. The reason is that the relevant flag is checked from an incorrect `AVPacket` instance, which is used to receive packets with older libavcodec versions. This defect prevents e.g. sending forced or the periodic keyframes in the beginning of the stream.

This PR contains the following improvements pertaining to libavcodec version 58.137 and later:
* Fix to the aforementioned keyframe issue
* Unreference the correct `AVPacket` instance in the reception loop
* Safeguards against buffer overflow