### PR TITLE
Fix flaky CI: widen tsx retransmission timing tolerance in ci-mode

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -521,7 +521,7 @@ jobs:
     - name: pjlib-test
       run: cd pjlib/build && ../bin/pjlib-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS udp_ioqueue_test tcp_ioqueue_test ioqueue_stress_test udp_ioqueue_unreg_test ioqueue_perf_test0 ioqueue_perf_test1 activesock_test ssl_sock_test iocp_unregister_test
     - name: pjsip-test
-      run: cd pjsip/build && ../bin/pjsip-test-`make -s -C ../.. infotarget` $CI_ARGS resolve_test inv_offer_answer_test transport_udp_test transport_tcp_test regc_test tsx_destroy_test
+      run: cd pjsip/build && ../bin/pjsip-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS resolve_test inv_offer_answer_test transport_udp_test transport_tcp_test regc_test tsx_destroy_test
     - name: set up Python 3.10 for pjsua test
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -576,7 +576,7 @@ jobs:
     - name: pjlib-test
       run: cd pjlib/build && ../bin/pjlib-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS udp_ioqueue_test tcp_ioqueue_test ioqueue_stress_test udp_ioqueue_unreg_test ioqueue_perf_test0 ioqueue_perf_test1 activesock_test ssl_sock_test iocp_unregister_test
     - name: pjsip-test
-      run: cd pjsip/build && ../bin/pjsip-test-`make -s -C ../.. infotarget` $CI_ARGS resolve_test inv_offer_answer_test transport_udp_test transport_tcp_test regc_test tsx_destroy_test
+      run: cd pjsip/build && ../bin/pjsip-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS resolve_test inv_offer_answer_test transport_udp_test transport_tcp_test regc_test tsx_destroy_test
     - name: pjsua-test
       run: make pjsua-test
     - name: upload artifacts on failure

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -261,7 +261,7 @@ jobs:
         $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
         $env:PATH+=";$env:OPENSSL_DIR\bin"
         cd pjsip/bin
-        Invoke-Expression "$env:CI_RUNNER ./pjsip-test-i386-Win32-vc14-Release.exe $env:CI_WIN_ARGS"
+        Invoke-Expression "$env:CI_RUNNER ./pjsip-test-i386-Win32-vc14-Release.exe $env:CI_MODE $env:CI_WIN_ARGS"
       shell: powershell
     - name: python pjsua tests
       run: |
@@ -715,7 +715,7 @@ jobs:
         $env:SDL_DIR = Get-Content .\sdl_dir.txt
         $env:PATH+=";$env:SDL_DIR\lib\x86;"
         cd pjsip/bin
-        Invoke-Expression "$env:CI_RUNNER ./pjsip-test-i386-Win32-vc14-Release.exe $env:CI_WIN_ARGS"
+        Invoke-Expression "$env:CI_RUNNER ./pjsip-test-i386-Win32-vc14-Release.exe $env:CI_MODE $env:CI_WIN_ARGS"
       shell: powershell
     - name: upload artifacts on failure
       if: ${{ failure() }}
@@ -906,7 +906,7 @@ jobs:
         $env:OPENSSL_DIR = Get-Content .\openssl_dir.txt
         $env:PATH+=";$env:OPENSSL_DIR\bin"
         cd pjsip/bin
-        Invoke-Expression "$env:CI_RUNNER ./pjsip-test-i386-Win32-vc14-Release.exe $env:CI_WIN_ARGS resolve_test inv_offer_answer_test transport_udp_test transport_tcp_test regc_test tsx_destroy_test"
+        Invoke-Expression "$env:CI_RUNNER ./pjsip-test-i386-Win32-vc14-Release.exe $env:CI_MODE $env:CI_WIN_ARGS resolve_test inv_offer_answer_test transport_udp_test transport_tcp_test regc_test tsx_destroy_test"
       shell: powershell
     - name: build test tools cmp_wav
       run: |

--- a/Makefile
+++ b/Makefile
@@ -129,16 +129,16 @@ pjlib-test: pjlib/bin/pjlib-test-$(TARGET_NAME)
 	cd pjlib/build && $(CI_RUNNER) ../bin/pjlib-test-$(TARGET_NAME) $(CI_ARGS) $(CI_MODE)
 
 pjlib-util-test: pjlib-util/bin/pjlib-util-test-$(TARGET_NAME)
-	cd pjlib-util/build && $(CI_RUNNER) ../bin/pjlib-util-test-$(TARGET_NAME) $(CI_ARGS)
+	cd pjlib-util/build && $(CI_RUNNER) ../bin/pjlib-util-test-$(TARGET_NAME) $(CI_ARGS) $(CI_MODE)
 
 pjnath-test: pjnath/bin/pjnath-test-$(TARGET_NAME)
-	cd pjnath/build && $(CI_RUNNER) ../bin/pjnath-test-$(TARGET_NAME) $(CI_ARGS)
+	cd pjnath/build && $(CI_RUNNER) ../bin/pjnath-test-$(TARGET_NAME) $(CI_ARGS) $(CI_MODE)
 
 pjmedia-test: pjmedia/bin/pjmedia-test-$(TARGET_NAME)
-	cd pjmedia/build && $(CI_RUNNER) ../bin/pjmedia-test-$(TARGET_NAME) $(CI_ARGS)
+	cd pjmedia/build && $(CI_RUNNER) ../bin/pjmedia-test-$(TARGET_NAME) $(CI_ARGS) $(CI_MODE)
 
 pjsip-test: pjsip/bin/pjsip-test-$(TARGET_NAME)
-	cd pjsip/build && $(CI_RUNNER) ../bin/pjsip-test-$(TARGET_NAME) $(CI_ARGS)
+	cd pjsip/build && $(CI_RUNNER) ../bin/pjsip-test-$(TARGET_NAME) $(CI_ARGS) $(CI_MODE)
 
 pjsua-test: cmp_wav
 	cd tests/pjsua && python runall.py -t 2

--- a/pjsip/src/test/dns_test.c
+++ b/pjsip/src/test/dns_test.c
@@ -411,7 +411,7 @@ static int test_resolve(const char *title,
  */
 static int round_robin_test(pj_pool_t *pool)
 {
-    enum { COUNT = 400, PCT_ALLOWANCE = 10 };
+    enum { COUNT = 800, PCT_ALLOWANCE = 15 };
     unsigned i;
     struct server_hit
     {

--- a/pjsip/src/test/tsx_uac_test.c
+++ b/pjsip/src/test/tsx_uac_test.c
@@ -89,8 +89,8 @@ static char *TEST9_BRANCH_ID = PJSIP_RFC3261_BRANCH_ID "-UAC-Test09";
 
 #define BRANCH_LEN   (7+11)
 
-// An effort to accommodate CPU load spike on some test machines.
-#define      TEST1_ALLOWED_DIFF     500 //(150)
+/* Widen timing tolerance in CI mode — shared runners can be 5-10x slower. */
+#define      TEST1_ALLOWED_DIFF    (test_app.ut_app.prm_ci_mode ? 2500 : 500)
 #define      TEST4_RETRANSMIT_CNT   3
 #define      TEST5_RETRANSMIT_CNT   3
 

--- a/pjsip/src/test/tsx_uas_test.c
+++ b/pjsip/src/test/tsx_uas_test.c
@@ -164,8 +164,8 @@ static struct tsx_uas_test_global_t
 
 #define TEST_TIMEOUT_ERROR      -30
 
-// An effort to accommodate CPU load spike on some test machines.
-#define MAX_ALLOWED_DIFF        500 //150
+/* Widen timing tolerance in CI mode — shared runners can be 5-10x slower. */
+#define MAX_ALLOWED_DIFF    (test_app.ut_app.prm_ci_mode ? 2500 : 500)
 
 static void tsx_user_on_tsx_state(pjsip_transaction *tsx, pjsip_event *e);
 static pj_bool_t on_rx_message(pjsip_rx_data *rdata);


### PR DESCRIPTION
## Summary
- Widen retransmission timing tolerance in `tsx_uas_test` and `tsx_uac_test` from fixed 500ms to 2500ms when `--ci-mode` is active
- Pass `--ci-mode` (`$CI_MODE`) to **all** test executables in CI workflows and Makefile (was only passed to pjlib-test)
- Increase DNS SRV round-robin test sample count (400→800) and tolerance (10%→15%) to prevent statistical flakes

## Background

**tsx timing**: `tsx_uas_test` test7 (INVITE non-2xx retransmission) fails intermittently on Windows CI — the test expects a 4000ms retransmission timer but the GitHub Actions runner delivered it at 6027ms (2s late), exceeding the 500ms tolerance.

The `--ci-mode` flag and `prm_ci_mode` infrastructure already exists (used by pjlib sleep/timestamp tests), but was not passed to pjsip-test, pjlib-util-test, pjmedia-test, or pjnath-test.

**DNS round-robin**: `round_robin_test()` uses 400 samples with 10% tolerance. A server weighted at 65% has ~2.4% std dev at n=400, making >10% deviations statistically possible. Increasing to 800 samples halves the std dev.

**Failing CI runs**:
- tsx_uas_test: https://github.com/pjsip/pjproject/actions/runs/24436651988/job/71392199170
- dns round-robin: https://github.com/pjsip/pjproject/actions/runs/24438642848/job/71398418694

## Test plan
- [x] Normal mode retains 500ms tolerance (no regression for local testing)
- [ ] CI: `tsx_uas_test`, `tsx_uac_test`, and `resolve_test` should stop flaking on slow runners

Co-Authored-By: Claude Code