### PR TITLE
Redesign SSL send path with producer-consumer queue

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -558,12 +558,14 @@ jobs:
               #define PJ_TODO(x)
               #define PJ_IOQUEUE_FAST_TRACK 0
               #define PJ_IOQUEUE_IMP PJ_IOQUEUE_IMP_SELECT
+              #define PJ_RACE_ME(x) pj_thread_sleep(pj_rand() % (x))
             configure_args: ""
             install_deps: ""
           - name: epoll+gtls
             config_site: |
               #define PJ_TODO(x)
               #define PJ_IOQUEUE_FAST_TRACK 0
+              #define PJ_RACE_ME(x) pj_thread_sleep(pj_rand() % (x))
             configure_args: "--with-gnutls=/usr/"
             install_deps: "sudo apt-get update && sudo apt-get install -y libgnutls28-dev"
     name: ioq-no-fast-track / ${{ matrix.name }}

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -842,6 +842,62 @@
 
 
 /**
+ * Maximum number of SSL send operations that can be queued (encrypted
+ * and waiting for the network). When this limit is reached,
+ * pj_ssl_sock_send() returns PJ_EBUSY and the application must retry
+ * later.
+ *
+ * This prevents unbounded memory growth when the network stalls (e.g.,
+ * TCP window full, slow receiver). Each queued operation holds a pool
+ * with the encrypted TLS record (~4-16 KB depending on record size).
+ * Embedded or memory-constrained deployments may set this to bound
+ * memory usage per SSL socket.
+ *
+ * Default: 0 (disabled — consistent with ioqueue write_list which
+ * is also unbounded). Set to a positive value to enable.
+ */
+#ifndef PJ_SSL_SEND_OP_ACTIVE_MAX
+#   define PJ_SSL_SEND_OP_ACTIVE_MAX    0
+#endif
+
+
+/**
+ * Maximum number of completed SSL send operations kept in a free list
+ * for recycling. Each send operation has its own pool (~4-16 KB for
+ * the encrypted TLS record). Recycling avoids repeated pool
+ * allocation/release on busy connections.
+ *
+ * Higher values reduce allocation overhead at the cost of resident
+ * memory per SSL socket. With asynchronous sends (PJ_IOQUEUE_FAST_TRACK
+ * disabled), operations cycle rapidly through alloc-send-free, so a
+ * larger free list reduces churn.
+ *
+ * Set to 0 to disable recycling (always release pools immediately).
+ *
+ * Default: 16
+ */
+#ifndef PJ_SSL_SEND_OP_FREE_LIST_MAX
+#   define PJ_SSL_SEND_OP_FREE_LIST_MAX     16
+#endif
+
+
+/**
+ * Minimum encrypted data buffer size for SSL send operations. When a
+ * send is smaller than this value, the buffer is padded to this size
+ * so that the operation can be reused from the free list for future
+ * sends of varying sizes without reallocation.
+ *
+ * Should be at least as large as a typical TLS record overhead plus
+ * a common application payload (e.g., a SIP response ~1-2 KB).
+ *
+ * Default: 4000
+ */
+#ifndef PJ_SSL_SEND_OP_MIN_BUF_SIZE
+#   define PJ_SSL_SEND_OP_MIN_BUF_SIZE      4000
+#endif
+
+
+/**
  * Determine if FD_SETSIZE is changeable/set-able. If so, then we will
  * set it to PJ_IOQUEUE_MAX_HANDLES. Currently we detect this by checking
  * for Winsock.

--- a/pjlib/src/pj/ssl_sock_gtls.c
+++ b/pjlib/src/pj/ssl_sock_gtls.c
@@ -1196,6 +1196,8 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
         status = PJ_EPENDING;
     } else {
         /* Fatal error invalidates session, no fallback */
+        PJ_LOG(1, ("tls", "gnutls_handshake() error: %s (%d)",
+                   gnutls_strerror(ret), ret));
         status = PJ_EINVAL;
     }
 
@@ -1280,22 +1282,20 @@ static pj_status_t ssl_renegotiate(pj_ssl_sock_t *ssock)
     gnutls_sock_t *gssock = (gnutls_sock_t *)ssock;
     int status;
 
-    /* First call gnutls_rehandshake() to see if this is even possible */
-    status = gnutls_rehandshake(gssock->session);
-
-    if (status == GNUTLS_E_SUCCESS) {
-        /* Rehandshake is possible, so try a GnuTLS handshake now. The eventual
-         * gnutls_record_recv() calls could return a few specific values during
-         * this state:
-         *
-         *   - GNUTLS_E_REHANDSHAKE: rehandshake message processing
-         *   - GNUTLS_E_WARNING_ALERT_RECEIVED: client does not wish to
-         *                                      renegotiate
+    if (!ssock->is_server) {
+        /* GnuTLS does not support client-initiated renegotiation.
+         * gnutls_rehandshake() is server-only (sends HelloRequest),
+         * and gnutls_handshake() on an established session fails.
          */
-        return PJ_SUCCESS;
-    } else {
-        return tls_status_from_err(ssock, status);
+        return PJ_ENOTSUP;
     }
+
+    /* Server: send HelloRequest to ask client to renegotiate */
+    status = gnutls_rehandshake(gssock->session);
+    if (status == GNUTLS_E_SUCCESS)
+        return PJ_SUCCESS;
+
+    return tls_status_from_err(ssock, status);
 }
 
 #endif /* PJ_HAS_SSL_SOCK */

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -487,14 +487,209 @@ static ssl_send_op_t* alloc_send_op(pj_ssl_sock_t *ssock, pj_size_t enc_len)
 static void free_send_op(pj_ssl_sock_t *ssock, ssl_send_op_t *op)
 {
     pj_list_erase(op);
+    if (ssock->send_op_active_cnt > 0)
+        ssock->send_op_active_cnt--;
 
     if (ssock->send_op_free_cnt < PJ_SSL_SEND_OP_FREE_LIST_MAX) {
         pj_list_push_back(&ssock->send_op_free, op);
         ssock->send_op_free_cnt++;
     } else {
         /* Free list full, release the pool to truly free memory */
-        pj_pool_release(op->pool);
+        pj_pool_secure_release(&op->pool);
     }
+}
+
+/* Forward declarations */
+static pj_status_t ssl_do_handshake_and_flush(pj_ssl_sock_t *ssock);
+static pj_bool_t on_handshake_complete(pj_ssl_sock_t *ssock,
+                                       pj_status_t status);
+
+/* Enqueue encrypted data from ssl_write_buf into a send op.
+ * MUST be called with write_mutex held.
+ * On return, *p_drain is PJ_TRUE if caller must call drain_send_queue().
+ */
+static pj_status_t enqueue_ssl_write_buf(pj_ssl_sock_t *ssock,
+                                         pj_ioqueue_op_key_t *send_key,
+                                         pj_size_t orig_len,
+                                         unsigned flags,
+                                         pj_bool_t *p_drain)
+{
+    pj_ssize_t len;
+    ssl_send_op_t *op;
+
+    *p_drain = PJ_FALSE;
+
+    if (io_empty(ssock, &ssock->ssl_write_buf))
+        return PJ_SUCCESS;
+
+    len = io_size(ssock, &ssock->ssl_write_buf);
+    if (len == 0)
+        return PJ_SUCCESS;
+
+    op = alloc_send_op(ssock, len);
+    if (!op)
+        return PJ_ENOMEM;
+
+    pj_ioqueue_op_key_init(&op->key, sizeof(pj_ioqueue_op_key_t));
+    op->key.user_data = op;
+    op->app_key = send_key;
+    op->plain_data_len = orig_len;
+    op->enc_len = len;
+    op->flags = flags;
+    io_read(ssock, &ssock->ssl_write_buf, (pj_uint8_t *)op->enc_data, len);
+
+    pj_list_push_back(&ssock->send_op_active, op);
+    ssock->send_op_active_cnt++;
+
+    if (ssock->sending) {
+        /* Another thread/callback is draining. Just queue. */
+        return PJ_EPENDING;
+    }
+
+    ssock->sending = PJ_TRUE;
+    *p_drain = PJ_TRUE;
+    return PJ_EPENDING;
+}
+
+/* Drain the send_op_active queue. Called WITHOUT holding write_mutex.
+ * Caller must have set ssock->sending = PJ_TRUE.
+ *
+ * suppress_first_cb: when PJ_TRUE, the first synchronously completed
+ * op does NOT get its callback fired — the caller (flush_ssl_write_buf)
+ * returns the status to the app directly. When PJ_FALSE (called from
+ * ssock_on_data_sent), all sync completions fire callbacks because
+ * their callers already received PJ_EPENDING.
+ */
+static pj_status_t drain_send_queue(pj_ssl_sock_t *ssock,
+                                    pj_bool_t suppress_first_cb)
+{
+    pj_status_t first_status = PJ_SUCCESS;
+    pj_bool_t is_first = suppress_first_cb;
+
+    for (;;) {
+        ssl_send_op_t *op;
+        pj_ioqueue_op_key_t *app_key;
+        pj_ssize_t plain_data_len;
+        pj_ssize_t len;
+        pj_status_t status;
+
+        /* Pop the front of the queue — remove BEFORE sending so that
+         * ssock_on_data_sent → drain_send_queue won't double-send.
+         * Set send_op_inflight BEFORE releasing the lock so that
+         * ssl_on_destroy can find it if the socket closes between
+         * the send and the async callback.
+         */
+        pj_lock_acquire(ssock->write_mutex);
+        if (pj_list_empty(&ssock->send_op_active)) {
+            ssock->sending = PJ_FALSE;
+            pj_lock_release(ssock->write_mutex);
+            break;
+        }
+        op = ssock->send_op_active.next;
+        pj_list_erase(op);
+        pj_assert(ssock->send_op_inflight == NULL);
+        ssock->send_op_inflight = op;
+        pj_lock_release(ssock->write_mutex);
+
+        /* Send WITHOUT holding write_mutex — no deadlock possible */
+        len = op->enc_len;
+#ifdef SSL_SOCK_IMP_USE_OWN_NETWORK
+        status = network_send(ssock, &op->key, op->enc_data, &len,
+                              op->flags);
+#else
+        if (ssock->param.sock_type == pj_SOCK_STREAM()) {
+            status = pj_activesock_send(ssock->asock, &op->key,
+                                        op->enc_data, &len, op->flags);
+        } else {
+            status = pj_activesock_sendto(ssock->asock, &op->key,
+                                          op->enc_data, &len, op->flags,
+                                          (pj_sockaddr_t*)&ssock->rem_addr,
+                                          ssock->addr_len);
+        }
+#endif
+
+        if (status == PJ_EPENDING) {
+            /* Async — ssock_on_data_sent will resume draining.
+             * send_op_inflight is already set above under write_mutex.
+             */
+            if (is_first)
+                first_status = PJ_EPENDING;
+            break;
+        }
+
+        /* Completed synchronously — clear inflight, free op */
+        app_key = op->app_key;
+        plain_data_len = (pj_ssize_t)op->plain_data_len;
+
+        pj_lock_acquire(ssock->write_mutex);
+        ssock->send_op_inflight = NULL;
+        free_send_op(ssock, op);
+        pj_lock_release(ssock->write_mutex);
+
+        if (status != PJ_SUCCESS) {
+            /* Send error — stop draining */
+            pj_lock_acquire(ssock->write_mutex);
+            ssock->sending = PJ_FALSE;
+            pj_lock_release(ssock->write_mutex);
+
+            if (is_first) {
+                first_status = status;
+            } else if (app_key != &ssock->handshake_op_key &&
+                       app_key != &ssock->shutdown_op_key &&
+                       ssock->param.cb.on_data_sent)
+            {
+                /* Non-first op's caller got PJ_EPENDING — must fire
+                 * an error callback since the op was already freed.
+                 */
+                pj_bool_t ret;
+                ret = (*ssock->param.cb.on_data_sent)(ssock, app_key,
+                                                      -(pj_ssize_t)status);
+                if (!ret) {
+                    return first_status;  /* destroyed */
+                }
+            }
+            break;
+        }
+
+        if (is_first) {
+            first_status = PJ_SUCCESS;
+            is_first = PJ_FALSE;
+            continue;  /* first op: caller returns status directly */
+        }
+
+        /* Non-first op completed sync: its caller got PJ_EPENDING,
+         * so we must fire the callback here.
+         */
+        if (ssock->ssl_state == SSL_STATE_HANDSHAKING) {
+            pj_status_t hs;
+            hs = ssl_do_handshake_and_flush(ssock);
+            if (hs != PJ_EPENDING) {
+                if (!on_handshake_complete(ssock, hs))
+                    return first_status;
+            }
+        } else if (app_key != &ssock->handshake_op_key &&
+                   app_key != &ssock->shutdown_op_key)
+        {
+            if (ssock->param.cb.on_data_sent) {
+                pj_bool_t ret;
+                ret = (*ssock->param.cb.on_data_sent)(ssock, app_key,
+                                                       plain_data_len);
+                if (!ret)
+                    return first_status;  /* destroyed */
+            }
+        }
+
+        /* After processing a handshake op, try to flush delayed sends.
+         * During renegotiation, sends are delayed in write_pending.
+         * When the last handshake op completes (renego done), the
+         * delayed sends can now proceed.
+         */
+        if (!pj_list_empty(&ssock->write_pending)) {
+            flush_delayed_send(ssock);
+        }
+    }
+
+    return first_status;
 }
 
 /* Flush SSL write buffer to network socket. */
@@ -502,71 +697,16 @@ static pj_status_t flush_ssl_write_buf(pj_ssl_sock_t *ssock,
                                        pj_ioqueue_op_key_t *send_key,
                                        pj_size_t orig_len, unsigned flags)
 {
-    pj_ssize_t len;
-    ssl_send_op_t *op;
+    pj_bool_t should_drain;
     pj_status_t status;
 
     pj_lock_acquire(ssock->write_mutex);
-
-    /* Check if there is data in the SSL write buffer, flush it if any */
-    if (io_empty(ssock, &ssock->ssl_write_buf)) {
-        pj_lock_release(ssock->write_mutex);
-        return PJ_SUCCESS;
-    }
-
-    /* Get data and its length */
-    len = io_size(ssock, &ssock->ssl_write_buf);
-    if (len == 0) {
-        pj_lock_release(ssock->write_mutex);
-        return PJ_SUCCESS;
-    }
-
-    /* Allocate send op */
-    op = alloc_send_op(ssock, len);
-    if (!op) {
-        pj_lock_release(ssock->write_mutex);
-        return PJ_ENOMEM;
-    }
-    pj_ioqueue_op_key_init(&op->key, sizeof(pj_ioqueue_op_key_t));
-    op->key.user_data = op;
-    op->app_key = send_key;
-    op->plain_data_len = orig_len;
-    op->enc_len = len;
-    io_read(ssock, &ssock->ssl_write_buf, (pj_uint8_t *)op->enc_data, len);
-
-    /* Track in active list */
-    pj_list_push_back(&ssock->send_op_active, op);
-
-    /* Ticket #4533: Lock before write_mutex release for send order */
-    pj_lock_acquire(ssock->asock_send_mutex);
-
-    /* Ticket #1573: Don't hold mutex while calling PJLIB socket send(). */
+    status = enqueue_ssl_write_buf(ssock, send_key, orig_len, flags,
+                                   &should_drain);
     pj_lock_release(ssock->write_mutex);
 
-    /* Send encrypted data */
-#ifdef SSL_SOCK_IMP_USE_OWN_NETWORK
-    status = network_send(ssock, &op->key, op->enc_data, &len, flags);
-#else
-    if (ssock->param.sock_type == pj_SOCK_STREAM()) {
-        status = pj_activesock_send(ssock->asock, &op->key,
-                                    op->enc_data, &len, flags);
-    } else {
-        status = pj_activesock_sendto(ssock->asock, &op->key,
-                                      op->enc_data, &len, flags,
-                                      (pj_sockaddr_t*)&ssock->rem_addr,
-                                      ssock->addr_len);
-    }
-#endif
-
-    pj_lock_release(ssock->asock_send_mutex);
-
-    if (status != PJ_EPENDING) {
-        /* Send completed (success or error), recycle the send op. */
-        pj_lock_acquire(ssock->write_mutex);
-        free_send_op(ssock, op);
-        pj_lock_release(ssock->write_mutex);
-
-    }
+    if (should_drain)
+        status = drain_send_queue(ssock, PJ_TRUE);
 
     return status;
 }
@@ -626,25 +766,100 @@ static void on_timer(pj_timer_heap_t *th, struct pj_timer_entry *te)
     }
 }
 
+/* Fire error callbacks for pending sends that will never complete.
+ * Called from pj_ssl_sock_close() so callbacks fire synchronously
+ * while the app's resources are still valid. Must be called AFTER
+ * ssl_reset_sock_state (sockets closed, no more async completions).
+ */
+static void cancel_pending_sends(pj_ssl_sock_t *ssock)
+{
+    /* In-flight send_op — removed from send_op_active but pending in
+     * ioqueue. Socket close cancelled it without callback.
+     */
+    if (ssock->send_op_inflight) {
+        ssl_send_op_t *op = ssock->send_op_inflight;
+        pj_ioqueue_op_key_t *app_key = op->app_key;
+
+        ssock->send_op_inflight = NULL;
+
+        if (app_key != &ssock->handshake_op_key &&
+            app_key != &ssock->shutdown_op_key &&
+            ssock->param.cb.on_data_sent)
+        {
+            (*ssock->param.cb.on_data_sent)(ssock, app_key,
+                                            -PJ_ECANCELLED);
+        }
+
+        pj_lock_acquire(ssock->write_mutex);
+        free_send_op(ssock, op);
+        pj_lock_release(ssock->write_mutex);
+    }
+
+    /* Active send_ops — encrypted data queued but not yet sent */
+    while (!pj_list_empty(&ssock->send_op_active)) {
+        ssl_send_op_t *op = ssock->send_op_active.next;
+        pj_ioqueue_op_key_t *app_key = op->app_key;
+
+        pj_list_erase(op);
+
+        if (app_key != &ssock->handshake_op_key &&
+            app_key != &ssock->shutdown_op_key &&
+            ssock->param.cb.on_data_sent)
+        {
+            (*ssock->param.cb.on_data_sent)(ssock, app_key,
+                                            -PJ_ECANCELLED);
+        }
+
+        pj_lock_acquire(ssock->write_mutex);
+        free_send_op(ssock, op);
+        pj_lock_release(ssock->write_mutex);
+    }
+
+    /* Delayed sends from renegotiation — never encrypted */
+    while (!pj_list_empty(&ssock->write_pending)) {
+        write_data_t *wp = ssock->write_pending.next;
+        pj_ioqueue_op_key_t *app_key = wp->app_key;
+
+        pj_list_erase(wp);
+
+        if (app_key != &ssock->handshake_op_key &&
+            app_key != &ssock->shutdown_op_key &&
+            ssock->param.cb.on_data_sent)
+        {
+            (*ssock->param.cb.on_data_sent)(ssock, app_key,
+                                            -PJ_ECANCELLED);
+        }
+    }
+}
+
 static void ssl_on_destroy(void *arg)
 {
     pj_ssl_sock_t *ssock = (pj_ssl_sock_t*)arg;
 
     ssl_destroy(ssock);
 
+    /* Defensive: free any remaining ops without callbacks.
+     * Normally cancel_pending_sends() in pj_ssl_sock_close() already
+     * drained these, but handle the case where destroy fires without
+     * a prior close (e.g., grp_lock ref dropped externally).
+     */
+    if (ssock->send_op_inflight) {
+        pj_pool_secure_release(&ssock->send_op_inflight->pool);
+        ssock->send_op_inflight = NULL;
+    }
+    while (!pj_list_empty(&ssock->send_op_active)) {
+        ssl_send_op_t *op = ssock->send_op_active.next;
+        pj_list_erase(op);
+        pj_pool_secure_release(&op->pool);
+    }
+
     /* Release all send op pools (each op has its own pool) */
     while (!pj_list_empty(&ssock->send_op_free)) {
         ssl_send_op_t *op = ssock->send_op_free.next;
         pj_list_erase(op);
-        pj_pool_release(op->pool);
+        pj_pool_secure_release(&op->pool);
     }
     ssock->send_op_free_cnt = 0;
-
-    while (!pj_list_empty(&ssock->send_op_active)) {
-        ssl_send_op_t *op = ssock->send_op_active.next;
-        pj_list_erase(op);
-        pj_pool_release(op->pool);
-    }
 
     if (ssock->ssl_read_buf_mutex) {
         pj_lock_destroy(ssock->ssl_read_buf_mutex);
@@ -655,11 +870,6 @@ static void ssl_on_destroy(void *arg)
         pj_lock_destroy(ssock->ssl_write_buf_mutex);
         ssock->ssl_write_buf_mutex = NULL;
         ssock->write_mutex = NULL;
-    }
-
-    if (ssock->asock_send_mutex) {
-        pj_lock_destroy(ssock->asock_send_mutex);
-        ssock->asock_send_mutex = NULL;
     }
 
     /* Secure release pool, i.e: all memory blocks will be zeroed first */
@@ -772,6 +982,12 @@ static pj_bool_t ssock_on_data_read (pj_ssl_sock_t *ssock,
             } else if (status_ == PJ_SUCCESS) {
                 break;
             } else if (status_ == PJ_ETRYAGAIN) {
+                /* SSL_read may have produced handshake data (e.g.
+                 * ServerHello during renegotiation). Flush it before
+                 * calling ssl_do_handshake which may not produce more.
+                 */
+                flush_ssl_write_buf(ssock, &ssock->handshake_op_key,
+                                    0, 0);
                 status = ssl_do_handshake_and_flush(ssock);
                 if (status == PJ_SUCCESS) {
                     /* Renegotiation completed */
@@ -780,7 +996,7 @@ static pj_bool_t ssock_on_data_read (pj_ssl_sock_t *ssock,
                     ssl_update_certs_info(ssock);
 
                     // Ticket #1573: Don't hold mutex while calling
-                    //               PJLIB socket send(). 
+                    //               PJLIB socket send().
                     //pj_lock_acquire(ssock->write_mutex);
                     status = flush_delayed_send(ssock);
                     //pj_lock_release(ssock->write_mutex);
@@ -815,6 +1031,22 @@ static pj_bool_t ssock_on_data_read (pj_ssl_sock_t *ssock,
         } while (1);
     }
 
+    /* SSL_read may have generated protocol-level responses in the
+     * write buffer (e.g. renegotiation rejection alert, session
+     * ticket, etc.) that must be sent to the peer. Flush them.
+     */
+    flush_ssl_write_buf(ssock, &ssock->handshake_op_key, 0, 0);
+
+    /* Flush delayed sends that may have been queued during
+     * renegotiation. OpenSSL handles renegotiation transparently
+     * inside SSL_read, so by the time ssl_read returns application
+     * data again, the renegotiation has completed and delayed sends
+     * can proceed.
+     */
+    if (!pj_list_empty(&ssock->write_pending)) {
+        flush_delayed_send(ssock);
+    }
+
     return PJ_TRUE;
 
 on_error:
@@ -839,31 +1071,44 @@ static pj_bool_t ssock_on_data_sent (pj_ssl_sock_t *ssock,
                                      pj_ioqueue_op_key_t *send_key,
                                      pj_ssize_t sent)
 {
-    ssl_send_op_t *op = (ssl_send_op_t *)send_key->user_data;
-    pj_ioqueue_op_key_t *app_key = op->app_key;
+    ssl_send_op_t *op;
+    pj_ioqueue_op_key_t *app_key;
     pj_ssize_t sent_len;
 
+    /* Skip late callbacks arriving after close (e.g., IOCP cancelled
+     * completions, or ioqueue drain on epoll/select). All pending ops
+     * are handled by cancel_pending_sends() in pj_ssl_sock_close().
+     */
+    if (ssock->is_closing)
+        return PJ_FALSE;
+
+    op = (ssl_send_op_t *)send_key->user_data;
+    app_key = op->app_key;
     sent_len = (sent > 0) ? (pj_ssize_t)op->plain_data_len : sent;
 
-    /* Free the send op */
+    /* Clear in-flight tracking and free the completed send op */
     pj_lock_acquire(ssock->write_mutex);
+    ssock->send_op_inflight = NULL;
     free_send_op(ssock, op);
     pj_lock_release(ssock->write_mutex);
     op = NULL;
 
     if (ssock->ssl_state == SSL_STATE_HANDSHAKING) {
-        /* Initial handshaking */
+        /* Handshaking — continue handshake */
         pj_status_t status;
 
         status = ssl_do_handshake_and_flush(ssock);
-        /* Not pending is either success or failed */
-        if (status != PJ_EPENDING)
-            return on_handshake_complete(ssock, status);
+        if (status != PJ_EPENDING) {
+            pj_bool_t ret = on_handshake_complete(ssock, status);
+            if (!ret)
+                return PJ_FALSE;
+            /* Fall through to drain remaining queue */
+        }
 
     } else if (app_key != &ssock->handshake_op_key &&
                app_key != &ssock->shutdown_op_key)
     {
-        /* Application data has been sent, notify application */
+        /* Application data — notify application */
         if (ssock->param.cb.on_data_sent) {
             pj_bool_t ret;
             ret = (*ssock->param.cb.on_data_sent)(ssock, app_key,
@@ -873,14 +1118,18 @@ static pj_bool_t ssock_on_data_sent (pj_ssl_sock_t *ssock,
                 return PJ_FALSE;
             }
         }
-    } else {
-        /* Handshake or shutdown send, no app callback needed */
     }
 
-    /* Try to drain write_pending (delayed sends from renegotiation) */
+    /* Drain write_pending (delayed sends from renegotiation) */
     if (!pj_list_empty(&ssock->write_pending)) {
         flush_delayed_send(ssock);
     }
+
+    /* Continue draining the send queue — ssock->sending is still
+     * PJ_TRUE from the original drain_send_queue call. Don't
+     * suppress callbacks: all remaining ops' callers got PJ_EPENDING.
+     */
+    drain_send_queue(ssock, PJ_FALSE);
 
     return PJ_TRUE;
 }
@@ -1418,10 +1667,7 @@ PJ_DEF(pj_status_t) pj_ssl_sock_create (pj_pool_t *pool,
         return status;
 
     /* Create active socket send mutex */
-    status = pj_lock_create_recursive_mutex(pool, pool->obj_name,
-                                            &ssock->asock_send_mutex);
-    if (status != PJ_SUCCESS)
-        return status;
+    ssock->sending = PJ_FALSE;
 
     /* Init secure socket param */
     pj_ssl_sock_param_copy(pool, &ssock->param, param);
@@ -1466,6 +1712,13 @@ PJ_DEF(pj_status_t) pj_ssl_sock_close(pj_ssl_sock_t *ssock)
     }
 
     ssl_reset_sock_state(ssock);
+
+    /* Fire error callbacks for pending sends synchronously, while
+     * the app's context is still valid (before we return from close).
+     * Must be after ssl_reset_sock_state which closes the socket,
+     * ensuring no more async completions can race with us.
+     */
+    cancel_pending_sends(ssock);
 
     /* Wipe out cert & key buffer. */
     if (ssock->cert) {
@@ -1691,26 +1944,41 @@ static pj_status_t ssl_send (pj_ssl_sock_t *ssock,
 {
     pj_status_t status;
     int nwritten = 0;
+    pj_bool_t should_drain = PJ_FALSE;
 
-    /* Write the plain data to SSL, after SSL encrypts it, the buffer will
-     * contain the secured data to be sent via socket. Note that re-
-     * negotitation may be on progress, so sending data should be delayed
-     * until re-negotiation is completed.
+    /* Encrypt and enqueue atomically under write_mutex.
+     * This eliminates the race between ssl_write and flush that could
+     * merge encrypted data from different threads into one send op.
      */
     pj_lock_acquire(ssock->write_mutex);
     status = ssl_write(ssock, data, size, &nwritten);
-    pj_lock_release(ssock->write_mutex);
 
     if (status == PJ_SUCCESS && nwritten == size) {
-        /* All data written, flush write buffer to network socket */
-        status = flush_ssl_write_buf(ssock, send_key, size, flags);
+        /* All data written — enqueue for sending (still under lock) */
+        status = enqueue_ssl_write_buf(ssock, send_key, size, flags,
+                                       &should_drain);
+        pj_lock_release(ssock->write_mutex);
+
+        if (should_drain)
+            status = drain_send_queue(ssock, PJ_TRUE);
+
     } else if (status == PJ_ETRYAGAIN) {
-        /* Re-negotiation is on progress, flush re-negotiation data */
-        status = flush_ssl_write_buf(ssock, &ssock->handshake_op_key, 0, 0);
-        if (status == PJ_SUCCESS || status == PJ_EPENDING) {
-            /* Just return PJ_EBUSY when re-negotiation is on progress */
+        /* Re-negotiation in progress — flush handshake data */
+        status = enqueue_ssl_write_buf(ssock, &ssock->handshake_op_key,
+                                       0, 0, &should_drain);
+        pj_lock_release(ssock->write_mutex);
+
+        if (should_drain) {
+            pj_status_t ds = drain_send_queue(ssock, PJ_TRUE);
+            if (ds == PJ_SUCCESS || ds == PJ_EPENDING)
+                status = PJ_EBUSY;
+            else
+                status = ds;
+        } else {
             status = PJ_EBUSY;
         }
+    } else {
+        pj_lock_release(ssock->write_mutex);
     }
 
     return status;
@@ -1858,11 +2126,22 @@ PJ_DEF(pj_status_t) pj_ssl_sock_send (pj_ssl_sock_t *ssock,
      * re-negotiation is on-progress.
      */
     status = flush_delayed_send(ssock);
-    if (status == PJ_EBUSY) {
+    if (status == PJ_EBUSY || status == PJ_EPENDING) {
         /* Re-negotiation or flushing is on progress, delay sending */
         status = delay_send(ssock, send_key, data, *size, flags);
         goto on_return;
     } else if (status != PJ_SUCCESS) {
+        goto on_return;
+    }
+
+    /* Prevent unbounded queue growth when the network stalls.
+     * Check BEFORE ssl_send which encrypts the plaintext — once
+     * encrypted, the data cannot be "un-sent" without corruption.
+     */
+    if (PJ_SSL_SEND_OP_ACTIVE_MAX > 0 &&
+        ssock->send_op_active_cnt >= PJ_SSL_SEND_OP_ACTIVE_MAX)
+    {
+        status = PJ_EBUSY;
         goto on_return;
     }
 

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -75,19 +75,10 @@ typedef struct write_data_t {
  * Replaces the old send_buf ring buffer + write_data_t for network sends.
  */
 
-/* Minimum encrypted data buffer size. Ensures small sends get reusable
- * buffers. Override in config_site.h if needed.
+/* PJ_SSL_SEND_OP_MIN_BUF_SIZE, PJ_SSL_SEND_OP_FREE_LIST_MAX, and
+ * PJ_SSL_SEND_OP_ACTIVE_MAX are defined in pj/config.h.
  */
-#ifndef PJ_SSL_SEND_OP_MIN_BUF_SIZE
-#   define PJ_SSL_SEND_OP_MIN_BUF_SIZE     4000
-#endif
 
-/* Maximum number of send ops kept in the free list for recycling.
- * Excess ops have their pools released (true memory free).
- */
-#ifndef PJ_SSL_SEND_OP_FREE_LIST_MAX
-#   define PJ_SSL_SEND_OP_FREE_LIST_MAX    4
-#endif
 
 typedef struct ssl_send_op_t {
     PJ_DECL_LIST_MEMBER(struct ssl_send_op_t);
@@ -97,6 +88,7 @@ typedef struct ssl_send_op_t {
     pj_size_t            plain_data_len;/* plaintext length for callback   */
     pj_size_t            enc_len;       /* actual encrypted data length    */
     pj_size_t            enc_buf_cap;   /* embedded buffer capacity        */
+    unsigned             flags;         /* send flags                      */
     char                 enc_data[1];   /* variable-length encrypted data  */
 } ssl_send_op_t;
 
@@ -155,11 +147,14 @@ struct pj_ssl_sock_t
     write_data_t          write_pending;/* list of pending write to ssl */
     write_data_t          write_pending_empty; /* cache for write_pending   */
     pj_bool_t             flushing_write_pend; /* flag of flushing is ongoing*/
-    ssl_send_op_t         send_op_active;  /* list: in-flight send ops     */
+    ssl_send_op_t         send_op_active;  /* send queue (pending + in-flight)*/
+    unsigned              send_op_active_cnt;/* active queue count          */
     ssl_send_op_t         send_op_free;    /* free list for recycling      */
     unsigned              send_op_free_cnt;/* free list count              */
     pj_lock_t            *write_mutex;  /* protect ssl_write_buf & send ops */
-    pj_lock_t            *asock_send_mutex; /* protect send order */
+    pj_bool_t             sending;      /* drain loop active or async send
+                                         * in flight (under write_mutex)  */
+    ssl_send_op_t        *send_op_inflight; /* op pending in ioqueue       */
 
     circ_buf_t            ssl_read_buf;
     pj_lock_t            *ssl_read_buf_mutex;

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1258,6 +1258,22 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
     }
 #endif
 
+    /* Note: SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION is intentionally
+     * NOT set — it enables the CVE-2009-3555 MitM attack. OpenSSL's
+     * secure renegotiation (RFC 5746) works without it.
+     */
+
+#ifdef SSL_OP_ALLOW_CLIENT_RENEGOTIATION
+    /* OpenSSL 3.x disables client-initiated renegotiation by default.
+     * Only enable on server sockets to avoid DoS exposure — a
+     * malicious client could repeatedly request renegotiation to
+     * exhaust server CPU with asymmetric crypto operations.
+     */
+    if (ssock->is_server && ssock->param.enable_renegotiation) {
+        ssl_opt |= SSL_OP_ALLOW_CLIENT_RENEGOTIATION;
+    }
+#endif
+
     if (ssl_opt)
         SSL_CTX_set_options(ctx, ssl_opt);
 
@@ -1801,7 +1817,7 @@ static void ssl_destroy(pj_ssl_sock_t *ssock)
 /* Reset SSL socket state */
 static void ssl_reset_sock_state(pj_ssl_sock_t *ssock)
 {
-    int post_unlock_flush_circ_buf = 0;
+    int post_unlock_flush_write_buf = 0;
 
     ossl_sock_t *ossock = (ossl_sock_t *)ssock;
 
@@ -1832,7 +1848,7 @@ static void ssl_reset_sock_state(pj_ssl_sock_t *ssock)
             if (ret == 0) {
                 /* SSL_shutdown will potentially trigger a bunch of
                  * data to dump to the socket */
-                post_unlock_flush_circ_buf = 1;
+                post_unlock_flush_write_buf = 1;
             }
         }
     }
@@ -1841,9 +1857,21 @@ static void ssl_reset_sock_state(pj_ssl_sock_t *ssock)
 
     pj_lock_release(ssock->write_mutex);
 
-    if (post_unlock_flush_circ_buf) {
-        /* Flush data to send close notify. */
-        flush_ssl_write_buf(ssock, &ssock->shutdown_op_key, 0, 0);
+    if (post_unlock_flush_write_buf) {
+        pj_status_t flush_status;
+
+        /* Flush data to send close_notify. */
+        flush_status = flush_ssl_write_buf(ssock, &ssock->shutdown_op_key,
+                                           0, 0);
+        if (flush_status == PJ_EPENDING) {
+            /* close_notify is being sent asynchronously. Closing the
+             * socket now will abort it — the peer may not receive the
+             * graceful shutdown. This is acceptable; ssl_on_destroy
+             * will clean up the orphaned send op.
+             */
+            PJ_LOG(5, (ssock->pool->obj_name,
+                       "close_notify send pending, closing anyway"));
+        }
     }
 
     ssl_close_sockets(ssock);
@@ -2557,7 +2585,7 @@ static pj_status_t ssl_read(pj_ssl_sock_t *ssock, void *data, int *size)
         pj_status_t status;
         int err = SSL_get_error(ossock->ossl_ssl, size_);
 
-        /* SSL might just return SSL_ERROR_WANT_READ in 
+        /* SSL might just return SSL_ERROR_WANT_READ in
          * re-negotiation.
          */
         if (err != SSL_ERROR_NONE && err != SSL_ERROR_WANT_READ &&
@@ -2584,7 +2612,7 @@ static pj_status_t ssl_read(pj_ssl_sock_t *ssock, void *data, int *size)
                 return status;
             }
         }
-        
+
         /* Return PJ_ETRYAGAIN when SSL needs renegotiation */
         if (!SSL_is_init_finished(ossock->ossl_ssl)) {
             pj_lock_release(ssock->write_mutex);

--- a/pjlib/src/pj/ssl_sock_schannel.c
+++ b/pjlib/src/pj/ssl_sock_schannel.c
@@ -382,6 +382,7 @@ static void ssl_reset_sock_state(pj_ssl_sock_t* ssock)
 {
     sch_ssl_sock_t* sch_ssock = (sch_ssl_sock_t*)ssock;
     SECURITY_STATUS ss;
+    int post_unlock_flush_write_buf = 0;
 
     LOG_DEBUG(SNAME(ssock), "SSL reset");
 
@@ -434,10 +435,9 @@ static void ssl_reset_sock_state(pj_ssl_sock_t* ssock)
                                     buf_out[0].cbBuffer);
                 if (status != PJ_SUCCESS) {
                     PJ_PERROR(1, (SNAME(ssock), status,
-                        "Failed to queuehandshake packets"));
+                        "Failed to queue shutdown packets"));
                 } else {
-                    flush_ssl_write_buf(ssock, &ssock->shutdown_op_key,
-                                          0, 0);
+                    post_unlock_flush_write_buf = 1;
                 }
             }
         } else {
@@ -457,10 +457,21 @@ static void ssl_reset_sock_state(pj_ssl_sock_t* ssock)
         SecInvalidateHandle(&sch_ssock->cred_handle);
     }
     circ_reset(&ssock->ssl_read_buf);
-    circ_reset(&ssock->ssl_write_buf);
+    if (!post_unlock_flush_write_buf)
+        circ_reset(&ssock->ssl_write_buf);
     circ_reset(&sch_ssock->decrypted_buf);
 
     pj_lock_release(ssock->write_mutex);
+
+    if (post_unlock_flush_write_buf) {
+        pj_status_t flush_st;
+        flush_st = flush_ssl_write_buf(ssock, &ssock->shutdown_op_key,
+                                       0, 0);
+        circ_reset(&ssock->ssl_write_buf);
+        if (flush_st == PJ_EPENDING) {
+            PJ_LOG(5, (SNAME(ssock), "close_notify send pending"));
+        }
+    }
 
     ssl_close_sockets(ssock);
 }

--- a/pjlib/src/pjlib-test/ssl_sock_stress.c
+++ b/pjlib/src/pjlib-test/ssl_sock_stress.c
@@ -42,6 +42,8 @@ struct send_load_state
     int                 pending_cnt;
     int                 sent_cb_cnt;
     int                 send_idx;
+    int                 renego_at;
+    pj_bool_t           renego_done;
     pj_ioqueue_op_key_t op_keys[SEND_LOAD_COUNT];
     char                send_data[SEND_LOAD_PKT_LEN];
 };
@@ -69,23 +71,27 @@ static pj_bool_t load_on_connect_complete(pj_ssl_sock_t *ssock,
         return PJ_FALSE;
     }
 
-    /* Blast sends — many rapid sends naturally trigger PJ_EPENDING
-     * as the SSL/network buffers fill up.
+    /* Blast sends. When renego_at > 0, only send the first half here;
+     * the second half is sent from on_data_read after renegotiation
+     * completes (during polling, so handshake messages can be exchanged).
      */
-    for (i = 0; i < SEND_LOAD_COUNT; i++) {
-        pj_ssize_t len = SEND_LOAD_PKT_LEN;
+    {
+        int count = (st->renego_at > 0) ? st->renego_at : SEND_LOAD_COUNT;
+        for (i = 0; i < count; i++) {
+            pj_ssize_t len = SEND_LOAD_PKT_LEN;
 
-        status = pj_ssl_sock_send(ssock, &st->op_keys[i],
-                                  st->send_data, &len, 0);
-        if (status == PJ_EPENDING) {
-            st->pending_cnt++;
-        } else if (status == PJ_SUCCESS) {
-            st->sent += len;
-        } else {
-            st->err = status;
-            return PJ_FALSE;
+            status = pj_ssl_sock_send(ssock, &st->op_keys[i],
+                                      st->send_data, &len, 0);
+            if (status == PJ_EPENDING || status == PJ_EBUSY) {
+                st->pending_cnt++;
+            } else if (status == PJ_SUCCESS) {
+                st->sent += len;
+            } else {
+                st->err = status;
+                return PJ_FALSE;
+            }
+            st->send_idx++;
         }
-        st->send_idx++;
     }
 
     return PJ_TRUE;
@@ -144,14 +150,66 @@ static pj_bool_t load_on_data_read(pj_ssl_sock_t *ssock,
     if (size > 0) {
         st->recv += size;
 
+        /* Server: trigger renegotiation if configured */
+        if (st->is_server && st->renego_at > 0 && !st->renego_done) {
+            pj_size_t threshold = (pj_size_t)st->renego_at *
+                                  SEND_LOAD_PKT_LEN;
+            if (st->recv >= threshold) {
+                pj_status_t s = pj_ssl_sock_renegotiate(ssock);
+                if (s != PJ_SUCCESS && s != PJ_EPENDING) {
+                    PJ_LOG(3, ("", "...server renegotiate: %d", s));
+                }
+                st->renego_done = PJ_TRUE;
+            }
+        }
+
         /* Server echoes data back */
         if (st->echo) {
             pj_ssize_t sz = (pj_ssize_t)size;
             pj_status_t s;
 
             s = pj_ssl_sock_send(ssock, &st->op_keys[0], data, &sz, 0);
-            if (s != PJ_SUCCESS && s != PJ_EPENDING) {
+            if (s != PJ_SUCCESS && s != PJ_EPENDING &&
+                s != PJ_EBUSY)
+            {
                 st->err = s;
+            }
+        }
+
+        /* Client: trigger renegotiation + send second half when first
+         * half has been echoed back (during polling, so handshake can
+         * complete via ioqueue event processing).
+         */
+        if (!st->is_server && st->renego_at > 0 && !st->renego_done) {
+            pj_size_t threshold = (pj_size_t)st->renego_at *
+                                  SEND_LOAD_PKT_LEN;
+            if (st->recv >= threshold) {
+                pj_status_t s;
+                int i;
+
+                s = pj_ssl_sock_renegotiate(ssock);
+                if (s != PJ_SUCCESS && s != PJ_EPENDING) {
+                    PJ_LOG(3, ("", "...client renegotiate: %d", s));
+                    st->err = s;
+                }
+                st->renego_done = PJ_TRUE;
+
+                /* Send second half */
+                for (i = st->send_idx; i < SEND_LOAD_COUNT; i++) {
+                    pj_ssize_t len = SEND_LOAD_PKT_LEN;
+
+                    s = pj_ssl_sock_send(ssock, &st->op_keys[i],
+                                         st->send_data, &len, 0);
+                    if (s == PJ_EPENDING || s == PJ_EBUSY) {
+                        st->pending_cnt++;
+                    } else if (s == PJ_SUCCESS) {
+                        st->sent += len;
+                    } else {
+                        st->err = s;
+                        return PJ_FALSE;
+                    }
+                    st->send_idx++;
+                }
             }
         }
 
@@ -196,7 +254,10 @@ static pj_bool_t load_on_data_sent(pj_ssl_sock_t *ssock,
     return PJ_TRUE;
 }
 
-static int send_load_test(void)
+/* renego_at: trigger renegotiation after this many sends/packets.
+ * renego_srv: PJ_TRUE = server-initiated, PJ_FALSE = client-initiated.
+ */
+static int send_load_test_inner(int renego_at, pj_bool_t renego_srv)
 {
     pj_pool_t *pool = NULL;
     pj_ioqueue_t *ioqueue = NULL;
@@ -244,7 +305,7 @@ static int send_load_test(void)
                          pj_strset2(&tmp_st, "127.0.0.1"), 0);
     }
 
-    /* Fill send data with pattern */
+    /* Fill send data with repeating byte pattern. */
     for (i = 0; i < SEND_LOAD_PKT_LEN; i++)
         state_cli.send_data[i] = (char)(i & 0xFF);
 
@@ -252,6 +313,7 @@ static int send_load_test(void)
     state_serv.pool = pool;
     state_serv.echo = PJ_TRUE;
     state_serv.is_server = PJ_TRUE;
+    state_serv.renego_at = renego_srv ? renego_at : 0;
     param.user_data = &state_serv;
     param.require_client_cert = PJ_FALSE;
 
@@ -268,6 +330,7 @@ static int send_load_test(void)
     state_cli.pool = pool;
     state_cli.echo = PJ_FALSE;
     state_cli.is_server = PJ_FALSE;
+    state_cli.renego_at = renego_srv ? 0 : renego_at;
 
     status = pj_ssl_sock_create(pool, &param, &ssock_cli);
     if (status != PJ_SUCCESS) {
@@ -299,7 +362,12 @@ static int send_load_test(void)
             pj_get_timestamp(&t_now);
             elapsed = pj_elapsed_msec(&t_start, &t_now);
             if (elapsed > 30000) {
-                PJ_LOG(1, ("", "...send_load_test TIMEOUT after 30s"));
+                PJ_LOG(1, ("", "...send_load_test TIMEOUT after 30s "
+                           "(sent=%lu recv=%lu pend=%d cb=%d)",
+                           (unsigned long)state_cli.sent,
+                           (unsigned long)state_cli.recv,
+                           state_cli.pending_cnt,
+                           state_cli.sent_cb_cnt));
                 status = PJ_ETIMEDOUT;
                 goto on_return;
             }
@@ -313,14 +381,15 @@ static int send_load_test(void)
     }
 
     /* Verify results */
-    PJ_LOG(3, ("", "...send_load_test: sent=%lu, recv=%lu, "
+    PJ_LOG(3, ("", "...send_load_test%s: sent=%lu, recv=%lu, "
                "pending=%d, sent_cb=%d",
+               renego_at ? " (renego)" : "",
                (unsigned long)state_cli.sent,
                (unsigned long)state_cli.recv,
                state_cli.pending_cnt,
                state_cli.sent_cb_cnt));
 
-    if (state_cli.pending_cnt == 0) {
+    if (state_cli.pending_cnt == 0 && !renego_at) {
         PJ_LOG(3, ("", "...NOTE: all sends completed synchronously, "
                    "async path NOT tested. Set PJ_IOQUEUE_FAST_TRACK=0 "
                    "in config_site.h to force async path."));
@@ -387,7 +456,10 @@ struct close_pending_state
     pj_bool_t           done;
     int                 pending_cnt;
     int                 sent_cb_cnt;
+    int                 err_cb_cnt;
     int                 send_idx;
+    int                 renego_at;
+    pj_bool_t           renego_done;
     pj_ioqueue_op_key_t op_keys[SEND_LOAD_COUNT];
     char                send_data[SEND_LOAD_PKT_LEN];
     pj_bool_t           blast_done;
@@ -416,8 +488,16 @@ static pj_bool_t cp_on_connect_complete(pj_ssl_sock_t *ssock,
         return PJ_FALSE;
     }
 
-    /* Blast sends */
+    /* Blast sends, with optional renegotiation mid-stream */
     for (i = 0; i < SEND_LOAD_COUNT; i++) {
+        if (st->renego_at > 0 && i == st->renego_at) {
+            pj_status_t s = pj_ssl_sock_renegotiate(ssock);
+            if (s != PJ_SUCCESS && s != PJ_EPENDING) {
+                st->err = s;
+                break;
+            }
+        }
+
         len = SEND_LOAD_PKT_LEN;
         status = pj_ssl_sock_send(ssock, &st->op_keys[i],
                                   st->send_data, &len, 0);
@@ -473,6 +553,8 @@ static pj_bool_t cp_on_data_sent(pj_ssl_sock_t *ssock,
     /* Tolerate errors — socket may be closing under us */
     if (sent > 0)
         st->sent += sent;
+    else
+        st->err_cb_cnt++;
     st->sent_cb_cnt++;
 
     return PJ_TRUE;
@@ -584,8 +666,9 @@ static int close_pending_test(void)
     }
 
     /* Close client while sends may still be pending */
-    PJ_LOG(3, ("", "...close_pending_test: closing client with "
-               "pending=%d", state_cli.pending_cnt));
+    PJ_LOG(3, ("", "...close_pending_test: closing with pending=%d "
+               "sent_cb=%d", state_cli.pending_cnt,
+               state_cli.sent_cb_cnt));
     pj_ssl_sock_close(ssock_cli);
     ssock_cli = NULL;
 
@@ -597,7 +680,24 @@ static int close_pending_test(void)
             pj_ioqueue_poll(ioqueue, &delay);
     }
 
-    PJ_LOG(3, ("", "...close_pending_test: completed (no crash)"));
+    PJ_LOG(3, ("", "...close_pending_test: pending=%d sent_cb=%d "
+               "err_cb=%d",
+               state_cli.pending_cnt, state_cli.sent_cb_cnt,
+               state_cli.err_cb_cnt));
+
+    /* Every send that returned PJ_EPENDING must get a callback:
+     * either a successful completion or an error/cancel on destroy.
+     */
+    if (state_cli.pending_cnt > 0 &&
+        state_cli.pending_cnt != state_cli.sent_cb_cnt)
+    {
+        PJ_LOG(1, ("", "...close_pending_test: pending=%d != sent_cb=%d "
+                   "(callbacks lost on destroy!)",
+                   state_cli.pending_cnt, state_cli.sent_cb_cnt));
+        status = PJ_EBUG;
+        goto on_return;
+    }
+
     status = PJ_SUCCESS;
 
 on_return:
@@ -627,6 +727,180 @@ on_return:
 }
 
 
+/* Renegotiation support check — only OpenSSL and GnuTLS actually
+ * support initiating renegotiation. Must use TLS 1.2 (already the
+ * default for all stress tests). */
+/* Client-initiated renegotiation: OpenSSL only.
+ * GnuTLS does not support client-initiated renegotiation. */
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+#   define HAS_CLIENT_RENEGO_TEST  1
+#else
+#   define HAS_CLIENT_RENEGO_TEST  0
+#endif
+
+/* Server-initiated renegotiation: OpenSSL and GnuTLS. */
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL) || \
+    (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_GNUTLS)
+#   define HAS_RENEGO_TEST  1
+#else
+#   define HAS_RENEGO_TEST  0
+#endif
+
+/*
+ * Destroy-during-renegotiation test: close socket while sends are delayed
+ * due to renegotiation. Verifies on_data_sent callbacks fire with error.
+ */
+#if HAS_CLIENT_RENEGO_TEST
+static int destroy_during_renego_test(void)
+{
+    pj_pool_t *pool = NULL;
+    pj_ioqueue_t *ioqueue = NULL;
+    pj_timer_heap_t *timer = NULL;
+    pj_ssl_sock_t *ssock_serv = NULL;
+    pj_ssl_sock_t *ssock_cli = NULL;
+    pj_ssl_sock_param param;
+    struct close_pending_state state_serv;
+    struct close_pending_state state_cli;
+    pj_sockaddr addr, listen_addr;
+    pj_status_t status;
+    int i;
+
+    pool = pj_pool_create(mem, "ssl_drenego", 8192, 4096, NULL);
+    pj_bzero(&state_serv, sizeof(state_serv));
+    pj_bzero(&state_cli, sizeof(state_cli));
+
+    status = pj_ioqueue_create(pool, 4, &ioqueue);
+    if (status != PJ_SUCCESS) goto on_return;
+
+    status = pj_timer_heap_create(pool, 4, &timer);
+    if (status != PJ_SUCCESS) goto on_return;
+
+    pj_ssl_sock_param_default(&param);
+    param.cb.on_accept_complete2 = &load_on_accept_complete;
+    param.cb.on_connect_complete = &cp_on_connect_complete;
+    param.cb.on_data_read = &cp_on_data_read;
+    param.cb.on_data_sent = &cp_on_data_sent;
+    param.ioqueue = ioqueue;
+    param.timer_heap = timer;
+    param.proto = PJ_SSL_SOCK_PROTO_TLS1_2;
+    param.ciphers_num = 0;
+
+    {
+        pj_str_t tmp_st;
+        pj_sockaddr_init(PJ_AF_INET, &addr,
+                         pj_strset2(&tmp_st, "127.0.0.1"), 0);
+    }
+
+    for (i = 0; i < SEND_LOAD_PKT_LEN; i++)
+        state_cli.send_data[i] = (char)(i & 0xFF);
+
+    /* SERVER */
+    state_serv.pool = pool;
+    state_serv.is_server = PJ_TRUE;
+    param.user_data = &state_serv;
+    param.require_client_cert = PJ_FALSE;
+
+    listen_addr = addr;
+    status = ssl_test_create_server(pool, &param, "destroy_renego",
+                                    &ssock_serv, &listen_addr);
+    if (status != PJ_SUCCESS) goto on_return;
+
+    /* CLIENT — renegotiate mid-blast so second half gets delayed */
+    state_cli.pool = pool;
+    state_cli.is_server = PJ_FALSE;
+    state_cli.renego_at = SEND_LOAD_COUNT / 2;
+    param.user_data = &state_cli;
+
+    status = pj_ssl_sock_create(pool, &param, &ssock_cli);
+    if (status != PJ_SUCCESS) goto on_return;
+
+    status = pj_ssl_sock_start_connect(ssock_cli, pool, &addr,
+                                       &listen_addr,
+                                       pj_sockaddr_get_len(&addr));
+    if (status == PJ_SUCCESS)
+        cp_on_connect_complete(ssock_cli, PJ_SUCCESS);
+    else if (status != PJ_EPENDING)
+        goto on_return;
+
+    /* Poll until blast is done (all sends attempted, some delayed) */
+    {
+        pj_timestamp t_start, t_now;
+        pj_uint32_t elapsed;
+        pj_get_timestamp(&t_start);
+        while (!state_cli.blast_done && !state_cli.err) {
+            pj_time_val delay = {0, 100};
+            pj_ioqueue_poll(ioqueue, &delay);
+            pj_timer_heap_poll(timer, NULL);
+            pj_get_timestamp(&t_now);
+            elapsed = pj_elapsed_msec(&t_start, &t_now);
+            if (elapsed > 30000) {
+                status = PJ_ETIMEDOUT;
+                goto on_return;
+            }
+        }
+    }
+
+    /* Close immediately — DO NOT wait for renegotiation to complete.
+     * Delayed sends in write_pending must get callbacks on destroy.
+     */
+    PJ_LOG(3, ("", "...destroy_renego: closing with pending=%d",
+               state_cli.pending_cnt));
+    pj_ssl_sock_close(ssock_cli);
+    ssock_cli = NULL;
+
+    {
+        pj_time_val delay = {0, 500};
+        int n = 20;
+        while (n-- > 0)
+            pj_ioqueue_poll(ioqueue, &delay);
+    }
+
+    PJ_LOG(3, ("", "...destroy_renego: pending=%d sent_cb=%d err_cb=%d",
+               state_cli.pending_cnt, state_cli.sent_cb_cnt,
+               state_cli.err_cb_cnt));
+
+    if (state_cli.pending_cnt == 0) {
+        PJ_LOG(3, ("", "...NOTE: all sends completed synchronously, "
+                   "destroy callback path NOT tested"));
+    }
+
+    if (state_cli.pending_cnt != state_cli.sent_cb_cnt) {
+        PJ_LOG(1, ("", "...destroy_renego: pending=%d != sent_cb=%d",
+                   state_cli.pending_cnt, state_cli.sent_cb_cnt));
+        status = PJ_EBUG;
+        goto on_return;
+    }
+
+    if (state_cli.pending_cnt > 0 && state_cli.err_cb_cnt == 0) {
+        PJ_LOG(1, ("", "...destroy_renego: pending=%d but 0 error "
+                   "callbacks", state_cli.pending_cnt));
+        status = PJ_EBUG;
+        goto on_return;
+    }
+
+    status = PJ_SUCCESS;
+
+on_return:
+    if (ssock_cli) pj_ssl_sock_close(ssock_cli);
+    if (state_serv.accepted_ssock)
+        pj_ssl_sock_close(state_serv.accepted_ssock);
+    if (ssock_serv) pj_ssl_sock_close(ssock_serv);
+
+    if (ioqueue) {
+        pj_time_val delay = {0, 500};
+        int n = 50;
+        while (n-- > 0 && pj_ioqueue_poll(ioqueue, &delay) > 0)
+            ;
+    }
+    if (timer) pj_timer_heap_destroy(timer);
+    if (ioqueue) pj_ioqueue_destroy(ioqueue);
+    if (pool) pj_pool_release(pool);
+
+    return (status == PJ_SUCCESS) ? 0 : -1;
+}
+#endif /* HAS_CLIENT_RENEGO_TEST */
+
+
 /*
  * Bidirectional simultaneous load test: both sides send independent data.
  */
@@ -643,9 +917,11 @@ struct bidir_state
     pj_size_t           recv;
     pj_uint8_t          read_buf[8192];
     pj_bool_t           done;
+    pj_bool_t           recv_done;
     int                 pending_cnt;
     int                 sent_cb_cnt;
     int                 send_idx;
+    int                 renego_at;
     pj_ioqueue_op_key_t op_keys[BIDIR_SEND_COUNT];
     char                send_data[BIDIR_PKT_LEN];
     pj_size_t           expected_recv;
@@ -660,9 +936,18 @@ static pj_bool_t bidir_blast_sends(pj_ssl_sock_t *ssock,
         pj_ssize_t len = BIDIR_PKT_LEN;
         pj_status_t s;
 
+        /* Trigger renegotiation mid-stream if configured */
+        if (st->renego_at > 0 && i == st->renego_at) {
+            s = pj_ssl_sock_renegotiate(ssock);
+            if (s != PJ_SUCCESS && s != PJ_EPENDING) {
+                st->err = s;
+                return PJ_FALSE;
+            }
+        }
+
         s = pj_ssl_sock_send(ssock, &st->op_keys[i],
                              st->send_data, &len, 0);
-        if (s == PJ_EPENDING) {
+        if (s == PJ_EPENDING || s == PJ_EBUSY) {
             st->pending_cnt++;
         } else if (s == PJ_SUCCESS) {
             st->sent += len;
@@ -761,8 +1046,12 @@ static pj_bool_t bidir_on_data_read(pj_ssl_sock_t *ssock,
 
     if (size > 0) {
         st->recv += size;
-        if (st->recv >= st->expected_recv)
-            st->done = PJ_TRUE;
+        if (st->recv >= st->expected_recv) {
+            st->recv_done = PJ_TRUE;
+            /* If all pending sends have completed too, we're fully done */
+            if (st->pending_cnt == st->sent_cb_cnt)
+                st->done = PJ_TRUE;
+        }
     }
 
     if (status != PJ_SUCCESS) {
@@ -793,10 +1082,15 @@ static pj_bool_t bidir_on_data_sent(pj_ssl_sock_t *ssock,
 
     st->sent += sent;
     st->sent_cb_cnt++;
+
+    /* Check if all pending sends completed while recv was already done */
+    if (st->recv_done && st->pending_cnt == st->sent_cb_cnt)
+        st->done = PJ_TRUE;
+
     return PJ_TRUE;
 }
 
-static int bidir_test(void)
+static int bidir_test_inner(int renego_at)
 {
     pj_pool_t *pool = NULL;
     pj_ioqueue_t *ioqueue = NULL;
@@ -867,6 +1161,7 @@ static int bidir_test(void)
     state_cli.pool = pool;
     state_cli.is_server = PJ_FALSE;
     state_cli.expected_recv = BIDIR_SEND_COUNT * BIDIR_PKT_LEN;
+    state_cli.renego_at = renego_at;
     param.user_data = &state_cli;
 
     status = pj_ssl_sock_create(pool, &param, &ssock_cli);
@@ -1399,33 +1694,503 @@ on_return:
     return (status == PJ_SUCCESS) ? 0 : -1;
 }
 
+/*
+ * Concurrent send test: multiple threads blast-send on the SAME SSL socket.
+ * This simulates production SIP where worker threads share a TLS transport.
+ * Detects out-of-order TLS records (causes connection reset) and data
+ * corruption from interleaved ssl_write_buf access.
+ */
+#define CS_SENDER_THREADS   3
+#define CS_SENDS_PER_THREAD 30
+#define CS_PKT_LEN          512
+
+struct cs_sender_arg
+{
+    pj_ssl_sock_t      *ssock;
+    pj_ioqueue_op_key_t op_keys[CS_SENDS_PER_THREAD];
+    char                send_data[CS_PKT_LEN];
+    int                 send_cnt;
+    int                 pending_cnt;
+    int                 sent_cb_cnt;
+    pj_size_t           sent;
+    pj_status_t         err;
+    pj_bool_t           done;
+};
+
+struct cs_state
+{
+    pj_pool_t          *pool;
+    pj_ssl_sock_t      *accepted_ssock;
+    pj_bool_t           is_server;
+    pj_bool_t           echo;
+    pj_status_t         err;
+    pj_size_t           sent;
+    pj_size_t           recv;
+    pj_uint8_t          read_buf[8192];
+    pj_bool_t           done;
+    int                 pending_cnt;
+    int                 sent_cb_cnt;
+    int                 send_idx;
+    int                 renego_at;
+    pj_bool_t           renego_done;
+    pj_ioqueue_op_key_t send_key;
+    char                send_data[CS_PKT_LEN];
+    pj_size_t           expected_recv;
+};
+
+static pj_bool_t cs_on_connect_complete(pj_ssl_sock_t *ssock,
+                                        pj_status_t status)
+{
+    struct cs_state *st = (struct cs_state *)
+                           pj_ssl_sock_get_user_data(ssock);
+    void *read_buf[1];
+
+    if (status != PJ_SUCCESS) {
+        st->err = status;
+        return PJ_FALSE;
+    }
+
+    read_buf[0] = st->read_buf;
+    status = pj_ssl_sock_start_read2(ssock, st->pool,
+                                     sizeof(st->read_buf),
+                                     (void **)read_buf, 0);
+    if (status != PJ_SUCCESS) {
+        st->err = status;
+        return PJ_FALSE;
+    }
+
+    /* Sends will happen from worker threads, not here */
+    st->done = PJ_FALSE;
+    return PJ_TRUE;
+}
+
+static pj_bool_t cs_on_accept_complete(pj_ssl_sock_t *ssock,
+                                       pj_ssl_sock_t *newsock,
+                                       const pj_sockaddr_t *src_addr,
+                                       int src_addr_len,
+                                       pj_status_t accept_status)
+{
+    struct cs_state *parent_st = (struct cs_state *)
+                                  pj_ssl_sock_get_user_data(ssock);
+    struct cs_state *st;
+    void *read_buf[1];
+    pj_status_t status;
+
+    PJ_UNUSED_ARG(src_addr);
+    PJ_UNUSED_ARG(src_addr_len);
+
+    if (accept_status != PJ_SUCCESS)
+        return PJ_FALSE;
+
+    st = (struct cs_state *)pj_pool_zalloc(parent_st->pool,
+                                           sizeof(struct cs_state));
+    *st = *parent_st;
+    pj_ssl_sock_set_user_data(newsock, st);
+    parent_st->accepted_ssock = newsock;
+
+    read_buf[0] = st->read_buf;
+    status = pj_ssl_sock_start_read2(newsock, st->pool,
+                                     sizeof(st->read_buf),
+                                     (void **)read_buf, 0);
+    if (status != PJ_SUCCESS) {
+        st->err = status;
+        return PJ_FALSE;
+    }
+
+    return PJ_TRUE;
+}
+
+static pj_bool_t cs_on_data_read(pj_ssl_sock_t *ssock,
+                                 void *data,
+                                 pj_size_t size,
+                                 pj_status_t status,
+                                 pj_size_t *remainder)
+{
+    struct cs_state *st = (struct cs_state *)
+                           pj_ssl_sock_get_user_data(ssock);
+
+    if (remainder)
+        *remainder = 0;
+
+    if (size > 0) {
+        st->recv += size;
+
+        /* Server echoes data back */
+        if (st->echo) {
+            pj_ssize_t sz = (pj_ssize_t)size;
+            pj_status_t s;
+
+            s = pj_ssl_sock_send(ssock, &st->send_key, data, &sz, 0);
+            if (s != PJ_SUCCESS && s != PJ_EPENDING && s != PJ_EBUSY)
+                st->err = s;
+        }
+
+        /* Client: check completion */
+        if (!st->is_server && st->recv >= st->expected_recv)
+            st->done = PJ_TRUE;
+    }
+
+    if (status != PJ_SUCCESS) {
+        if (status == PJ_EEOF)
+            st->done = PJ_TRUE;
+        else
+            st->err = status;
+    }
+
+    if (st->err != PJ_SUCCESS || st->done)
+        return PJ_FALSE;
+
+    return PJ_TRUE;
+}
+
+static pj_bool_t cs_on_data_sent(pj_ssl_sock_t *ssock,
+                                 pj_ioqueue_op_key_t *op_key,
+                                 pj_ssize_t sent)
+{
+    struct cs_state *st = (struct cs_state *)
+                           pj_ssl_sock_get_user_data(ssock);
+    PJ_UNUSED_ARG(op_key);
+
+    if (sent < 0) {
+        st->err = (pj_status_t)-sent;
+        return PJ_FALSE;
+    }
+
+    st->sent += sent;
+    st->sent_cb_cnt++;
+    return PJ_TRUE;
+}
+
+static int cs_sender_proc(void *arg)
+{
+    struct cs_sender_arg *sa = (struct cs_sender_arg *)arg;
+    int i;
+
+    for (i = 0; i < CS_SENDS_PER_THREAD; i++) {
+        pj_ssize_t len = CS_PKT_LEN;
+        pj_status_t status;
+
+        status = pj_ssl_sock_send(sa->ssock, &sa->op_keys[i],
+                                  sa->send_data, &len, 0);
+        if (status == PJ_EPENDING || status == PJ_EBUSY) {
+            sa->pending_cnt++;
+        } else if (status == PJ_SUCCESS) {
+            sa->sent += len;
+        } else {
+            PJ_LOG(3, ("", "...cs_sender[%p] send %d err=%d",
+                       arg, i, status));
+            sa->err = status;
+            break;
+        }
+        sa->send_cnt++;
+    }
+    sa->done = PJ_TRUE;
+    return 0;
+}
+
+static int concurrent_send_test(void)
+{
+    pj_pool_t *pool = NULL;
+    pj_ioqueue_t *ioqueue = NULL;
+    pj_timer_heap_t *timer = NULL;
+    pj_ssl_sock_t *ssock_serv = NULL;
+    pj_ssl_sock_t *ssock_cli = NULL;
+    pj_ssl_sock_param param;
+    struct cs_state state_serv;
+    struct cs_state state_cli;
+    struct cs_sender_arg senders[CS_SENDER_THREADS];
+    pj_thread_t *sender_threads[CS_SENDER_THREADS];
+    pj_thread_t *poll_thread = NULL;
+    struct mt_test_ctx poll_ctx;
+    pj_sockaddr addr, listen_addr;
+
+    pj_status_t status;
+    pj_size_t total_expected;
+    int i;
+
+    pool = pj_pool_create(mem, "ssl_cs", 32000, 4096, NULL);
+
+    pj_bzero(&state_serv, sizeof(state_serv));
+    pj_bzero(&state_cli, sizeof(state_cli));
+    pj_bzero(senders, sizeof(senders));
+    pj_bzero(sender_threads, sizeof(sender_threads));
+    pj_bzero(&poll_ctx, sizeof(poll_ctx));
+
+    status = pj_ioqueue_create(pool, 4, &ioqueue);
+    if (status != PJ_SUCCESS) {
+        app_perror("...concurrent_send_test: ioqueue create", status);
+        goto on_return;
+    }
+
+    status = pj_timer_heap_create(pool, 4, &timer);
+    if (status != PJ_SUCCESS) {
+        app_perror("...concurrent_send_test: timer create", status);
+        goto on_return;
+    }
+
+    pj_ssl_sock_param_default(&param);
+    param.cb.on_accept_complete2 = &cs_on_accept_complete;
+    param.cb.on_connect_complete = &cs_on_connect_complete;
+    param.cb.on_data_read = &cs_on_data_read;
+    param.cb.on_data_sent = &cs_on_data_sent;
+    param.ioqueue = ioqueue;
+    param.timer_heap = timer;
+    param.proto = PJ_SSL_SOCK_PROTO_TLS1_2;
+    param.ciphers_num = 0;
+
+    {
+        pj_str_t tmp_st;
+        pj_sockaddr_init(PJ_AF_INET, &addr,
+                         pj_strset2(&tmp_st, "127.0.0.1"), 0);
+    }
+
+    total_expected = (pj_size_t)CS_SENDER_THREADS * CS_SENDS_PER_THREAD *
+                     CS_PKT_LEN;
+
+    /* SERVER */
+    state_serv.pool = pool;
+    state_serv.echo = PJ_TRUE;
+    state_serv.is_server = PJ_TRUE;
+    param.user_data = &state_serv;
+    param.require_client_cert = PJ_FALSE;
+
+    listen_addr = addr;
+    status = ssl_test_create_server(pool, &param, "concurrent_send_test",
+                                    &ssock_serv, &listen_addr);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+
+    /* CLIENT */
+    state_cli.pool = pool;
+    state_cli.is_server = PJ_FALSE;
+    state_cli.expected_recv = total_expected;
+    param.user_data = &state_cli;
+
+    status = pj_ssl_sock_create(pool, &param, &ssock_cli);
+    if (status != PJ_SUCCESS) {
+        app_perror("...concurrent_send_test: client create", status);
+        goto on_return;
+    }
+
+    status = pj_ssl_sock_start_connect(ssock_cli, pool, &addr,
+                                       &listen_addr,
+                                       pj_sockaddr_get_len(&addr));
+    if (status == PJ_SUCCESS) {
+        cs_on_connect_complete(ssock_cli, PJ_SUCCESS);
+    } else if (status != PJ_EPENDING) {
+        app_perror("...concurrent_send_test: connect", status);
+        goto on_return;
+    }
+
+    /* Poll until handshake completes (connect callback fires) */
+    {
+        pj_ssl_sock_info info;
+        pj_timestamp t_start, t_now;
+
+        pj_get_timestamp(&t_start);
+        for (;;) {
+            pj_time_val delay = {0, 100};
+            pj_ioqueue_poll(ioqueue, &delay);
+            pj_timer_heap_poll(timer, NULL);
+
+            if (state_cli.err) {
+                status = state_cli.err;
+                app_perror("...concurrent_send_test: connect error",
+                           status);
+                goto on_return;
+            }
+
+            status = pj_ssl_sock_get_info(ssock_cli, &info);
+            if (status == PJ_SUCCESS && info.established)
+                break;
+
+            pj_get_timestamp(&t_now);
+            if (pj_elapsed_msec(&t_start, &t_now) > 10000) {
+                PJ_LOG(1, ("", "...concurrent_send_test: "
+                           "connect TIMEOUT"));
+                status = PJ_ETIMEDOUT;
+                goto on_return;
+            }
+        }
+    }
+
+    /* Start poll thread */
+    poll_ctx.ioqueue = ioqueue;
+    poll_ctx.timer = timer;
+    poll_ctx.quit_flag = PJ_FALSE;
+    status = pj_thread_create(pool, "cs_poll", &mt_worker_proc,
+                              &poll_ctx, 0, 0, &poll_thread);
+    if (status != PJ_SUCCESS) {
+        app_perror("...concurrent_send_test: poll thread create", status);
+        goto on_return;
+    }
+
+    /* Launch sender threads — all send on the SAME ssock_cli */
+    for (i = 0; i < CS_SENDER_THREADS; i++) {
+        int k;
+
+        senders[i].ssock = ssock_cli;
+        for (k = 0; k < CS_PKT_LEN; k++)
+            senders[i].send_data[k] = (char)((i + k) & 0xFF);
+
+        status = pj_thread_create(pool, "cs_send", &cs_sender_proc,
+                                  &senders[i], 0, 0, &sender_threads[i]);
+        if (status != PJ_SUCCESS) {
+            app_perror("...concurrent_send_test: sender create", status);
+            goto on_return;
+        }
+    }
+
+    /* Wait for all senders to finish */
+    for (i = 0; i < CS_SENDER_THREADS; i++) {
+        if (sender_threads[i]) {
+            pj_thread_join(sender_threads[i]);
+            pj_thread_destroy(sender_threads[i]);
+            sender_threads[i] = NULL;
+        }
+    }
+
+    /* Poll until client receives all echoed data or error */
+    {
+        pj_timestamp t_start, t_now;
+
+        pj_get_timestamp(&t_start);
+        while (!state_cli.err && !state_cli.done) {
+            pj_time_val delay = {0, 100};
+
+            /* Main thread also polls */
+            pj_ioqueue_poll(ioqueue, &delay);
+            pj_timer_heap_poll(timer, NULL);
+
+            pj_get_timestamp(&t_now);
+            if (pj_elapsed_msec(&t_start, &t_now) > 30000) {
+                PJ_LOG(1, ("", "...concurrent_send_test TIMEOUT "
+                           "(recv=%lu expected=%lu err=%d)",
+                           (unsigned long)state_cli.recv,
+                           (unsigned long)total_expected,
+                           (int)state_cli.err));
+                status = PJ_ETIMEDOUT;
+                goto on_return;
+            }
+        }
+    }
+
+    if (state_cli.err) {
+        PJ_LOG(1, ("", "...concurrent_send_test: connection error=%d "
+                   "(recv=%lu/%lu) — likely out-of-order TLS records",
+                   (int)state_cli.err,
+                   (unsigned long)state_cli.recv,
+                   (unsigned long)total_expected));
+        status = state_cli.err;
+        goto on_return;
+    }
+
+    /* Verify */
+    {
+        int total_sends = 0;
+        int total_pending = 0;
+        pj_size_t total_sent = 0;
+
+        for (i = 0; i < CS_SENDER_THREADS; i++) {
+            total_sends += senders[i].send_cnt;
+            total_pending += senders[i].pending_cnt;
+            total_sent += senders[i].sent;
+            if (senders[i].err) {
+                PJ_LOG(1, ("", "...sender[%d] error=%d after %d sends",
+                           i, senders[i].err, senders[i].send_cnt));
+                status = senders[i].err;
+                goto on_return;
+            }
+        }
+
+        PJ_LOG(3, ("", "...concurrent_send_test: threads=%d "
+                   "total_sends=%d recv=%lu/%lu",
+                   CS_SENDER_THREADS, total_sends,
+                   (unsigned long)state_cli.recv,
+                   (unsigned long)total_expected));
+    }
+
+    status = PJ_SUCCESS;
+
+on_return:
+    poll_ctx.quit_flag = PJ_TRUE;
+    if (poll_thread) {
+        pj_thread_join(poll_thread);
+        pj_thread_destroy(poll_thread);
+    }
+    for (i = 0; i < CS_SENDER_THREADS; i++) {
+        if (sender_threads[i]) {
+            pj_thread_join(sender_threads[i]);
+            pj_thread_destroy(sender_threads[i]);
+        }
+    }
+
+    if (ssock_cli)
+        pj_ssl_sock_close(ssock_cli);
+    if (state_serv.accepted_ssock)
+        pj_ssl_sock_close(state_serv.accepted_ssock);
+    if (ssock_serv)
+        pj_ssl_sock_close(ssock_serv);
+
+    if (ioqueue) {
+        pj_time_val delay = {0, 500};
+        int n = 50;
+        while (n-- > 0 && pj_ioqueue_poll(ioqueue, &delay) > 0)
+            ;
+    }
+
+    if (timer)
+        pj_timer_heap_destroy(timer);
+    if (ioqueue)
+        pj_ioqueue_destroy(ioqueue);
+    if (pool)
+        pj_pool_release(pool);
+
+    return (status == PJ_SUCCESS) ? 0 : -1;
+}
+
 #endif /* PJ_HAS_THREADS */
 
+
+static int send_load_test(void) { return send_load_test_inner(0, PJ_FALSE); }
+static int bidir_test(void)     { return bidir_test_inner(0); }
+
+#define RUN_SUBTEST(name, call) \
+    do { \
+        PJ_LOG(3,("", ".." name)); \
+        ret = call; \
+        if (ret != 0) { \
+            PJ_LOG(1,("", "FAILED: " name " (rc=%d)", ret)); \
+            return ret; \
+        } \
+    } while (0)
 
 int ssl_sock_stress_test(void)
 {
     int ret;
 
-    PJ_LOG(3,("", "..send load test"));
-    ret = send_load_test();
-    if (ret != 0)
-        return ret;
-
-    PJ_LOG(3,("", "..close under pending sends test"));
-    ret = close_pending_test();
-    if (ret != 0)
-        return ret;
-
-    PJ_LOG(3,("", "..bidirectional simultaneous load test"));
-    ret = bidir_test();
-    if (ret != 0)
-        return ret;
+    RUN_SUBTEST("send load test", send_load_test());
+    RUN_SUBTEST("close under pending sends test", close_pending_test());
+    RUN_SUBTEST("bidirectional simultaneous load test", bidir_test());
 
 #if PJ_HAS_THREADS
-    PJ_LOG(3,("", "..multi-threaded send load test"));
-    ret = mt_send_load_test();
-    if (ret != 0)
-        return ret;
+    RUN_SUBTEST("multi-threaded send load test", mt_send_load_test());
+    RUN_SUBTEST("concurrent send (same socket) test",
+                concurrent_send_test());
+#endif
+
+#if HAS_CLIENT_RENEGO_TEST
+    RUN_SUBTEST("send load + client renegotiation test",
+                send_load_test_inner(SEND_LOAD_COUNT / 2, PJ_FALSE));
+    RUN_SUBTEST("bidirectional + renegotiation test",
+                bidir_test_inner(BIDIR_SEND_COUNT / 2));
+    RUN_SUBTEST("destroy during renegotiation test",
+                destroy_during_renego_test());
+#endif
+
+#if HAS_RENEGO_TEST
+    RUN_SUBTEST("send load + server renegotiation test",
+                send_load_test_inner(SEND_LOAD_COUNT / 2, PJ_TRUE));
 #endif
 
     return 0;


### PR DESCRIPTION
## Summary

Follow-up to #4909. Addresses feedback from @azertyfun ([comment](https://github.com/pjsip/pjproject/pull/4909#issuecomment-4212827269)):

### 1. Send queue redesign (thread-safety)
Replace lock-juggling send path with producer-consumer queue. `write_mutex` is never held during `pj_activesock_send` — no deadlock possible regardless of `PJ_IOQUEUE_CALLBACK_NO_LOCK` setting. Removes `asock_send_mutex`. Data mixing race between `ssl_write` and `flush_ssl_write_buf` eliminated (encrypt+enqueue is atomic under `write_mutex`).

### 2. Callback correctness
- `cancel_pending_sends()` fires `on_data_sent(-PJ_ECANCELLED)` synchronously from `pj_ssl_sock_close()` — app resources are guaranteed valid during callbacks
- `ssock_on_data_sent` checks `is_closing` to skip late async callbacks (IOCP cancelled completions, ioqueue drain) — prevents use-after-free on all platforms
- Tracks in-flight op via `send_op_inflight` (set under `write_mutex` before send, asserted NULL, cleared on completion)
- `drain_send_queue(suppress_first_cb)`: continuation drains from `ssock_on_data_sent` fire callbacks for all sync completions; error path fires callback and checks return for PJ_FALSE
- `ssl_on_destroy` only frees straggler ops defensively (no callbacks)

### 3. Renegotiation
- OpenSSL 3.x: `SSL_OP_ALLOW_CLIENT_RENEGOTIATION` on server sockets only (DoS mitigation)
- `SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION` removed (CVE-2009-3555)
- GnuTLS: client-initiated renegotiation returns `PJ_ENOTSUP` (`gnutls_rehandshake` is server-only)
- Write BIO flush after `SSL_read` loop and before `ssl_do_handshake`
- `PJ_EPENDING` from `flush_delayed_send` handled in `pj_ssl_sock_send`

### 4. Security hardening
- Send op pools use `pj_pool_secure_release` (zeroes ciphertext on free)
- Schannel: `flush_ssl_write_buf` moved outside `write_mutex`; `circ_reset` deferred until after flush
- Close_notify flush return handled in OpenSSL and Schannel

### 5. Tuning macros (in `pj/config.h`)
Three configurable macros to tune SSL send queue behavior:
- **`PJ_SSL_SEND_OP_ACTIVE_MAX`** (default: 0 = disabled) — bounds the active send queue size. When set, `pj_ssl_sock_send()` returns `PJ_EBUSY` if the limit is reached. Disabled by default for consistency with the unbounded ioqueue `write_list`.
- **`PJ_SSL_SEND_OP_FREE_LIST_MAX`** (default: 16) — number of completed send ops kept for recycling. Reduces pool alloc/release churn on busy connections.
- **`PJ_SSL_SEND_OP_MIN_BUF_SIZE`** (default: 4000) — minimum encrypted buffer size, enabling free-list reuse across varying send sizes.

## Issues caught by tests (before fixes)

- **Renegotiation timeout** (`send_load_test + client renego`): 50 sends stuck with 0 callbacks — `flush_delayed_send` never delivered after renegotiation. 30s timeout.
- **Destroy callback loss** (`close_pending_test`): `pending=100 sent_cb=99` — in-flight op orphaned when ioqueue cancels without callback on socket close.
- **First-op callback suppression** (`drain_send_queue`): continuation drain from `ssock_on_data_sent` suppressed first sync completion callback.
- **GnuTLS renegotiation failure**: `gnutls_rehandshake()` returned `GNUTLS_E_INVALID_REQUEST` on client socket.

## Test plan

- [x] `ssl_sock_test` — basic SSL (18s)
- [x] `ssl_sock_stress_test` — all stress/renegotiation/destroy tests (5s)
- [x] `ssl_sock_stress_test` with `PJ_IOQUEUE_FAST_TRACK=0` + OpenSSL (24s)
- [x] `ssl_sock_stress_test` with GnuTLS (4s)
- [ ] CI matrix: OpenSSL, GnuTLS, no-SSL, FAST_TRACK=0 + PJ_RACE_ME

Co-Authored-By: Claude Code
