### PR TITLE
PJSUA2 call.hpp should include account.hpp

### DIFF
--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -23,6 +23,7 @@
  * @brief PJSUA2 Call manipulation
  */
 #include <pjsua-lib/pjsua.h>
+#include <pjsua2/account.hpp>
 #include <pjsua2/media.hpp>
 
 /** PJSUA2 API is inside pj namespace */

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -15,7 +15,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#include <pjsua2/account.hpp>
 #include <pjsua2/call.hpp>
 #include <pjsua2/endpoint.hpp>
 #include <pj/ctype.h>

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -16,7 +16,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
  */
 #include <pjsua2/endpoint.hpp>
-#include <pjsua2/account.hpp>
 #include <pjsua2/call.hpp>
 #include <pjsua2/presence.hpp>
 #include <algorithm>


### PR DESCRIPTION
This clarifies the header dependencies, some types used in `call.hpp` are defined in `account.hpp`.

Thanks to Imre Nagy for the report.