### PR TITLE
Fix deadlock in UDP transport detach with PJ_IOQUEUE_CALLBACK_NO_LOCK

### DIFF
--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -1055,8 +1055,10 @@ static void transport_detach( pjmedia_transport *tp,
          * during its wait loop, causing a deadlock.
          *
          * It is safe to unlock here because:
-         * - Callbacks (rtp_cb/rtcp_cb) have been set to NULL above, so
-         *   any in-flight callback will be a no-op.
+         * - Callbacks (rtp_cb/rtp_cb2/rtcp_cb) have been set to NULL
+         *   above, so no new application callbacks will be invoked
+         *   after this point (although an in-flight callback that has
+         *   already copied the function pointer may still complete).
          * - pj_ioqueue_clear_key() handles its own locking internally.
          */
         pj_ioqueue_unlock_key(udp->rtcp_key);


### PR DESCRIPTION
## Summary

- Fix a deadlock in `transport_udp_detach()` that causes intermittent CI failures in SIPp tests (e.g. `uac-inv-two-media-but-one-disabled-no-rtpmap` [here](https://github.com/pjsip/pjproject/actions/runs/22656181110/job/65666355913) (the lower failure, not the ASan))
- The deadlock occurs when a read callback is active during stream destruction on re-INVITE, causing a 1-second hang that makes SIPp time out
- Root cause: `transport_detach()` holds the ioqueue key lock while calling `pj_ioqueue_clear_key()`, but with `PJ_IOQUEUE_CALLBACK_NO_LOCK=1` (default), `clear_key` needs the lock to be fully releasable to wait for callbacks to finish

### Deadlock scenario

1. **Thread A** (SIP worker): `transport_detach()` acquires key lock (count=1), calls `pj_ioqueue_clear_key()` which re-acquires recursively (count=2), then waits for `read_callback_thread == NULL`
2. **Thread B** (ioqueue poll): finished executing the read callback, needs to acquire the key lock to set `read_callback_thread = NULL`
3. Thread A's wait loop unlocks once (count 2→1, still locked), so Thread B remains blocked → **deadlock** until 1-second timeout

### Fix

Release the key locks after NULLing the callbacks but before calling `pj_ioqueue_clear_key()`. This is safe because:
- Callbacks (`rtp_cb`/`rtcp_cb`) are already NULL, so any in-flight callback is a no-op
- `pj_ioqueue_clear_key()` handles its own locking internally

## Test plan

- [ ] Verify `uac-inv-two-media-but-one-disabled-no-rtpmap` SIPp test passes consistently
- [ ] Run full pjsua-test suite to check for regressions
- [ ] Verify on both select and IOCP ioqueue backends (the same deadlock pattern exists in `ioqueue_winnt.c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)