### PR TITLE
Fixed potential ptime integer overflow calculation in audio stream

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2078,7 +2078,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
         ptime <<= 1;
 
         /* Allocate buffer */
-        stream->enc_buf_size = afd->clock_rate * ptime / 1000 / 1000;
+        stream->enc_buf_size = ptime / 1000 * afd->clock_rate / 1000;
         c_strm->enc_buf = (pj_int16_t*)
                           pj_pool_alloc(pool, stream->enc_buf_size * 2);
 


### PR DESCRIPTION
As per original report by Gil Portnoy:
"
The expression afd->clock_rate * ptime at line 2081 is computed as 32-bit unsigned multiplication, where ptime is in microseconds (derived from afd->frame_time_usec, potentially doubled at line 2078). For Opus at 48000 Hz with a large enc_ptime negotiated via SDP (e.g., enc_ptime=120 → ptime=240000 after conversion and doubling), the product 48000 * 240000 = 11,520,000,000 exceeds UINT32_MAX (4,294,967,295), wrapping to a small value.

This results in an undersized buffer allocation.
"

Thank you to Gil Portnoy (@dhkts1) for the analysis. 
