### PR TITLE
Flaky CI: fix race condition in pjmedia codec_test_vectors

### DIFF
--- a/pjmedia/src/test/test.c
+++ b/pjmedia/src/test/test.c
@@ -109,7 +109,12 @@ int test_main(int argc, char *argv[])
     UT_ADD_TEST(&test_app.ut_app, jbuf_test, 0);
 #endif
 #if HAS_CODEC_VECTOR_TEST
-    UT_ADD_TEST(&test_app.ut_app, codec_test_vectors, 0);
+    /* Run in exclusive mode: creates/destroys a local pjmedia_endpt which
+     * sets/clears the global def_codec_mgr. If sdp_neg_test runs
+     * concurrently, it may access the codec manager mutex after it has
+     * been destroyed, causing an assertion failure.
+     */
+    UT_ADD_TEST(&test_app.ut_app, codec_test_vectors, PJ_TEST_EXCLUSIVE);
 #endif
 
     if (ut_run_tests(&test_app.ut_app, "pjmedia tests", argc, argv)) {


### PR DESCRIPTION
Mark `codec_test_vectors` as `PJ_TEST_EXCLUSIVE` to fix a race condition when running with `--shuffle` and multiple worker threads.

`codec_test_vectors` creates and destroys a local `pjmedia_endpt`, which sets/clears the global `def_codec_mgr` pointer. When `sdp_neg_test` runs concurrently on another worker thread, the following race occurs:

1. `codec_test_vectors` creates endpoint, setting `def_codec_mgr` to the local endpoint's codec manager
2. `sdp_neg_test` calls `init_mapping()` → `pjmedia_codec_mgr_get_dyn_codecs(NULL)` which resolves to `def_codec_mgr`, and acquires `mgr->mutex`
3. `codec_test_vectors` finishes and destroys the endpoint, which destroys the mutex and zeroes the codec_mgr struct
4. `sdp_neg_test` tries to unlock the now-destroyed mutex, triggering: `Assertion mutex->owner == pj_thread_this() failed` → SIGABRT

Observed in CI: https://github.com/pjsip/pjproject/actions/runs/23226367723/job/67509811321

### Test plan

- [ ] pjmedia-test passes with `--shuffle -w 3` (the CI configuration)

Co-Authored-By: Claude Code