### PR TITLE
Fix flaky select_test on CI with high fd numbers

### DIFF
--- a/pjlib/src/pjlib-test/select.c
+++ b/pjlib/src/pjlib-test/select.c
@@ -61,7 +61,7 @@ static int do_select( pj_sock_t sock1, pj_sock_t sock2,
 {
     pj_fd_set_t fds[3];
     pj_time_val timeout;
-    int i, n;
+    int i, n, nfds;
 
     for (i=0; i<3; ++i) {
         PJ_FD_ZERO(&fds[i]);
@@ -73,7 +73,8 @@ static int do_select( pj_sock_t sock1, pj_sock_t sock2,
     timeout.sec = 5;
     timeout.msec = 0;
 
-    n = pj_sock_select(PJ_IOQUEUE_MAX_HANDLES, &fds[0], &fds[1], &fds[2],
+    nfds = (int)(sock1 > sock2 ? sock1 : sock2) + 1;
+    n = pj_sock_select(nfds, &fds[0], &fds[1], &fds[2],
                        &timeout);
     if (n < 0)
         return n;


### PR DESCRIPTION
## Summary
- `select_test` passes `PJ_IOQUEUE_MAX_HANDLES` (64) as `nfds` to `pj_sock_select()`
- On POSIX, `select()` only monitors fds 0..nfds-1
- On CI with ASan + parallel worker threads, socket fds can exceed 64, causing `select()` to silently ignore them and timeout after 5 seconds (error -60)
- Fix: compute `nfds` as `max(sock1, sock2) + 1`

Previous attempts to fix this flaky test (#4833, #4835) addressed port conflicts and timing tolerances but did not identify the root cause.

## Test plan
- [x] Builds cleanly
- [ ] Verify select_test passes on CI with ASan + parallel workers

Co-Authored-By: Claude Code