### PR TITLE
Fixed crash if pjsua is destroyed prematurely

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -4141,9 +4141,11 @@ PJ_DEF(void) pjsua_call_hangup_all(void)
     // This may deadlock, see https://github.com/pjsip/pjproject/issues/1305
     //PJSUA_LOCK();
 
-    for (i=0; i<pjsua_var.ua_cfg.max_calls; ++i) {
-        if (pjsua_var.calls[i].inv)
-            pjsua_call_hangup(i, 0, NULL, NULL);
+    if (pjsua_var.calls) {
+        for (i=0; i<pjsua_var.ua_cfg.max_calls; ++i) {
+            if (pjsua_var.calls[i].inv)
+                pjsua_call_hangup(i, 0, NULL, NULL);
+        }
     }
 
     //PJSUA_UNLOCK();

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1977,15 +1977,17 @@ PJ_DEF(pj_status_t) pjsua_destroy2(unsigned flags)
         pj_log_push_indent();
 
         /* Terminate all calls. */
-        if ((flags & PJSUA_DESTROY_NO_TX_MSG) == 0) {
-            pjsua_call_hangup_all();
-        } else {
-            /* Deinit media channel of all calls (see #1717) */
-            for (i=0; i<(int)pjsua_var.ua_cfg.max_calls; ++i) {
-                /* TODO: check if we're not allowed to send to network in the
-                 *       "flags", and if so do not do TURN allocation...
-                 */
-                pjsua_media_channel_deinit(i);
+        if (pjsua_var.calls) {
+            if ((flags & PJSUA_DESTROY_NO_TX_MSG) == 0) {
+                pjsua_call_hangup_all();
+            } else {
+                /* Deinit media channel of all calls (see #1717) */
+                for (i=0; i<(int)pjsua_var.ua_cfg.max_calls; ++i) {
+                    /* TODO: check if we're not allowed to send to network in
+                     *       the "flags", and if so do not do TURN allocation...
+                     */
+                    pjsua_media_channel_deinit(i);
+                }
             }
         }
 


### PR DESCRIPTION
If pjsua initialization `pjsua_init()` fails or app calls pjsua destroy without proper initialization, app may crash:
```
  * frame #0: 0x00000001000a0c20 pjsua-aarch64-apple-darwin24.5.0`pjsua_call_hangup_all at pjsua_call.c:4141:32
    frame #1: 0x00000001000b7dc4 pjsua-aarch64-apple-darwin24.5.0`pjsua_destroy2(flags=0) at pjsua_core.c:1981:13
    frame #2: 0x00000001000b17b0 pjsua-aarch64-apple-darwin24.5.0`pjsua_destroy at pjsua_core.c:2236:12
    frame #3: 0x0000000100008c2c pjsua-aarch64-apple-darwin24.5.0`app_destroy at pjsua_app.c:2252:14
    frame #4: 0x0000000100007ea4 pjsua-aarch64-apple-darwin24.5.0`pjsua_app_destroy at pjsua_app.c:2281:14
    frame #5: 0x000000010000188c pjsua-aarch64-apple-darwin24.5.0`main_func(argc=2, argv=0x000000016fdff3b8) at main.c:143:13
```
This is because since #4585, pjsua calls variable is dynamically allocated, so if initialization has not been properly completed, accessing `pjsua_var.calls[i]` variable will result in an illegal access.

A simple way to reproduce this is by running the sample app with `--help`.
