### PR TITLE
Add zero padding in TURN ChannelData

### DIFF
--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -1051,6 +1051,10 @@ PJ_DEF(pj_status_t) pj_turn_session_sendto( pj_turn_session *sess,
         cd->ch_number = pj_htons((pj_uint16_t)ch->num);
         cd->length = pj_htons((pj_uint16_t)pkt_len);
         pj_memcpy(cd+1, pkt, pkt_len);
+        /* Add zero padding, if data is not 4-bytes aligned. */
+        if (pkt_len & 0x03) {
+            pj_bzero(((pj_uint8_t *)(cd+1)) + pkt_len, 4 - (pkt_len & 0x03));
+        }
 
         pj_assert(sess->srv_addr != NULL);
 


### PR DESCRIPTION
As per original report by Gil Portnoy:
"
`pj_turn_session_sendto()` pads ChannelData payload to a 4-byte boundary per RFC 5766 Section 11.4: total_len = (pkt_len + sizeof(*cd) + 3) & (~3). After copying the payload, padding bytes at [4+pkt_len .. total_len) are never zeroed.

The encoding buffer sess->tx_pkt is a fixed-size 3000-byte struct member (PJ_TURN_MAX_PKT_LEN) reused across all TURN sends, so prior message content persists.

Impact

1-3 bytes of tx_pkt buffer residual leak per ChannelData frame with unaligned payload.
"

Thank you to Gil Portnoy (@dhkts1) for the analysis.