### PR TITLE
Fix null pointer dereference in STUN session send_response()

### DIFF
--- a/pjnath/src/pjnath/stun_session.c
+++ b/pjnath/src/pjnath/stun_session.c
@@ -1220,8 +1220,9 @@ static pj_status_t send_response(pj_stun_session *sess, void *token,
     out_pkt = (pj_uint8_t*) pj_pool_alloc(pool, out_max_len);
 
     /* Encode */
-    status = pj_stun_msg_encode(response, out_pkt, out_max_len, 0, 
-                                &auth_info->auth_key, &out_len);
+    status = pj_stun_msg_encode(response, out_pkt, out_max_len, 0,
+                                auth_info ? &auth_info->auth_key : NULL,
+                                &out_len);
     if (status != PJ_SUCCESS) {
         LOG_ERR_(sess, "Error encoding message", status);
         return status;


### PR DESCRIPTION
## Summary
- Add NULL check for `auth_info` before dereferencing `auth_info->auth_key` in `send_response()`
- TURN clients have `sess->cred = NULL` since they only configure outbound credentials and never expect to handle incoming requests requiring server-side credential validation

## Details
Discovered by OSS-Fuzz (`fuzz-stun`) with UBSan:
```
stun_session.c:1224:45: runtime error: member access within null pointer
  of type 'const pj_stun_req_cred_info'
    #0 send_response (stun_session.c:1224)
    #1 pj_stun_session_on_rx_pkt (stun_session.c:1502)
    #2 pj_turn_session_on_rx_pkt2 (turn_session.c:1307)
```

When `pj_stun_session_on_rx_pkt()` fails to decode a message, it calls `send_response()` with `NULL` for `auth_info` (line 1503). The function then unconditionally dereferences it at line 1224.

The existing `apply_msg_options()` (line 286) already handles `auth_info == NULL` safely. `pj_stun_msg_encode()` only uses the auth key when MESSAGE-INTEGRITY is present; error responses don't include it, so passing NULL is safe.

## Test plan
- [ ] Build succeeds
- [ ] UBSan no longer reports null pointer dereference on fuzz-stun corpus
- [ ] STUN/TURN connectivity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)