### PR TITLE
Fix ioqueue unregister test stuck due to packet loss

### DIFF
--- a/pjlib/src/pjlib-test/ioq_unreg.c
+++ b/pjlib/src/pjlib-test/ioq_unreg.c
@@ -280,7 +280,7 @@ static int perform_unreg_test(pj_ioqueue_t *ioqueue,
             status = pj_sock_send(sock_data.csock, sendbuf, &size, 0);
             if (status != PJ_SUCCESS)
                 app_perror("send() error for callback trigger", status);
-            
+
             pj_thread_sleep(200);
         }
 


### PR DESCRIPTION
Reduce false negatives in CI tests.

Sample failed test:
https://github.com/pjsip/pjproject/actions/runs/22046580489/job/63699613160
The test was terminated after ~1hr:
```
03:12:35 cirunner: Execution timeout, terminating process..
```

I managed to reproduce this locally and the patch seems to fix it.