### PR TITLE
pjsip: Avoid stale 408 triggering BYE on tsx termination

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4672,8 +4672,13 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
 
     /* Note that 481 response to CANCEL does not terminate dialog usage,
      * but only the transaction.
+     *
+     * Avoid acting on the subsequent COMPLETED->TERMINATED transition
+     * (e.g. Timer D), which can happen long after the response/timeout
+     * was already processed.
      */
     if (inv->state != PJSIP_INV_STATE_DISCONNECTED &&
+        e->body.tsx_state.prev_state != PJSIP_TSX_STATE_COMPLETED &&
         ((tsx->status_code == PJSIP_SC_CALL_TSX_DOES_NOT_EXIST &&
             tsx->method.id != PJSIP_CANCEL_METHOD) ||
          (tsx->status_code == PJSIP_SC_REQUEST_TIMEOUT &&


### PR DESCRIPTION
Ignore the later COMPLETED->TERMINATED transition (e.g., Timer D) in handle_uac_tsx_response() so an old INVITE 408 can’t tear down a dialog that was established by a subsequent failover INVITE.

Asterisk with multiple outbound proxies hit this scenario: Asterisk initiated a call to the device via proxy A, received a 408, and then retried via proxy B using a new transaction; the call connected successfully. ~32 seconds later, the original transaction’s cleanup timer fired and the resulting state transition caused a BYE to be sent on the new dialog/session, tearing down the established call.