### PR TITLE
Fix heap-use-after-free when processing incoming RTP/RTCP after stream destroy

### DIFF
--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -1465,7 +1465,9 @@ PJ_DEF(pj_status_t) pj_ioqueue_clear_key( pj_ioqueue_key_t *key )
     do {
         unsigned counter = 0;
 
-        while (key->read_callback_thread) {
+        while (key->read_callback_thread &&
+               key->read_callback_thread != pj_thread_this())
+        {
             /* Callback is running, unlock while waiting, since the callback
              * may need the lock.
              */

--- a/pjlib/src/pj/ioqueue_winnt.c
+++ b/pjlib/src/pj/ioqueue_winnt.c
@@ -858,7 +858,9 @@ static pj_status_t cancel_all_pending_op(pj_ioqueue_key_t *key)
     do {
         unsigned counter = 0;
 
-        while (key->read_callback_thread) {
+        while (key->read_callback_thread &&
+               key->read_callback_thread != pj_thread_this())
+        {
             /* Callback is running, unlock while waiting, since the callback
              * may need the lock.
              */


### PR DESCRIPTION
As reported by ASan:
```
==10715==ERROR: AddressSanitizer: heap-use-after-free on address 0x52500003b168 at pc 0x7f0066e7d96f bp 0x7f0062ffcb00 sp 0x7f0062ffc2a8
READ of size 19 at 0x52500003b168 thread T1
    #0 0x7f0066e7d96e in strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x55aaa84c67df in pj_log ../src/pj/log.c:406
    #2 0x55aaa84c7a36 in pj_log_5 ../src/pj/log.c:562
    #3 0x55aaa7f92355 in parse_rtcp_bye ../src/pjmedia/rtcp.c:830
    #4 0x55aaa7f92906 in pjmedia_rtcp_rx_rtcp ../src/pjmedia/rtcp.c:915
    #5 0x55aaa7f0894d in on_rx_rtcp ../src/pjmedia/stream_imp_common.c:384
    #6 0x55aaa7f4f2be in srtp_rtcp_cb ../src/pjmedia/transport_srtp.c:1768
    #7 0x55aaa7f53017 in call_rtcp_cb ../src/pjmedia/transport_udp.c:535
    #8 0x55aaa7f53ba6 in on_rx_rtcp ../src/pjmedia/transport_udp.c:728
    #9 0x55aaa84ade9c in ioqueue_dispatch_read_event ../src/pj/ioqueue_common_abs.c:686
    #10 0x55aaa84b3d5b in pj_ioqueue_poll ../src/pj/ioqueue_select.c:1093
    #11 0x55aaa7eca4d5 in worker_proc ../src/pjmedia/endpoint.c:352
    #12 0x55aaa84a5c9d in thread_main ../src/pj/os_core_unix.c:765
    #13 0x7f0066e5ea41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #14 0x7f006609caa3 in start_thread nptl/pthread_create.c:447
    #15 0x7f0066129c6b in clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

0x52500003b168 is located 6248 bytes inside of 8000-byte region [0x525000039900,0x52500003b840)
freed by thread T3 here:
    #0 0x7f0066efc4d8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55aaa84fa736 in default_block_free ../src/pj/pool_policy_malloc.c:77
    #2 0x55aaa84ca926 in reset_pool ../src/pj/pool.c:278
    #3 0x55aaa84caa6c in pj_pool_destroy_int ../src/pj/pool.c:318
    #4 0x55aaa84cbb4c in cpool_release_pool ../src/pj/pool_caching.c:254
    #5 0x55aaa84c9bfe in pj_pool_release ../include/pj/pool_i.h:155
    #6 0x55aaa84c9c5b in pj_pool_safe_release ../include/pj/pool_i.h:164
    #7 0x55aaa7f0ae9a in on_destroy ../src/pjmedia/stream_imp_common.c:678
    #8 0x55aaa84c4ce2 in grp_lock_destroy ../src/pj/lock.c:397
    #9 0x55aaa84c55f5 in grp_lock_dec_ref ../src/pj/lock.c:563
    #10 0x55aaa84c5670 in pj_grp_lock_dec_ref ../src/pj/lock.c:654
    #11 0x55aaa7f1c57c in pjmedia_stream_destroy ../src/pjmedia/stream.c:2595
   ...
```

This is perhaps related to the new behavior introduced by #4721, media transport detach is now asynchronous.