### PR TITLE
Fix undefined behavior: left shift of negative signed integers in G.722 codec

### DIFF
--- a/pjmedia/src/pjmedia-codec/g722/g722_dec.c
+++ b/pjmedia/src/pjmedia-codec/g722/g722_dec.c
@@ -124,7 +124,8 @@ static int block4l (g722_dec_t *dec, int dl)
     dec->sgl[1] = dec->plt[1] >> 15 ;
     dec->sgl[2] = dec->plt[2] >> 15 ;
 
-    wd1 = dec->al[1] << 2;
+    // orig: wd1 = dec->al[1] << 2;
+    wd1 = dec->al[1] * 4;
     SATURATE(wd1, 32767, -32768);
 
     if ( dec->sgl[0] == dec->sgl[1] )  wd2 = - wd1 ;
@@ -132,7 +133,7 @@ static int block4l (g722_dec_t *dec, int dl)
     if (wd2 > 32767) wd2 = 32767;
     wd2 = wd2 >> 7 ;
 
-    if ( dec->sgl[0] == dec->sgl[2] )  wd3 = 128 ; 
+    if ( dec->sgl[0] == dec->sgl[2] )  wd3 = 128 ;
     else  wd3 = - 128 ;
 
     wd4 = wd2 + wd3 ;
@@ -140,7 +141,7 @@ static int block4l (g722_dec_t *dec, int dl)
 
     dec->apl[2] = wd4 + wd5 ;
     SATURATE(dec->apl[2], 12288, -12288);
-    
+
     /* UPPOL1 */
     dec->sgl[0] = dec->plt[0] >> 15 ;
     dec->sgl[1] = dec->plt[1] >> 15 ;
@@ -186,11 +187,13 @@ static int block4l (g722_dec_t *dec, int dl)
     }
 
     /* FILTEP */
-    wd1 = dec->rlt[1] << 1;
+    // orig: wd1 = dec->rlt[1] << 1;
+    wd1 = dec->rlt[1] + dec->rlt[1];
     SATURATE(wd1, 32767, -32768);
     wd1 = ( dec->al[1] * wd1 ) >> 15 ;
 
-    wd2 = dec->rlt[2] << 1;
+    // orig: wd2 = dec->rlt[2] << 1;
+    wd2 = dec->rlt[2] + dec->rlt[2];
     SATURATE(wd2, 32767, -32768);
     wd2 = ( dec->al[2] * wd2 ) >> 15 ;
 
@@ -200,7 +203,8 @@ static int block4l (g722_dec_t *dec, int dl)
     /* FILTEZ */
     dec->szl = 0 ;
     for (i=6; i>0; i--) {
-        wd = dec->dlt[i] << 1;
+        // orig: wd = dec->dlt[i] << 1;
+        wd = dec->dlt[i] + dec->dlt[i];
         SATURATE(wd, 32767, -32768);
         dec->szl += (dec->bl[i] * wd) >> 15 ;
         SATURATE(dec->szl, 32767, -32768);
@@ -347,7 +351,8 @@ static int block4h (g722_dec_t *dec, int d)
     dec->sgh[1] = dec->ph[1] >> 15 ;
     dec->sgh[2] = dec->ph[2] >> 15 ;
 
-    wd1 = dec->ah[1] << 2;
+    // orig: wd1 = dec->ah[1] << 2;
+    wd1 = dec->ah[1] * 4;
     SATURATE(wd1, 32767, -32768);
 
     if ( dec->sgh[0] == dec->sgh[1] )  wd2 = - wd1 ;
@@ -356,7 +361,7 @@ static int block4h (g722_dec_t *dec, int d)
 
     wd2 = wd2 >> 7 ;
 
-    if ( dec->sgh[0] == dec->sgh[2] )  wd3 = 128 ; 
+    if ( dec->sgh[0] == dec->sgh[2] )  wd3 = 128 ;
     else  wd3 = - 128 ;
 
     wd4 = wd2 + wd3 ;
@@ -364,7 +369,7 @@ static int block4h (g722_dec_t *dec, int d)
 
     dec->aph[2] = wd4 + wd5 ;
     SATURATE(dec->aph[2], 12288, -12288);
-    
+
     /* UPPOL1 */
     dec->sgh[0] = dec->ph[0] >> 15 ;
     dec->sgh[1] = dec->ph[1] >> 15 ;
@@ -398,7 +403,7 @@ static int block4h (g722_dec_t *dec, int d)
         wd3 = (dec->bh[i] * 32640) >> 15 ;
         dec->bph[i] = wd2 + wd3 ;
     }
- 
+
     /* DELAYA */
     for ( i = 6; i > 0; i-- ) {
         dec->dh[i] = dec->dh[i-1] ;
@@ -412,11 +417,13 @@ static int block4h (g722_dec_t *dec, int d)
     }
 
     /* FILTEP */
-    wd1 = dec->rh[1] << 1 ;
+    // orig: wd1 = dec->rh[1] << 1 ;
+    wd1 = dec->rh[1] + dec->rh[1] ;
     SATURATE(wd1, 32767, -32768);
     wd1 = ( dec->ah[1] * wd1 ) >> 15 ;
 
-    wd2 = dec->rh[2] << 1;
+    // orig: wd2 = dec->rh[2] << 1;
+    wd2 = dec->rh[2] + dec->rh[2];
     SATURATE(wd2, 32767, -32768);
     wd2 = ( dec->ah[2] * wd2 ) >> 15 ;
 
@@ -426,7 +433,8 @@ static int block4h (g722_dec_t *dec, int d)
     /* FILTEZ */
     dec->szh = 0 ;
     for (i=6; i>0; i--) {
-        wd = dec->dh[i] << 1;
+        // orig: wd = dec->dh[i] << 1;
+        wd = dec->dh[i] + dec->dh[i];
         SATURATE(wd, 32767, -32768);
         dec->szh += (dec->bh[i] * wd) >> 15 ;
         SATURATE(dec->szh, 32767, -32768);

--- a/pjmedia/src/pjmedia-codec/g722/g722_enc.c
+++ b/pjmedia/src/pjmedia-codec/g722/g722_enc.c
@@ -189,7 +189,8 @@ static int block4l (g722_enc_t *enc, int dl)
     enc->sgl[1] = enc->plt[1] >> 15 ;
     enc->sgl[2] = enc->plt[2] >> 15 ;
 
-    wd1 = enc->al[1] << 2;
+    // orig: wd1 = enc->al[1] << 2;
+    wd1 = enc->al[1] * 4;
     SATURATE(wd1, 32767, -32768);
 
     if ( enc->sgl[0] == enc->sgl[1] )  wd2 = - wd1 ;
@@ -394,7 +395,8 @@ static int block4h (g722_enc_t *enc, int d)
     enc->sgh[1] = enc->ph[1] >> 15 ;
     enc->sgh[2] = enc->ph[2] >> 15 ;
 
-    wd1 = enc->ah[1] << 2;
+    // orig: wd1 = enc->ah[1] << 2;
+    wd1 = enc->ah[1] * 4;
     SATURATE(wd1, 32767, -32768);
 
     if ( enc->sgh[0] == enc->sgh[1] )  wd2 = - wd1 ;


### PR DESCRIPTION
## Summary
- Replace left-shift operations on potentially negative signed integers with arithmetic equivalents to avoid undefined behavior per C99 §6.5.7
- The G.722 encoder already uses the correct pattern (addition instead of left shift) in 6 out of 8 similar locations; this aligns the remaining 2 encoder locations and all 8 decoder locations to use the same safe approach: `<< 1` becomes `x + x`, and `<< 2` becomes `x * 4`
- Pure arithmetic equivalence — no behavioral change

## Details
Discovered by OSS-Fuzz (`fuzz-audio`) with UBSan:
```
g722_dec.c:415:22: runtime error: left shift of negative value -2
```

The G.722 signal processing uses signed integers in range [-32768, 32767]. Negative values are legitimate and expected. Left-shifting negative signed integers is undefined behavior in C99 (§6.5.7), though most compilers produce the intended two's complement result.

### Files changed
- `pjmedia/src/pjmedia-codec/g722/g722_dec.c` — 8 locations fixed
- `pjmedia/src/pjmedia-codec/g722/g722_enc.c` — 2 locations fixed

## Test plan
- [ ] Build succeeds with no warnings
- [ ] G.722 codec tests pass (encode/decode round-trip unchanged)
- [ ] UBSan no longer reports left-shift errors on fuzz-audio corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)