### PR TITLE
Deadlock when registration retry and IP change handling triggered simultaneously

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -4161,9 +4161,11 @@ PJ_DEF(pj_status_t) pjsua_handle_ip_change(const pjsua_ip_change_param *param)
         sd_param.include_udp = PJ_FALSE;
 
         PJ_LOG(4,(THIS_FILE, "IP change shutting down transports.."));
+        PJSUA_LOCK();
         status = pjsip_tpmgr_shutdown_all(
                                     pjsip_endpt_get_tpmgr(pjsua_var.endpt),
                                     &sd_param);
+        PJSUA_UNLOCK();
 
         /* Provide dummy info instead of NULL info to avoid possible crash
          * (if app does not check).


### PR DESCRIPTION
Registration retry acquires the PJSUA lock followed by the transport manager lock, whereas IP change acquires them in the reverse order.

#### Call stack trace

IP change:
```
pj_mutex_lock + 136
PJSUA_LOCK + 28
pjsua_acc_on_tp_state_changed + 112
on_tp_state_callback + 140
pjsip_transport_shutdown2 + 308
pjsip_tpmgr_shutdown_all + 312
pjsua_handle_ip_change + 604
pj::Endpoint::handleIpChange + 64
```

Registration retry:
```
pj_mutex_lock + 136
pj_lock_acquire + 116
pjsip_tpmgr_acquire_transport2 + 60
pjsip_endpt_acquire_transport2 + 72
pjsua_acc_get_uac_addr + 2076
pjsua_acc_create_uac_contact + 244
pjsua_regc_init + 384
pjsua_acc_set_registration + 564
auto_rereg_timer_cb + 496
pj_timer_heap_poll + 640
pjsip_endpt_handle_events2 + 92
pjsua_handle_events + 72
worker_thread + 44
thread_main + 188
```

Thanks to Yeuda for the report.
