### PR TITLE
Signed-off-by: Pesala Silva <pesala.silva@ifs.com> Fixing_provisional_media_cleanup_for_non_active_INVITE_Transactions

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -6502,7 +6502,15 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
             /* Either we get non-2xx or media update failed,
              * revert back provisional media.
              */
-            pjsua_media_prov_revert(call->index);
+            if (inv->invite_tsx == NULL || tsx == inv->invite_tsx) {
+                pjsua_media_prov_revert(call->index);
+            }
+            else
+            {
+                PJ_LOG(4, (THIS_FILE, "Retaining provisional media for call %d "
+                    "since this is not the active Invite",
+                    call->index));
+            }
         }
     } else if (tsx->role == PJSIP_ROLE_UAC &&
                pjsip_method_cmp(&tsx->method, &pjsip_update_method)==0 &&


### PR DESCRIPTION
 **Fixing_provisional_media_cleanup_for_non_active_INVITE_Transactions**

- Add validation to ensure provisional media is only reverted when the transaction matches the active invite transaction. This prevents incorrect cleanup when multiple INVITE attempts are in progress (e.g., during failover scenarios where the first attempt times out and a second attempt is made via an alternate proxy).
- With this fix, the cleanup only occurs if the transaction is NULL or matches the invite_tsx, preventing the race condition.



