### PR TITLE
Assertion in video stream's sending manager thread

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -269,12 +269,6 @@ static void send_mgr_on_destroy(void *arg)
 {
     send_manager* mgr = (send_manager*)arg;
 
-    if (mgr->thread) {
-        mgr->is_quitting = PJ_TRUE;
-        pj_thread_join(mgr->thread);
-        pj_thread_destroy(mgr->thread);
-    }
-
     if (mgr->pool)
         pj_pool_safe_release(&mgr->pool);
 }
@@ -358,6 +352,13 @@ static pj_status_t detach_send_manager(send_stream *ss)
     }
     ss->mgr = NULL;
     pj_grp_lock_release(mgr->grp_lock);
+
+    /* Stop send manager thread */
+    if (mgr->thread) {
+        mgr->is_quitting = PJ_TRUE;
+        pj_thread_join(mgr->thread);
+        pj_thread_destroy(mgr->thread);
+    }
 
     /* Decrease ref counter */
     return pj_grp_lock_dec_ref(mgr->grp_lock);


### PR DESCRIPTION
Call stack trace:
```
__assert_fail (assertion=0x7eff3fb17090 "pj_atomic_get(glock->ref_cnt) > 0"
grp_lock_acquire ()
pj_grp_lock_acquire ()
send_worker_thread ()
```
Thanks to Alban Islami for the report.

It seems that the send manager's reference counter is decremented to zero while the thread is still looping.