### PR TITLE
Fix Android SWIG Java build and pjsua2 sample app issues

### DIFF
--- a/pjsip-apps/src/swig/java/Makefile
+++ b/pjsip-apps/src/swig/java/Makefile
@@ -14,10 +14,6 @@ SWIG_FLAGS += $(GEN_DOC)
 
 ifneq ($(findstring android,$(TARGET_NAME)),)
  OS=android
- ifeq ("$(JAVA_HOME)","")
-   # Set dummy JAVA_HOME as JNI is bundled in Android NDK, only need javac here
-   JAVA_HOME := $(dir $(shell which javac))
- endif
 else
  ifneq ($(findstring darwin,$(TARGET_NAME)),)
   OS=darwin
@@ -39,9 +35,12 @@ else
   endif
 endif
 
-# Get JDK location
+# Get JDK location (not needed for Android — Gradle handles Java build)
 CHECK_JDK := 1
 ifeq ($(findstring clean,$(MAKECMDGOALS)),clean)
+  CHECK_JDK := 0
+endif
+ifeq ($(OS),android)
   CHECK_JDK := 0
 endif
 
@@ -175,7 +174,7 @@ endif
 
 MY_APP_JAVA := android/app/src/main/java/$(subst .,/,$(MY_PACKAGE_NAME))/app/MyApp.java
 
-.PHONY: all java install uninstall
+.PHONY: all java install uninstall android_helpers
 
 all: $(LIBPJSUA2_SO) java
 
@@ -204,7 +203,7 @@ clean distclean realclean:
 		$(MY_PACKAGE_PATH)/*.java $(MY_PACKAGE_PATH)/*.class \
 		$(MY_PACKAGE_PATH)/../*.java $(MY_PACKAGE_PATH)/../*.class
 
-java: $(MY_PACKAGE_PATH)/Error.class $(MY_PACKAGE_PATH)/test.class $(MY_PACKAGE_PATH)/sample.class
+android_helpers: $(OUT_DIR)/pjsua2_wrap.cpp
 ifneq (,$(findstring PJMEDIA_VIDEO_DEV_HAS_ANDROID=1,$(ANDROID_CFLAGS)))
 	@echo "Copying Android camera helper components..."
 	cp $(PJDIR)/pjmedia/src/pjmedia-videodev/android/PjCamera*.java $(MY_PACKAGE_PATH)/..
@@ -212,6 +211,12 @@ endif
 ifneq (,$(findstring PJMEDIA_AUDIO_DEV_HAS_OBOE=1,$(OBOE_CFLAGS)))
 	@echo "Copying Android Oboe audio device helper components..."
 	cp $(PJDIR)/pjmedia/src/pjmedia-audiodev/android/PjAudioDevInfo.java $(MY_PACKAGE_PATH)/..
+endif
+
+ifeq ($(OS),android)
+java: $(OUT_DIR)/pjsua2_wrap.cpp android_helpers
+else
+java: $(MY_PACKAGE_PATH)/Error.class $(MY_PACKAGE_PATH)/test.class $(MY_PACKAGE_PATH)/sample.class
 endif
 
 $(MY_PACKAGE_PATH)/Error.class: $(MY_PACKAGE_PATH)/Error.java

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
@@ -142,20 +142,13 @@ public class CallActivity extends Activity
         }
     }
 
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        
-        WindowManager wm;
-        Display display;
-        int rotation;
+    private void updateCaptureOrientation() {
         int orient;
-
-        wm = (WindowManager)this.getSystemService(Context.WINDOW_SERVICE);
-        display = wm.getDefaultDisplay();
-        rotation = display.getRotation();
+        WindowManager wm = (WindowManager)this.getSystemService(
+                                                  Context.WINDOW_SERVICE);
+        int rotation = wm.getDefaultDisplay().getRotation();
         System.out.println("Device orientation changed: " + rotation);
-        
+
         switch (rotation) {
         case Surface.ROTATION_0:   // Portrait
             orient = pjmedia_orient.PJMEDIA_ORIENT_ROTATE_270DEG;
@@ -183,6 +176,13 @@ public class CallActivity extends Activity
                 System.out.println(e);
             }
         }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateCaptureOrientation();
 
         /* Re-apply video/preview layout after rotation. We must wait for
          * the post-rotation layout pass to actually complete — using
@@ -192,8 +192,7 @@ public class CallActivity extends Activity
          */
         final View videoLayout = findViewById(R.id.bottom_layout);
         if (videoLayout != null && MainActivity.currentCall != null) {
-            final ViewTreeObserver vto = videoLayout.getViewTreeObserver();
-            vto.addOnGlobalLayoutListener(
+            videoLayout.getViewTreeObserver().addOnGlobalLayoutListener(
                 new ViewTreeObserver.OnGlobalLayoutListener() {
                     @Override
                     public void onGlobalLayout() {
@@ -226,11 +225,13 @@ public class CallActivity extends Activity
 
             /* The parent may not be measured yet when PJMEDIA_EVENT_FMT_CHANGED
              * arrives early — defer until it is, otherwise we'd divide by zero
-             * and end up with a 0-sized invisible surface.
+             * and end up with a 0-sized invisible surface. Guard against the
+             * activity tearing down so we don't loop forever.
              */
             if (videoLayout.getMeasuredWidth() == 0 ||
                 videoLayout.getMeasuredHeight() == 0)
             {
+                if (!videoLayout.isAttachedToWindow()) return;
                 videoLayout.post(new Runnable() {
                     @Override public void run() { setupIncomingVideoLayout(); }
                 });
@@ -278,10 +279,14 @@ public class CallActivity extends Activity
             final RelativeLayout videoLayout = findViewById(R.id.bottom_layout);
             if (videoLayout == null) return;
 
-            /* Defer until parent has been measured to avoid 0-sized preview. */
+            /* Defer until parent has been measured to avoid 0-sized preview.
+             * Guard against the activity tearing down so we don't loop
+             * forever.
+             */
             if (videoLayout.getMeasuredWidth() == 0 ||
                 videoLayout.getMeasuredHeight() == 0)
             {
+                if (!videoLayout.isAttachedToWindow()) return;
                 videoLayout.post(new Runnable() {
                     @Override public void run() { setupVideoPreviewLayout(); }
                 });
@@ -366,10 +371,11 @@ public class CallActivity extends Activity
 
             if (MainActivity.currentCall.vidWin != null) {
                 /* Set capture orientation according to current
-                 * device orientation.
+                 * device orientation. Call the helper directly to
+                 * avoid the onConfigurationChanged() relayout path,
+                 * which is only needed for real rotation events.
                  */
-                onConfigurationChanged(getResources().getConfiguration());
-
+                updateCaptureOrientation();
             }
 
             if (MainActivity.currentCall.vidPrev != null) {

--- a/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
+++ b/pjsip-apps/src/swig/java/android/app/src/main/java/org/pjsip/pjsua2/app/CallActivity.java
@@ -25,6 +25,7 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -107,6 +108,14 @@ public class CallActivity extends Activity
         SurfaceView surfaceInVideo = findViewById(R.id.surfaceIncomingVideo);
         SurfaceView surfacePreview = findViewById(R.id.surfacePreviewCapture);
 
+        /* Local preview must sit above the remote video SurfaceView.
+         * Two overlapping SurfaceViews share the same compositor layer by
+         * default, so the preview would be hidden behind the remote video
+         * without this. Using media-overlay (not on-top) keeps regular UI
+         * (buttons, text) above the preview.
+         */
+        surfacePreview.setZOrderMediaOverlay(true);
+
         /* Avoid visible black boxes (blank video views) initially */
         if (MainActivity.currentCall == null ||
             MainActivity.currentCall.vidWin == null)
@@ -174,6 +183,31 @@ public class CallActivity extends Activity
                 System.out.println(e);
             }
         }
+
+        /* Re-apply video/preview layout after rotation. We must wait for
+         * the post-rotation layout pass to actually complete — using
+         * View.post() is not enough, as it can fire before the parent's
+         * new dimensions are applied, causing the preview to be placed
+         * using stale margins (and end up off-screen, disappearing).
+         */
+        final View videoLayout = findViewById(R.id.bottom_layout);
+        if (videoLayout != null && MainActivity.currentCall != null) {
+            final ViewTreeObserver vto = videoLayout.getViewTreeObserver();
+            vto.addOnGlobalLayoutListener(
+                new ViewTreeObserver.OnGlobalLayoutListener() {
+                    @Override
+                    public void onGlobalLayout() {
+                        videoLayout.getViewTreeObserver()
+                                   .removeOnGlobalLayoutListener(this);
+                        if (MainActivity.currentCall == null) return;
+                        if (MainActivity.currentCall.vidWin != null)
+                            setupIncomingVideoLayout();
+                        if (MainActivity.currentCall.vidPrev != null)
+                            setupVideoPreviewLayout();
+                    }
+                });
+            videoLayout.requestLayout();
+        }
     }
 
     @Override
@@ -186,12 +220,27 @@ public class CallActivity extends Activity
     private void setupIncomingVideoLayout()
     {
         try {
+            /* Adjust width to match the parent layout */
+            final RelativeLayout videoLayout = findViewById(R.id.bottom_layout);
+            if (videoLayout == null) return;
+
+            /* The parent may not be measured yet when PJMEDIA_EVENT_FMT_CHANGED
+             * arrives early — defer until it is, otherwise we'd divide by zero
+             * and end up with a 0-sized invisible surface.
+             */
+            if (videoLayout.getMeasuredWidth() == 0 ||
+                videoLayout.getMeasuredHeight() == 0)
+            {
+                videoLayout.post(new Runnable() {
+                    @Override public void run() { setupIncomingVideoLayout(); }
+                });
+                return;
+            }
+
             StreamInfo si = MainActivity.currentCall.getStreamInfo(MainActivity.currentCall.vidGetStreamIdx());
             int w = (int)si.getVidCodecParam().getDecFmt().getWidth();
             int h = (int)si.getVidCodecParam().getDecFmt().getHeight();
 
-            /* Adjust width to match the parent layout */
-            RelativeLayout videoLayout = findViewById(R.id.bottom_layout);
             h = (int)((double)videoLayout.getMeasuredWidth() / w * h);
             w = videoLayout.getMeasuredWidth();
 
@@ -226,12 +275,24 @@ public class CallActivity extends Activity
         try {
             int w, h;
             SurfaceView surfacePreview = findViewById(R.id.surfacePreviewCapture);
+            final RelativeLayout videoLayout = findViewById(R.id.bottom_layout);
+            if (videoLayout == null) return;
+
+            /* Defer until parent has been measured to avoid 0-sized preview. */
+            if (videoLayout.getMeasuredWidth() == 0 ||
+                videoLayout.getMeasuredHeight() == 0)
+            {
+                videoLayout.post(new Runnable() {
+                    @Override public void run() { setupVideoPreviewLayout(); }
+                });
+                return;
+            }
+
             VideoWindowInfo vwi = MainActivity.currentCall.vidPrev.getVideoWindow().getInfo();
             w = (int) vwi.getSize().getW();
             h = (int) vwi.getSize().getH();
 
             /* Adjust width to match the parent layout */
-            RelativeLayout videoLayout = findViewById(R.id.bottom_layout);
             h = (int) ((double) videoLayout.getMeasuredWidth() / 2 / w * h);
             w = videoLayout.getMeasuredWidth() / 2;
 
@@ -267,12 +328,9 @@ public class CallActivity extends Activity
 
     public void hangupCall(View view)
     {
-        localVideoHandler.resetVideoWindow();
-        remoteVideoHandler.resetVideoWindow();
-
-        handler_ = null;
-        finish();
-
+        /* Issue the SIP hangup first, while the activity (and its handler)
+         * is still alive, so any resulting callbacks can still be delivered.
+         */
         if (MainActivity.currentCall != null) {
             CallOpParam prm = new CallOpParam();
             prm.setStatusCode(pjsip_status_code.PJSIP_SC_DECLINE);
@@ -282,6 +340,12 @@ public class CallActivity extends Activity
                 System.out.println(e);
             }
         }
+
+        localVideoHandler.resetVideoWindow();
+        remoteVideoHandler.resetVideoWindow();
+
+        handler_ = null;
+        finish();
     }
     
 


### PR DESCRIPTION
## Summary

Two fixes surfaced while building the PJSUA2 Android sample in Android Studio on a Windows machine without a JDK in PATH:

1. **`pjsip-apps/src/swig/java/Makefile`** — the Android path required `javac` for .class targets, even though Gradle/Android Studio actually compiles Java. Without a JDK, the build either errored with *"Cannot determine JDK include/library path"* or silently skipped the `PjCamera*.java` / `PjAudioDevInfo.java` helper-source copy, and Android Studio then failed with unresolved symbols. Android now skips `CHECK_JDK` entirely and the helper-copy is its own target, independent of .class prerequisites.

2. **`pjsip-apps/src/swig/java/android/app/.../CallActivity.java`** — four pjsua2 Android sample bugs:
   - Local preview was hidden behind the remote video (overlapping SurfaceViews needed `setZOrderMediaOverlay(true)`).
   - Layout helpers assumed the parent was already measured, producing 0-sized invisible surfaces on fast `CALL_MEDIA_STATE` / `PJMEDIA_EVENT_FMT_CHANGED`.
   - After device rotation the preview stayed at pre-rotation margins and went off-screen. Fixed via `OnGlobalLayoutListener` (`View.post()` was unreliable — it could fire before the parent had its new dimensions). Capture-orientation update was also split out of `onConfigurationChanged()` into its own helper so the `CALL_MEDIA_STATE` path doesn't schedule extra relayout passes.
   - `hangupCall()` finished the activity before issuing the SIP hangup.

## Test plan
- [x] `make java` in `pjsip-apps/src/swig` on Windows with no `javac` in PATH now produces the expected output (SWIG-generated `.java` files in `android/pjsua2/src/main/java/org/pjsip/pjsua2/` + `PjCamera*.java` + `libpjsua2.so`).
- [x] Android Studio builds the `pjsua2` app without unresolved symbols.
- [x] Video call with local + remote video: local preview is visible on top of remote video.
- [x] Device rotation during an active video call: preview stays visible and repositions to the new bottom-right corner.
- [x] Hang up and re-make video call: no crashes / stale surfaces.
