### PR TITLE
Fix wrong TCP/TLS source port in Contact & Via

### DIFF
--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -678,7 +678,12 @@ static pj_status_t tcp_create( struct tcp_listener *listener,
 
     /* Use listener's published address, if any. */
     tcp->base.has_addr_name = listener->factory.has_addr_name;
-    tcp->base.local_name = listener->factory.addr_name;
+    if (listener->factory.has_addr_name) {
+        tcp->base.local_name = listener->factory.addr_name;
+    } else {
+        sockaddr_to_host_port(pool, &tcp->base.local_name,
+                              &tcp->base.local_addr);
+    }
 
     sockaddr_to_host_port(pool, &tcp->base.remote_name, remote);
     tcp->base.dir = is_server? PJSIP_TP_DIR_INCOMING : PJSIP_TP_DIR_OUTGOING;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -925,7 +925,12 @@ static pj_status_t tls_create( struct tls_listener *listener,
     
     /* Use listener's published address, if any. */
     tls->base.has_addr_name = listener->factory.has_addr_name;
-    tls->base.local_name = listener->factory.addr_name;
+    if (listener->factory.has_addr_name) {
+        tls->base.local_name = listener->factory.addr_name;
+    } else {
+        sockaddr_to_host_port(pool, &tls->base.local_name,
+                              &tls->base.local_addr);
+    }
 
     if (tls->remote_name.slen) {
         tls->base.remote_name.host = tls->remote_name;


### PR DESCRIPTION
It was reported that the Contact and Via headers in REGISTER requests are using the listener port instead of the actual port, which did not occur in older PJSIP versions.

Upon investigation, this behavior appears to be introduced by #4411, which always initializes the TCP/TLS local name using the listener's local name, regardless of whether the published address setting is configured

Thanks to Marcus Froeschl for the report.