### PR TITLE
Fix GnuTLS renegotiation failure on GNUTLS_E_GOT_APPLICATION_DATA

### DIFF
--- a/pjlib/src/pj/ssl_sock_gtls.c
+++ b/pjlib/src/pj/ssl_sock_gtls.c
@@ -1196,8 +1196,17 @@ static pj_status_t ssl_do_handshake(pj_ssl_sock_t *ssock)
         /* System are GO */
         ssock->ssl_state = SSL_STATE_ESTABLISHED;
         status = PJ_SUCCESS;
-    } else if (!gnutls_error_is_fatal(ret)) {
-        /* Non fatal error, retry later (busy or again) */
+    } else if (!gnutls_error_is_fatal(ret) ||
+               ret == GNUTLS_E_GOT_APPLICATION_DATA)
+    {
+        /* Non fatal error, retry later (busy or again).
+         * GNUTLS_E_GOT_APPLICATION_DATA means the peer sent application
+         * data while we expected handshake records (common during
+         * renegotiation).  The app data sits in GnuTLS's internal record
+         * buffer and will be returned by the next gnutls_record_recv().
+         * Treat it as non-fatal so the caller retries after draining the
+         * buffered application data.
+         */
         status = PJ_EPENDING;
     } else {
         /* Fatal error invalidates session, no fallback */
@@ -1301,8 +1310,13 @@ static pj_status_t ssl_renegotiate(pj_ssl_sock_t *ssock)
         return PJ_ENOTSUP;
     }
 
-    /* Server: send HelloRequest to ask client to renegotiate */
+    /* Server: send HelloRequest to ask client to renegotiate.
+     * Hold write_mutex for session access consistency with
+     * ssl_do_handshake() and ssl_read().
+     */
+    pj_lock_acquire(ssock->write_mutex);
     status = gnutls_rehandshake(gssock->session);
+    pj_lock_release(ssock->write_mutex);
     if (status == GNUTLS_E_SUCCESS)
         return PJ_SUCCESS;
 


### PR DESCRIPTION
## Summary
- Handle `GNUTLS_E_GOT_APPLICATION_DATA` (-38) as non-fatal in `ssl_do_handshake()`, returning `PJ_EPENDING` so renegotiation retries after draining buffered application data
- Add `write_mutex` around `gnutls_rehandshake()` for session access consistency with `ssl_do_handshake()` and `ssl_read()`

## Background

During server-initiated TLS renegotiation under load, the client's `gnutls_handshake()` may encounter application data records (echoed by the server) instead of the expected handshake records, returning `GNUTLS_E_GOT_APPLICATION_DATA` (-38). On some GnuTLS builds (notably macOS Homebrew), `gnutls_error_is_fatal()` classifies this as fatal, causing `ssl_do_handshake()` to return `PJ_EINVAL` and abort the renegotiation.

The fix treats this as non-fatal (`PJ_EPENDING`). The buffered application data is consumed by subsequent `gnutls_record_recv()` calls in the normal read path, and the handshake retries incrementally until completion.

**CI failures**: This has been failing consistently on the `GnuTLS / pjlib,util,pjmedia,pjnath` job across multiple PRs since the `ssl_sock_stress_test` renegotiation subtest was introduced:
- https://github.com/pjsip/pjproject/actions/runs/24388112149/job/71226856744
- https://github.com/pjsip/pjproject/actions/runs/24391009862/job/71236772876
- https://github.com/pjsip/pjproject/actions/runs/24392970976/job/71243572307

## Test plan
- [x] Reproduced locally with GnuTLS 3.8.3 on Linux (`ssl_sock_stress_test -w 2`): fails on "send load + server renegotiation test" with identical error
- [x] Applied fix: `ssl_sock_stress_test` passes 5/5 runs
- [x] `ssl_sock_test` passes (no regression)
- [ ] CI: GnuTLS job should now pass the renegotiation subtest

Co-Authored-By: Claude Code