### PR TITLE
Fix use-after-free in STUN retransmit timer callback

### DIFF
--- a/pjnath/src/pjnath/stun_transaction.c
+++ b/pjnath/src/pjnath/stun_transaction.c
@@ -355,24 +355,26 @@ PJ_DEF(pj_status_t) pj_stun_client_tsx_send_msg(pj_stun_client_tsx *tsx,
 
 
 /* Retransmit timer callback */
-static void retransmit_timer_callback(pj_timer_heap_t *timer_heap, 
+static void retransmit_timer_callback(pj_timer_heap_t *timer_heap,
                                       pj_timer_entry *timer)
 {
     pj_stun_client_tsx *tsx = (pj_stun_client_tsx *) timer->user_data;
+    /* Save grp_lock to local variable since tsx may be destroyed during
+     * callbacks below (e.g. on_send_msg, on_complete), after which
+     * tsx->grp_lock must not be accessed.
+     */
+    pj_grp_lock_t *grp_lock = tsx->grp_lock;
     pj_status_t status;
 
     PJ_UNUSED_ARG(timer_heap);
-    pj_grp_lock_acquire(tsx->grp_lock);
+    pj_grp_lock_acquire(grp_lock);
 
     if (tsx->is_destroying) {
-        pj_grp_lock_release(tsx->grp_lock);
+        pj_grp_lock_release(grp_lock);
         return;
     }
 
     if (tsx->transmit_count >= PJ_STUN_MAX_TRANSMIT_COUNT) {
-        /* tsx may be destroyed when calling the callback below */
-        pj_grp_lock_t *grp_lock = tsx->grp_lock;
-
         /* Retransmission count exceeded. Transaction has failed */
         tsx->retransmit_timer.id = 0;
         PJ_LOG(4,(tsx->obj_name, "STUN timeout waiting for response"));
@@ -391,6 +393,11 @@ static void retransmit_timer_callback(pj_timer_heap_t *timer_heap,
 
     tsx->retransmit_timer.id = 0;
     status = tsx_transmit_msg(tsx, PJ_TRUE);
+    if (status == PJNATH_ESTUNDESTROYED) {
+        /* We've been destroyed, don't access tsx anymore. */
+        pj_grp_lock_release(grp_lock);
+        return;
+    }
     if (status != PJ_SUCCESS) {
         tsx->retransmit_timer.id = 0;
         if (!tsx->complete) {
@@ -401,7 +408,7 @@ static void retransmit_timer_callback(pj_timer_heap_t *timer_heap,
         }
     }
 
-    pj_grp_lock_release(tsx->grp_lock);
+    pj_grp_lock_release(grp_lock);
     /* We might have been destroyed, don't try to access the object */
 }
 


### PR DESCRIPTION
## Summary

- Fix use-after-free in `retransmit_timer_callback()` where `tsx->grp_lock` was read from freed memory after callbacks destroyed the transaction
- Save `tsx->grp_lock` to a local variable at function entry, use it for all lock operations
- Handle `PJNATH_ESTUNDESTROYED` return from `tsx_transmit_msg()` to avoid further tsx access

## Details

`retransmit_timer_callback()` in `stun_transaction.c` read `tsx->grp_lock` multiple times throughout the function. On the timeout path, `on_complete(PJNATH_ESTUNTIMEDOUT)` chains through `stun_tsx_on_complete()` → `destroy_tdata(force=TRUE)` → `tdata_on_destroy()` → `pj_pool_safe_release(&tdata->pool)`, which frees the pool containing `tsx`. After this, `tsx->grp_lock` reads from freed heap memory.

The timeout path already had a partial fix (saving `grp_lock` to a local inside the timeout block), but the retransmit path at the end of the function used `tsx->grp_lock` directly, which was vulnerable to the same issue.

The grp_lock itself stays alive during the callback (timer heap ref + acquire ref prevent ref_cnt from reaching 0), so using a saved local pointer is safe.

**Observed crash**: Windows CI `OpenSSL / pjnath` job — access violation in `grp_lock_release()` at `lock.c:335`, called from `retransmit_timer_callback`. The grp_lock pointer was `0x0041004d` (freed memory reused by string data). Stack: `grp_lock_release` ← `retransmit_timer_callback` ← `pj_timer_heap_poll` ← `worker_thread_proc`. CI run: https://github.com/pjsip/pjproject/actions/runs/24325801763/job/71020742879

## Test plan

- [x] Build passes with zero warnings (`make -j3`)
- [x] `make pjnath-test` — 70/70 tests pass (0 failures)

Co-Authored-By: Claude Code