### PR TITLE
Fixed tdata double dec ref in Fuzzer sip transaction

### DIFF
--- a/tests/fuzz/fuzz-sip-transaction.c
+++ b/tests/fuzz/fuzz-sip-transaction.c
@@ -85,7 +85,9 @@ static void test_uas_transaction(pj_pool_t *pool, const uint8_t *data, size_t si
     /* Create and send response through transaction */
     pjsip_tx_data *tdata = NULL;
     if (pjsip_endpt_create_response(endpt, &rdata, 200, NULL, &tdata) == PJ_SUCCESS && tdata) {
-        pjsip_tsx_send_msg(tsx, tdata);
+        pj_status_t status = pjsip_tsx_send_msg(tsx, tdata);
+        if (status != PJ_SUCCESS)
+            pjsip_tx_data_dec_ref(tdata);
     }
 
     /* Force transaction termination to prevent leaks */
@@ -118,15 +120,14 @@ static void test_uac_transaction(pj_pool_t *pool, const uint8_t *data, size_t si
     pj_status_t status = pjsip_tsx_create_uac(&tsx_user, tdata, &tsx);
     
     if (status == PJ_SUCCESS && tsx) {
-        pjsip_tsx_send_msg(tsx, NULL);
+        status = pjsip_tsx_send_msg(tsx, NULL);
+        if (status != PJ_SUCCESS)
+            pjsip_tx_data_dec_ref(tdata);
         
         /* Force transaction termination to prevent leaks */
         if (tsx->state != PJSIP_TSX_STATE_TERMINATED)
             pjsip_tsx_terminate_async(tsx, 408);
     }
-    
-    /* Release transmit data buffer */
-    pjsip_tx_data_dec_ref(tdata);
 }
 
 /* Test sip_util.c request creation functions */


### PR DESCRIPTION
There's a bug related to #4820 ( Add fuzzer for sip transaction and util ):

```
fuzz-sip-transaction: ../src/pjsip/sip_transport.c:581: pj_status_t pjsip_tx_data_dec_ref(pjsip_tx_data *): Assertion `ref_cnt >= 0' failed.
==248== ERROR: libFuzzer: deadly signal
    #8 0x79c73bf6afd5 in __assert_fail /build/glibc-B3wQXB/glibc-2.31/assert/assert.c:103:3
    #9 0x55f7501687a9 in pjsip_tx_data_dec_ref pjsip/pjsip/src/pjsip/sip_transport.c:581:5
    #10 0x55f75017b787 in tsx_shutdown pjsip/pjsip/src/pjsip/sip_transaction.c:1254:9
    #11 0x55f75017d37f in tsx_set_state pjsip/pjsip/src/pjsip/sip_transaction.c:1529:9
    #12 0x55f750183485 in tsx_on_state_terminated pjsip/pjsip/src/pjsip/sip_transaction.c:3883:5
    #13 0x55f750180d2f in tsx_timer_callback pjsip/pjsip/src/pjsip/sip_transaction.c:1402:9
    #14 0x55f7501e237a in pj_timer_heap_poll pjsip/pjlib/src/pj/timer.c:926:13
    #15 0x55f75015843e in pjsip_endpt_handle_events2 pjsip/pjsip/src/pjsip/sip_endpoint.c:737:9
    #16 0x55f750134dfb in LLVMFuzzerTestOneInput pjsip/tests/fuzz/fuzz-sip-transaction.c:300:5
```

As `pjsip_tsx_send_msg()` doc states:
` This function decrements the reference counter of the transmit buffer only when it returns PJ_SUCCESS`.

So decreasing the reference in success cases will cause `tx_data_dec_ref()` to be called twice.
