### PR TITLE
pj_pool_alloc_from_block: Eliminate unsafe cast

### DIFF
--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -58,12 +58,10 @@ PJ_IDEF(void*) pj_pool_alloc_from_block( pj_pool_block *block, pj_size_t alignme
     //    size = (size + alignment) & ~(alignment -1);
     //}
     ptr = PJ_POOL_ALIGN_PTR(block->cur, alignment);
-    if (block->cur <= ptr && /* check pointer overflow */
-        block->end - ptr >= (pj_ssize_t)size) /* check available size */
+    if (block->cur <= ptr && /* check pointer not overflowing */
+        ptr <= block->end && /* check alignment not exceeding the upper limit */
+        (pj_size_t)(block->end - ptr) >= size) /* check available size */
     {
-    //if (ptr + size <= block->end &&
-    //    /* here we check pointer overflow */
-    //    block->cur <= ptr && ptr <= ptr + size) {
         block->cur = ptr + size;
         return ptr;
     }


### PR DESCRIPTION
If the most significant bit of the `size` argument was set, casting to `pj_ssize_t` yielded a negative value, causing false positives in the size check. This resulted in returning a pointer to a buffer that has less capacity than requested.

This fixes regressions caused by #4382, #4389 and #4391. The original check prior to these PRs was correct, though a bit hard to read for both humans and compilers.