### PR TITLE
Fixed SIP Multipart CID URI length check

### DIFF
--- a/pjsip/src/pjsip/sip_multipart.c
+++ b/pjsip/src/pjsip/sip_multipart.c
@@ -549,12 +549,14 @@ static pj_str_t cid_uri_to_hdr_value(pj_pool_t *pool, pj_str_t *cid_uri)
     pj_size_t cid_len = pj_strlen(cid_uri);
     pj_size_t alloc_len = cid_len + 2 /* for the leading and trailing angle brackets */;
     pj_str_t uri_overlay;
-    pj_str_t cid_hdr;
+    pj_str_t cid_hdr = {0};
     pj_str_t hdr_overlay;
 
     pj_strassign(&uri_overlay, cid_uri);
     /* If the URI is already enclosed in angle brackets, remove them. */
     if (uri_overlay.ptr[0] == '<') {
+        if (uri_overlay.slen < 2)
+            return cid_hdr;
         uri_overlay.ptr++;
         uri_overlay.slen -= 2;
     }


### PR DESCRIPTION
As per original report by Gil Portnoy:
"
When parsing Content-ID URIs, slen -= 2 (line 559) strips <> delimiters. If slen is 1, the signed subtraction produces -1 (pj_str_t.slen is pj_ssize_t). This negative value is implicitly cast to a very large pj_size_t when passed to subsequent string operations (pj_strncmp2, pj_strcpy_unescape), causing out-of-bounds reads.
"

Thank you to Gil Portnoy (@dhkts1) for the analysis. 