### PR TITLE
Contact not updated on IP change

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4495,6 +4495,9 @@ pj_status_t pjsua_acc_update_contact_on_ip_change(pjsua_acc *acc)
                "by IP change", (int)acc->cfg.id.slen,
                acc->cfg.id.ptr, (need_unreg ? "un-" : "")));
 
+    /* Prepare for contact rewrite */
+    acc->contact_rewritten = PJ_FALSE;
+
     status = pjsua_acc_set_registration(acc->index, !need_unreg);
     if ((status != PJ_SUCCESS)
         && (acc->ip_change_op == PJSUA_IP_CHANGE_OP_ACC_UPDATE_CONTACT))


### PR DESCRIPTION
There is a report that sometimes the Contact header is not updated during an IP change, even when the Via header in the REGISTER response has changed.

Thanks to Evgeny Smitenko for the report.

During investigation, it appears that `acc->contact_rewritten` is reset only when a registration does not update the contact, for example in periodic registration refresh. Consequently, if two consecutive IP change events occur without a registration refresh in between, the flag remains set and the Contact header is not updated correctly.
