### PR TITLE
Fix stack buffer overflow in pjsip_auth_create_digest2()

### DIFF
--- a/pjsip/src/pjsip/sip_auth_client.c
+++ b/pjsip/src/pjsip/sip_auth_client.c
@@ -382,7 +382,7 @@ PJ_DEF(pj_status_t) pjsip_auth_create_digest2( pj_str_t *result,
     } else {
         AUTH_TRACE_((THIS_FILE, " Using pre computed digest for %.*s digest",
                 (int)algorithm->iana_name.slen, algorithm->iana_name.ptr));
-        pj_memcpy( ha1, cred_info->data.ptr, cred_info->data.slen );
+        pj_memcpy( ha1, cred_info->data.ptr, digest_strlen );
     }
 
     AUTH_TRACE_((THIS_FILE, " ha1=%.*s", algorithm->digest_str_length, ha1));


### PR DESCRIPTION
## Summary

- Fix stack buffer overflow in `pjsip_auth_create_digest2()` when `cred_info->data_type` is `PJSIP_CRED_DATA_DIGEST` and `cred_info->data.slen` exceeds the `ha1` stack buffer size (128 bytes).
- The existing lower-bound check (`>= digest_strlen`) is preserved for backward compatibility; the fix caps the `pj_memcpy` length to `digest_strlen` instead of using `data.slen`.
- Not remotely exploitable (`cred_info` is always application-provided), but worth fixing as defensive programming.

## Credit

Reported by Feynman Hou <feynman.hou@zoom.us>

## Test plan

- [ ] Verify existing auth digest tests pass (`make pjsip-test`)
- [ ] Verify no regression in SIP authentication scenarios

Co-Authored-By: Claude Code