### PR TITLE
Fix assertion in DTLS-SRTP

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -1299,6 +1299,7 @@ static pj_status_t dtls_on_recv(pjmedia_transport *tp, unsigned idx,
         pjmedia_transport_get_info(ds->srtp->member_tp, &info);
 
         if (idx == RTP_CHANNEL &&
+            pj_sockaddr_has_addr(&info.src_rtp_name) &&
             pj_sockaddr_cmp(&ds->rem_addr, &info.src_rtp_name))
         {
             pj_sockaddr_cp(&ds->rem_addr, &info.src_rtp_name);

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -236,7 +236,7 @@ static void keystroke_help()
     puts("|  a  Answer call              |  i  Send IM              | !a  Modify accnt. |");
     puts("|  h  Hangup call  (ha=all)    |  s  Subscribe presence   | rr  (Re-)register |");
     puts("|  H  Hold call                |  u  Unsubscribe presence | ru  Unregister    |");
-    puts("|  o Toggle call SDP offer     |  D  Subscribe dlg event  |                   |");
+    puts("|  o  Toggle call SDP offer    |  D  Subscribe dlg event  |                   |");
     puts("|                              |  Du Unsub dlg event      |                   |");
     puts("|  v  re-inVite (release hold) |  t  Toggle online status |  >  Cycle next ac.|");
     puts("|  U  send UPDATE              |  T  Set online status    |  <  Cycle prev ac.|");


### PR DESCRIPTION
An assertion was triggered in `pj_sockaddr_get_len()` because the address family was 0.

Call stack trace:
```
_wassert(const wchar_t * expression, const wchar_t * file_name, unsigned int line_number) Line 444	C++
pj_sockaddr_get_len(const void * addr) Line 393	C
pj_sockaddr_cp(void * dst, const void * src) Line 416	C
dtls_on_recv(pjmedia_transport * tp, unsigned int idx, const void * pkt, unsigned __int64 size) Line 1305	C
dtls_on_recv_rtp(pjmedia_transport * tp, const void * pkt, unsigned __int64 size) Line 1437	C
pjmedia_transport_send_rtp(pjmedia_transport * tp, const void * pkt, unsigned __int64 size) Line 873	C
srtp_rtp_cb(pjmedia_tp_cb_param * param) Line 1586	C
call_rtp_cb(transport_udp * udp, __int64 bytes_read, int * rem_switch) Line 514	C
on_rx_rtp(pj_ioqueue_key_t * key, pj_ioqueue_op_key_t * op_key, __int64 bytes_read) Line 584	C
poll_iocp(void * hIocp, unsigned long dwTimeout, __int64 * p_bytes, pj_ioqueue_key_t * * p_key) Line 1060	C
pj_ioqueue_poll(pj_ioqueue_t * ioqueue, const pj_time_val * timeout) Line 1259	C
worker_proc(void * arg) Line 352	C
thread_main(void * param) Line 628	C
```

PS: also includes a minor alignment fix in pjsua app menu (found while debugging this).