### PR TITLE
Add concurrency, test robustness, and test runner guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -179,7 +179,7 @@ Follow the official PJSIP coding style: https://docs.pjsip.org/en/latest/get-sta
 - Media and SIP run on separate thread groups (media endpoint has its own ioqueue worker).
 - Use `pj_mutex_t` / `pj_lock_t` for synchronization - NOT pthread directly.
 - Callback functions may be called from worker threads - be thread-safe.
-- Never invoke user callbacks while holding a mutex — this is prone to deadlock. Release the lock before calling callbacks, then re-acquire if needed.
+- Avoid invoking user callbacks while holding a mutex — this is prone to deadlock. Where possible, release the lock before calling callbacks, then re-acquire if needed.
 - `pj_init()` and `pj_shutdown()` must be called from the main thread; calls must be balanced.
 - Non-main threads must register via `pj_thread_register()` after `pj_init()`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Follow the official PJSIP coding style: https://docs.pjsip.org/en/latest/get-sta
 - Media and SIP run on separate thread groups (media endpoint has its own ioqueue worker).
 - Use `pj_mutex_t` / `pj_lock_t` for synchronization - NOT pthread directly.
 - Callback functions may be called from worker threads - be thread-safe.
-- Never invoke user callbacks while holding a mutex — this is prone to deadlock. Release the lock before calling callbacks, then re-acquire if needed.
+- Avoid invoking user callbacks while holding a mutex — this is prone to deadlock. Where possible, release the lock before calling callbacks, then re-acquire if needed.
 - `pj_init()` and `pj_shutdown()` must be called from the main thread; calls must be balanced.
 - Non-main threads must register via `pj_thread_register()` after `pj_init()`.
 


### PR DESCRIPTION
## Summary
- Add concurrency guidelines: avoid callbacks while holding mutex, ensure object lifetime outlives async ops, never destroy referenced locks
- Add test robustness guidelines: no precise timing dependencies, ASan compatibility for platform-specific code
- Document how to run specific unit tests (positional args, `--list`, common options)
- ... (anything else)?

Applied to both `CLAUDE.md` and `.github/copilot-instructions.md`.

## Test plan
- [ ] Verify docs render correctly on GitHub

Co-Authored-By: Claude Code