### PR TITLE
[pjsip-ua]|[pjsip-simple] regc/publishc: prevent integer underflow when calculating refresh timer delay

### DIFF
--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -37,6 +37,11 @@
 
 #define REFRESH_TIMER           1
 #define DELAY_BEFORE_REFRESH    PJSIP_PUBLISHC_DELAY_BEFORE_REFRESH
+
+/* This defines the minimum value for the refresh timer in milliseconds.
+ * If the calculated expiry for the refresh timer falls below this; it will be clamped to this value.
+ */
+#define MIN_REFRESH_MSEC        500
 #define THIS_FILE               "publishc.c"
 
 
@@ -718,7 +723,9 @@ static void tsx_callback(void *token, pjsip_event *event)
             if (pubc->auto_refresh && expiration!=0 &&
                 expiration!=PJSIP_PUBC_EXPIRATION_NOT_SPECIFIED)
             {
-                pj_time_val delay = { 0, 0};
+                const long min_delay_sec = MIN_REFRESH_MSEC / 1000;
+                const long min_delay_msec = MIN_REFRESH_MSEC % 1000;
+                pj_time_val delay = {0, 0};
 
                 /* Cancel existing timer, if any */
                 if (pubc->timer.id != 0) {
@@ -726,14 +733,31 @@ static void tsx_callback(void *token, pjsip_event *event)
                     pubc->timer.id = 0;
                 }
 
-                delay.sec = expiration - DELAY_BEFORE_REFRESH;
+                /* prevent underflow in case the remote answers with an unexpectedly low expiry value */
+                if (expiration > DELAY_BEFORE_REFRESH) {
+                    delay.sec = expiration - DELAY_BEFORE_REFRESH;
+                }
                 if (pubc->expires != PJSIP_PUBC_EXPIRATION_NOT_SPECIFIED && 
                     delay.sec > (pj_int32_t)pubc->expires) 
                 {
                     delay.sec = pubc->expires;
                 }
-                if (delay.sec < DELAY_BEFORE_REFRESH) 
-                    delay.sec = DELAY_BEFORE_REFRESH;
+                if (delay.sec < DELAY_BEFORE_REFRESH) {
+                    if (expiration <= DELAY_BEFORE_REFRESH) {
+                        /* Very small expiration: refresh before expiry. */
+                        delay.sec  = (expiration > 1) ? (long)expiration - 1 : 0;
+                        delay.msec = (expiration > 1) ? 0 : 500;
+                    } else {
+                        delay.sec = DELAY_BEFORE_REFRESH;
+                    }
+                }
+                
+                /* enforce minimum refresh interval */
+                if( delay.sec < min_delay_sec ||
+                    (delay.sec == min_delay_sec && delay.msec < min_delay_msec) ) {
+                    delay.sec  = min_delay_sec;
+                    delay.msec = min_delay_msec;
+                }
                 pubc->timer.cb = &pubc_refresh_timer_cb;
                 pubc->timer.id = REFRESH_TIMER;
                 pubc->timer.user_data = pubc;

--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -723,8 +723,8 @@ static void tsx_callback(void *token, pjsip_event *event)
             if (pubc->auto_refresh && expiration!=0 &&
                 expiration!=PJSIP_PUBC_EXPIRATION_NOT_SPECIFIED)
             {
-                const long min_delay_sec = MIN_REFRESH_MSEC / 1000;
-                const long min_delay_msec = MIN_REFRESH_MSEC % 1000;
+                const pj_time_val min_delay = {MIN_REFRESH_MSEC / 1000,
+                                               MIN_REFRESH_MSEC % 1000};
                 pj_time_val delay = {0, 0};
 
                 /* Cancel existing timer, if any */
@@ -753,10 +753,8 @@ static void tsx_callback(void *token, pjsip_event *event)
                 }
                 
                 /* make sure we don't go below the minimum */
-                if (delay.sec < min_delay_sec ||
-                    (delay.sec == min_delay_sec && delay.msec < min_delay_msec)) {
-                    delay.sec  = min_delay_sec;
-                    delay.msec = min_delay_msec;
+                if (PJ_TIME_VAL_LT(delay, min_delay)) {
+                    delay = min_delay;
                 }
                 pubc->timer.cb = &pubc_refresh_timer_cb;
                 pubc->timer.id = REFRESH_TIMER;

--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -752,9 +752,9 @@ static void tsx_callback(void *token, pjsip_event *event)
                     }
                 }
                 
-                /* enforce minimum refresh interval */
-                if( delay.sec < min_delay_sec ||
-                    (delay.sec == min_delay_sec && delay.msec < min_delay_msec) ) {
+                /* make sure we don't go below the minimum */
+                if (delay.sec < min_delay_sec ||
+                    (delay.sec == min_delay_sec && delay.msec < min_delay_msec)) {
                     delay.sec  = min_delay_sec;
                     delay.msec = min_delay_msec;
                 }
@@ -764,7 +764,7 @@ static void tsx_callback(void *token, pjsip_event *event)
                 pjsip_endpt_schedule_timer( pubc->endpt, &pubc->timer, &delay);
                 pj_gettimeofday(&pubc->last_refresh);
                 pubc->next_refresh = pubc->last_refresh;
-                pubc->next_refresh.sec += delay.sec;
+                PJ_TIME_VAL_ADD(pubc->next_refresh, delay);
             }
 
         } else {

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -859,19 +859,22 @@ static void regc_refresh_timer_cb( pj_timer_heap_t *timer_heap,
 static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
 {
     if (regc->auto_reg && expiration > 0 && expiration != NOEXP) {
-        pj_time_val delay = { 0, 0};
+        pj_time_val delay = {0, 0};
 
         pj_timer_heap_cancel_if_active(pjsip_endpt_get_timer_heap(regc->endpt),
                                        &regc->timer, 0);
 
-        delay.sec = expiration - regc->delay_before_refresh;
+        /* prevent underflow in case the remote answers with an unexpectedly low Expires field */
+        if (expiration > regc->delay_before_refresh) {
+            delay.sec = expiration - regc->delay_before_refresh;
+        }
         if (regc->expires != PJSIP_REGC_EXPIRATION_NOT_SPECIFIED && 
-            delay.sec > (pj_int32_t)regc->expires) 
-        {
+            delay.sec > (pj_int32_t)regc->expires) {
             delay.sec = regc->expires;
         }
-        if (delay.sec < DELAY_BEFORE_REFRESH) 
+        if (delay.sec < DELAY_BEFORE_REFRESH) {
             delay.sec = DELAY_BEFORE_REFRESH;
+        }
         regc->timer.cb = &regc_refresh_timer_cb;
         regc->timer.id = REFRESH_TIMER;
         regc->timer.user_data = regc;

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -864,8 +864,8 @@ static void regc_refresh_timer_cb( pj_timer_heap_t *timer_heap,
 static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
 {
     if (regc->auto_reg && expiration > 0 && expiration != NOEXP) {
-        const long min_delay_sec = MIN_REFRESH_MSEC / 1000;
-        const long min_delay_msec = MIN_REFRESH_MSEC % 1000;
+        const pj_time_val min_delay = {MIN_REFRESH_MSEC / 1000,
+                                       MIN_REFRESH_MSEC % 1000};
         pj_time_val delay = {0, 0};
 
         pj_timer_heap_cancel_if_active(pjsip_endpt_get_timer_heap(regc->endpt),
@@ -890,10 +890,8 @@ static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
         }
 
         /* make sure we don't go below the minimum */
-        if (delay.sec < min_delay_sec ||
-            (delay.sec == min_delay_sec && delay.msec < min_delay_msec)) {
-            delay.sec  = min_delay_sec;
-            delay.msec = min_delay_msec;
+        if (PJ_TIME_VAL_LT(delay, min_delay)) {
+            delay = min_delay;
         }
         regc->timer.cb = &regc_refresh_timer_cb;
         regc->timer.id = REFRESH_TIMER;

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -888,10 +888,10 @@ static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
                 delay.sec = DELAY_BEFORE_REFRESH;
             }
         }
-        
-        /* enforce minimum refresh interval */
-        if( delay.sec < min_delay_sec ||
-            (delay.sec == min_delay_sec && delay.msec < min_delay_msec) ) {
+
+        /* make sure we don't go below the minimum */
+        if (delay.sec < min_delay_sec ||
+            (delay.sec == min_delay_sec && delay.msec < min_delay_msec)) {
             delay.sec  = min_delay_sec;
             delay.msec = min_delay_msec;
         }
@@ -901,7 +901,7 @@ static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
         pjsip_endpt_schedule_timer( regc->endpt, &regc->timer, &delay);
         pj_gettimeofday(&regc->last_reg);
         regc->next_reg = regc->last_reg;
-        regc->next_reg.sec += delay.sec;
+        PJ_TIME_VAL_ADD(regc->next_reg, delay);
     }
 }
 

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -37,10 +37,15 @@
 
 #define REFRESH_TIMER           1
 #define DELAY_BEFORE_REFRESH    PJSIP_REGISTER_CLIENT_DELAY_BEFORE_REFRESH
+
+/* This defines the minimum value for the refresh timer in milliseconds.
+ * If the calculated expiry for the refresh timer falls below this; it will be clamped to this value.
+ */
+#define MIN_REFRESH_MSEC        500
 #define THIS_FILE               "sip_reg.c"
 
 /* Outgoing transaction timeout when server sends 100 but never replies
- * with final response. Value is in MILISECONDS!
+ * with final response. Value is in MILLISECONDS!
  */
 #define REGC_TSX_TIMEOUT        33000
 
@@ -859,6 +864,8 @@ static void regc_refresh_timer_cb( pj_timer_heap_t *timer_heap,
 static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
 {
     if (regc->auto_reg && expiration > 0 && expiration != NOEXP) {
+        const long min_delay_sec = MIN_REFRESH_MSEC / 1000;
+        const long min_delay_msec = MIN_REFRESH_MSEC % 1000;
         pj_time_val delay = {0, 0};
 
         pj_timer_heap_cancel_if_active(pjsip_endpt_get_timer_heap(regc->endpt),
@@ -873,7 +880,20 @@ static void schedule_registration ( pjsip_regc *regc, pj_uint32_t expiration )
             delay.sec = regc->expires;
         }
         if (delay.sec < DELAY_BEFORE_REFRESH) {
-            delay.sec = DELAY_BEFORE_REFRESH;
+            if (expiration <= DELAY_BEFORE_REFRESH) {
+                /* Very small expiration: refresh before expiry. */
+                delay.sec  = (expiration > 1) ? (long)expiration - 1 : 0;
+                delay.msec = (expiration > 1) ? 0 : 500;
+            } else {
+                delay.sec = DELAY_BEFORE_REFRESH;
+            }
+        }
+        
+        /* enforce minimum refresh interval */
+        if( delay.sec < min_delay_sec ||
+            (delay.sec == min_delay_sec && delay.msec < min_delay_msec) ) {
+            delay.sec  = min_delay_sec;
+            delay.msec = min_delay_msec;
         }
         regc->timer.cb = &regc_refresh_timer_cb;
         regc->timer.id = REFRESH_TIMER;


### PR DESCRIPTION
I encountered an issue where my app wouldn't reregister to a server.
My app is configured with the account parameters
`reg_timeout=120` and `reg_delay_before_refresh=40`.
When the registrar answers with an Expires header value of less then reg_delay_before_refresh (in my case it was 15)
then an integer underflow occurs and the refresh timeout becomes very large.
The proposed fix does the following:
- Introduce a new compilation unit local `#define MIN_REFRESH_MSEC`
- Don't calculate delay if it would underflow
- If the calculated delay is below `DELAY_BEFORE_REFRESH`, make sure the delay is set before the expiration time.
- After calculating the delay, make sure a hardcoded minimum `MIN_REFRESH_MSEC` is not undercut

@nanangizz Noticed the same issue for calculating refreshes for subscriptions in [publishc](https://github.com/pjsip/pjproject/blob/6b1036daa2af2204436491dcdc7f8699c25ac550/pjsip/src/pjsip-simple/publishc.c#L729-L736)
so the same steps are applied there.
