### PR TITLE
Add manual host candidates for ICE

### DIFF
--- a/pjnath/include/pjnath/ice_strans.h
+++ b/pjnath/include/pjnath/ice_strans.h
@@ -248,6 +248,17 @@ typedef struct pj_ice_strans_stun_cfg
     unsigned             max_host_cands;
 
     /**
+     * Optional configuration for manually specifying host candidates.
+     * Useful for applications that need to assign a specific IP address
+     * as the host candidate. The candidate will use the same port as
+     * the automatic/base host candidate.
+     *
+     * Note that this setting will be used only when STUN server is
+     * not configured.
+     */
+    pj_sockaddr          manual_host[PJ_ICE_MAX_STUN];
+
+    /**
      * Include loopback addresses in the host candidates.
      *
      * Default: PJ_FALSE

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -3894,6 +3894,17 @@ typedef struct pjsua_ice_config
     int                 ice_max_host_cands;
 
     /**
+     * Optional configuration for manually specifying host candidates.
+     * Useful for applications that need to assign a specific IP address
+     * as the host candidate. The candidate will use the same port as
+     * the automatic/base host candidate.
+     *
+     * Note that this setting will be used only when STUN server is
+     * not configured.
+     */
+    pj_sockaddr         ice_manual_host[PJ_ICE_MAX_STUN];
+
+    /**
      * ICE session options.
      */
     pj_ice_sess_options ice_opt;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1267,6 +1267,11 @@ static pj_status_t create_ice_media_transport(
 
             /* Configure max packet size */
             ice_cfg.stun_tp[i].cfg.max_pkt_size = PJMEDIA_MAX_MRU;
+
+            /* Configure manual host candidates */
+            pj_memcpy(&ice_cfg.stun_tp[i].manual_host,
+                      &acc_cfg->ice_cfg.ice_manual_host,
+                      sizeof(ice_cfg.stun_tp[i].manual_host));
         }
     }
 


### PR DESCRIPTION
This is useful in systems that have both internal and public IP addresses and aim to use ICE without STUN, thereby simplifying the overall architecture.

This feature can be used via `pjsua_ice_config.ice_manual_host`:
```
    /**
     * Optional configuration for manually specifying host candidates.
     * Useful for applications that need to assign a specific IP address
     * as the host candidate. The candidate will use the same port as
     * the automatic/base host candidate.
     *
     * Note that this setting will be used only when STUN server is
     * not configured.
     */
    pj_sockaddr         ice_manual_host[PJ_ICE_MAX_STUN];
```

Thanks Hyun Chul Kim for the feedback.