### PR TITLE
Fix uninitialized memory in ioqueue select() implementation

### DIFF
--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -223,7 +223,7 @@ PJ_DEF(pj_status_t) pj_ioqueue_create2(pj_pool_t *pool,
                      sizeof(union operation_key), PJ_EBUG);
 
     /* Create and init common ioqueue stuffs */
-    ioqueue = PJ_POOL_ALLOC_T(pool, pj_ioqueue_t);
+    ioqueue = PJ_POOL_ZALLOC_T(pool, pj_ioqueue_t);
     ioqueue_init(ioqueue);
 
     if (cfg)


### PR DESCRIPTION
## Summary
- Use `PJ_POOL_ZALLOC_T` instead of `PJ_POOL_ALLOC_T` when allocating the ioqueue structure to ensure it is fully zero-initialized before use

## Details
Discovered by OSS-Fuzz (`fuzz-stun`) with MemorySanitizer:
```
use-of-uninitialized-value in PJ_FD_SET (sock_select.c:57)
  → ioqueue_add_to_set2 (ioqueue_select.c:688)
  → pj_ioqueue_recvfrom
  → pj_activesock_start_recvfrom2
  → pj_stun_sock_create
```

### Root cause analysis

The `pj_fd_set_t` wrapper struct is intentionally oversized to safely accommodate the native `fd_set`:

| Region | Size (x86_64) | Initialized by `PJ_FD_ZERO`? |
|--------|---------------|-------------------------------|
| `data[0]` (count) | 8 bytes | Yes (`PART_COUNT = 0`) |
| `data[1..16]` (native `fd_set`) | 128 bytes | Yes (`FD_ZERO`) |
| `data[17..67]` (padding) | 408 bytes | **No** |

The pool allocator uses `malloc()` internally without zero-initialization. While `PJ_FD_ZERO()` properly initializes the native `fd_set` portion, the remaining padding in `pj_fd_set_t` retains indeterminate values from `malloc()`. MSan detects this as use of uninitialized memory.

### Fix
Replace `PJ_POOL_ALLOC_T` with `PJ_POOL_ZALLOC_T` to zero-initialize the entire ioqueue struct (including all `pj_fd_set_t` padding) at allocation time. This is a one-line change.

## Test plan
- [ ] Build succeeds
- [ ] MSan no longer reports uninitialized memory in fd_set operations
- [ ] ioqueue/select tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)