### PR TITLE
Fix libc++ duplicate libraries warning on Mac

### DIFF
--- a/build.mak.in
+++ b/build.mak.in
@@ -330,9 +330,15 @@ export APP_LDLIBS := $(PJSUA_LIB_LDLIB) \
         $(APP_THIRD_PARTY_EXT)\
         $(PJLIB_LDLIB) \
         @LIBS@
+
+ifeq ($(findstring darwin,$(TARGET_NAME)),darwin)
+export APP_LDXXLIBS := $(PJSUA2_LIB_LDLIB) \
+        $(APP_LDLIBS)
+else
 export APP_LDXXLIBS := $(PJSUA2_LIB_LDLIB) \
         -lstdc++ \
         $(APP_LDLIBS)
+endif
 
 # Here are the variables to use if application is using the library
 # from within the source distribution


### PR DESCRIPTION
`ld: warning: ignoring duplicate libraries: '-lc++'`

To make sure the patch doesn't break builds on other platforms, the fix is limited to Apple Darwin.
(According to https://libcxx.llvm.org/UserDocumentation.html#using-libc-when-it-is-not-the-system-default
`This flag is not required on systems where libc++ is the default standard library, such as macOS and FreeBSD.`)