### PR TITLE
fix: stdatomic.h false positive on GCC 4.8

### DIFF
--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -47,7 +47,10 @@
 
 #if PJ_HAS_THREADS
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
-                                && !defined(__STDC_NO_ATOMICS__)
+                                && !defined(__STDC_NO_ATOMICS__)  \
+                                && (!defined(__GNUC__) || defined(__clang__) \
+                                || __GNUC__ > 4 \
+                                || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))
 #    define HAS_STD_ATOMICS 1
 #    include <stdatomic.h>
 #  else


### PR DESCRIPTION
GCC 4.8 does not ship stdatomic.h but -std=gnu11 causes __STDC_VERSION__ >= 201112L to evaluate true, resulting in a false positive and fatal build error on CentOS 7 / RHEL 7.

Add GCC version guard to prevent inclusion on GCC < 4.9.

Resolves #4933