### PR TITLE
Fix pjsua registration failure when PJSIP_HAS_DIGEST_AKA_AUTH=1

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -57,8 +57,11 @@ static void usage(void)
     puts  ("  --password=string   Set authentication password");
 
 #if PJSIP_HAS_DIGEST_AKA_AUTH
-    puts  ("  --aka-op=hex        Set OP value to use in Digest AKA authentication");
-    puts  ("  --aka-amf=hex       Set AMF value to use in Digest AKA authentication");
+    puts  ("  --aka-op=hex        Set OP value for Digest AKA authentication.");
+    puts  ("                      Specifying --aka-op or --aka-amf switches the");
+    puts  ("                      current credential to AKA mode (K is taken from");
+    puts  ("                      --password).");
+    puts  ("  --aka-amf=hex       Set AMF value for Digest AKA authentication");
 #endif
 
     puts  ("  --contact=url       Optionally override the Contact information");
@@ -938,12 +941,9 @@ static pj_status_t parse_args(int argc, char *argv[],
         case OPT_PASSWORD:   /* authentication password */
             cur_acc->cred_info[cur_acc->cred_count].data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
             cur_acc->cred_info[cur_acc->cred_count].data = pj_str(pj_optarg);
-#if PJSIP_HAS_DIGEST_AKA_AUTH
-            cur_acc->cred_info[cur_acc->cred_count].data_type |= PJSIP_CRED_DATA_EXT_AKA;
-            cur_acc->cred_info[cur_acc->cred_count].ext.aka.k = pj_str(pj_optarg);
-            cur_acc->cred_info[cur_acc->cred_count].ext.aka.cb = &pjsip_auth_create_aka_response;
             break;
 
+#if PJSIP_HAS_DIGEST_AKA_AUTH
         case OPT_AKA_OP:    /* aka op */
             {
                 pj_str_t hex = pj_str(pj_optarg);
@@ -1658,6 +1658,24 @@ static pj_status_t parse_args(int argc, char *argv[],
         {
             acfg->cred_count++;
         }
+
+#if PJSIP_HAS_DIGEST_AKA_AUTH
+        /* Promote credentials to AKA if --aka-op or --aka-amf was supplied.
+         * Order-independent: --aka-op/--aka-amf may appear before or after
+         * --password on the command line. K is taken from the password.
+         */
+        {
+            unsigned j;
+            for (j=0; j<acfg->cred_count; ++j) {
+                pjsip_cred_info *c = &acfg->cred_info[j];
+                if (c->ext.aka.op.slen || c->ext.aka.amf.slen) {
+                    c->data_type |= PJSIP_CRED_DATA_EXT_AKA;
+                    c->ext.aka.k = c->data;
+                    c->ext.aka.cb = &pjsip_auth_create_aka_response;
+                }
+            }
+        }
+#endif
 
         if (acfg->ice_cfg.enable_ice) {
             acfg->ice_cfg_use = PJSUA_ICE_CONFIG_USE_CUSTOM;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -980,8 +980,8 @@ static pj_status_t parse_args(int argc, char *argv[],
                     return PJ_EINVAL;
                 }
             }
-#endif
             break;
+#endif
 
         case OPT_REG_RETRY_INTERVAL:
             cur_acc->reg_retry_interval = (unsigned)pj_strtoul(pj_cstr(&tmp, pj_optarg));
@@ -1662,13 +1662,21 @@ static pj_status_t parse_args(int argc, char *argv[],
 #if PJSIP_HAS_DIGEST_AKA_AUTH
         /* Promote credentials to AKA if --aka-op or --aka-amf was supplied.
          * Order-independent: --aka-op/--aka-amf may appear before or after
-         * --password on the command line. K is taken from the password.
+         * --password on the command line. K is taken from the password, so
+         * --password is required for AKA — skip promotion if it's missing
+         * rather than silently running AKA with an all-zero K.
          */
         {
             unsigned j;
             for (j=0; j<acfg->cred_count; ++j) {
                 pjsip_cred_info *c = &acfg->cred_info[j];
                 if (c->ext.aka.op.slen || c->ext.aka.amf.slen) {
+                    if (c->data.slen == 0) {
+                        PJ_LOG(1,(THIS_FILE,
+                                  "Error: --aka-op/--aka-amf requires "
+                                  "--password (used as AKA K)"));
+                        return PJ_EINVAL;
+                    }
                     c->data_type |= PJSIP_CRED_DATA_EXT_AKA;
                     c->ext.aka.k = c->data;
                     c->ext.aka.cb = &pjsip_auth_create_aka_response;

--- a/pjsip/src/pjsip/sip_auth_aka.c
+++ b/pjsip/src/pjsip/sip_auth_aka.c
@@ -68,7 +68,7 @@ PJ_DEF(pj_status_t) pjsip_auth_create_aka_response(
          */
         pjsip_cred_info plain_cred;
         pj_memcpy(&plain_cred, cred, sizeof(plain_cred));
-        plain_cred.data_type &= ~PJSIP_CRED_DATA_EXT_MASK;
+        plain_cred.data_type &= ~PJSIP_CRED_DATA_EXT_AKA;
 
         status = pjsip_auth_create_digest(&auth->response, &auth->nonce,
                                  &auth->nc, &auth->cnonce, &auth->qop,

--- a/pjsip/src/pjsip/sip_auth_aka.c
+++ b/pjsip/src/pjsip/sip_auth_aka.c
@@ -62,11 +62,18 @@ PJ_DEF(pj_status_t) pjsip_auth_create_aka_response(
     if (chal->algorithm.slen==0 || pj_stricmp2(&chal->algorithm, "md5") == 0) {
         /*
          * A normal MD5 authentication is requested. Fallback to the usual
-         * MD5 digest creation.
+         * MD5 digest creation. pjsip_auth_create_digest() asserts that the
+         * credential is NOT an AKA credential, so clear the EXT_AKA flag
+         * on a local copy before calling it.
          */
-        status = pjsip_auth_create_digest(&auth->response, &auth->nonce, 
-                                 &auth->nc, &auth->cnonce, &auth->qop, 
-                                 &auth->uri, &auth->realm, cred, method);
+        pjsip_cred_info plain_cred;
+        pj_memcpy(&plain_cred, cred, sizeof(plain_cred));
+        plain_cred.data_type &= ~PJSIP_CRED_DATA_EXT_MASK;
+
+        status = pjsip_auth_create_digest(&auth->response, &auth->nonce,
+                                 &auth->nc, &auth->cnonce, &auth->qop,
+                                 &auth->uri, &auth->realm, &plain_cred,
+                                 method);
 
         return status;
 


### PR DESCRIPTION
## Summary

Building pjsua with `PJSIP_HAS_DIGEST_AKA_AUTH=1` forced every `--password` credential into AKA mode, breaking plain Digest (MD5/SHA-256) registration against non-AKA servers. This PR makes AKA opt-in and also fixes a latent self-assertion in the AKA → MD5 fallback path.

## Problem

With `PJSIP_HAS_DIGEST_AKA_AUTH=1`, `OPT_PASSWORD` in `pjsua_app_config.c` unconditionally OR'd `PJSIP_CRED_DATA_EXT_AKA` into `data_type` and wired the AKA callback. The result:

1. Auth client (`sip_auth_client.c:662/690`) sees `PJSIP_CRED_DATA_IS_AKA(cred)` → routes every challenge to `pjsip_auth_create_aka_response`.
2. For a plain MD5 Digest server, that function falls back (`sip_auth_aka.c:62-71`) to `pjsip_auth_create_digest(cred, ...)`. But `pjsip_auth_create_digest` asserts `!PJSIP_CRED_DATA_IS_AKA(cred_info)` — the cred still carries `EXT_AKA`, so it returns `PJ_EINVAL`. No response is built, REGISTER retry fails.
3. For SHA-256/SHA-512 servers, the AKA callback just returns `PJSIP_EINVALIDALGORITHM`.

Result: users who enable AKA at compile time cannot register against any non-AKA server.

## Fix

### `pjsua_app_config.c` — make AKA opt-in

- `OPT_PASSWORD` sets only `PJSIP_CRED_DATA_PLAIN_PASSWD` + `data`. No implicit AKA.
- Post-parse pass (already walks every account to finalize `cred_count`) promotes a credential to AKA when `ext.aka.op.slen` or `ext.aka.amf.slen` is non-zero. K is taken from the password.
- Order-independent: `--aka-op` / `--aka-amf` may appear before or after `--password`.
- Help text updated.

No new CLI flag — the existing `--aka-op` / `--aka-amf` signal AKA intent.

### `sip_auth_aka.c` — library hardening

The MD5 fallback in `pjsip_auth_create_aka_response` now copies `cred` and clears `PJSIP_CRED_DATA_EXT_MASK` before passing to `pjsip_auth_create_digest`, matching what the AKAv1/v2 paths already do at line 140-141. Self-consistent regardless of caller hygiene.

## Test plan

- [x] Build pjsip lib with `PJSIP_HAS_DIGEST_AKA_AUTH=1` — clean, no warnings.
- [x] Build pjsua (with `-lmilenage`) — clean.
- [x] `pjsua --help` shows updated AKA description.
- [ ] Register against a plain MD5 Digest server with `--username X --password Y` — should succeed (previously failed with `PJ_EINVAL`).
- [ ] Register against a plain SHA-256 Digest server — should succeed.
- [ ] Register against an AKA/IMS server with `--username X --password K --aka-op HEX --aka-amf HEX` — should succeed; ordering of the AKA options vs `--password` should not matter.
- [ ] MSVC build.