### PR TITLE
Fix failed android unit test on video call

### DIFF
--- a/pjsip-apps/src/swig/java/android/app/build.gradle
+++ b/pjsip-apps/src/swig/java/android/app/build.gradle
@@ -40,6 +40,7 @@ android {
 dependencies {
     implementation project(path: ':pjsua2')
     implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.5.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
@@ -331,6 +331,10 @@ public class CallActivity extends Activity
 
                 remoteVideoHandler.setVideoWindow(cmi.getVideoWindow());
                 setupIncomingVideoLayout();
+                if (BuildConfig.IS_TEST) {
+                    if (!MainActivity.getIdlingResource().isIdleNow())
+                        MainActivity.getIdlingResource().decrement();
+                }
             }
 
         } else {

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/MainActivity.java
@@ -44,6 +44,7 @@ import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import androidx.core.app.ActivityCompat;
+import androidx.test.espresso.idling.CountingIdlingResource;
 
 import org.pjsip.PjCameraInfo2;
 import org.pjsip.pjsua2.AccountConfig;
@@ -85,6 +86,13 @@ public class MainActivity extends Activity
     private int buddyListSelectedIdx = -1;
     ArrayList<Map<String, String>> buddyList;
     private String lastRegStatus = "";
+
+    private static CountingIdlingResource idlingResource =
+        new CountingIdlingResource("TestResource");
+
+    public static CountingIdlingResource getIdlingResource() {
+        return idlingResource;
+    }
 
     private final Handler handler = new Handler(this);
     public class MSG_TYPE
@@ -498,6 +506,7 @@ public class MainActivity extends Activity
            {
                return;
            }
+           idlingResource.increment();
        }
 
         if (buddyListSelectedIdx == -1)
@@ -731,8 +740,9 @@ public class MainActivity extends Activity
         }
         /* Forward the message to CallActivity */
         if (CallActivity.handler_ != null) {
+            OnCallMediaEventParam cpParam = new OnCallMediaEventParam(prm);
             Message m = Message.obtain(CallActivity.handler_,
-                MSG_TYPE.CALL_MEDIA_EVENT, prm);
+                MSG_TYPE.CALL_MEDIA_EVENT, cpParam);
             m.sendToTarget();
         }
     }

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -184,6 +184,7 @@ using namespace pj;
     %ignore pj::Endpoint::utilAddPendingJob;
 #endif
 
+%copyctor pj::OnCallMediaEventParam;
 
 //
 // Ignore stuffs in pjsua2


### PR DESCRIPTION
On the Android unit test (#4372), it sometimes fails when checking for the incoming video.

The incoming video is set up in
https://github.com/pjsip/pjproject/blob/680c32931fba7dae5b163c2a5da154057148d9c5/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java#L316-L333

which is executed by the message handler thread. 

The `onCallMediaEvent()` callback will pass the `OnCallMediaEventParam` object to the message handler.
However, when it is executed, the original `OnCallMediaEventParam` object might have been deleted.
Therefore, no incoming video will be displayed, and the unit test failed.

This patch will add an option to generate a copy constructor for `OnCallMediaEventParam` and pass the copy instead of using the original object.

This patch also changes the method to check if a view is shown/displayed by using the `CountIdlingResource`. 
This will speed up the unit test ~5s.