### PR TITLE
Test 3rd-party media support

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -598,6 +598,51 @@ jobs:
         name: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ matrix.name }}-${{ github.run_id }}
         path: artifacts
 
+  alt-pjsua:
+    # Build pjsua-lib with PJSUA_MEDIA_HAS_PJMEDIA=0 (third-party media mode)
+    # and test the alt_pjsua sample application.
+    needs: [detect-changes]
+    if: github.event_name == 'push' || needs.detect-changes.outputs.any_src == 'true'
+    runs-on: ubuntu-latest
+    name: alt_pjsua / 3rdparty media
+    steps:
+    - uses: actions/checkout@v2
+    - name: install cirunner
+      run: |
+        git clone --depth 1 https://github.com/pjsip/cirunner.git
+        cirunner/installlinux.sh
+    - name: install dependencies
+      run: sudo apt-get update && sudo apt-get install -y sip-tester
+    - name: config site
+      run: cp pjsip-apps/src/3rdparty_media_sample/config_site.h pjlib/include/pj/config_site.h
+    - name: configure
+      run: |
+        CFLAGS="-g -fPIC -Wno-unused-label" CXXFLAGS="-g -fPIC" LDFLAGS="-rdynamic" \
+        ./configure --enable-ext-sound --disable-speex-aec \
+          --disable-g711-codec --disable-l16-codec --disable-gsm-codec \
+          --disable-g722-codec --disable-g7221-codec --disable-speex-codec \
+          --disable-ilbc-codec --disable-opencore-amrnb \
+          --disable-sdl --disable-ffmpeg --disable-v4l2
+    - name: make
+      run: make -j3 lib
+    - name: build alt_pjsua
+      run: cd pjsip-apps/src/3rdparty_media_sample && make
+    - name: set up Python 3.10 for pjsua test
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: alt_pjsua-test
+      run: |
+        cd tests/pjsua
+        python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uac-custom-sdp.xml
+        python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-custom-sdp.xml
+    - name: upload artifacts on failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.run_id }}
+        path: artifacts
+
   cmake-build:
     runs-on: ubuntu-latest
     name: CMake / ${{ matrix.build_type }}

--- a/pjsip-apps/src/3rdparty_media_sample/Makefile
+++ b/pjsip-apps/src/3rdparty_media_sample/Makefile
@@ -14,7 +14,7 @@ OBJS = alt_pjsua_aud.o alt_pjsua_txt.o alt_pjsua_vid.o pjsua_app.o main.o pjsua_
 all: alt_pjsua
 
 alt_pjsua: $(OBJS)
-	$(PJ_CC) -o $@ $(OBJS) $(_CFLAGS) $(_LDFLAGS)
+	$(PJ_CC) -o $@ $(OBJS) $(_CFLAGS) -Wl,--allow-multiple-definition $(_LDFLAGS)
 
 pjsua_app.o: ../pjsua/pjsua_app.c
 	$(PJ_CC) $(_CFLAGS) -c -o $@ $<

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
@@ -648,11 +648,11 @@ PJ_DEF(pj_status_t) pjsua_set_snd_dev2(const pjsua_snd_dev_param *snd_param)
     return PJ_SUCCESS;
 }
 
-/* Use null sound device. */
+/* Use null sound device. Alt media backend has no real sound device,
+ * so this is a no-op that always succeeds. */
 PJ_DEF(pj_status_t) pjsua_set_null_snd_dev(void)
 {
-    UNIMPLEMENTED(pjsua_set_null_snd_dev)
-    return PJ_ENOTSUP;
+    return PJ_SUCCESS;
 }
 
 /* Use no device! */

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
@@ -705,5 +705,119 @@ PJ_DEF(pj_status_t) pjsua_vid_conf_update_port(pjsua_conf_port_id id)
     return PJ_ENOTSUP;
 }
 
+/* Get video conference port id of a call stream. */
+PJ_DEF(pjsua_conf_port_id) pjsua_call_get_vid_conf_port(
+                                                    pjsua_call_id call_id,
+                                                    pjmedia_dir dir)
+{
+    PJ_UNUSED_ARG(call_id);
+    PJ_UNUSED_ARG(dir);
+    UNIMPLEMENTED(pjsua_call_get_vid_conf_port)
+    return PJSUA_INVALID_ID;
+}
+
+/* Reset AVI player data (internal, called from pjsua_core). */
+void pjsua_reset_avi_player_data(pjsua_avi_player_id id)
+{
+    PJ_UNUSED_ARG(id);
+}
+
+/* Reset AVI recorder data (internal, called from pjsua_core). */
+void pjsua_reset_avi_recorder_data(pjsua_avi_rec_id id)
+{
+    PJ_UNUSED_ARG(id);
+}
+
+/* Create AVI player. */
+PJ_DEF(pj_status_t) pjsua_avi_player_create(const pj_str_t *filename,
+                                             pjsua_avi_player_id *id)
+{
+    PJ_UNUSED_ARG(filename);
+    PJ_UNUSED_ARG(id);
+    UNIMPLEMENTED(pjsua_avi_player_create)
+    return PJ_ENOTSUP;
+}
+
+/* Destroy AVI player. */
+PJ_DEF(pj_status_t) pjsua_avi_player_destroy(pjsua_avi_player_id id)
+{
+    PJ_UNUSED_ARG(id);
+    UNIMPLEMENTED(pjsua_avi_player_destroy)
+    return PJ_ENOTSUP;
+}
+
+/* Get audio conference port of AVI player. */
+PJ_DEF(pjsua_conf_port_id) pjsua_avi_player_get_conf_port(
+                                                        pjsua_avi_player_id id,
+                                                        pjmedia_type strm_type,
+                                                        unsigned strm_idx)
+{
+    PJ_UNUSED_ARG(id);
+    PJ_UNUSED_ARG(strm_type);
+    PJ_UNUSED_ARG(strm_idx);
+    UNIMPLEMENTED(pjsua_avi_player_get_conf_port)
+    return PJSUA_INVALID_ID;
+}
+
+/* Get video device index of AVI player. */
+PJ_DEF(pjmedia_vid_dev_index) pjsua_avi_player_get_vid_dev(
+                                                        pjsua_avi_player_id id)
+{
+    PJ_UNUSED_ARG(id);
+    UNIMPLEMENTED(pjsua_avi_player_get_vid_dev)
+    return PJMEDIA_VID_INVALID_DEV;
+}
+
+/* Create AVI recorder. */
+PJ_DEF(pj_status_t) pjsua_avi_recorder_create(const pj_str_t *filename,
+                                               pj_ssize_t max_size,
+                                               const pjmedia_format *vid_fmt,
+                                               const pjmedia_format *aud_fmt,
+                                               unsigned options,
+                                               pjsua_avi_rec_id *id)
+{
+    PJ_UNUSED_ARG(filename);
+    PJ_UNUSED_ARG(max_size);
+    PJ_UNUSED_ARG(vid_fmt);
+    PJ_UNUSED_ARG(aud_fmt);
+    PJ_UNUSED_ARG(options);
+    PJ_UNUSED_ARG(id);
+    UNIMPLEMENTED(pjsua_avi_recorder_create)
+    return PJ_ENOTSUP;
+}
+
+/* Destroy AVI recorder. */
+PJ_DEF(pj_status_t) pjsua_avi_recorder_destroy(pjsua_avi_rec_id id)
+{
+    PJ_UNUSED_ARG(id);
+    UNIMPLEMENTED(pjsua_avi_recorder_destroy)
+    return PJ_ENOTSUP;
+}
+
+/* Get audio conference port of AVI recorder. */
+PJ_DEF(pjsua_conf_port_id) pjsua_avi_recorder_get_conf_port(
+                                                        pjsua_avi_rec_id id,
+                                                        unsigned strm_idx)
+{
+    PJ_UNUSED_ARG(id);
+    PJ_UNUSED_ARG(strm_idx);
+    UNIMPLEMENTED(pjsua_avi_recorder_get_conf_port)
+    return PJSUA_INVALID_ID;
+}
+
+/* Set AVI recorder callback. */
+PJ_DEF(pj_status_t) pjsua_avi_recorder_set_cb(
+                                    pjsua_avi_rec_id id,
+                                    void *user_data,
+                                    void(*cb)(pjsua_avi_rec_id rec_id,
+                                              void *usr_data))
+{
+    PJ_UNUSED_ARG(id);
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(cb);
+    UNIMPLEMENTED(pjsua_avi_recorder_set_cb)
+    return PJ_ENOTSUP;
+}
+
 #endif  /* PJSUA_HAS_VIDEO */
 

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1272,6 +1272,44 @@ void on_playfile_done(pjmedia_port *port, void *usr_data)
                                &delay);
 }
 
+/* Callback to replace the generated SDP with a custom one (--custom-sdp).
+ * Only compiled when PJSUA_MEDIA_HAS_PJMEDIA=0 (alt media backend). */
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+static void on_call_sdp_created_cb(pjsua_call_id call_id,
+                                   pjmedia_sdp_session *sdp,
+                                   pj_pool_t *pool,
+                                   const pjmedia_sdp_session *rem_sdp)
+{
+    pjmedia_sdp_session *custom = NULL;
+    pj_str_t sdp_str;
+    pj_status_t status;
+
+    PJ_UNUSED_ARG(call_id);
+    PJ_UNUSED_ARG(rem_sdp);
+
+    if (app_config.custom_sdp.slen == 0)
+        return;
+
+    /* Make a writable copy since pjmedia_sdp_parse modifies the buffer */
+    sdp_str.ptr = (char*)pj_pool_alloc(pool,
+                                       (pj_size_t)(app_config.custom_sdp.slen + 1));
+    pj_memcpy(sdp_str.ptr, app_config.custom_sdp.ptr,
+              (pj_size_t)app_config.custom_sdp.slen);
+    sdp_str.ptr[app_config.custom_sdp.slen] = '\0';
+    sdp_str.slen = app_config.custom_sdp.slen;
+
+    status = pjmedia_sdp_parse(pool, sdp_str.ptr, (pj_size_t)sdp_str.slen,
+                               &custom);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(1,(THIS_FILE, status,
+                     "Failed to parse custom SDP, using generated SDP"));
+        return;
+    }
+
+    pj_memcpy(sdp, custom, sizeof(*sdp));
+}
+#endif /* !PJSUA_MEDIA_HAS_PJMEDIA */
+
 /* IP change progress callback. */
 void on_ip_change_progress(pjsua_ip_change_op op,
                            pj_status_t status,
@@ -1650,6 +1688,9 @@ static pj_status_t app_init(void)
     app_config.cfg.cb.on_snd_dev_operation = &on_snd_dev_operation;
     app_config.cfg.cb.on_call_media_event = &on_call_media_event;
     app_config.cfg.cb.on_ip_change_progress = &on_ip_change_progress;
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+    app_config.cfg.cb.on_call_sdp_created = &on_call_sdp_created_cb;
+#endif
 #ifdef TRANSPORT_ADAPTER_SAMPLE
     app_config.cfg.cb.on_create_media_transport = &on_create_media_transport;
 #endif

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -187,6 +187,12 @@ typedef struct pjsua_app_config
     /* CLI setting */
     pj_bool_t               use_cli;
     cli_cfg_t               cli_cfg;
+
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+    /* Custom SDP to inject via on_call_sdp_created (replaces generated SDP).
+     * Only available when PJSUA_MEDIA_HAS_PJMEDIA=0 (alt media backend). */
+    pj_str_t                custom_sdp;
+#endif
 } pjsua_app_config;
 
 /** Extern variable declaration **/

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -175,6 +175,10 @@ static void usage(void)
     puts  ("  --no-tones          Disable audible tones");
     puts  ("  --jb-max-size       Specify jitter buffer maximum size, in msec (default=-1)");
     puts  ("  --extra-audio       Add one more audio stream");
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+    puts  ("  --custom-sdp=STR    Replace generated SDP with this string.");
+    puts  ("                      Use \\r\\n or \\n as line separators. The full SDP is replaced as-is.");
+#endif
 
 #if PJSUA_HAS_VIDEO
     puts  ("");
@@ -422,6 +426,9 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_VCAPTURE_DEV, OPT_VRENDER_DEV, OPT_PLAY_AVI, OPT_AUTO_PLAY_AVI,
            OPT_REC_AVI, OPT_REC_AVI_SIZE, OPT_REC_AVI_AUDIO, OPT_AUTO_REC_AVI,
            OPT_USE_CLI, OPT_CLI_TELNET_PORT, OPT_DISABLE_CLI_CONSOLE
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+           , OPT_CUSTOM_SDP
+#endif
     };
     struct pj_getopt_option long_options[] = {
         { "config-file",1, 0, OPT_CONFIG_FILE},
@@ -578,6 +585,9 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "use-cli",    0, 0, OPT_USE_CLI},
         { "cli-telnet-port", 1, 0, OPT_CLI_TELNET_PORT},
         { "no-cli-console", 0, 0, OPT_DISABLE_CLI_CONSOLE},
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+        { "custom-sdp",     1, 0, OPT_CUSTOM_SDP},
+#endif
         { NULL, 0, 0, 0}
     };
     pj_status_t status;
@@ -1609,6 +1619,38 @@ static pj_status_t parse_args(int argc, char *argv[],
             cfg->cli_cfg.cli_fe &= (~CLI_FE_CONSOLE);
             break;
 
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+        case OPT_CUSTOM_SDP:
+        {
+            /* Unescape \r\n and \n in the option value so the user can
+             * pass the SDP as a single command-line argument.
+             */
+            const char *src = pj_optarg;
+            char *dst;
+            pj_size_t len = pj_ansi_strlen(pj_optarg);
+
+            cfg->custom_sdp.ptr = (char*)pj_pool_alloc(cfg->pool, len + 1);
+            dst = cfg->custom_sdp.ptr;
+            while (*src) {
+                if (src[0] == '\\' && src[1] == 'r' && src[2] == '\\' &&
+                    src[3] == 'n')
+                {
+                    *dst++ = '\r';
+                    *dst++ = '\n';
+                    src += 4;
+                } else if (src[0] == '\\' && src[1] == 'n') {
+                    *dst++ = '\n';
+                    src += 2;
+                } else {
+                    *dst++ = *src++;
+                }
+            }
+            *dst = '\0';
+            cfg->custom_sdp.slen = (pj_ssize_t)(dst - cfg->custom_sdp.ptr);
+            break;
+        }
+#endif /* !PJSUA_MEDIA_HAS_PJMEDIA */
+
         default:
             PJ_LOG(1,(THIS_FILE,
                       "Argument \"%s\" is not valid. Use --help to see help",
@@ -2557,6 +2599,40 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
                               config->cfg.timer_setting.sess_expires);
         pj_strcat2(&cfg, line);
     }
+
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+    if (config->custom_sdp.slen) {
+        /* Escape actual CRLF/LF back to \r\n/\n when saving */
+        const char *src = config->custom_sdp.ptr;
+        const char *end = src + config->custom_sdp.slen;
+        pj_str_t escaped;
+        char *ebuf;
+        char *ep;
+
+        /* Worst case: every byte becomes 4 chars (\r\n) */
+        ebuf = (char*)pj_pool_alloc(config->pool,
+                                    (pj_size_t)(config->custom_sdp.slen * 4 + 1));
+        ep = ebuf;
+        while (src < end) {
+            if (src[0] == '\r' && src + 1 < end && src[1] == '\n') {
+                *ep++ = '\\'; *ep++ = 'r'; *ep++ = '\\'; *ep++ = 'n';
+                src += 2;
+            } else if (src[0] == '\n') {
+                *ep++ = '\\'; *ep++ = 'n';
+                src++;
+            } else {
+                *ep++ = *src++;
+            }
+        }
+        *ep = '\0';
+        escaped.ptr = ebuf;
+        escaped.slen = (pj_ssize_t)(ep - ebuf);
+
+        pj_strcat2(&cfg, "--custom-sdp \"");
+        pj_strcat(&cfg, &escaped);
+        pj_strcat2(&cfg, "\"\n");
+    }
+#endif /* !PJSUA_MEDIA_HAS_PJMEDIA */
 
     *(cfg.ptr + cfg.slen) = '\0';
     return (int)cfg.slen;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3329,6 +3329,22 @@ pj_status_t pjsua_media_channel_create_sdp(pjsua_call_id call_id,
                                                    pool, rem_sdp);
     }
 
+    if (sdp->media_count > PJSUA_MAX_CALL_MEDIA) {
+        PJ_LOG(1, (THIS_FILE,
+                   "Error in provided SDP: media count %u exceeds "
+                   "PJSUA_MAX_CALL_MEDIA=%u",
+                   sdp->media_count, PJSUA_MAX_CALL_MEDIA));
+        status = PJ_ETOOMANY;
+        goto on_error;
+    }
+
+    /* Sync med_prov_cnt with the final SDP media count in case the callback
+     * added or replaced media sections (e.g. custom SDP with more m= lines).
+     * Mirrors the same invariant maintained for the rem_sdp (UAS) path above:
+     * med_prov_cnt must never decrease. */
+    if (call->med_prov_cnt < sdp->media_count)
+        call->med_prov_cnt = sdp->media_count;
+
     *p_sdp = sdp;
     return PJ_SUCCESS;
 

--- a/tests/pjsua/runall.py
+++ b/tests/pjsua/runall.py
@@ -41,7 +41,10 @@ excluded_tests = [
     "uas-mwi",
     "uas-register-ip-change-port-only",
     "uas-register-ip-change",
-    "uas-timer-update"
+    "uas-timer-update",
+    # These require alt_pjsua (PJSUA_MEDIA_HAS_PJMEDIA=0); run explicitly with --exe alt_pjsua
+    "alt-pjsua-uac-custom-sdp",
+    "alt-pjsua-uas-custom-sdp",
 ]
 
 # Exclude scripts-sipp/uac-reinvite-bad-via-branch on MacOS due to unreliable result

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.py
@@ -2,7 +2,8 @@
 # Test driver for alt-pjsua-uac-custom-sdp.xml
 #
 # alt_pjsua acts as UAC. It places a call to SIPp (UAS) using a custom SDP
-# with only PCMU. The call should reach STATE_CONFIRMED.
+# with audio (PCMU) and video (H263-1998). The call should reach
+# STATE_CONFIRMED.
 #
 # Run with alt_pjsua:
 #   cd tests/pjsua && python3 run.py \
@@ -13,7 +14,9 @@ import inc_const as const
 
 # pjsua instance: UAC. No URI in args so the call is initiated via CLI
 # after cli_main() has set up the telnet log redirect.
-# --rtp-port 4000 pins the RTP port so it matches the custom SDP body.
+# --rtp-port 4000 pins the audio RTP port; video uses 4002 (next even port).
+# PJMEDIA_HAS_VIDEO=1 in config_site.h makes pjsua_call_setting_default set
+# vid_cnt=1, so med_prov_cnt=2 (audio+video), matching the custom SDP.
 PJSUA = [
     "--null-audio --max-calls=1 --no-tcp --rtp-port 4000 "
     "--custom-sdp \"v=0\\r\\no=- 1234567890 1234567890 IN IP4 127.0.0.1"
@@ -24,11 +27,12 @@ PJSUA = [
 
 PJSUA_CLI_EXPECTS = [
     [0, "", "call new $SIPP_URI"],
-    # Verify the audio SDP SIPp sends in its 200 OK is received by alt_pjsua.
+    # Verify the SDP SIPp sends in its 200 OK is received by alt_pjsua.
     # Codec check only (no IP/port) for environment independence.
     [0, r"v=0", ""],
     [0, r"s=-", ""],
     [0, r"t=0 0", ""],
     [0, r"a=rtpmap:0 PCMU/8000", ""],
+    [0, r"a=rtpmap:96 H263-1998/90000", ""],
     [0, const.STATE_CONFIRMED, "call hangup"],
 ]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.py
@@ -1,0 +1,34 @@
+#
+# Test driver for alt-pjsua-uac-custom-sdp.xml
+#
+# alt_pjsua acts as UAC. It places a call to SIPp (UAS) using a custom SDP
+# with only PCMU. The call should reach STATE_CONFIRMED.
+#
+# Run with alt_pjsua:
+#   cd tests/pjsua && python3 run.py \
+#       --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua \
+#       mod_sipp.py scripts-sipp/alt-pjsua-uac-custom-sdp.xml
+#
+import inc_const as const
+
+# pjsua instance: UAC. No URI in args so the call is initiated via CLI
+# after cli_main() has set up the telnet log redirect.
+# --rtp-port 4000 pins the RTP port so it matches the custom SDP body.
+PJSUA = [
+    "--null-audio --max-calls=1 --no-tcp --rtp-port 4000 "
+    "--custom-sdp \"v=0\\r\\no=- 1234567890 1234567890 IN IP4 127.0.0.1"
+    "\\r\\ns=-\\r\\nc=IN IP4 127.0.0.1\\r\\nt=0 0"
+    "\\r\\nm=audio 4000 RTP/AVP 0\\r\\na=rtpmap:0 PCMU/8000"
+    "\\r\\nm=video 4002 RTP/AVP 96\\r\\na=rtpmap:96 H263-1998/90000\""
+]
+
+PJSUA_CLI_EXPECTS = [
+    [0, "", "call new $SIPP_URI"],
+    # Verify the audio SDP SIPp sends in its 200 OK is received by alt_pjsua.
+    # Codec check only (no IP/port) for environment independence.
+    [0, r"v=0", ""],
+    [0, r"s=-", ""],
+    [0, r"t=0 0", ""],
+    [0, r"a=rtpmap:0 PCMU/8000", ""],
+    [0, const.STATE_CONFIRMED, "call hangup"],
+]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- SIPp acts as UAS. alt_pjsua sends an INVITE with its custom SDP
+     (audio PCMU). SIPp verifies the codec appears in the INVITE, answers
+     200 OK with a matching audio SDP, then waits for BYE. -->
+
+<scenario name="alt_pjsua UAC custom SDP: SIPp as UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <!-- Verify the INVITE carries the custom SDP injected by alt_pjsua.
+           Check codec only (no IP/port) so the test is environment-independent.
+           search_in="msg" searches the entire SIP message. The condexec nop
+           avoids SIPp 3.7 exiting on "referenced 1 times" warning. -->
+      <ereg regexp="a=rtpmap:0 PCMU/8000" search_in="msg"
+            check_it="true" assign_to="1"/>
+    </action>
+  </recv>
+  <nop condexec="1"></nop>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 100 Trying
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+v=0
+o=sipp 1234567890 1234567890 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+
+    ]]>
+  </send>
+
+  <recv request="ACK" crlf="true">
+  </recv>
+
+  <recv request="BYE" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uac-custom-sdp.xml
@@ -2,22 +2,26 @@
 <!DOCTYPE scenario SYSTEM "sipp.dtd">
 
 <!-- SIPp acts as UAS. alt_pjsua sends an INVITE with its custom SDP
-     (audio PCMU). SIPp verifies the codec appears in the INVITE, answers
-     200 OK with a matching audio SDP, then waits for BYE. -->
+     containing audio (PCMU) and video (H263-1998). SIPp verifies both
+     codecs appear in the INVITE, answers 200 OK with matching audio and
+     video, then waits for BYE. -->
 
 <scenario name="alt_pjsua UAC custom SDP: SIPp as UAS">
 
   <recv request="INVITE" crlf="true">
     <action>
       <!-- Verify the INVITE carries the custom SDP injected by alt_pjsua.
-           Check codec only (no IP/port) so the test is environment-independent.
-           search_in="msg" searches the entire SIP message. The condexec nop
-           avoids SIPp 3.7 exiting on "referenced 1 times" warning. -->
+           Check codecs only (no IP/port) so the test is environment-independent.
+           search_in="msg" searches the entire SIP message. The condexec nops
+           avoid SIPp 3.7 exiting on "referenced 1 times" warning. -->
       <ereg regexp="a=rtpmap:0 PCMU/8000" search_in="msg"
             check_it="true" assign_to="1"/>
+      <ereg regexp="a=rtpmap:96 H263-1998/90000" search_in="msg"
+            check_it="true" assign_to="2"/>
     </action>
   </recv>
   <nop condexec="1"></nop>
+  <nop condexec="2"></nop>
 
   <send>
     <![CDATA[
@@ -53,6 +57,8 @@ c=IN IP[media_ip_type] [media_ip]
 t=0 0
 m=audio [media_port] RTP/AVP 0
 a=rtpmap:0 PCMU/8000
+m=video [media_port+2] RTP/AVP 96
+a=rtpmap:96 H263-1998/90000
 
     ]]>
   </send>

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-custom-sdp.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-custom-sdp.py
@@ -1,0 +1,39 @@
+#
+# Test driver for alt-pjsua-uas-custom-sdp.xml
+#
+# alt_pjsua (or pjsua) acts as UAS with --auto-answer=200. SIPp sends an
+# INVITE with a PCMU offer. pjsua answers with its custom SDP. The call
+# should reach STATE_CONFIRMED before SIPp terminates it with BYE.
+#
+# Run with standard pjsua:
+#   cd tests/pjsua && python3 run.py mod_sipp.py \
+#       scripts-sipp/alt-pjsua-uas-custom-sdp.xml
+#
+# Run with alt_pjsua:
+#   cd tests/pjsua && python3 run.py \
+#       --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua \
+#       mod_sipp.py scripts-sipp/alt-pjsua-uas-custom-sdp.xml
+#
+import inc_const as const
+
+# pjsua instance: UAS, auto-answers with custom SDP.
+# --rtp-port 4002 pins the audio RTP port; video uses 4004 (next even port).
+PJSUA = [
+    "--null-audio --max-calls=1 --no-tcp --rtp-port 4002 "
+    "--auto-answer=200 "
+    "--custom-sdp \"v=0\\r\\no=- 1234567890 1234567890 IN IP4 127.0.0.1"
+    "\\r\\ns=-\\r\\nc=IN IP4 127.0.0.1\\r\\nt=0 0"
+    "\\r\\nm=audio 4002 RTP/AVP 0\\r\\na=rtpmap:0 PCMU/8000"
+    "\\r\\nm=video 4004 RTP/AVP 96\\r\\na=rtpmap:96 H263-1998/90000\""
+]
+
+PJSUA_CLI_EXPECTS = [
+    # Verify the full SDP SIPp sends in its INVITE is received by alt_pjsua.
+    # Codec check only (no IP/port) for environment independence.
+    [0, r"v=0", ""],
+    [0, r"s=-", ""],
+    [0, r"t=0 0", ""],
+    [0, r"a=rtpmap:0 PCMU/8000", ""],
+    [0, r"a=rtpmap:96 H263-1998/90000", ""],
+    [0, const.STATE_CONFIRMED, ""],
+]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-custom-sdp.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-custom-sdp.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- SIPp acts as UAC and sends an INVITE with a PCMU+H263-1998 SDP offer.
+     alt_pjsua auto-answers 200 OK with its custom SDP. SIPp verifies the
+     200 OK body contains both audio and video codecs from the custom SDP,
+     sends ACK, waits briefly, then sends BYE. -->
+
+<scenario name="alt_pjsua UAS custom SDP: SIPp as UAC">
+
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: alt_pjsua UAS custom SDP test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+v=0
+o=sipp 1234567890 1234567890 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+m=video [media_port+2] RTP/AVP 96
+a=rtpmap:96 H263-1998/90000
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true">
+  </recv>
+
+  <recv response="180" optional="true">
+  </recv>
+
+  <recv response="200" rtd="true">
+    <action>
+      <!-- Verify the 200 OK carries the custom SDP injected by alt_pjsua.
+           Check codecs only (no IP/port) so the test is environment-independent.
+           search_in="msg" searches the entire SIP message. The condexec nop
+           avoids SIPp 3.7 exiting on "referenced 1 times" warning. -->
+      <ereg regexp="a=rtpmap:0 PCMU/8000" search_in="msg"
+            check_it="true" assign_to="1"/>
+      <ereg regexp="a=rtpmap:96 H263-1998/90000" search_in="msg"
+            check_it="true" assign_to="2"/>
+    </action>
+  </recv>
+  <nop condexec="1"></nop>
+  <nop condexec="2"></nop>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 2 BYE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" crlf="true">
+  </recv>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>


### PR DESCRIPTION
The alt_pjsua demo lacked a way to supply application-defined SDP, making it impossible to verify that third-party media stacks can inject arbitrary session descriptions into outgoing INVITEs and 200 OK answers.

This PR adds tests for UAS and UAC that are using 3rd-party media.