### PR TITLE
Fix Coverity static analysis warnings

### DIFF
--- a/pjlib-util/src/pjlib-util-test/websock_test.c
+++ b/pjlib-util/src/pjlib-util-test/websock_test.c
@@ -125,6 +125,8 @@ static pj_size_t server_decode_frame(const pj_uint8_t *data, pj_size_t len,
     /* Client frames must be masked */
     if (!(data[1] & 0x80)) return 0;
     if (len < pos + 4 + pl) return 0;
+    /* Cap payload length to caller's buffer size */
+    if (pl > SERVER_BUF_SIZE) return 0;
     pj_memcpy(mask, &data[pos], 4);
     pos += 4;
     for (i = 0; i < pl; ++i)

--- a/pjlib-util/src/pjlib-util/websock.c
+++ b/pjlib-util/src/pjlib-util/websock.c
@@ -312,6 +312,10 @@ static pj_size_t decode_frame_header(const pj_uint8_t *data, pj_size_t len,
     if (len < hdr_len + *payload_len)
         return 0;
 
+    /* Explicit cap for static analysis (redundant with check above) */
+    if (*payload_len > len)
+        return 0;
+
     *payload = &data[hdr_len];
 
     if (has_mask) {

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2141,12 +2141,12 @@ PJ_DEF(pj_status_t) pj_ssl_sock_send (pj_ssl_sock_t *ssock,
      * Check BEFORE ssl_send which encrypts the plaintext — once
      * encrypted, the data cannot be "un-sent" without corruption.
      */
-    if (PJ_SSL_SEND_OP_ACTIVE_MAX > 0 &&
-        ssock->send_op_active_cnt >= PJ_SSL_SEND_OP_ACTIVE_MAX)
-    {
+#if PJ_SSL_SEND_OP_ACTIVE_MAX > 0
+    if (ssock->send_op_active_cnt >= PJ_SSL_SEND_OP_ACTIVE_MAX) {
         status = PJ_EBUSY;
         goto on_return;
     }
+#endif
 
     /* Write data to SSL */
     status = ssl_send(ssock, send_key, data, *size, flags);

--- a/pjlib/src/pjlib-test/ioq_unreg.c
+++ b/pjlib/src/pjlib-test/ioq_unreg.c
@@ -100,8 +100,8 @@ static void on_read_complete(pj_ioqueue_key_t *key,
         if (PJ_TIME_VAL_GTE(now, time_to_unregister)) { 
             sock_data.unregistered = 1;
             TRACE((THIS_FILE, "......on_read_complete(): unregistering"));
-            pj_ioqueue_unregister(key);
             pj_mutex_unlock(sock_data.mutex);
+            pj_ioqueue_unregister(key);
             return;
         }
     }

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -1131,13 +1131,13 @@ static pj_status_t  codec_decode( pjmedia_codec *codec,
         opus_data->dec_frame[0].timestamp = input->timestamp;
         pj_memcpy(opus_data->dec_frame[0].buf, input->buf, input->size);
         opus_data->dec_frame_index = 0;
-        pj_mutex_unlock (opus_data->mutex);
 
         /* Return zero decoded bytes */
         output->size = 0;
         output->type = PJMEDIA_FRAME_TYPE_NONE;
         output->timestamp = input->timestamp;
 
+        pj_mutex_unlock (opus_data->mutex);
         return PJ_SUCCESS;
     }
 

--- a/pjnath/src/pjturn-srv/main.c
+++ b/pjnath/src/pjturn-srv/main.c
@@ -132,8 +132,13 @@ int main()
     if (status != PJ_SUCCESS)
         return err("pj_init() error", status);
 
-    pjlib_util_init();
-    pjnath_init();
+    status = pjlib_util_init();
+    if (status != PJ_SUCCESS)
+        return err("pjlib_util_init() error", status);
+
+    status = pjnath_init();
+    if (status != PJ_SUCCESS)
+        return err("pjnath_init() error", status);
 
     pj_caching_pool_init(&g_cp, NULL, 0);
 

--- a/pjsip-apps/src/samples/clidemo.c
+++ b/pjsip-apps/src/samples/clidemo.c
@@ -153,9 +153,13 @@ int main()
     pj_status_t status;
     unsigned i;
 
-    pj_init();
+    status = pj_init();
+    if (status != PJ_SUCCESS)
+        return 1;
     pj_caching_pool_init(&cp, NULL, 0);
-    pjlib_util_init();
+    status = pjlib_util_init();
+    if (status != PJ_SUCCESS)
+        return 1;
 
     /*
      * Create CLI app.

--- a/pjsip-apps/src/samples/httpdemo.c
+++ b/pjsip-apps/src/samples/httpdemo.c
@@ -158,10 +158,18 @@ int main(int argc, char *argv[])
 
     pj_log_set_level(5);
 
-    pj_init();
+    status = pj_init();
+    if (status != PJ_SUCCESS) {
+        puts("pj_init() error");
+        return 1;
+    }
     pj_caching_pool_init(&cp, NULL, 0);
     mem = &cp.factory;
-    pjlib_util_init();
+    status = pjlib_util_init();
+    if (status != PJ_SUCCESS) {
+        puts("pjlib_util_init() error");
+        return 1;
+    }
 
     if (argc > 2)
         f = fopen(argv[2], "wb");

--- a/pjsip-apps/src/samples/strerror.c
+++ b/pjsip-apps/src/samples/strerror.c
@@ -53,8 +53,8 @@ int main(int argc, char *argv[])
 
     pj_init();
     pj_caching_pool_init(&cp, NULL, 0);
-    pjlib_util_init();
-    pjnath_init();
+    (void)pjlib_util_init();
+    (void)pjnath_init();
     pjmedia_endpt_create(&cp.factory, NULL, 0, &med_ept);
     pjsip_endpt_create(&cp.factory, "localhost", &sip_ept);
     pjsip_evsub_init_module(sip_ept);

--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -1864,7 +1864,7 @@ static void on_tsx_state_uac( pjsip_evsub *sub, pjsip_transaction *tsx,
         if (tsx->status_code==401 || tsx->status_code==407) {
             pjsip_tx_data *tdata;
             pj_status_t status;
-            pjsip_auth_clt_async_on_chal_param chal_param;
+            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
             if (tsx->state == PJSIP_TSX_STATE_TERMINATED) {
                 /* Previously failed transaction has terminated */
@@ -2332,7 +2332,7 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
             pjsip_tx_data *tdata;
             pj_status_t status;
             pjsip_rx_data *rdata = event->body.tsx_state.src.rdata;
-            pjsip_auth_clt_async_on_chal_param chal_param;
+            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
             /* Handled by other module already (e.g: invite module) */
             if (tsx->last_tx->auth_retry)

--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -648,7 +648,7 @@ static void tsx_callback(void *token, pjsip_event *event)
     {
         pjsip_rx_data *rdata = event->body.tsx_state.src.rdata;
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param;
+        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
         /* Per-challenge token allocated from tsx->pool, kept alive
          * by the grp_lock ref until consumed (send or abandon).

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4111,7 +4111,7 @@ static void inv_handle_bye_response( pjsip_inv_session *inv,
     if (tsx->status_code == 401 || tsx->status_code == 407) {
 
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param;
+        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
         struct tsx_inv_data *tsx_inv_data;
 
         /* Dialog grp_lock is held by the caller (pjsip_dlg_on_tsx_state).
@@ -4329,7 +4329,7 @@ static pj_bool_t inv_handle_update_response( pjsip_inv_session *inv,
         (tsx->status_code == 401 || tsx->status_code == 407))
     {
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param;
+        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
         /* UPDATE auth: abandon_impl is NULL because abandoning a
          * mid-dialog UPDATE does not terminate the session.
@@ -4849,7 +4849,7 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
     {
         pjsip_tx_data *tdata;
         pj_status_t status;
-        pjsip_auth_clt_async_on_chal_param chal_param;
+        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
         struct tsx_inv_data *tsx_inv_data;
 
         /* Clear invite_tsx so pjsip_inv_send_msg() can accept the
@@ -4983,7 +4983,7 @@ static void handle_uac_call_rejection(pjsip_inv_session *inv, pjsip_event *e)
          * Resend the request with Authorization header.
          */
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param;
+        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
         /* Initial INVITE auth: abandoning terminates the session.
          * Dialog grp_lock is held by the caller; see BYE handler comment.

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1231,7 +1231,7 @@ static void regc_tsx_callback(void *token, pjsip_event *event)
         pjsip_rx_data *rdata = event->body.tsx_state.src.rdata;
         pjsip_tx_data *tdata;
         pj_bool_t is_unreg;
-        pjsip_auth_clt_async_on_chal_param chal_param;
+        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
         /* Capture is_unreg but keep current_op alive so that
          * async auth callbacks can read it if needed.  It will be

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -2266,7 +2266,7 @@ void pjsip_dlg_on_rx_response( pjsip_dialog *dlg, pjsip_rx_data *rdata )
         {
             pjsip_transaction *tsx = pjsip_rdata_get_tsx(rdata);
             pjsip_tx_data *tdata;
-            pjsip_auth_clt_async_on_chal_param chal_param;
+            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
 
             /* Check if application handles the authentication.
              * Allocate a per-challenge token from tsx->pool so that

--- a/pjsip/src/pjsua-lib/pjsua_im.c
+++ b/pjsip/src/pjsua-lib/pjsua_im.c
@@ -447,7 +447,7 @@ static void im_callback(void *token, pjsip_event *e)
         {
             pjsip_rx_data *rdata = e->body.tsx_state.src.rdata;
             pjsip_tx_data *tdata;
-            pjsip_auth_clt_async_on_chal_param chal_param;
+            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
             im_auth_ctx *ctx;
             pjsua_im_data *im_data2;
             pj_status_t status;
@@ -611,7 +611,7 @@ static void typing_callback(void *token, pjsip_event *e)
         {
             pjsip_rx_data *rdata = e->body.tsx_state.src.rdata;
             pjsip_tx_data *tdata;
-            pjsip_auth_clt_async_on_chal_param chal_param;
+            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
             im_auth_ctx *ctx;
             pj_status_t status;
 


### PR DESCRIPTION
## Summary
Address multiple Coverity Scan findings across pjlib, pjlib-util, pjmedia, pjnath, and pjsip:

- **UNINIT** (7 CIDs): Zero-initialize `chal_param` struct in all `pjsip_auth_clt_async_impl_on_challenge()` call sites so `user_data` is not left uninitialized
- **LOCK_EVASION**: Move Opus codec `output` frame writes before mutex unlock in `codec_decode()`, consistent with other return paths
- **NO_EFFECT**: Use `#if` preprocessor guard for `PJ_SSL_SEND_OP_ACTIVE_MAX` check, eliminating unsigned->=0 tautology at default value
- **SLEEP**: Release mutex before `pj_ioqueue_unregister()` in ioqueue unregister test callback to avoid potential blocking under lock
- **TAINTED_SCALAR** (2 CIDs): Add explicit payload length bounds in WebSocket frame decoders (test + production)
- **CHECKED_RETURN** (4 CIDs): Check `pjlib_util_init()`/`pjnath_init()` return values in sample apps and pjturn-srv. In `strerror.c`, return values are cast to `(void)` instead — this sample intentionally continues on partial init failure since its purpose is translating error codes and partial initialization still covers other error ranges.

### Not addressed (false positives)
- **WRAPPER_ESCAPE** (5 CIDs): `unique_ptr<TestAccount>` correctly manages Account lifetime via RAII destructor
- **REVERSE_INULL** (1 CID): `udp` is always non-NULL at dereference point; null check at cleanup is defensive for goto pattern

## Test plan
- [x] Build passes (zero errors, zero new warnings)
- [ ] CI

Co-Authored-By: Claude Code