### PR TITLE
Avoid generate `#define WORDS_BIGENDIAN 0` when compiling with CMake on little-endian systems

### DIFF
--- a/pjlib/include/pj/compat/m_auto.h.cm
+++ b/pjlib/include/pj/compat/m_auto.h.cm
@@ -37,7 +37,7 @@
 #endif
 #else
 /* Endianness, as detected by autoconf */
-#cmakedefine01 WORDS_BIGENDIAN
+#cmakedefine WORDS_BIGENDIAN 1
 #endif
 
 #if defined(WORDS_BIGENDIAN) && WORDS_BIGENDIAN == 1


### PR DESCRIPTION
This change avoid to get issues when srtp is compiled without OpenSSL