### PR TITLE
pjsua_media: Exclude usage of potentially uninitialized mvididx array when video is disabled.

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -2427,13 +2427,13 @@ pj_status_t pjsua_media_channel_init(pjsua_call_id call_id,
     const pj_str_t STR_TEXT  = { "text", 4 };
     pjsua_call *call = &pjsua_var.calls[call_id];
     pjsua_acc *acc = &pjsua_var.acc[call->acc_id];
-    pj_uint8_t maudidx[PJSUA_MAX_CALL_MEDIA];
+    pj_uint8_t maudidx[PJSUA_MAX_CALL_MEDIA] = {0};
     unsigned maudcnt = PJ_ARRAY_SIZE(maudidx);
     unsigned mtotaudcnt = PJ_ARRAY_SIZE(maudidx);
-    pj_uint8_t mvididx[PJSUA_MAX_CALL_MEDIA];
+    pj_uint8_t mvididx[PJSUA_MAX_CALL_MEDIA] = {0};
     unsigned mvidcnt = PJ_ARRAY_SIZE(mvididx);
     unsigned mtotvidcnt = PJ_ARRAY_SIZE(mvididx);
-    pj_uint8_t mtxtidx[PJSUA_MAX_CALL_MEDIA];
+    pj_uint8_t mtxtidx[PJSUA_MAX_CALL_MEDIA] = {0};
     unsigned mtxtcnt = PJ_ARRAY_SIZE(mtxtidx);
     unsigned mtottxtcnt = PJ_ARRAY_SIZE(mtxtidx);
     unsigned mi;
@@ -4396,15 +4396,15 @@ pj_status_t pjsua_media_channel_update(pjsua_call_id call_id,
     const pj_str_t STR_AUDIO = { "audio", 5 };
     const pj_str_t STR_VIDEO = { "video", 5 };
     const pj_str_t STR_TEXT  = { "text", 4 };
-    pj_uint8_t maudidx[PJSUA_MAX_CALL_MEDIA];
+    pj_uint8_t maudidx[PJSUA_MAX_CALL_MEDIA] = {0};
     unsigned maudcnt = PJ_ARRAY_SIZE(maudidx);
     unsigned mtotaudcnt = PJ_ARRAY_SIZE(maudidx);
-    pj_uint8_t mvididx[PJSUA_MAX_CALL_MEDIA];
+    pj_uint8_t mvididx[PJSUA_MAX_CALL_MEDIA] = {0};
     unsigned mvidcnt = PJ_ARRAY_SIZE(mvididx);
     unsigned mtotvidcnt = PJ_ARRAY_SIZE(mvididx);
-    pj_uint8_t mtxtidx[PJSUA_MAX_CALL_MEDIA];
-    unsigned mtxtcnt = PJ_ARRAY_SIZE(mvididx);
-    unsigned mtottxtcnt = PJ_ARRAY_SIZE(mvididx);
+    pj_uint8_t mtxtidx[PJSUA_MAX_CALL_MEDIA] = {0};
+    unsigned mtxtcnt = PJ_ARRAY_SIZE(mtxtidx);
+    unsigned mtottxtcnt = PJ_ARRAY_SIZE(mtxtidx);
     pj_bool_t need_renego_sdp = PJ_FALSE;
 
     if (pjsua_get_state() != PJSUA_STATE_RUNNING)


### PR DESCRIPTION
Fixes warning (as errors) with GCC compilers:
* gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
* gcc (Ubuntu 14.2.0-19ubuntu2) 14.2.0
* Other compilers (like clang and Visual Studio) do not report this error.

```C
In function ‘pj_memchr’,
    inlined from ‘pjsua_media_channel_init’ at pjsip/pjproject/pjsip/src/pjsua-lib/pjsua_media.c:2694:20:
pjsip/pjproject/pjlib/include/pj/string.h:897:12: error: ‘mvididx’ may be used uninitialized [-Werror=maybe-uninitialized]
  897 |     return (void*)memchr((void*)buf, c, size);

In function ‘pj_memchr’,
    inlined from ‘pjsua_media_channel_init’ at pjsip/pjproject/pjsip/src/pjsua-lib/pjsua_media.c:2697:17:
pjsip/pjproject/pjlib/include/pj/string.h:897:12: error: ‘mvididx’ may be used uninitialized [-Werror=maybe-uninitialized]
  897 |     return (void*)memchr((void*)buf, c, size);
```

After some bisecting, it was introduced indirectly by #4585 seemingly because the `pjsua_var.calls` array is no longer pre-allocated-- likely confusing the GCC optimizer.

Let me know if this is the correct fix.