### PR TITLE
Fixed crash when freeing OpenSSL private key and cert

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -434,7 +434,7 @@ PJ_DECL(pj_status_t) pj_ssl_cert_load_from_store(
  * In OpenSSL version 3, the SSL socket utilizes the reference counting
  * feature to manage object lifetimes. Specifically,
  * pj_ssl_sock_set_certificate() increments the reference count and
- * pj_ssl_close() decrements it.
+ * pj_ssl_sock_close() decrements it.
  *
  * @param pool          The pool.
  * @param cert_direct   The backend specific objects.

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2315,6 +2315,10 @@ PJ_DEF(void) pj_ssl_cert_wipe_keys(pj_ssl_cert_t *cert)
         cert->criteria.type = PJ_SSL_CERT_LOOKUP_NONE;
         wipe_buf(&cert->criteria.keyword);
 #endif
+
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+        ssl_free_cert(cert);
+#endif
     }
 }
 

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -272,6 +272,9 @@ static void ssl_reset_sock_state(pj_ssl_sock_t *ssock);
 static void ssl_ciphers_populate();
 static pj_ssl_cipher ssl_get_cipher(pj_ssl_sock_t *ssock);
 static void ssl_update_certs_info(pj_ssl_sock_t *ssock);
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+static void ssl_free_cert(pj_ssl_cert_t *cert);
+#endif
 
 /* SSL session functions */
 static void ssl_set_state(pj_ssl_sock_t *ssock, pj_bool_t is_server);


### PR DESCRIPTION
To fix #4717.

```
==14215==ERROR: AddressSanitizer: heap-use-after-free on address 0x6150000206b0 at pc 0x00010350c898 bp 0x00016d3f6290 sp 0x00016d3f6288
READ of size 8 at 0x6150000206b0 thread T4
    #0 0x10350c894 in ssl_destroy ssl_sock_ossl.c:1730
    #1 0x1034feab4 in ssl_on_destroy ssl_sock_imp_common.c:730
    #2 0x1034e0d04 in grp_lock_destroy lock.c:397
    #3 0x1034e17d8 in grp_lock_dec_ref lock.c:563
    #4 0x1034e174c in pj_grp_lock_dec_ref lock.c:654
    #5 0x102edd99c in lis_destroy sip_transport_tls.c:780
    #6 0x102d244a8 in pjsua_transport_close pjsua_core.c:3064
```
This is because the pool has been released:
```
    #6 0x1034e8d44 in pj_pool_secure_release pool_i.h:183
    #7 0x102edafb8 in lis_on_destroy sip_transport_tls.c:751
    #8 0x1034e0d04 in grp_lock_destroy lock.c:397
    #9 0x1034e17d8 in grp_lock_dec_ref lock.c:563
    #10 0x1034e174c in pj_grp_lock_dec_ref lock.c:654
    #11 0x102edd99c in lis_destroy sip_transport_tls.c:780
    #12 0x102d244a8 in pjsua_transport_close pjsua_core.c:3064
```

The issue is introduced since #4566 (Direct OpenSSL objects for TLS credentials (key, certificate)).
