### PR TITLE
Lock ordering issue between sip dialog and sip transaction

### DIFF
--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -2240,6 +2240,9 @@ void pjsip_dlg_on_tsx_state( pjsip_dialog *dlg,
               tsx->obj_name, pjsip_tsx_state_str(tsx->state)));
     pj_log_push_indent();
 
+    /* Lock the dialog and increment session. */
+    pjsip_dlg_inc_lock(dlg);
+
     /* Pass to dialog usages. */
     for (i=0; i<dlg->usage_cnt; ++i) {
 
@@ -2258,17 +2261,12 @@ void pjsip_dlg_on_tsx_state( pjsip_dialog *dlg,
         tsx->mod_data[dlg->ua->id] == dlg)
     {
         pj_assert(dlg->tsx_count>0);
-
-        /* Lock the dialog and increment session. */
-        pjsip_dlg_inc_lock(dlg);
-
         --dlg->tsx_count;
         tsx->mod_data[dlg->ua->id] = NULL;
-
-        /* Unlock dialog and dec session, may destroy dialog. */
-        pjsip_dlg_dec_lock(dlg);
     }
 
+    /* Unlock dialog and dec session, may destroy dialog. */
+    pjsip_dlg_dec_lock(dlg);
     pj_log_pop_indent();
 }
 


### PR DESCRIPTION
This is a classic lock ordering inversion issue in outgoing message and incoming message flows between sip dialog and sip transaction. In outgoing flow, dlg lock will be locked first then tsx, while in incoming flow, tsx lock will be locked first.

Example stack traces:
* UAC dialog:
```
# Mutex M1 acquired here while holding mutex M0 in thread T2:
#4 pj_grp_lock_acquire ../src/pj/lock.c:486
#5 pjsip_tsx_set_transport ../src/pjsip/sip_transaction.c:1841
#6 pjsip_dlg_send_request ../src/pjsip/sip_dialog.c:1384
#7 pjsip_inv_send_msg ../src/pjsip-ua/sip_inv.c:3825
#8 perform_test ../src/test/inv_offer_answer_test.c:474

# Mutex M0 acquired here while holding mutex M1 in thread T2:
#8 pj_grp_lock_acquire ../src/pj/lock.c:486
#9 pjsip_dlg_inc_lock ../src/pjsip/sip_dialog.c:965
#10 pjsip_dlg_on_tsx_state ../src/pjsip/sip_dialog.c:2249
#11 mod_ua_on_tsx_state ../src/pjsip/sip_ua_layer.c:186
#12 tsx_set_state ../src/pjsip/sip_transaction.c:1460
#13 tsx_on_state_proceeding_uac ../src/pjsip/sip_transaction.c:3404
#14 pjsip_tsx_recv_msg ../src/pjsip/sip_transaction.c:2061
```
* UAS dialog:
```
Mutex M0 acquired here while holding mutex M1 in thread T4:
#4 pj_grp_lock_acquire ../src/pj/lock.c:486
#5 create_uas_dialog ../src/pjsip/sip_dialog.c:577
#6 pjsip_dlg_create_uas_and_inc_lock ../src/pjsip/sip_dialog.c:668
#7 on_rx_request ../src/test/inv_offer_answer_test.c:326
#8 pjsip_endpt_process_rx_data ../src/pjsip/sip_endpoint.c:961

Mutex M1 acquired here while holding mutex M0 in thread T4:
#11 pjsip_dlg_inc_lock ../src/pjsip/sip_dialog.c:965
#12 pjsip_dlg_on_tsx_state ../src/pjsip/sip_dialog.c:2252
#13 mod_ua_on_tsx_state ../src/pjsip/sip_ua_layer.c:186
#14 tsx_set_state ../src/pjsip/sip_transaction.c:1458
#15 tsx_on_state_null ../src/pjsip/sip_transaction.c:2842
#16 pjsip_tsx_recv_msg ../src/pjsip/sip_transaction.c:2059
#17 pjsip_dlg_on_rx_request ../src/pjsip/sip_dialog.c:1882
#18 mod_ua_on_rx_request ../src/pjsip/sip_ua_layer.c:745
#19 pjsip_endpt_process_rx_data ../src/pjsip/sip_endpoint.c:967
```

There doesn't seem to be any straightforward solution to fix the problem, so even though not ideal, we just use a TSan suppression filter for now.

A few ideas to solve the issue in the future:
* Using chain lock
Patch here: https://github.com/pjsip/pjproject/pull/4755/commits/87bfa3d6b71597c4499adf94a8ffdd60f4b76b82
Pro: This should be able to solve any deadlock should it occur
Con: Unfortunately, TSan will have no knowledge that the two locks have been chained together so it will still report it.
Before chain:
TX flow: `dlg_lock->tsx_lock`
RX flow: `tsx_lock->dlg_lock`
After chain:
TX flow: `dlg_lock->(dlg_lock->tsx_lock)`
RX flow: `(dlg_lock->tsx_lock)->dlg_lock`

  **Note**: One idea (by @nanangizz [below](https://github.com/pjsip/pjproject/pull/4755#issuecomment-3809568652)) to solve this is by allowing certain locks to skip locking if it is already held (note that info about the lock owner and nesting counter is available but only in debug mode).
* Using a single group lock between sip dlg and sip tsx
  Pro: Solve any potential deadlock issue and will also clear TSan
  Con:
  - Performance penalty (should not be much though (?) since a dialog should not have that many transactions happening simultaneously).
  - **Major**: Need to address sip tsx lifetime issue because by using a single group lock, all transactions will only be destroyed much later, together with dlg. So perhaps sip tsx needs a separate ref counter (by using a separate group lock?)

Note that we may be able to safely avoid locking in `pjsip_dlg_on_tsx_state()` (patch: https://github.com/pjsip/pjproject/pull/4755/commits/4e1979ff9be7861a78d33cf7c943d16798d39cae) since dialog usages shouldn't change midway. However, since removing the dlg lock here won't help much with the lock ordering issue (because we will still lock the dialog in another function anyway), there's not much benefit in committing the patch.

