### PR TITLE
Fix --ci-mode silently skipping pjnath tests on Windows CI

### DIFF
--- a/pjlib/src/pjlib-test/main.c
+++ b/pjlib/src/pjlib-test/main.c
@@ -48,7 +48,6 @@ static void usage()
     ut_usage();
 
     puts("  --skip-e         Skip essential tests");
-    puts("  --ci-mode        Running in slow CI  mode");
     puts("  -i               Ask ENTER before quitting");
     puts("  -p PORT          Use port PORT for echo port");
     puts("  -s SERVER        Use SERVER as ech oserver");
@@ -110,7 +109,6 @@ int main(int argc, char *argv[])
     }
     test_app.param_skip_essentials = pj_argparse_get_bool(&argc, argv,
                                                           "--skip-e");
-    test_app.param_ci_mode = pj_argparse_get_bool(&argc, argv, "--ci-mode");
 
 
     if (pj_argparse_peek_next_option(argv)) {

--- a/pjlib/src/pjlib-test/sleep.c
+++ b/pjlib/src/pjlib-test/sleep.c
@@ -90,7 +90,7 @@ static int simple_sleep_test(void)
 
 static int sleep_duration_test(void)
 {
-    const unsigned MAX_SLIP = test_app.param_ci_mode? 200 : 20;
+    const unsigned MAX_SLIP = test_app.ut_app.prm_ci_mode? 200 : 20;
     long duration[] = { 2000, 1000, 500, 200, 100 };
     unsigned i;
     unsigned avg_diff, max_diff;

--- a/pjlib/src/pjlib-test/test.c
+++ b/pjlib/src/pjlib-test/test.c
@@ -44,7 +44,6 @@ struct test_app_t test_app = {
     PJ_LOG_HAS_NEWLINE | PJ_LOG_HAS_TIME |
         PJ_LOG_HAS_MICRO_SEC | PJ_LOG_HAS_INDENT,
                                         /* .param_log_decor */
-    PJ_FALSE,                           /* .param_ci_mode */
 };
 
 int null_func()
@@ -403,7 +402,7 @@ int test_inner(int argc, char *argv[])
 
     pj_caching_pool_init( &caching_pool, NULL, 0 );
 
-    if (test_app.param_ci_mode)
+    if (test_app.ut_app.prm_ci_mode)
         PJ_LOG(3,(THIS_FILE, "Using ci-mode"));
 
     if (!test_app.param_skip_essentials) {

--- a/pjlib/src/pjlib-test/test.h
+++ b/pjlib/src/pjlib-test/test.h
@@ -168,7 +168,6 @@ struct test_app_t
     const char *param_echo_server;
     int         param_echo_port;
     int         param_log_decor;
-    pj_bool_t   param_ci_mode;
     pj_bool_t   param_skip_essentials;
 };
 extern struct test_app_t test_app;

--- a/pjlib/src/pjlib-test/test_util.h
+++ b/pjlib/src/pjlib-test/test_util.h
@@ -35,6 +35,7 @@ typedef struct ut_app_t
     int                  prm_list_test;
     pj_bool_t            prm_stop_on_error;
     pj_bool_t            prm_shuffle;
+    pj_bool_t            prm_ci_mode;
     int                  prm_seed;
     unsigned             flags;
     unsigned             verbosity;
@@ -176,19 +177,23 @@ PJ_INLINE(pj_status_t) ut_run_tests(ut_app_t *ut_app, const char *title,
 
     if (argc > 1) {
         int i;
+        pj_bool_t has_error = PJ_FALSE;
         for (i=1; i<argc; ++i) {
             pj_test_case *tc;
-            for (tc=ut_app->suite.tests.next; tc!=&ut_app->suite.tests; 
+            for (tc=ut_app->suite.tests.next; tc!=&ut_app->suite.tests;
                  tc=tc->next)
             {
                 if (pj_ansi_strcmp(argv[i], tc->obj_name)==0)
                     break;
             }
             if (tc==&ut_app->suite.tests) {
-                PJ_LOG(2,(THIS_FILE, "Test \"%s\" is not found in %s",
+                PJ_LOG(1,(THIS_FILE, "Test \"%s\" is not found in %s",
                           argv[i], title));
+                has_error = PJ_TRUE;
             }
         }
+        if (has_error)
+            return PJ_ENOTFOUND;
     }
 
     if (ut_app->ntests <= 0)
@@ -229,6 +234,7 @@ PJ_INLINE(void) ut_usage()
     puts("  -L, --list       List the tests and exit");
     puts("  --stop-err       Stop testing on error");
     puts("  --shuffle        Shuffle the test order");
+    puts("  --ci-mode        Running in slow CI mode");
     puts("  --seed N         Set shuffle random seed (must be >= 0)");
     puts("  --stdout-buf N   Set stdout buffering mode:");
     puts("  --stderr-buf N   Set stderr buffering mode:");
@@ -250,6 +256,7 @@ PJ_INLINE(pj_status_t) ut_parse_args(ut_app_t *ut_app, int *argc, char *argv[])
                             pj_argparse_get_bool(argc, argv, "--list");
     ut_app->prm_stop_on_error = pj_argparse_get_bool(argc, argv, "--stop-err");
     ut_app->prm_shuffle = pj_argparse_get_bool(argc, argv, "--shuffle");
+    ut_app->prm_ci_mode = pj_argparse_get_bool(argc, argv, "--ci-mode");
     if (pj_argparse_get_bool(argc, argv, "--log-no-cache")) {
         ut_app->flags |= PJ_TEST_LOG_NO_CACHE;
     }

--- a/pjlib/src/pjlib-test/timestamp.c
+++ b/pjlib/src/pjlib-test/timestamp.c
@@ -86,7 +86,7 @@ static int timestamp_accuracy()
         diff = -diff;
 
     /* In CI mode, allow max 10 msec mismatch */
-    if (test_app.param_ci_mode) {
+    if (test_app.ut_app.prm_ci_mode) {
         if (diff > (pj_int64_t)(freq.u64 / 100)) {
             PJ_LOG(3,(THIS_FILE, "....error: timestamp drifted by %d usec after "
                                  "%d msec",

--- a/pjlib/src/pjlib-test/unittest_test.c
+++ b/pjlib/src/pjlib-test/unittest_test.c
@@ -630,7 +630,7 @@ int unittest_parallel_test()
     pj_test_runner_destroy(runner);
     pj_pool_release(pool);
 
-    if (test_app.param_ci_mode) {
+    if (test_app.ut_app.prm_ci_mode) {
         /* In CI mode, only verify grouping constraints without requiring
          * exact completion order within parallel groups, since sleep-based
          * ordering is unreliable on loaded CI runners.


### PR DESCRIPTION
The `--ci-mode` flag was only parsed by pjlib-test's `main.c`. When Windows CI passed it to pjnath-test (`ci-win.yml`), it was not consumed by `ut_parse_args()` and remained in `argv`, where `ut_test_included()` treated it as a test name filter. Since no test matched `--ci-mode`, zero tests were added and `ut_run_tests()` returned success — **silently skipping all pjnath tests on every Windows CI run**.

Example CI run showing the issue ([job log](https://github.com/pjsip/pjproject/actions/runs/24388112214/job/71226856116)) — exits 0 with no tests executed:
```
cirunner: running. cmd="pjnath-test-i386-Win32-vc14-Release.exe",
    args=['-w', '3', '--shuffle', '--ci-mode'], timeout=3600
test.c Test "--ci-mode" is not found in pjnath tests
cirunner: Exiting with exit code 0
```

Changes:
- Move `--ci-mode` parsing from pjlib-test's `main.c` into `ut_parse_args()` in `test_util.h`, so all test binaries (pjlib, pjnath, pjlib-util, pjmedia, pjsip) properly consume it. The `prm_ci_mode` field is added to the common `ut_app_t` struct, and pjlib-test references are updated accordingly.
- Update `ut_run_tests()` to return `PJ_ENOTFOUND` when any command-line argument does not match a registered test name, instead of merely logging a warning and continuing with zero tests. This is a **behavioral change**: previously `test_bin test_a bogus` would warn and still run `test_a`; now it returns error without running any tests. This is independent of `--stop-err`, which governs test execution failures, not argument validation.

## Test plan
- [x] `pjnath-test --ci-mode --list` — lists all 70 tests
- [x] `pjnath-test --ci-mode stun_test` — runs stun_test, exits 0
- [x] `pjnath-test --bogus-option` — errors, exits non-zero
- [x] `pjnath-test nonexistent_test` — errors, exits non-zero
- [x] `pjlib-test --ci-mode --list` — prints "Using ci-mode", lists tests
- [x] `pjlib-test --bogus` — "unknown argument", exits 1
- [x] `pjlib-util-test --ci-mode --list` — lists tests (flag consumed)
- [x] Full `make -j3` — zero warnings, zero errors

Co-Authored-By: Claude Code
