### PR TITLE
Set started flag after restarting audio device when modifying EC setting

### DIFF
--- a/pjmedia/src/pjmedia/sound_port.c
+++ b/pjmedia/src/pjmedia/sound_port.c
@@ -852,7 +852,10 @@ PJ_DEF(pj_status_t) pjmedia_snd_port_set_ec( pjmedia_snd_port *snd_port,
         snd_port->ec_tail_len = tail_ms;
 
         if (restart_stream)
-            pjmedia_aud_stream_start(snd_port->aud_stream);
+            status = pjmedia_aud_stream_start(snd_port->aud_stream);
+            if (status == PJ_SUCCESS) {
+                snd_port->aud_started = PJ_TRUE;
+            }
     }
 
     return status;


### PR DESCRIPTION
This is to fix a bug of #4683, the `aud_started` flag is not set back after audio device is restarted in `pjmedia_snd_port_set_ec()`.

Thanks to Yogesh Deshpande for the report.