### PR TITLE
Fix race condition in GnuTLS/mbedTLS SSL handshake and read

### DIFF
--- a/pjlib/src/pj/ssl_sock_gtls.c
+++ b/pjlib/src/pj/ssl_sock_gtls.c
@@ -1184,8 +1184,13 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
     int ret;
     pj_status_t status;
 
-    /* Perform SSL handshake */
+    /* Perform SSL handshake.
+     * Hold write_mutex to prevent concurrent session access from
+     * read and write callbacks (ioqueue may fire them in parallel).
+     */
+    pj_lock_acquire(ssock->write_mutex);
     ret = gnutls_handshake(gssock->session);
+    pj_lock_release(ssock->write_mutex);
 
     if (ret == GNUTLS_E_SUCCESS) {
         /* System are GO */
@@ -1212,8 +1217,14 @@ static pj_status_t ssl_read(pj_ssl_sock_t *ssock, void *data, int *size)
     int decrypted_size;
 
     /* Decrypt received data using GnuTLS (will read our input
-     * circular buffer) */
+     * circular buffer).
+     * Hold write_mutex because gnutls_record_recv() may produce
+     * handshake data during renegotiation (same as OpenSSL's
+     * SSL_read approach).
+     */
+    pj_lock_acquire(ssock->write_mutex);
     decrypted_size = gnutls_record_recv(gssock->session, data, *size);
+    pj_lock_release(ssock->write_mutex);
     *size = 0;
     if (decrypted_size > 0) {
         *size = decrypted_size;

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1337,10 +1337,10 @@ static pj_bool_t ssock_on_accept_complete (pj_ssl_sock_t *ssock_parent,
     /* Use write_mutex (not ssl_read_buf_mutex) to serialise the
      * ssl_state transition and the first ssl_do_handshake() call
      * against a concurrent ssock_on_data_read() that could fire on
-     * the newly-registered ioqueue key.  write_mutex is correct
-     * because ssl_do_handshake() now acquires write_mutex internally
-     * (for every backend), and the consistent lock order everywhere
-     * is: write_mutex -> ssl_read_buf_mutex.
+     * the newly-registered ioqueue key.  write_mutex is the correct
+     * outer lock here because backends that touch shared SSL session
+     * state acquire write_mutex internally, and the consistent lock
+     * order everywhere is: write_mutex -> ssl_read_buf_mutex.
      */
     pj_lock_acquire(ssock->write_mutex);
     ssock->ssl_state = SSL_STATE_HANDSHAKING;

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1334,16 +1334,19 @@ static pj_bool_t ssock_on_accept_complete (pj_ssl_sock_t *ssock_parent,
     }
 
     /* Start SSL handshake */
-    /* Prevent data race with on_data_read() until ssl_do_handshake()
-     * completes.
+    /* Use write_mutex (not ssl_read_buf_mutex) to serialise the
+     * ssl_state transition and the first ssl_do_handshake() call
+     * against a concurrent ssock_on_data_read() that could fire on
+     * the newly-registered ioqueue key.  write_mutex is correct
+     * because ssl_do_handshake() now acquires write_mutex internally
+     * (for every backend), and the consistent lock order everywhere
+     * is: write_mutex -> ssl_read_buf_mutex.
      */
-    if (ssock->ssl_read_buf_mutex)
-        pj_lock_acquire(ssock->ssl_read_buf_mutex);
+    pj_lock_acquire(ssock->write_mutex);
     ssock->ssl_state = SSL_STATE_HANDSHAKING;
     ssl_set_state(ssock, PJ_TRUE);
     status = ssl_do_handshake_and_flush(ssock);
-    if (ssock->ssl_read_buf_mutex)
-        pj_lock_release(ssock->ssl_read_buf_mutex);
+    pj_lock_release(ssock->write_mutex);
 
 on_return:
     if (ssock && status != PJ_EPENDING) {

--- a/pjlib/src/pj/ssl_sock_mbedtls.c
+++ b/pjlib/src/pj/ssl_sock_mbedtls.c
@@ -828,7 +828,12 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
     pj_status_t handshake_status;
     int ret;
 
+    /* Hold write_mutex to prevent concurrent session access from
+     * read and write callbacks (ioqueue may fire them in parallel).
+     */
+    pj_lock_acquire(ssock->write_mutex);
     ret = mbedtls_ssl_handshake(&mssock->ssl_ctx);
+    pj_lock_release(ssock->write_mutex);
     handshake_status = ssl_status_from_err(ssock, ret);
 
     if (handshake_status == PJ_EPENDING)
@@ -856,8 +861,15 @@ static pj_status_t ssl_renegotiate(pj_ssl_sock_t *ssock)
 static pj_status_t ssl_read(pj_ssl_sock_t *ssock, void *data, int *size)
 {
     mbedtls_sock_t *mssock = (mbedtls_sock_t *)ssock;
+    int ret;
 
-    int ret = mbedtls_ssl_read(&mssock->ssl_ctx, data, *size);
+    /* Hold write_mutex because mbedtls_ssl_read() may produce
+     * handshake data during renegotiation (same as OpenSSL's
+     * SSL_read approach).
+     */
+    pj_lock_acquire(ssock->write_mutex);
+    ret = mbedtls_ssl_read(&mssock->ssl_ctx, data, *size);
+    pj_lock_release(ssock->write_mutex);
     if (ret >= 0) {
         *size = ret;
         return PJ_SUCCESS;


### PR DESCRIPTION
With `PJ_IOQUEUE_CALLBACK_NO_LOCK=1` (default), the ioqueue prevents concurrent callbacks of the *same type* (read vs read, write vs write) via `read_callback_thread`/`write_callback_thread` guards, but read and write callbacks **can execute concurrently** on the same key from different threads.

During SSL handshake, both `ssock_on_data_sent` (write completion) and `ssock_on_data_read` (incoming data) call `ssl_do_handshake()`, which invokes the backend's handshake function on the same session simultaneously — corrupting session state and producing fatal errors.

OpenSSL and Darwin backends already hold `write_mutex` around their handshake and read calls. GnuTLS and mbedTLS did not.

**CI failure:** [`ioq-no-fast-track / epoll+gtls`](https://github.com/pjsip/pjproject/actions/runs/24325801765/job/71020743906) — `mt_send_load_test` client 2 handshake failed with `PJ_EINVAL`. The no-fast-track config forces all sends through the async ioqueue path, creating separate write completion events that overlap with read events. Combined with `PJ_RACE_ME()` random delays, this reliably exposes the race.

**Changes:**
- `ssl_sock_gtls.c`: acquire `write_mutex` in `ssl_do_handshake()` around `gnutls_handshake()`, and in `ssl_read()` around `gnutls_record_recv()`
- `ssl_sock_mbedtls.c`: acquire `write_mutex` in `ssl_do_handshake()` around `mbedtls_ssl_handshake()`, and in `ssl_read()` around `mbedtls_ssl_read()`
- `ssl_sock_imp_common.c`: change `ssock_on_accept_complete()` to use `write_mutex` instead of `ssl_read_buf_mutex` to avoid lock-order inversion (consistent order: `write_mutex` → `ssl_read_buf_mutex`)

**Lock ordering:**
All paths now follow: `write_mutex` first, `ssl_read_buf_mutex` second. Both are recursive mutexes. The old accept handler held `ssl_read_buf_mutex` while calling into `ssl_do_handshake_and_flush()` — with this fix that would be a lock-order inversion, so it was changed to `write_mutex`.

## Test plan
- [x] Build passes with zero warnings
- [x] `ssl_sock_test` passes (OpenSSL)
- [x] `ssl_sock_stress_test` passes (OpenSSL)
- [ ] CI: `ioq-no-fast-track / epoll+gtls` — the failing job that exposed this bug

Co-Authored-By: Claude Code