### PR TITLE
Various fixes for iOS pjsua sample app

### DIFF
--- a/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
+++ b/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
@@ -35,8 +35,15 @@
 
 #define THIS_FILE       "ipjsuaAppDelegate.m"
 
-/* Specify if we use push notification. */
-#define USE_PUSH_NOTIFICATION 1
+/* Specify if we use push notification.
+ * Note that you need to setup your SIP server first to support it.
+ */
+#define USE_PUSH_NOTIFICATION 0
+
+/* Specify if we want to use video.
+ * Note that video can only work in the foreground.
+ */
+#define USE_VIDEO 1
 
 /* Specify the timeout (in sec) to wait for the incoming INVITE
  * to come after we receive push notification.
@@ -312,6 +319,8 @@ static void pjsuaOnAppConfigCb(pjsua_app_config *cfg)
     int argc = PJ_ARRAY_SIZE(pjsua_app_def_argv) -1;
     pj_status_t status;
     
+    REGISTER_THREAD;
+
     isShuttingDown = false;
     displayMsg("Starting..");
     
@@ -358,10 +367,10 @@ static void pjsuaOnAppConfigCb(pjsua_app_config *cfg)
         cfg.cred_info[0].scheme = pj_str("digest");
         cfg.cred_info[0].username = pj_str(SIP_USER);
         cfg.cred_info[0].data = pj_str(SIP_PASSWD);
-        /* Uncomment this to enable video. Note that video can only
-         * work in the foreground.
-         */
-        // app_config_init_video(&cfg);
+
+#if USE_VIDEO
+        app_config_init_video(&cfg);
+#endif
 
         /* If we have Push Notification token, put it in the registration
          * Contact URI params.
@@ -480,6 +489,9 @@ didDectivateAudioSession:(AVAudioSession *) audioSession
 
     long code = (long)END_CALL | (call_id << 4);
     pjsua_schedule_timer2(pjsip_funcs, (void *)code, 0);
+}
+
+- (void)providerDidReset:(nonnull CXProvider *)provider {
 }
 
 - (void)pushRegistry:(PKPushRegistry *)registry

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1089,11 +1089,6 @@ static void ui_delete_account()
     }
 }
 
-static void ui_unset_loam_mode()
-{
-    app_config.enable_loam = PJ_FALSE;
-}
-
 static void ui_call_hold()
 {
     if (current_call != -1) {


### PR DESCRIPTION
* Fix thread registration assertion during startup:
```
14:53:53.096           pjsua_core.c  .PJSUA state changed: STARTING --> RUNNING

Assertion failed: (!"Calling pjlib from unknown/external thread. You must " "register external threads with pj_thread_register() " "before calling any pjlib functions."), function pj_thread_this, file os_core_unix.c, line 974.

#4	0x0000000104ee56f0 in pj_thread_this at pjlib/src/pj/os_core_unix.c:972
#5	0x0000000104ee5278 in pj_mutex_lock at pjlib/src/pj/os_core_unix.c:1628
#6	0x0000000104ef6708 in pj_lock_acquire at pjlib/src/pj/lock.c:179
#7	0x0000000104efa694 in cpool_create_pool at pjlib/src/pj/pool_caching.c:145
#8	0x0000000104ef9944 in pj_pool_aligned_create at pjlib/include/pj/pool_i.h:138
#9	0x0000000104ef98f0 in pj_pool_create at pjlib/include/pj/pool_i.h:128
#10	0x0000000104dfbfd8 in pjsua_pool_create at pjsip/src/pjsua-lib/pjsua_core.c:2314
#11	0x0000000104dfbcf4 in pjsua_create at pjsip/src/pjsua-lib/pjsua_core.c:1002
#12	0x0000000104d86af0 in app_init at pjsip-apps/src/pjsua/pjsua_app.c:1486
#13	0x0000000104d86a14 in pjsua_app_init at pjsip-apps/src/pjsua/pjsua_app.c:2084
#14	0x0000000104d6ccc8 in -[ipjsuaAppDelegate pjsuaStart] at pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m:331
```

* Change push notification to disabled since users will need to do some configurations first in order to make this work.
* Add `USE_VIDEO` (default: enabled) setting to enable video in the sample app.

Minor warning fixes:
* Fix warning: `Class 'ipjsuaAppDelegate' does not conform to protocol 'CXProviderDelegate'`

* Fix warning: `pjsip-apps/src/pjsua/pjsua_app_legacy.c:1092:13 Unused function 'ui_unset_loam_mode'`
