### PR TITLE
Lock order inversion issue in sip transport

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2003,11 +2003,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_destroy( pjsip_tpmgr *mgr )
 
     PJ_LOG(5, (THIS_FILE, "Destroying transport manager"));
 
-    /* Last chance to wait for other tpmgr functions to finish before
-     * we destroy everything.
-     */
     pj_lock_acquire(mgr->lock);
-    pj_lock_release(mgr->lock);
 
     /*
      * Destroy all transports in the hash table.
@@ -2031,6 +2027,8 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_destroy( pjsip_tpmgr *mgr )
 
         factory = next;
     }
+
+    pj_lock_release(mgr->lock);
 
 #if defined(PJ_DEBUG) && PJ_DEBUG!=0
     /* If you encounter assert error on this line, it means there are

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -2003,7 +2003,12 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_destroy( pjsip_tpmgr *mgr )
 
     PJ_LOG(5, (THIS_FILE, "Destroying transport manager"));
 
+    /* Last chance to wait for other tpmgr functions to finish before
+     * we destroy everything. This should not be needed though, as all
+     * worker threads should have already been stopped at this point. 
+     */
     pj_lock_acquire(mgr->lock);
+    pj_lock_release(mgr->lock);
 
     /*
      * Destroy all transports in the hash table.
@@ -2027,8 +2032,6 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_destroy( pjsip_tpmgr *mgr )
 
         factory = next;
     }
-
-    pj_lock_release(mgr->lock);
 
 #if defined(PJ_DEBUG) && PJ_DEBUG!=0
     /* If you encounter assert error on this line, it means there are

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1411,8 +1411,8 @@ static pj_status_t destroy_transport( pjsip_tpmgr *mgr,
 
     TRACE_((THIS_FILE, "Transport %s is being destroyed", tp->obj_name));
 
-    pj_lock_acquire(tp->lock);
     pj_lock_acquire(mgr->lock);
+    pj_lock_acquire(tp->lock);
 
     /*
      * Unregister timer, if any.
@@ -1477,8 +1477,8 @@ static pj_status_t destroy_transport( pjsip_tpmgr *mgr,
                               "not found in the hash table", tp->obj_name));
     }
 
-    pj_lock_release(mgr->lock);
     pj_lock_release(tp->lock);
+    pj_lock_release(mgr->lock);
 
     /* Dec ref transport group lock, if any */
     if (tp->grp_lock) {

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1512,18 +1512,15 @@ PJ_DEF(pj_status_t) pjsip_transport_shutdown2(pjsip_transport *tp,
     PJ_LOG(4, (THIS_FILE, "Transport %s shutting down, force=%d",
                           tp->obj_name, force));
 
-    pj_lock_acquire(tp->lock);
-
     mgr = tp->tpmgr;
 
-    // Acquiring manager lock after transport lock may cause deadlock.
-    // And it does not seem necessary as well.
-    //pj_lock_acquire(mgr->lock);
+    pj_lock_acquire(mgr->lock);
+    pj_lock_acquire(tp->lock);
 
     /* Do nothing if transport is being shutdown/destroyed already */
     if (tp->is_shutdown || tp->is_destroying) {
-        //pj_lock_release(mgr->lock);
         pj_lock_release(tp->lock);
+        pj_lock_release(mgr->lock);
         return PJ_SUCCESS;
     }
 
@@ -1553,8 +1550,8 @@ PJ_DEF(pj_status_t) pjsip_transport_shutdown2(pjsip_transport *tp,
         pjsip_transport_dec_ref(tp);
     }
 
-    //pj_lock_release(mgr->lock);
     pj_lock_release(tp->lock);
+    pj_lock_release(mgr->lock);
 
     return status;
 }

--- a/tests/sanitizers/tsan.supp
+++ b/tests/sanitizers/tsan.supp
@@ -40,11 +40,11 @@ deadlock:pjsip_dlg_on_tsx_state
 
 # Lock-order-inversion destroy_transport ../src/pjsip/sip_transport.c with:
 # - udp_shutdown ../src/pjsip/sip_transport_udp.c
-deadlock:destroy_transport
+#deadlock:destroy_transport
 
 # Lock-order-inversion lis_destroy ../src/pjsip/sip_transport_tcp.c with:
 # - pjsip_transport_register ../src/pjsip/sip_transport.c
-deadlock:lis_destroy
+#deadlock:lis_destroy
 
 #=============================================================================
 # Lock-order-inversion in pjsip_endpoint

--- a/tests/sanitizers/tsan.supp
+++ b/tests/sanitizers/tsan.supp
@@ -37,16 +37,6 @@ deadlock:stateless_send_transport_cb
 
 deadlock:pjsip_dlg_on_tsx_state
 #=============================================================================
-
-# Lock-order-inversion destroy_transport ../src/pjsip/sip_transport.c with:
-# - udp_shutdown ../src/pjsip/sip_transport_udp.c
-#deadlock:destroy_transport
-
-# Lock-order-inversion lis_destroy ../src/pjsip/sip_transport_tcp.c with:
-# - pjsip_transport_register ../src/pjsip/sip_transport.c
-#deadlock:lis_destroy
-
-#=============================================================================
 # Lock-order-inversion in pjsip_endpoint
 # Example stack trace:
 # Mutex of pjsip_endpoint acquired here while holding mutex of pjsip_tsx:


### PR DESCRIPTION
Lock order inversion in sip transport between pjsip_transport and pjsip_tpmgr.

Example stack trace:
```
# Mutex of pj_ioqueue acquired here while holding mutex of pjsip_tpmgr:
#5 pj_ioqueue_lock_key ../src/pj/ioqueue_common_abs.c:1478
#6 pj_ioqueue_connect ../src/pj/ioqueue_common_abs.c:1305
#7 pj_activesock_start_connect ../src/pj/activesock.c:961
#8 lis_create_transport ../src/pjsip/sip_transport_tcp.c:1063
#9 pjsip_tpmgr_acquire_transport2 ../src/pjsip/sip_transport.c:2800
#10 pjsip_tpmgr_acquire_transport ../src/pjsip/sip_transport.c:2493
#11 pjsip_endpt_acquire_transport ../src/pjsip/sip_endpoint.c:1234
#
# Mutex of pjsip_tpmgr acquired here while holding mutex of pj_ioqueue:
#2 pj_lock_acquire ../src/pj/lock.c:179
#3 tp_state_callback ../src/pjsip/sip_transport.c:2924
#4 on_connect_complete ../src/pjsip/sip_transport_tcp.c:1569
#5 ioqueue_on_connect_complete ../src/pj/activesock.c:976
#6 ioqueue_dispatch_write_event ../src/pj/ioqueue_common_abs.c:287
#7 pj_ioqueue_poll ../src/pj/ioqueue_select.c:1097
#
# Mutex of pjsip_tpmgr acquired here while holding mutex of pjsip_transport:
#2 pj_lock_acquire ../src/pj/lock.c:179
#3 destroy_transport ../src/pjsip/sip_transport.c:1415
#4 pjsip_transport_destroy ../src/pjsip/sip_transport.c:1583
```

This can cause issues such as https://github.com/pjsip/pjproject/pull/4307.

Proposed fix:
Obey a uniform lock order: always lock pjsip_tpmgr first, and then pjsip_transport
The reason for this order is that the natural usage is top-down, i.e. by using APIs such as: `pjsip_tpmgr_acquire_transport()`, `pjsip_tpmgr_shutdown_all()`, `pjsip_transport_shutdown()`, `pjsip_transport_destroy()`, while there doesn't seem to be any bottom-up flow from `pjsip_transport` into `pjsip_tpmgr`.

By following the above order, the modifications are as follows:
* Avoid locking in `pjsip_tpmgr_destroy()` as  it doesn't seem to be much useful anyway since the worker thread should have already been stopped by that time, and we're going to destroy the lock and the pool anyway at the end of the function . Only in the beginning we try to wait for the lock, just in case that there are still other tpmgr functions still in progress.
* Swap the lock order in `destroy_transport()` (called by `pjsip_transport_destroy()`) to lock tpmgr first and then pjsip_transport.
* Use the same lock order in `pjsip_transport_shutdown()` to lock tpmgr first and then pjsip_transport. Note that this will revert the lock usage removal in #4307, and will swap the order instead. This is because it will still cause lock order inversion in SIP UDP transport:
```
Mutex M1 acquired here while holding mutex M0 in main thread:
    #2 pj_lock_acquire ../src/pj/lock.c:179 (pjsua-x86_64-pc-linux-gnu+0x414a54) (BuildId: 713254ae3b173bf4d5c9cc4ec8d848fc756f6725)
    #3 pjsip_transport_dec_ref ../src/pjsip/sip_transport.c:1268 (pjsua-x86_64-pc-linux-gnu+0x165060) (BuildId: 713254ae3b173bf4d5c9cc4ec8d848fc756f6725)
    #4 udp_shutdown ../src/pjsip/sip_transport_udp.c:523 (pjsua-x86_64-pc-linux-gnu+0x16bec0) (BuildId: 713254ae3b173bf4d5c9cc4ec8d848fc756f6725)
    #5 pjsip_transport_shutdown2 ../src/pjsip/sip_transport.c:1534 (pjsua-x86_64-pc-linux-gnu+0x165ca3) (BuildId: 713254ae3b173bf4d5c9cc4ec8d848fc756f6725)
```
