### PR TITLE
sound_port: Added missing braces for stream restart.

### DIFF
--- a/pjmedia/src/pjmedia/sound_port.c
+++ b/pjmedia/src/pjmedia/sound_port.c
@@ -851,11 +851,12 @@ PJ_DEF(pj_status_t) pjmedia_snd_port_set_ec( pjmedia_snd_port *snd_port,
         snd_port->ec_options = options;
         snd_port->ec_tail_len = tail_ms;
 
-        if (restart_stream)
+        if (restart_stream) {
             status = pjmedia_aud_stream_start(snd_port->aud_stream);
             if (status == PJ_SUCCESS) {
                 snd_port->aud_started = PJ_TRUE;
             }
+        }
     }
 
     return status;


### PR DESCRIPTION
Fixes warning:

```C
pjproject/pjmedia/src/pjmedia/sound_port.c: In function ‘pjmedia_snd_port_set_ec’:
pjproject/pjmedia/src/pjmedia/sound_port.c:854:9: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
  854 |         if (restart_stream)
      |         ^~
pjproject/pjmedia/src/pjmedia/sound_port.c:856:13: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  856 |             if (status == PJ_SUCCESS) {
      |             ^~
```