### PR TITLE
Remove `siprec` from Supported header when session recording is inactive

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2080,7 +2080,8 @@ static void cleanup_allow_sup_hdr(unsigned inv_option,
     /* If all extensions are enabled, nothing to do */
     if ((inv_option & PJSIP_INV_SUPPORT_100REL) &&
         (inv_option & PJSIP_INV_SUPPORT_TIMER) &&
-        (inv_option & PJSIP_INV_SUPPORT_TRICKLE_ICE))
+        (inv_option & PJSIP_INV_SUPPORT_TRICKLE_ICE) &&
+        (inv_option & PJSIP_INV_SUPPORT_SIPREC))
     {
         return;
     }


### PR DESCRIPTION
When `use_siprec` or `siprecUse` is set to `PJSUA_SIP_SIPREC_INACTIVE`, the Supported header must not include the `siprec` tag. It may activate something in the server that should not be activated.

Thanks Sean Riley for the report.