### PR TITLE
Add pjmedia_ice_parse_cand

### DIFF
--- a/pjmedia/include/pjmedia/transport_ice.h
+++ b/pjmedia/include/pjmedia/transport_ice.h
@@ -444,6 +444,22 @@ PJ_DECL(pj_status_t) pjmedia_ice_trickle_send_local_cand(
                                             pjmedia_sdp_session *sdp,
                                             pj_bool_t *p_end_of_cand);
 
+/**
+ * Parse an ICE candidate attribute string into a pj_ice_sess_cand structure.
+ *
+ * @param pool      Optional pool for string duplication. If NULL, the
+ *                  foundation string will point to the input string.
+ * @param cand_str  The candidate attribute string to parse (without
+ *                  "candidate:" prefix, just the value part).
+ * @param cand      Pointer to candidate structure to be filled.
+ *
+ * @return          PJ_SUCCESS on success, or PJNATH_EICEINCANDSDP on
+ *                  parsing error, or PJ_EINVAL if parameters are invalid.
+ */
+PJ_DECL(pj_status_t) pjmedia_ice_parse_cand(pj_pool_t *pool,
+                                            const pj_str_t *cand_str,
+                                            pj_ice_sess_cand *cand);
+
 
 PJ_END_DECL
 

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -775,6 +775,19 @@ PJ_DEF(pj_status_t) pjmedia_ice_trickle_send_local_cand(
 }
 
 
+/*
+ * Public wrapper for parse_cand with parameter validation.
+ */
+PJ_DEF(pj_status_t) pjmedia_ice_parse_cand(pj_pool_t *pool,
+                                           const pj_str_t *cand_str,
+                                           pj_ice_sess_cand *cand)
+{
+    PJ_ASSERT_RETURN(cand_str && cand, PJ_EINVAL);
+
+    return parse_cand("", pool, cand_str, cand);
+}
+
+
 /* Disable ICE when SDP from remote doesn't contain a=candidate line */
 static void set_no_ice(struct transport_ice *tp_ice, const char *reason,
                        pj_status_t err)


### PR DESCRIPTION
When PJMEDIA is used without SIP it's useful to be able to parse
candidate lines if they follow the same format as SDP. An example of
this is parsing candidates coming from WebRTC events.
