### PR TITLE
PJSUA(2): Support signaling-plane B2BUA

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -650,6 +650,7 @@ jobs:
         cd tests/pjsua
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uac-custom-sdp.xml
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-custom-sdp.xml
+        python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-amr-sdp.xml
     - name: upload artifacts on failure
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -651,6 +651,7 @@ jobs:
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uac-custom-sdp.xml
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-custom-sdp.xml
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-amr-sdp.xml
+        python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.xml
     - name: upload artifacts on failure
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -213,10 +213,13 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
         codec_id_st = pj_str(codec_id);
         status = pjmedia_codec_mgr_find_codecs_by_id(mgr, &codec_id_st,
                                                      &i, &p_info, NULL);
-        if (status != PJ_SUCCESS)
+        if (status == PJ_SUCCESS) {
+            pj_memcpy(&si->fmt, p_info, sizeof(pjmedia_codec_info));
+        } else if (status != PJ_ENOTFOUND &&
+                   status != PJMEDIA_CODEC_EUNSUP) {
             return status;
-
-        pj_memcpy(&si->fmt, p_info, sizeof(pjmedia_codec_info));
+        }
+        /* else: codec not in registry; si->fmt from rtpmap is used */
 
         /* Determine payload type for outgoing channel, by finding
          * dynamic payload type in remote SDP that matches the answer.

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -162,10 +162,18 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
             const pjmedia_codec_info *p_info;
 
             status = pjmedia_codec_mgr_get_codec_info( mgr, pt, &p_info);
-            if (status != PJ_SUCCESS)
+            if (status == PJ_SUCCESS) {
+                pj_memcpy(&si->fmt, p_info, sizeof(pjmedia_codec_info));
+            } else if (status == PJMEDIA_CODEC_EUNSUP ||
+                       status == PJ_ENOTFOUND) {
+                /* Static PT without rtpmap and codec not in registry.
+                 * Keep bare fmt so callers skip codec-specific tuning.
+                 */
+                si->fmt.type = si->type;
+                si->fmt.pt   = pt;
+            } else {
                 return status;
-
-            pj_memcpy(&si->fmt, p_info, sizeof(pjmedia_codec_info));
+            }
         }
 
         /* For static payload type, pt's are symetric */
@@ -248,14 +256,15 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
                                                  si->param);
 
     /* When codec is not in the registry but codec info was provided by SDP
-     * (e.g. via rtpmap for 3rd-party media stacks), treat unsupported/not
-     * found codec-param lookup as non-fatal: clear si->param so callers
-     * skip codec-specific tuning. Other errors may indicate malformed codec
-     * info or initialization failures and should be returned to the caller.
+     * (e.g. via rtpmap for 3rd-party media stacks, or a known static PT),
+     * treat unsupported/not-found codec-param lookup as non-fatal: clear
+     * si->param so callers skip codec-specific tuning. Other errors may
+     * indicate malformed codec info or initialization failures and should
+     * be returned to the caller.
      */
     if ((status == PJMEDIA_CODEC_EUNSUP || status == PJ_ENOTFOUND) &&
-        si->fmt.encoding_name.slen > 0 &&
-        si->fmt.clock_rate != 0) {
+        (si->fmt.pt < 96 ||
+         (si->fmt.encoding_name.slen > 0 && si->fmt.clock_rate != 0))) {
         si->param = NULL;
         status = PJ_SUCCESS;
     }

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -244,13 +244,15 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
     status = pjmedia_codec_mgr_get_default_param(mgr, &si->fmt,
                                                  si->param);
 
-    /* When codec is not in the registry but codec info was provided by an
-     * rtpmap attribute (e.g. for 3rd-party media stacks), treat the failure
-     * as non-fatal: clear si->param so callers skip codec-specific tuning.
-     * Other errors may indicate malformed codec info
-     * or initialization failures and should be returned to the caller.
+    /* When codec is not in the registry but codec info was provided by SDP
+     * (e.g. via rtpmap for 3rd-party media stacks), treat unsupported/not
+     * found codec-param lookup as non-fatal: clear si->param so callers
+     * skip codec-specific tuning. Other errors may indicate malformed codec
+     * info or initialization failures and should be returned to the caller.
      */
-    if (status == PJMEDIA_CODEC_EUNSUP && si->fmt.encoding_name.slen > 0) {
+    if ((status == PJMEDIA_CODEC_EUNSUP || status == PJ_ENOTFOUND) &&
+        si->fmt.encoding_name.slen > 0 &&
+        si->fmt.clock_rate != 0) {
         si->param = NULL;
         status = PJ_SUCCESS;
     }

--- a/pjmedia/src/pjmedia/stream_info.c
+++ b/pjmedia/src/pjmedia/stream_info.c
@@ -244,26 +244,38 @@ static pj_status_t get_audio_codec_info_param(pjmedia_stream_info *si,
     status = pjmedia_codec_mgr_get_default_param(mgr, &si->fmt,
                                                  si->param);
 
-    /* Get remote fmtp for our encoder. */
-    pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt,
-                                   &si->param->setting.enc_fmtp);
-
-    /* Get local fmtp for our decoder. */
-    pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt,
-                                   &si->param->setting.dec_fmtp);
-
-    if (!pj_stricmp2(&si->fmt.encoding_name, "opus")) {
-        get_opus_channels_and_clock_rate(&si->param->setting.enc_fmtp,
-                                         &si->param->setting.dec_fmtp,
-                                         &si->fmt.channel_cnt,
-                                         &si->fmt.clock_rate);
+    /* When codec is not in the registry but codec info was provided by an
+     * rtpmap attribute (e.g. for 3rd-party media stacks), treat the failure
+     * as non-fatal: clear si->param so callers skip codec-specific tuning.
+     * Other errors may indicate malformed codec info
+     * or initialization failures and should be returned to the caller.
+     */
+    if (status == PJMEDIA_CODEC_EUNSUP && si->fmt.encoding_name.slen > 0) {
+        si->param = NULL;
+        status = PJ_SUCCESS;
     }
 
+    if (si->param) {
+        /* Get remote fmtp for our encoder. */
+        pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt,
+                                       &si->param->setting.enc_fmtp);
+
+        /* Get local fmtp for our decoder. */
+        pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt,
+                                       &si->param->setting.dec_fmtp);
+
+        if (!pj_stricmp2(&si->fmt.encoding_name, "opus")) {
+            get_opus_channels_and_clock_rate(&si->param->setting.enc_fmtp,
+                                             &si->param->setting.dec_fmtp,
+                                             &si->fmt.channel_cnt,
+                                             &si->fmt.clock_rate);
+        }
+    }
 
     /* Get the remote ptime for our encoder. */
     attr = pjmedia_sdp_attr_find2(rem_m->attr_count, rem_m->attr,
                                   "ptime", NULL);
-    if (attr) {
+    if (attr && si->param) {
         pj_str_t tmp_val = attr->value;
         unsigned frm_per_pkt;
 

--- a/pjmedia/src/pjmedia/vid_stream_info.c
+++ b/pjmedia/src/pjmedia/vid_stream_info.c
@@ -99,10 +99,20 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
         i = 1;
         status = pjmedia_vid_codec_mgr_find_codecs_by_id(mgr, &codec_id_st,
                                                          &i, &p_info, NULL);
-        if (status != PJ_SUCCESS)
-            return status;
-
-        si->codec_info = *p_info;
+        if (status == PJ_SUCCESS) {
+            si->codec_info = *p_info;
+        } else {
+            /* Codec not in registry but rtpmap provides encoding name.
+             * Build partial codec_info so 3rd-party media stacks can
+             * operate without registering dummy codecs.
+             */
+            pj_bzero(&si->codec_info, sizeof(si->codec_info));
+            si->codec_info.pt = (pj_uint8_t)pt;
+            pj_strdup(pool, &si->codec_info.encoding_name, &rtpmap->enc_name);
+            si->codec_info.clock_rate = rtpmap->clock_rate;
+            si->codec_info.dir = PJMEDIA_DIR_ENCODING_DECODING;
+            status = PJ_SUCCESS;
+        }
     }
 
 
@@ -115,10 +125,20 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
                                                      &si->codec_info,
                                                      si->codec_param);
 
+    /* When codec is not in the registry (e.g. for 3rd-party media), treat
+     * as non-fatal: clear codec_param so callers skip codec-specific tuning.
+     */
+    if (status == PJMEDIA_CODEC_EUNSUP && si->codec_info.encoding_name.slen > 0) {
+        si->codec_param = NULL;
+        status = PJ_SUCCESS;
+    }
+
     /* Adjust encoding bitrate, if higher than remote preference. The remote
      * bitrate preference is read from SDP "b=TIAS" line in media level.
      */
-    if ((si->dir & PJMEDIA_DIR_ENCODING) && rem_m->bandw_count) {
+    if (si->codec_param && (si->dir & PJMEDIA_DIR_ENCODING) &&
+        rem_m->bandw_count)
+    {
         unsigned i, bandw = 0;
 
         for (i = 0; i < rem_m->bandw_count; ++i) {
@@ -142,13 +162,15 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
         }
     }
 
-    /* Get remote fmtp for our encoder. */
-    pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt,
-                                   &si->codec_param->enc_fmtp);
+    if (si->codec_param) {
+        /* Get remote fmtp for our encoder. */
+        pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt,
+                                       &si->codec_param->enc_fmtp);
 
-    /* Get local fmtp for our decoder. */
-    pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt,
-                                   &si->codec_param->dec_fmtp);
+        /* Get local fmtp for our decoder. */
+        pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt,
+                                       &si->codec_param->dec_fmtp);
+    }
 
     /* When direction is NONE (it means SDP negotiation has failed) we don't
      * need to return a failure here, as returning failure will cause

--- a/pjmedia/src/pjmedia/vid_stream_info.c
+++ b/pjmedia/src/pjmedia/vid_stream_info.c
@@ -101,7 +101,7 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
                                                          &i, &p_info, NULL);
         if (status == PJ_SUCCESS) {
             si->codec_info = *p_info;
-        } else {
+        } else if (status == PJ_ENOTFOUND){
             /* Codec not in registry but rtpmap provides encoding name.
              * Build partial codec_info so 3rd-party media stacks can
              * operate without registering dummy codecs.
@@ -112,6 +112,8 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
             si->codec_info.clock_rate = rtpmap->clock_rate;
             si->codec_info.dir = PJMEDIA_DIR_ENCODING_DECODING;
             status = PJ_SUCCESS;
+        } else {
+            return status;
         }
     }
 

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
@@ -28,11 +28,16 @@
 
 
 /*****************************************************************************
- * Our dummy codecs. Since we won't use any PJMEDIA codecs, we need to declare
- * our own codecs and register them to PJMEDIA's codec manager. We just need
- * the info so that they can be listed in SDP. The encoding and decoding will
- * happen in your third party media stream and will not use these codecs,
- * hence the "dummy" name.
+ * Our dummy codecs. Since we won't use any PJMEDIA codecs we have two options:
+ *
+ * - Declare our own codecs and register them to PJMEDIA's codec manager
+ *   in pjsua_aud_subsys_init().
+ *   Then they will be used for validating during SDP negotiation,
+ *   but the actual encoding and decoding will be done in our 3rd party media stream.
+ *
+ * - Do not register any codecs, and handle the failure in codec lookup during
+ *   SDP negotiation as non-fatal, so that the negotiation can proceed and the
+ *   3rd-party media stream can be used without registering any codecs.
  */
 static struct alt_codec
 {
@@ -168,16 +173,13 @@ static pjmedia_codec_factory_op alt_codec_factory_op =
 /* Initialize third party media library. */
 pj_status_t pjsua_aud_subsys_init()
 {
-    pjmedia_codec_mgr *codec_mgr;
-    pj_status_t status;
-
-    /* Register our "dummy" codecs */
-    alt_codec_factory.base.op = &alt_codec_factory_op;
-    codec_mgr = pjmedia_endpt_get_codec_mgr(pjsua_var.med_endpt);
-    status = pjmedia_codec_mgr_register_factory(codec_mgr,
-                                                &alt_codec_factory.base);
-    if (status != PJ_SUCCESS)
-        return status;
+    /* Codec registration is intentionally omitted: pjsua now handles an
+     * empty codec registry gracefully, so 3rd-party media stacks do not
+     * need to register dummy codecs.  The alt_codec_factory above is kept
+     * as reference documentation for implementors who do want to register.
+     */
+    (void)alt_codec_factory;
+    (void)alt_codec_factory_op;
 
     /* TODO: initialize your evil library here */
     return PJ_SUCCESS;

--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_vid.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2011-2011 Teluu Inc. (http://www.teluu.com)
  *
  * This program is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 #include <pjsua-lib/pjsua.h>
 #include <pjsua-lib/pjsua_internal.h>
@@ -28,7 +28,18 @@
 #define UNIMPLEMENTED(func)     PJ_LOG(2,(THIS_FILE, "*** Call to unimplemented function %s ***", #func));
 
 /*****************************************************************************
- * Our video codec descriptors
+ * Our video codec descriptors.
+ * Since we won't use any PJMEDIA codecs we have two options:
+ *
+ * - Declare our own codecs and register them to PJMEDIA's codec manager
+ *   in pjsua_vid_subsys_init().
+ *   Then they will be used for validating during SDP negotiation,
+ *   but the actual encoding and decoding will be done in our 3rd party media stream.
+ *
+ * - Do not register any codecs, and handle the failure in codec lookup during
+ *   SDP negotiation as non-fatal, so that the negotiation can proceed and the
+ *   3rd-party media stream can be used without registering any codecs.
+
  */
 struct alt_codec_desc
 {
@@ -198,7 +209,9 @@ pj_status_t pjsua_vid_subsys_init(void)
         return status;
     }
 
-    /* Create video codec manager singleton */
+    /* Create video codec manager singleton (required even when no codecs are
+     * registered, as the singleton pointer is used throughout PJMEDIA).
+     */
     status = pjmedia_vid_codec_mgr_create(pjsua_var.pool, &mgr);
     if (status != PJ_SUCCESS) {
         PJ_PERROR(1,(THIS_FILE, status,
@@ -206,13 +219,14 @@ pj_status_t pjsua_vid_subsys_init(void)
         return status;
     }
 
-    /* Register our codecs */
-    alt_vid_codec_factory.base.op = &alt_vid_codec_factory_op;
-    alt_vid_codec_factory.base.factory_data = NULL;
-
-    status = pjmedia_vid_codec_mgr_register_factory(mgr, &alt_vid_codec_factory.base);
-    if (status != PJ_SUCCESS)
-        return status;
+    /* Codec registration is intentionally omitted: pjsua now handles an
+     * empty video codec registry gracefully, so 3rd-party media stacks do
+     * not need to register dummy codecs.  The alt_vid_codec_factory above
+     * is kept as reference documentation for implementors who want to
+     * register codecs.
+     */
+    (void)alt_vid_codec_factory;
+    (void)alt_vid_codec_factory_op;
 
     /*
      * TODO: put your 3rd party library initialization routine here
@@ -331,7 +345,7 @@ pj_status_t pjsua_vid_channel_update(pjsua_call_media *call_med,
                                      const pjmedia_sdp_session *remote_sdp)
 {
     pj_status_t status;
-    
+
     PJ_LOG(4,(THIS_FILE, "Video channel update.."));
     pj_log_push_indent();
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1260,6 +1260,22 @@ on_return:
     return status;
 }
 
+/* Check whether an rtpmap/fmtp attribute value refers to the given payload
+ * type (SDP format). The attribute value must begin with the payload type
+ * token followed by whitespace or end-of-string. An empty fmt never matches.
+ */
+static pj_bool_t attr_matches_fmt(const pj_str_t *attr_val,
+                                  const pj_str_t *fmt)
+{
+    if (fmt->slen == 0)
+        return PJ_FALSE;
+
+    return (attr_val->slen >= fmt->slen &&
+            pj_memcmp(attr_val->ptr, fmt->ptr, fmt->slen) == 0 &&
+            (attr_val->slen == fmt->slen ||
+             pj_isspace((unsigned char)attr_val->ptr[fmt->slen])));
+}
+
 pj_status_t create_temp_sdp(pj_pool_t *pool,
                             const pjmedia_sdp_session *rem_sdp,
                             pjmedia_sdp_session **p_sdp)
@@ -1358,8 +1374,52 @@ pj_status_t create_temp_sdp(pj_pool_t *pool,
 
         /* Disable media if it has zero format/codec */
         if (m->desc.fmt_count == 0) {
+#if PJSUA_MEDIA_HAS_PJMEDIA
             m->desc.fmt[m->desc.fmt_count++] = pj_str("0");
             pjmedia_sdp_media_deactivate(pool, m);
+#else
+            /* For 3rd-party media (empty codec registry), copy formats and
+             * matching rtpmap/fmtp attributes from the remote offer so the
+             * temporary answer remains valid for
+             * pjsip_inv_verify_request3().
+             */
+            {
+                const pjmedia_sdp_media *rem_m = rem_sdp->media[i];
+                const pj_str_t STR_RTPMAP = { "rtpmap", 6 };
+                const pj_str_t STR_FMTP   = { "fmtp",   4 };
+                unsigned j, k;
+                for (j = 0; j < rem_m->desc.fmt_count &&
+                     m->desc.fmt_count < PJMEDIA_MAX_SDP_FMT; ++j)
+                {
+                    pj_strdup(pool, &m->desc.fmt[m->desc.fmt_count],
+                              &rem_m->desc.fmt[j]);
+                    ++m->desc.fmt_count;
+                }
+                for (j = 0; j < rem_m->attr_count &&
+                     m->attr_count < PJMEDIA_MAX_SDP_ATTR; ++j)
+                {
+                    const pjmedia_sdp_attr *rem_attr = rem_m->attr[j];
+                    const pj_str_t *attr_val;
+                    pj_bool_t match = PJ_FALSE;
+                    if (pj_stricmp(&rem_attr->name, &STR_RTPMAP) != 0 &&
+                        pj_stricmp(&rem_attr->name, &STR_FMTP) != 0)
+                    {
+                        continue;
+                    }
+                    attr_val = &rem_attr->value;
+                    for (k = 0; k < m->desc.fmt_count; ++k) {
+                        if (attr_matches_fmt(attr_val, &m->desc.fmt[k])) {
+                            match = PJ_TRUE;
+                            break;
+                        }
+                    }
+                    if (match) {
+                        m->attr[m->attr_count++] =
+                            pjmedia_sdp_attr_clone(pool, rem_attr);
+                    }
+                }
+            }
+#endif
         }
 
         sdp->media[sdp->media_count++] = m;

--- a/tests/pjsua/runall.py
+++ b/tests/pjsua/runall.py
@@ -45,6 +45,8 @@ excluded_tests = [
     # These require alt_pjsua (PJSUA_MEDIA_HAS_PJMEDIA=0); run explicitly with --exe alt_pjsua
     "alt-pjsua-uac-custom-sdp",
     "alt-pjsua-uas-custom-sdp",
+    "alt-pjsua-uas-amr-sdp",
+    "alt-pjsua-uas-static-pt-no-rtpmap",
 ]
 
 # Exclude scripts-sipp/uac-reinvite-bad-via-branch on MacOS due to unreliable result

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-amr-sdp.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-amr-sdp.py
@@ -1,0 +1,35 @@
+#
+# Test driver for alt-pjsua-uas-amr-sdp.xml
+#
+# alt_pjsua acts as UAS with --auto-answer=200. SIPp sends an INVITE with a
+# dynamic-PT AMR-WB (PT 116) + AMR (PT 96) SDP offer.  alt_pjsua answers with
+# its custom AMR-WB SDP. The call must reach STATE_CONFIRMED, which proves the
+# fix for the dynamic-PT code path in get_audio_codec_info_param():
+# pjmedia_codec_mgr_find_codecs_by_id() returning PJ_ENOTFOUND for unregistered
+# codecs no longer causes a hard failure.
+#
+# Run with alt_pjsua:
+#   cd tests/pjsua && python3 run.py \
+#       --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua \
+#       mod_sipp.py scripts-sipp/alt-pjsua-uas-amr-sdp.xml
+#
+import inc_const as const
+
+# pjsua instance: UAS, auto-answers with a custom SDP that uses AMR-WB
+# (PT 116, dynamic) so that the dynamic-PT code path in stream_info.c is
+# exercised.  --rtp-port 4002 pins the audio RTP port.
+PJSUA = [
+    "--null-audio --max-calls=1 --no-tcp --rtp-port 4002 "
+    "--auto-answer=200 "
+    "--custom-sdp \"v=0\\r\\no=- 1234567890 1234567890 IN IP4 127.0.0.1"
+    "\\r\\ns=-\\r\\nc=IN IP4 127.0.0.1\\r\\nt=0 0"
+    "\\r\\nm=audio 4002 RTP/AVP 116"
+    "\\r\\na=rtpmap:116 AMR-WB/16000/1\""
+]
+
+PJSUA_CLI_EXPECTS = [
+    # Verify the AMR-WB rtpmap from SIPp's INVITE is received.
+    [0, r"a=rtpmap:116 AMR-WB/16000", ""],
+    # The call must reach CONFIRMED state, proving dynamic-PT negotiation works.
+    [0, const.STATE_CONFIRMED, ""],
+]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-amr-sdp.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-amr-sdp.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- SIPp acts as UAC and sends an INVITE with an AMR-WB + AMR SDP offer
+     containing only dynamic payload types (PT 116 and PT 96).  This mirrors
+     the sdp_amr.txt scenario.  alt_pjsua acts as UAS and auto-answers 200 OK
+     with its custom SDP.  SIPp verifies the 200 OK body carries the expected
+     AMR-WB rtpmap, then sends ACK, waits briefly, and sends BYE. -->
+
+<scenario name="alt_pjsua UAS AMR dynamic-PT SDP: SIPp as UAC">
+
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: alt_pjsua UAS AMR dynamic-PT SDP test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+v=0
+o=sipp 1234567890 1234567890 IN IP[local_ip_type] [local_ip]
+s=-
+c=IN IP[media_ip_type] [media_ip]
+t=0 0
+m=audio [media_port] RTP/AVP 116 96 111 110
+a=rtpmap:116 AMR-WB/16000/1
+a=fmtp:116 mode-change-capability=2
+a=rtpmap:96 AMR/8000/1
+a=fmtp:96 mode-change-capability=2
+a=rtpmap:111 telephone-event/16000
+a=fmtp:111 0-15
+a=rtpmap:110 telephone-event/8000
+a=fmtp:110 0-15
+a=ptime:20
+a=sendrecv
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true">
+  </recv>
+
+  <recv response="180" optional="true">
+  </recv>
+
+  <recv response="200" rtd="true">
+    <action>
+      <!-- Verify the 200 OK carries the custom SDP injected by alt_pjsua.
+           Check for the AMR-WB dynamic PT rtpmap so the test is
+           environment-independent. The condexec nop avoids SIPp 3.7
+           exiting on "referenced 1 times" warning. -->
+      <ereg regexp="a=rtpmap:116 AMR-WB/16000" search_in="msg"
+            check_it="true" assign_to="1"/>
+    </action>
+  </recv>
+  <nop condexec="1"></nop>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 2 BYE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" crlf="true">
+  </recv>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.py
@@ -1,0 +1,33 @@
+#
+# Test driver for alt-pjsua-uas-static-pt-no-rtpmap.xml
+#
+# alt_pjsua acts as UAS with --auto-answer=200. SIPp sends an INVITE with a
+# static payload type (PT 0, PCMU) and NO a=rtpmap attribute, which is valid
+# per RFC 4566 but exercises the get_codec_info() fallback path in
+# get_audio_codec_info_param(). With an empty codec registry, that call
+# returns PJ_ENOTFOUND; the fix treats this as non-fatal so the call can
+# proceed. The test verifies STATE_CONFIRMED is reached.
+#
+# Run with alt_pjsua:
+#   cd tests/pjsua && python3 run.py \
+#       --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua \
+#       mod_sipp.py scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.xml
+#
+import inc_const as const
+
+# pjsua instance: UAS, auto-answers with a custom SDP that uses PT 0 (PCMU)
+# without a=rtpmap so that the get_codec_info() fallback path is exercised.
+# --rtp-port 4002 pins the audio RTP port.
+PJSUA = [
+    "--null-audio --max-calls=1 --no-tcp --rtp-port 4002 "
+    "--auto-answer=200 "
+    "--custom-sdp \"v=0\\r\\no=- 1234567890 1234567890 IN IP4 127.0.0.1"
+    "\\r\\ns=-\\r\\nc=IN IP4 127.0.0.1\\r\\nt=0 0"
+    "\\r\\nm=audio 4002 RTP/AVP 0\""
+]
+
+PJSUA_CLI_EXPECTS = [
+    # The call must reach CONFIRMED state, proving that a static PT without
+    # rtpmap is handled gracefully when the codec registry is empty.
+    [0, const.STATE_CONFIRMED, ""],
+]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <!DOCTYPE scenario SYSTEM "sipp.dtd">
 
-<!-- SIPp acts as UAC and sends an INVITE with an AMR-WB + AMR SDP offer
-     containing only dynamic payload types (PT 116 and PT 96). alt_pjsua
-     acts as UAS and auto-answers 200 OK with its custom SDP. SIPp
-     verifies the 200 OK body carries the expected AMR-WB rtpmap, then
-     sends ACK, waits briefly, and sends BYE. -->
+<!-- SIPp acts as UAC and sends an INVITE with a static payload type (PT 0,
+     PCMU) but WITHOUT an a=rtpmap attribute.  RFC 4566 makes rtpmap optional
+     for static PTs.  alt_pjsua acts as UAS and auto-answers 200 OK with its
+     custom SDP (also PT 0, no rtpmap).  The call must reach the confirmed
+     state, verifying that the no-rtpmap static-PT code path in
+     get_audio_codec_info_param() handles an empty codec registry gracefully.
+     SIPp sends ACK, waits briefly, and terminates with BYE. -->
 
-<scenario name="alt_pjsua UAS AMR dynamic-PT SDP: SIPp as UAC">
+<scenario name="alt_pjsua UAS static PT without rtpmap: SIPp as UAC">
 
   <send retrans="500">
     <![CDATA[
@@ -20,7 +22,7 @@
       CSeq: 1 INVITE
       Contact: sip:sipp@[local_ip]:[local_port]
       Max-Forwards: 70
-      Subject: alt_pjsua UAS AMR dynamic-PT SDP test
+      Subject: alt_pjsua UAS static PT no rtpmap test
       Content-Type: application/sdp
       Content-Length: [len]
 
@@ -29,17 +31,7 @@ o=sipp 1234567890 1234567890 IN IP[local_ip_type] [local_ip]
 s=-
 c=IN IP[media_ip_type] [media_ip]
 t=0 0
-m=audio [media_port] RTP/AVP 116 96 111 110
-a=rtpmap:116 AMR-WB/16000/1
-a=fmtp:116 mode-change-capability=2
-a=rtpmap:96 AMR/8000/1
-a=fmtp:96 mode-change-capability=2
-a=rtpmap:111 telephone-event/16000
-a=fmtp:111 0-15
-a=rtpmap:110 telephone-event/8000
-a=fmtp:110 0-15
-a=ptime:20
-a=sendrecv
+m=audio [media_port] RTP/AVP 0
 
     ]]>
   </send>
@@ -51,16 +43,7 @@ a=sendrecv
   </recv>
 
   <recv response="200" rtd="true">
-    <action>
-      <!-- Verify the 200 OK carries the custom SDP injected by alt_pjsua.
-           Check for the AMR-WB dynamic PT rtpmap so the test is
-           environment-independent. The condexec nop avoids SIPp 3.7
-           exiting on "referenced 1 times" warning. -->
-      <ereg regexp="a=rtpmap:116 AMR-WB/16000" search_in="msg"
-            check_it="true" assign_to="1"/>
-    </action>
   </recv>
-  <nop condexec="1"></nop>
 
   <send>
     <![CDATA[


### PR DESCRIPTION
A [signaling plane B2BUA](https://www.rfc-editor.org/rfc/rfc7092#section-3.1) should only operate on the SIP message protocol layer, i.e. be transparent for SDP.

In current PJSUA(2), SDP is validated by using locally registered codecs (codec factory), i.e. if codecs within third-party SDP are not registered, the call will be rejected by a SIP 488 response.
However, if the media server is in another process or even at another node, the process-internal codec registry does not make sense, because the knowledge of all possible codes would required.

The changes are tested by using UAS and UAC tests developed in https://github.com/pjsip/pjproject/pull/4923.



