### PR TITLE
Destroy transaction if endpoint sending fails

### DIFF
--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -114,8 +114,11 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
     tsx->mod_data[mod_stateful_util.id] = tsx_data;
 
     status = pjsip_tsx_send_msg(tsx, NULL);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
         pjsip_tx_data_dec_ref(tdata);
+        pjsip_tsx_terminate(tsx, tsx->status_code? tsx->status_code:
+                            PJSIP_SC_SERVICE_UNAVAILABLE);
+    }
 
     return status;
 }
@@ -181,6 +184,8 @@ PJ_DEF(pj_status_t) pjsip_endpt_respond(  pjsip_endpoint *endpt,
     status = pjsip_tsx_send_msg(tsx, tdata);
     if (status != PJ_SUCCESS) {
         pjsip_tx_data_dec_ref(tdata);
+        pjsip_tsx_terminate(tsx, tsx->status_code? tsx->status_code:
+                            PJSIP_SC_INTERNAL_SERVER_ERROR);
     } else if (p_tsx) {
         *p_tsx = tsx;
     }


### PR DESCRIPTION
To fix #4781.

When sending a message using `pjsip_endpt_send_request()` fails, the transaction will be left dangling:
```
15:33:27.013            pjsua_acc.c  .Acc 0: setting registration..
15:33:27.013         tsx0xb780778b0  ....Transaction created for Request msg REGISTER/cseq=10838 (tdta0xb7ac510b0)
15:33:27.013         tsx0xb780778b0  ...Sending Request msg REGISTER/cseq=10838 (tdta0xb7ac510b0) in state Null
15:33:27.013             sip_util.c  ....Unsuitable transport selected to reach destination
15:33:27.013              sip_reg.c  ...Error sending request: Unsuitable transport selected (PJSIP_ETPNOTSUITABLE)
```

This will only be cleaned up during `pjsua_destroy()`:
```
pjsip_regc_add_ref (pjsip/pjproject/pjsip/src/pjsip-ua/sip_reg.c:422)
regc_tsx_callback (pjsip/pjproject/pjsip/src/pjsip-ua/sip_reg.c:1107)
mod_util_on_tsx_state (pjsip/pjproject/pjsip/src/pjsip/sip_util_statefull.c:80)
tsx_set_state (pjsip/pjproject/pjsip/src/pjsip/sip_transaction.c:1460)
pjsip_tsx_terminate (pjsip/pjproject/pjsip/src/pjsip/sip_transaction.c:1890)
mod_tsx_layer_stop (pjsip/pjproject/pjsip/src/pjsip/sip_transaction.c:824)
pjsip_endpt_destroy (pjsip/pjproject/pjsip/src/pjsip/sip_endpoint.c:611)
pjsua_destroy2 (pjsip/pjproject/pjsip/src/pjsua-lib/pjsua_core.c:2144)
pjsua_destroy (pjsip/pjproject/pjsip/src/pjsua-lib/pjsua_core.c:2240)
```

Which obviously will be too late since the `regc` object has been destroyed.
