### PR TITLE
Fix Assert when parsing IPv6 Contact header

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2029,7 +2029,7 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
                  PJSIP_TRANSPORT_SECURE;
         
         /* Enclose IPv6 address in square brackets */
-        if (tp->key.type & PJSIP_TRANSPORT_IPV6) {
+        if ((tp->key.type & PJSIP_TRANSPORT_IPV6) && via_addr->ptr[0] != '[') {
             beginquote = "[";
             endquote = "]";
         } else {


### PR DESCRIPTION
## Summary
I got an Assert error during register phase with my IPv6 VoIP provider, the error is caused by double escaping with [] an already escaped IPv6 address. I proposed a trivial fix that solves the issue on my side, but I'm not expert enough on SIP or the codebase to know if it's a generalizable solution or there is some corner case that I have missed.

## The issue
The code produced double [] escaping of IPv6 address, causing `pjsip_parse_hdr()` to fail and producing this assert: `Assert failed: contact_hdr != NULL`.

The Contact: URI printed in PJSUA before parsing looked like `Contact URI: <sip:<user>@[[AAAA:BBBB:CCCC:DDDD:0:0:0:EEEE]]:5070;ob>`

The original message has already the IPv6 address escaped: `Contact: <sip:<user>@[AAAA:BBBB:CCCC:DDDD:0:0:0:EEEE]:5060;ob>`

## Context
tcpdump of original message:
<details>

  ```
  18:23:35.722310 IP6 quiet.sip > aaaa:bbbb:cccc:dddd:eeee:0:1:1.sip: SIP: REGISTER sip:<provider>:5060 SIP/2.0
  `..A...@*......P........*..	.....	............A.REGISTER sip:<provider>:5060 SIP/2.0
  Via: SIP/2.0/UDP [AAAA:BBBB:CCCC:DDDD:0:0:0:EEEE]:5060;rport;branch=z9hG4bKPj10aab6a1-a273-4e49-af14-d6eaf921e86d
  Route: <sip:proxy-voip-1.iliad.it:5060;lr>
  Max-Forwards: 70
  From: <sip:<user@provider>;user=phone>;tag=f067a41f-18f6-4dbb-a571-33032ef15abf
  To: <sip:<user@provider>;user=phone>
  Call-ID: 20ad71f7-3218-495c-b11b-a6b8d2c59144
  CSeq: 31913 REGISTER
  Contact: <sip:<user>@[AAAA:BBBB:CCCC:DDDD:0:0:0:EEEE]:5060;ob>
  Expires: 0
  [...]
  ```
</details>

PJSIP cli command used for testing:
`pjsua --id "sip:<user@provider>;user=phone" --registrar "sip:<provider>:5060" --realm "*" --username "<user>" --password "<password>" --proxy "sip:<provider-proxy>:5060;lr" --reg-timeout 1800 --ipv6 --auto-answer 200`