### PR TITLE
Optimize CI: conditional jobs, test rebalancing, macOS platform-aware gating

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -17,14 +17,14 @@ jobs:
     outputs:
       # Aggregate dependency groups — each combines the raw path filters
       # relevant to a set of test jobs, so per-job conditions are one-liners.
-      pjlib-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjnath-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjmedia-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjsip-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjmedia-pjsip-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjnath-pjmedia-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjnath-pjsip-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      any-src: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.pjsip-apps == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjlib_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjnath_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjmedia_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjsip_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjmedia_pjsip_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjnath_pjmedia_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjnath_pjsip_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      any_src: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.pjsip_apps == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
@@ -39,7 +39,7 @@ jobs:
             - 'Makefile'
             - '*.mak*'
             - 'third_party/**'
-          pjlib-util:
+          pjlib_util:
             - 'pjlib-util/**'
           pjnath:
             - 'pjnath/**'
@@ -47,7 +47,7 @@ jobs:
             - 'pjmedia/**'
           pjsip:
             - 'pjsip/**'
-          pjsip-apps:
+          pjsip_apps:
             - 'pjsip-apps/**'
           tests:
             - 'tests/**'
@@ -84,7 +84,7 @@ jobs:
   default-full-bundle-1:
     # full bundle: enable all codecs + AEC + DTLS
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.any-src == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
     runs-on: ubuntu-latest
     name: Default / pjsua
     steps:
@@ -140,7 +140,7 @@ jobs:
 
   default-full-bundle-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath_deps == 'true'
     runs-on: ubuntu-latest
     name: Default / pjlib,util,pjnath
     steps:
@@ -174,7 +174,7 @@ jobs:
 
   default-full-bundle-3:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia-pjsip-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia_pjsip_deps == 'true'
     runs-on: ubuntu-latest
     name: Default / pjmedia,pjsip
     steps:
@@ -204,7 +204,7 @@ jobs:
 
   no-tls:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjsip-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjsip_deps == 'true'
     runs-on: ubuntu-latest
     name: No SSL / pjlib,pjsip
     steps:
@@ -239,7 +239,7 @@ jobs:
 
   gnu-tls:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath-pjsip-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath_pjsip_deps == 'true'
     runs-on: ubuntu-latest
     name: GnuTLS / pjlib,pjnath,pjsip
     steps:
@@ -277,7 +277,7 @@ jobs:
 
   vid-openh264-1:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.any-src == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
     runs-on: ubuntu-latest
     name: OpenH264+VPX / pjsua
     steps:
@@ -350,7 +350,7 @@ jobs:
 
   vid-openh264-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath_deps == 'true'
     runs-on: ubuntu-latest
     name: OpenH264+VPX / pjlib,util,pjnath
     steps:
@@ -395,7 +395,7 @@ jobs:
 
   vid-openh264-3:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia-pjsip-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia_pjsip_deps == 'true'
     runs-on: ubuntu-latest
     name: OpenH264+VPX / pjmedia,pjsip
     steps:
@@ -444,7 +444,7 @@ jobs:
 
   vid-ffmpeg:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia_deps == 'true'
     runs-on: ubuntu-latest
     name: FFMPEG+x264 / pjmedia
     steps:
@@ -501,7 +501,7 @@ jobs:
 
   ioq-epoll-cb-with-lock-conf-thread:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.any-src == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
     runs-on: ubuntu-latest
     name: ioq-epoll-cb-with-lock-conf-thread / pjlib,pjsua
     steps:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -30,7 +30,7 @@ jobs:
       # codecs, AEC). Other components (pjlib-util, pjnath, pjsip, pjsip-apps)
       # are platform-independent protocol logic already covered by Linux CI.
       # Only run full Mac test suite for changes to platform-specific areas.
-      mac-full-tests: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      mac_full_tests: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
@@ -45,7 +45,7 @@ jobs:
             - 'Makefile'
             - '*.mak*'
             - 'third_party/**'
-          pjlib-util:
+          pjlib_util:
             - 'pjlib-util/**'
           pjnath:
             - 'pjnath/**'
@@ -53,7 +53,7 @@ jobs:
             - 'pjmedia/**'
           pjsip:
             - 'pjsip/**'
-          pjsip-apps:
+          pjsip_apps:
             - 'pjsip-apps/**'
           tests:
             - 'tests/**'
@@ -86,7 +86,7 @@ jobs:
   default-pjlib-util-pjmedia-pjnath:
     # full bundle: enable all codecs + AEC + DTLS
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: Default / pjmedia,pjnath
     steps:
@@ -118,7 +118,7 @@ jobs:
 
   default-pjsua-test:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: Default / pjsua-test
     steps:
@@ -164,7 +164,7 @@ jobs:
 
   default-pjsip-test:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: Default / pjlib,util,pjsip-test
     steps:
@@ -198,7 +198,7 @@ jobs:
 
   openssl-1:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: OpenSSL / pjlib,util,pjnath,pjmedia
     steps:
@@ -244,7 +244,7 @@ jobs:
 
   openssl-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: OpenSSL / pjsip
     steps:
@@ -278,7 +278,7 @@ jobs:
 
   gnu-tls-1:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: GnuTLS / pjlib,util,pjmedia,pjnath
     steps:
@@ -322,7 +322,7 @@ jobs:
 
   gnu-tls-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: GnuTLS / pjsip-test
     steps:
@@ -354,7 +354,7 @@ jobs:
 
   video-openh264-1:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: Openh264+VPX / pjsua
     steps:
@@ -400,7 +400,7 @@ jobs:
 
   video-openh264-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: Openh264+VPX / pjlib,util,pjnath
     steps:
@@ -434,7 +434,7 @@ jobs:
 
   video-openh264-3:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: Openh264+VPX / pjmedia,pjsip
     steps:
@@ -466,7 +466,7 @@ jobs:
 
   video-ffmpeg:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: FFMPEG+VPX+x264 / pjmedia
     steps:
@@ -506,7 +506,7 @@ jobs:
 
   video-vid-toolbox:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: VPX+VidToolbox / pjmedia
     steps:
@@ -540,7 +540,7 @@ jobs:
 
   ioq-cb-with-lock:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac-full-tests == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
     runs-on: macos-latest
     name: ioq-cb-with-lock / pjlib,pjsua
     steps:

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -16,14 +16,14 @@ jobs:
     outputs:
       # Aggregate dependency groups — each combines the raw path filters
       # relevant to a set of test jobs, so per-job conditions are one-liners.
-      pjlib-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjnath-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjmedia-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjsip-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjmedia-pjsip-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjnath-pjmedia-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      pjnath-pjsip-deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
-      any-src: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib-util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.pjsip-apps == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjlib_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjnath_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjmedia_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjsip_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjmedia_pjsip_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjnath_pjmedia_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      pjnath_pjsip_deps: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
+      any_src: ${{ steps.filter.outputs.core == 'true' || steps.filter.outputs.pjlib_util == 'true' || steps.filter.outputs.pjnath == 'true' || steps.filter.outputs.pjmedia == 'true' || steps.filter.outputs.pjsip == 'true' || steps.filter.outputs.pjsip_apps == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.ci == 'true' }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
@@ -38,7 +38,7 @@ jobs:
             - 'Makefile'
             - '*.mak*'
             - 'third_party/**'
-          pjlib-util:
+          pjlib_util:
             - 'pjlib-util/**'
           pjnath:
             - 'pjnath/**'
@@ -46,7 +46,7 @@ jobs:
             - 'pjmedia/**'
           pjsip:
             - 'pjsip/**'
-          pjsip-apps:
+          pjsip_apps:
             - 'pjsip-apps/**'
           tests:
             - 'tests/**'
@@ -104,7 +104,7 @@ jobs:
 
   openssl-1:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjmedia_deps == 'true'
     runs-on: windows-latest
     name: OpenSSL / pjlib,util,pjmedia
     steps:
@@ -178,7 +178,7 @@ jobs:
 
   openssl-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.any-src == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
     runs-on: windows-latest
     name: OpenSSL / pjsip,pjsua
     env:
@@ -281,7 +281,7 @@ jobs:
 
   openssl-3:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath_deps == 'true'
     runs-on: windows-latest
     name: OpenSSL / pjnath
     steps:
@@ -394,7 +394,7 @@ jobs:
 
   vid-libvpx-schannel-1:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath-pjmedia-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjnath_pjmedia_deps == 'true'
     runs-on: windows-latest
     name: VPX+SChannel / pjlib,util,pjmedia,pjnath
     env:
@@ -518,7 +518,7 @@ jobs:
 
   vid-libvpx-schannel-2:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.any-src == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
     runs-on: windows-latest
     name: VPX+SChannel / pjsua
     env:
@@ -641,7 +641,7 @@ jobs:
 
   vid-libvpx-schannel-3:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjsip-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjsip_deps == 'true'
     runs-on: windows-latest
     name: VPX+SChannel / pjsip
     steps:
@@ -799,7 +799,7 @@ jobs:
 
   iocp:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.pjlib-deps == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.pjlib_deps == 'true'
     runs-on: windows-latest
     name: IOCP / pjlib
     steps:
@@ -837,7 +837,7 @@ jobs:
 
   iocp-cb-with-lock:
     needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.any-src == 'true'
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
     runs-on: windows-latest
     name: iocp-cb-with-lock / pjlib,pjsua
     env:


### PR DESCRIPTION
## Background

PJPROJECT CI currently runs the full test suite on all three platforms (Linux, macOS, Windows) for every PR, regardless of which components changed. This leads to several pain points:

- **Long CI times**: A full CI run takes 30-50+ minutes per platform, with some test bundles exceeding 35 minutes each.
- **macOS runner queue bottleneck**: macOS runners on GitHub Actions have very limited concurrency. With ~15 jobs per PR, queue wait times regularly exceed **120 minutes** before jobs even start, creating a major bottleneck for PR review turnaround.
- **Unnecessary resource usage**: Platform-independent changes (e.g., pjsip protocol logic, pjnath) don't need full macOS testing since the code paths are identical to Linux — yet they still consume scarce macOS runner slots.
- **Unbalanced test bundles**: Some job bundles were significantly heavier than others (e.g., bundle-1 at 36.5m vs bundle-2 at 18.6m), leading to suboptimal wall-clock times.
- **Flaky CI perception**: Long queue times combined with occasional test flakiness make it hard to distinguish real failures from infrastructure issues, slowing down the merge cycle.

This PR addresses these issues by making CI jobs conditional on changed paths, rebalancing test bundles for better parallelism, and applying platform-aware gating to reduce macOS runner pressure.

Feedback, suggestions, and ideas for further CI improvements are very welcome!

## Summary
- Add `detect-changes` job using `dorny/paths-filter@v3` to all 3 CI workflows (Linux, macOS, Windows)
- Skip irrelevant test jobs on PRs based on which component paths changed
- Push to master always runs all jobs (`github.event_name == 'push'` check)
- **macOS optimization**: only run full test suite for pjlib/pjmedia changes (platform-specific code); other changes get build-only + CMake verification, with Linux CI providing full test coverage
- Rebalance test jobs: move pjmedia-test from pjsua bundles to pjsip bundles for better time distribution
- Fix ioqueue callback lock CI: default is now no-lock, so CI tests the opposite (with-lock)
- Merge macOS CMake Debug+Release into a single job to save a runner slot

### macOS conditional test strategy

macOS-specific code resides in pjlib (OS abstractions, ioqueue/kqueue, sockets, threading, SSL) and pjmedia (audio/video devices, native codecs, AEC). Other components are platform-independent protocol logic covered by Linux CI.

| PR changes | macOS behavior | Linux behavior |
|-----------|----------------|----------------|
| pjlib, pjmedia, tests, CI config | Full test suite (~15 jobs) | Full test suite (per-component) |
| pjlib-util, pjnath, pjsip, pjsip-apps | Build-only + CMake (2 jobs) | Full test suite (per-component) |
| Push to master | Always full suite | Always full suite |

### Linux/Windows job conditions by component dependency

| Tests run | Triggered by changes to |
|-----------|------------------------|
| pjlib only | core, tests, ci |
| pjlib-util, pjnath | core, pjlib-util, pjnath, tests, ci |
| pjmedia | core, pjlib-util, pjmedia, tests, ci |
| pjsip | core, pjlib-util, pjsip, tests, ci |
| pjmedia + pjsip | core, pjlib-util, pjmedia, pjsip, tests, ci |
| pjsua (full stack) | any source component, tests, ci |

### Test job rebalancing — Linux OpenH264+VPX

| Job | Before | After |
|-----|--------|-------|
| bundle-1 (pjsua) | pjmedia-test (15.2m) + pjsua-test (21.3m) = **36.5m** | pjsua-test (21.3m) = **21.3m** |
| bundle-2 (pjlib,util,pjnath) | 18.6m | 18.6m (no change) |
| bundle-3 (pjsip) | pjsip-test serial (20.8m) + parallel (15.2m) = **36.0m** | pjmedia-test (15.2m) + pjsip-test (36.0m) = **~51m** |

Note: Linux bundle-3 gets heavier but gains the correct `pjmedia-pjsip-deps` condition, so it skips on pjsua-only or pjnath-only PRs.

### Test job rebalancing — Linux Default

| Job | Before | After |
|-----|--------|-------|
| bundle-1 (pjsua) | pjmedia-test (3.6m) + pjsua-test (21.0m) = **24.6m** | pjsua-test (21.0m) = **21.0m** |
| bundle-3 (pjsip) | pjsip-test (14.4m) = **14.4m** | pjmedia-test (~3.6m) + pjsip-test (14.4m) = **~18.0m** |

### Test job rebalancing — macOS OpenH264+VPX

| Job | Before | After |
|-----|--------|-------|
| bundle-1 (pjsua) | pjmedia-test (7.7m) + pjsua-test (24.2m) = **32.0m** | pjsua-test (24.2m) = **24.2m** |
| bundle-2 (util,pjnath) | pjlib-util-test (3.1m) + pjnath-test (17.0m) = **20.1m** | pjlib-test (9.8m) + pjlib-util-test (3.1m) + pjnath-test (17.0m) = **29.9m** |
| bundle-3 (pjlib,pjsip) | pjlib-test (9.8m) + pjsip-test (19.2m) = **29.0m** | pjmedia-test (7.7m) + pjsip-test (19.2m) = **26.9m** |

Max job time: 32.0m → 29.9m (better balanced: 24/30/27m)

### Windows CI test times (no rebalancing needed)

| Job | Tests | Time |
|-----|-------|------|
| OpenSSL / pjlib,util,pjmedia | pjlib (4.6m) + util (3.1m) + pjmedia (0.9m) | **8.6m** |
| OpenSSL / pjnath | pjnath (12.6m) | **12.6m** |
| OpenSSL / pjsip,pjsua | pjsip (14.9m) | **14.9m** |
| VPX+SChannel / pjlib,util,pjmedia,pjnath | pjlib (4.4m) + util (3.1m) + pjmedia (3.1m) + pjnath (0.0m) | **10.7m** |
| VPX+SChannel / pjsip | pjsip (17.0m) | **17.0m** |
| IOCP / pjlib | pjlib (4.7m) | **4.7m** |
| iocp-cb-with-lock / pjlib,pjsua | pjlib (4.4m) + pjsip (9.3m) | **13.7m** |

Windows pjmedia is already separate from pjsua — no changes needed.

### Expected savings
- **Docs-only PR**: only build-only jobs run (~3 jobs across all OSes), all test jobs skipped
- **pjsip-only or pjnath-only PR**: full Linux+Windows tests, macOS build-only (2 jobs vs 15) — saves ~13 Mac runner slots and ~2h queue wait
- **pjlib or pjmedia PR**: full test suite on all platforms (as before)

## Test plan
- [ ] Verify `detect-changes` job runs and produces correct outputs on a PR
- [ ] Verify all jobs run on push to master
- [ ] Verify pjlib/pjmedia PR triggers full macOS tests
- [ ] Verify pjsip-only PR skips macOS tests (only build-only + CMake)
- [ ] Verify build-only jobs always run regardless of changes

Co-Authored-By: Claude Code