### PR TITLE
Fix 'braces around scalar initializer' errors with certain compilers.

### DIFF
--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -1864,7 +1864,7 @@ static void on_tsx_state_uac( pjsip_evsub *sub, pjsip_transaction *tsx,
         if (tsx->status_code==401 || tsx->status_code==407) {
             pjsip_tx_data *tdata;
             pj_status_t status;
-            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+            pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
             if (tsx->state == PJSIP_TSX_STATE_TERMINATED) {
                 /* Previously failed transaction has terminated */
@@ -2332,7 +2332,7 @@ static void on_tsx_state_uas( pjsip_evsub *sub, pjsip_transaction *tsx,
             pjsip_tx_data *tdata;
             pj_status_t status;
             pjsip_rx_data *rdata = event->body.tsx_state.src.rdata;
-            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+            pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
             /* Handled by other module already (e.g: invite module) */
             if (tsx->last_tx->auth_retry)

--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -648,7 +648,7 @@ static void tsx_callback(void *token, pjsip_event *event)
     {
         pjsip_rx_data *rdata = event->body.tsx_state.src.rdata;
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+        pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
         /* Per-challenge token allocated from tsx->pool, kept alive
          * by the grp_lock ref until consumed (send or abandon).

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4111,7 +4111,7 @@ static void inv_handle_bye_response( pjsip_inv_session *inv,
     if (tsx->status_code == 401 || tsx->status_code == 407) {
 
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+        pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
         struct tsx_inv_data *tsx_inv_data;
 
         /* Dialog grp_lock is held by the caller (pjsip_dlg_on_tsx_state).
@@ -4329,7 +4329,7 @@ static pj_bool_t inv_handle_update_response( pjsip_inv_session *inv,
         (tsx->status_code == 401 || tsx->status_code == 407))
     {
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+        pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
         /* UPDATE auth: abandon_impl is NULL because abandoning a
          * mid-dialog UPDATE does not terminate the session.
@@ -4849,7 +4849,7 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
     {
         pjsip_tx_data *tdata;
         pj_status_t status;
-        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+        pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
         struct tsx_inv_data *tsx_inv_data;
 
         /* Clear invite_tsx so pjsip_inv_send_msg() can accept the
@@ -4983,7 +4983,7 @@ static void handle_uac_call_rejection(pjsip_inv_session *inv, pjsip_event *e)
          * Resend the request with Authorization header.
          */
         pjsip_tx_data *tdata;
-        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+        pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
         /* Initial INVITE auth: abandoning terminates the session.
          * Dialog grp_lock is held by the caller; see BYE handler comment.

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1231,7 +1231,7 @@ static void regc_tsx_callback(void *token, pjsip_event *event)
         pjsip_rx_data *rdata = event->body.tsx_state.src.rdata;
         pjsip_tx_data *tdata;
         pj_bool_t is_unreg;
-        pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+        pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
         /* Capture is_unreg but keep current_op alive so that
          * async auth callbacks can read it if needed.  It will be

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -2266,7 +2266,7 @@ void pjsip_dlg_on_rx_response( pjsip_dialog *dlg, pjsip_rx_data *rdata )
         {
             pjsip_transaction *tsx = pjsip_rdata_get_tsx(rdata);
             pjsip_tx_data *tdata;
-            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+            pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
 
             /* Check if application handles the authentication.
              * Allocate a per-challenge token from tsx->pool so that

--- a/pjsip/src/pjsua-lib/pjsua_im.c
+++ b/pjsip/src/pjsua-lib/pjsua_im.c
@@ -447,7 +447,7 @@ static void im_callback(void *token, pjsip_event *e)
         {
             pjsip_rx_data *rdata = e->body.tsx_state.src.rdata;
             pjsip_tx_data *tdata;
-            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+            pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
             im_auth_ctx *ctx;
             pjsua_im_data *im_data2;
             pj_status_t status;
@@ -611,7 +611,7 @@ static void typing_callback(void *token, pjsip_event *e)
         {
             pjsip_rx_data *rdata = e->body.tsx_state.src.rdata;
             pjsip_tx_data *tdata;
-            pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
+            pjsip_auth_clt_async_on_chal_param chal_param = { 0 };
             im_auth_ctx *ctx;
             pj_status_t status;
 


### PR DESCRIPTION
Fixes for several errors for braced initializers under certain compilers:
* AppleClang 17.0.0.17000013
* GCC 13.2.0
* GCC 13.3.0
* GCC 14.2.0

```
pjproject/pjsip/src/pjsip/sip_dialog.c:2269:62: error: braces around scalar initializer [-Werror]
 2269 |             pjsip_auth_clt_async_on_chal_param chal_param = {{0}};
      |
```
