### PR TITLE
Skip locking in setting and getting Buddy's user data

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -421,8 +421,8 @@ pjsua_buddy_get_dlg_event_info( pjsua_buddy_id buddy_id,
 PJ_DEF(pj_status_t) pjsua_buddy_set_user_data( pjsua_buddy_id buddy_id,
                                                void *user_data)
 {
-    struct buddy_lock lck;
-    pj_status_t status;
+    //struct buddy_lock lck;
+    //pj_status_t status;
 
     PJ_ASSERT_RETURN(pjsua_buddy_is_valid(buddy_id), PJ_EINVAL);
 
@@ -446,8 +446,8 @@ PJ_DEF(pj_status_t) pjsua_buddy_set_user_data( pjsua_buddy_id buddy_id,
  */
 PJ_DEF(void*) pjsua_buddy_get_user_data(pjsua_buddy_id buddy_id)
 {
-    struct buddy_lock lck;
-    pj_status_t status;
+    //struct buddy_lock lck;
+    //pj_status_t status;
     void *user_data;
 
     PJ_ASSERT_RETURN(pjsua_buddy_is_valid(buddy_id), NULL);

--- a/pjsip/src/pjsua2/presence.cpp
+++ b/pjsip/src/pjsua2/presence.cpp
@@ -114,8 +114,10 @@ Buddy::~Buddy()
             delete bud;
         }
 
-        if (pjsua_buddy_del(id) != PJ_SUCCESS) {
+        pj_status_t status = pjsua_buddy_del(id);
+        if (status != PJ_SUCCESS) {
             // TODO: schedule retry to delete buddy
+            PJ_PERROR(1,(THIS_FILE, status, "Failed to delete buddy %d", id));
         }
 
 #if !DEPRECATED_FOR_TICKET_2232


### PR DESCRIPTION
To fix #4779.

In PJSUA2, a Buddy’s user data links the PJSUA2 `Buddy` instance with the corresponding PJSUA `buddy_id`. For example, it is used when forwarding callbacks from PJSUA to PJSUA2. However, `pjsua_buddy_get_user_data()` may return `NULL` if locking fails, which can prevent the callback from being invoked correctly.