### PR TITLE
Fix pj/os.h header file

### DIFF
--- a/pjlib/include/pj/os.h
+++ b/pjlib/include/pj/os.h
@@ -264,7 +264,7 @@ PJ_DECL(pj_status_t) pj_thread_register ( const char *thread_name,
  *
  * @return PJ_SUCCESS on success.
  */
-PJ_DECL(pj_status_t) pj_thread_unregister();
+PJ_DECL(pj_status_t) pj_thread_unregister(void);
 
 /**
  * Register a thread that was created by external or native API to PJLIB.


### PR DESCRIPTION
These warnings occur when compiling asterisk-20.17.0 together with pjproject 2.16

Example:
...
/usr/src/asterisk-20.17.0/third-party/pjproject/source/pjlib/include/pj/os.h:267:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  267 | PJ_DECL(pj_status_t) pj_thread_unregister();
      | ^~~~~~~
...