### PR TITLE
Fix race condition between ICE transport detach and RTP/RTCP callbacks

### DIFF
--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -2427,10 +2427,16 @@ static pj_status_t transport_attach2  (pjmedia_transport *tp,
 {
     struct transport_ice *tp_ice = (struct transport_ice*)tp;
 
+    if (tp->grp_lock)
+        pj_grp_lock_acquire(tp->grp_lock);
+
     tp_ice->stream = att_param->user_data;
     tp_ice->rtp_cb = att_param->rtp_cb;
     tp_ice->rtp_cb2 = att_param->rtp_cb2;
     tp_ice->rtcp_cb = att_param->rtcp_cb;
+
+    if (tp->grp_lock)
+        pj_grp_lock_release(tp->grp_lock);
 
     /* Check again if we are multiplexing RTP & RTCP. */
     tp_ice->use_rtcp_mux = (pj_sockaddr_has_addr(&att_param->rem_addr) &&
@@ -2455,14 +2461,18 @@ static void transport_detach(pjmedia_transport *tp,
 {
     struct transport_ice *tp_ice = (struct transport_ice*)tp;
 
-    /* TODO: need to solve ticket #460 here */
+    PJ_UNUSED_ARG(strm);
+
+    if (tp->grp_lock)
+        pj_grp_lock_acquire(tp->grp_lock);
 
     tp_ice->rtp_cb = NULL;
     tp_ice->rtp_cb2 = NULL;
     tp_ice->rtcp_cb = NULL;
     tp_ice->stream = NULL;
 
-    PJ_UNUSED_ARG(strm);
+    if (tp->grp_lock)
+        pj_grp_lock_release(tp->grp_lock);
 }
 
 
@@ -2537,19 +2547,37 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
 }
 
 
-static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id, 
+static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
                            void *pkt, pj_size_t size,
                            const pj_sockaddr_t *src_addr,
                            unsigned src_addr_len)
 {
     struct transport_ice *tp_ice;
     pj_bool_t discard = PJ_FALSE;
+    void (*rtp_cb)(void*, void*, pj_ssize_t);
+    void (*rtp_cb2)(pjmedia_tp_cb_param*);
+    void (*rtcp_cb)(void*, void*, pj_ssize_t);
+    void *stream;
 
     tp_ice = (struct transport_ice*) pj_ice_strans_get_user_data(ice_st);
     if (!tp_ice) {
         /* Destroy on progress */
         return;
     }
+
+    /* Snapshot callback pointers under lock to avoid race with
+     * transport_detach() clearing them.
+     */
+    if (tp_ice->base.grp_lock)
+        pj_grp_lock_acquire(tp_ice->base.grp_lock);
+
+    rtp_cb = tp_ice->rtp_cb;
+    rtp_cb2 = tp_ice->rtp_cb2;
+    rtcp_cb = tp_ice->rtcp_cb;
+    stream = tp_ice->stream;
+
+    if (tp_ice->base.grp_lock)
+        pj_grp_lock_release(tp_ice->base.grp_lock);
 
     if (comp_id == 1) {
         ++tp_ice->rtp_src_cnt;
@@ -2558,13 +2586,13 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
         pj_sockaddr_cp(&tp_ice->rtcp_src_addr, src_addr);
     }
 
-    if (comp_id==1 && (tp_ice->rtp_cb || tp_ice->rtp_cb2)) {
+    if (comp_id==1 && (rtp_cb || rtp_cb2)) {
         pj_bool_t rem_switch = PJ_FALSE;
 
         /* Simulate packet lost on RX direction */
         if (tp_ice->rx_drop_pct) {
             if ((pj_rand() % 100) <= (int)tp_ice->rx_drop_pct) {
-                PJ_LOG(5,(tp_ice->base.name, 
+                PJ_LOG(5,(tp_ice->base.name,
                           "RX RTP packet dropped because of pkt lost "
                           "simulation"));
                 return;
@@ -2572,19 +2600,19 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
         }
 
         if (!discard) {
-            if (tp_ice->rtp_cb2) {
+            if (rtp_cb2) {
                 pjmedia_tp_cb_param param;
 
-                param.user_data = tp_ice->stream;
+                param.user_data = stream;
                 param.pkt = pkt;
                 param.size = size;
                 param.src_addr = (tp_ice->use_ice? NULL:
                                   (pj_sockaddr_t *)src_addr);
                 param.rem_switch = PJ_FALSE;
-                (*tp_ice->rtp_cb2)(&param);
+                (*rtp_cb2)(&param);
                 rem_switch = param.rem_switch;
             } else {
-                (*tp_ice->rtp_cb)(tp_ice->stream, pkt, size);
+                (*rtp_cb)(stream, pkt, size);
             }
         }
         
@@ -2631,7 +2659,7 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
         PJ_UNUSED_ARG(rem_switch);
 #endif
 
-    } else if (comp_id==2 && tp_ice->rtcp_cb) {
+    } else if (comp_id==2 && rtcp_cb) {
 
 #if defined(PJMEDIA_TRANSPORT_SWITCH_REMOTE_ADDR) && \
     (PJMEDIA_TRANSPORT_SWITCH_REMOTE_ADDR == 1)
@@ -2668,7 +2696,7 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
 #endif
 
         if (!discard)
-            (*tp_ice->rtcp_cb)(tp_ice->stream, pkt, size);
+            (*rtcp_cb)(stream, pkt, size);
     }
 
     PJ_UNUSED_ARG(src_addr_len);

--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -1555,6 +1555,13 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
     void (*cb2)(pjmedia_tp_cb_param*) = NULL;
     void *cb_data = NULL;
 
+    /* Guard against race with transport_detach()/destroy().
+     * The underlying transport may invoke this callback after user_data
+     * has been cleared during detach.
+     */
+    if (!srtp)
+        return;
+
     if (srtp->bypass_srtp) {
         if (srtp->rtp_cb2) {
             pjmedia_tp_cb_param param2 = *param;
@@ -1763,6 +1770,12 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
     srtp_err_status_t err;
     void (*cb)(void*, void*, pj_ssize_t) = NULL;
     void *cb_data = NULL;
+
+    /* Guard against race with transport_detach()/destroy().
+     * See comment in srtp_rtp_cb().
+     */
+    if (!srtp)
+        return;
 
     if (srtp->bypass_srtp) {
         srtp->rtcp_cb(srtp->user_data, pkt, size);

--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -1778,7 +1778,8 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
         return;
 
     if (srtp->bypass_srtp) {
-        srtp->rtcp_cb(srtp->user_data, pkt, size);
+        if (srtp->rtcp_cb)
+            srtp->rtcp_cb(srtp->user_data, pkt, size);
         return;
     }
 

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -495,16 +495,30 @@ static pj_status_t transport_destroy(pjmedia_transport *tp)
 }
 
 /* Call RTP cb. */
-static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read, 
+static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
                         pj_bool_t *rem_switch)
 {
     void (*cb)(void*,void*,pj_ssize_t);
     void (*cb2)(pjmedia_tp_cb_param*);
     void *user_data;
 
+    /* Snapshot callback pointers under lock to avoid race with
+     * transport_detach() clearing them. Note that
+     * pj_ioqueue_lock_key() == pj_grp_lock_acquire() for the same
+     * group lock, so the detach side is already synchronized via
+     * pj_ioqueue_lock_key(). The lock is needed here because
+     * PJ_IOQUEUE_CALLBACK_NO_LOCK causes this callback to be invoked
+     * without the key lock held.
+     */
+    if (udp->base.grp_lock)
+        pj_grp_lock_acquire(udp->base.grp_lock);
+
     cb = udp->rtp_cb;
     cb2 = udp->rtp_cb2;
     user_data = udp->user_data;
+
+    if (udp->base.grp_lock)
+        pj_grp_lock_release(udp->base.grp_lock);
 
     if (cb2) {
         pjmedia_tp_cb_param param;
@@ -528,8 +542,15 @@ static void call_rtcp_cb(struct transport_udp *udp, pj_ssize_t bytes_read)
     void(*cb)(void*, void*, pj_ssize_t);
     void *user_data;
 
+    /* See comment in call_rtp_cb() above. */
+    if (udp->base.grp_lock)
+        pj_grp_lock_acquire(udp->base.grp_lock);
+
     cb = udp->rtcp_cb;
     user_data = udp->user_data;
+
+    if (udp->base.grp_lock)
+        pj_grp_lock_release(udp->base.grp_lock);
 
     if (cb)
         (*cb)(user_data, udp->rtcp_pkt, bytes_read);
@@ -1020,8 +1041,12 @@ static void transport_detach( pjmedia_transport *tp,
 
     //if (udp->attached) {
     if (1) {
-        /* Lock the ioqueue keys to make sure that callbacks are
-         * not executed. See ticket #460 for details.
+        /* Lock the ioqueue keys to synchronize with the RTP/RTCP
+         * callbacks. Note: pj_ioqueue_lock_key() acquires the
+         * transport's group lock (the same lock used by
+         * call_rtp_cb/call_rtcp_cb to snapshot callback pointers),
+         * so these clears are atomic with respect to the callbacks.
+         * See ticket #460 for details.
          */
 
         TRACE_((udp->base.name, "detach(): before locking keys"));
@@ -1048,18 +1073,16 @@ static void transport_detach( pjmedia_transport *tp,
 
         /* Unlock keys before clearing, to avoid deadlock with
          * PJ_IOQUEUE_CALLBACK_NO_LOCK. When that setting is enabled,
-         * pj_ioqueue_clear_key() waits for the read/write callback thread
-         * to finish, but the callback thread needs the key lock to clear
-         * its state (read_callback_thread). If we hold the lock here,
-         * pj_ioqueue_clear_key()'s recursive lock prevents full release
-         * during its wait loop, causing a deadlock.
+         * pj_ioqueue_clear_key() waits for the read/write callback
+         * thread to finish, but the callback thread may need the
+         * group lock (in call_rtp_cb/call_rtcp_cb) to snapshot the
+         * pointers. If we hold the lock here, the wait loop in
+         * pj_ioqueue_clear_key() would deadlock with the callback
+         * thread.
          *
-         * It is safe to unlock here because:
-         * - Callbacks (rtp_cb/rtp_cb2/rtcp_cb) have been set to NULL
-         *   above, so no new application callbacks will be invoked
-         *   after this point (although an in-flight callback that has
-         *   already copied the function pointer may still complete).
-         * - pj_ioqueue_clear_key() handles its own locking internally.
+         * It is safe to unlock here because the callback pointers
+         * have been cleared above under the lock, so any callback
+         * that snapshots after this point will see NULLs.
          */
         pj_ioqueue_unlock_key(udp->rtcp_key);
         pj_ioqueue_unlock_key(udp->rtp_key);


### PR DESCRIPTION
Fixes a race condition where `srtp_rtp_cb`/`srtp_rtcp_cb` could receive a NULL `user_data` pointer, causing a crash during call teardown. Reported by Christian Becker.

- **Root cause fix in ICE transport** (`transport_ice.c`): `transport_detach()` cleared callback pointers and `stream` (user_data) without any synchronization, while `ice_on_rx_data()` read them without protection. Now uses the transport's group lock to synchronize. The callback path uses a snapshot pattern — copies pointers under lock, invokes outside lock — to avoid deadlock.
- **Root cause fix in UDP transport** (`transport_udp.c`): Same race exists here. `transport_detach()` clears callback pointers under `pj_ioqueue_lock_key()` (which is `pj_grp_lock_acquire()` for the same group lock), but `call_rtp_cb()`/`call_rtcp_cb()` read them without any lock because `PJ_IOQUEUE_CALLBACK_NO_LOCK` (default: enabled) causes ioqueue callbacks to run with the key lock released. Added group lock acquire/release around the pointer snapshot in `call_rtp_cb()` and `call_rtcp_cb()`. The lock is released before callback invocation to avoid deadlock with `pj_ioqueue_clear_key()`'s wait loop.
- **Defensive NULL guard in SRTP** (`transport_srtp.c`): Added `if (!srtp) return;` at the top of `srtp_rtp_cb()` and `srtp_rtcp_cb()` as a safety net for other underlying transports that may have similar gaps.

The ICE transport's `transport_detach()` previously had `/* TODO: need to solve ticket #460 here */` — this PR resolves that TODO.

## Test plan

- [x] `make -j3` — zero errors, zero warnings
- [x] `make pjnath-test` — 69/70 passed (1 pre-existing SSL cert failure, unrelated)
- [x] pjsua smoke test on MSVC (SIP call with ICE+SRTP)

Co-Authored-By: Claude Code
