### PR TITLE
cmake: fix system-speex resampler support and cross-dir Pj::Dep aliases

### DIFF
--- a/pjmedia/CMakeLists.txt
+++ b/pjmedia/CMakeLists.txt
@@ -41,6 +41,16 @@ elseif(PJMEDIA_WITH_RESAMPLE STREQUAL "speex")
     message(FATAL_ERROR "Resampling backend cannot be set to `speex`, \
                          because Speex is not available")
   endif()
+  # Modern speex (1.2+) ships the resampler in libspeexdsp, separate from
+  # libspeex. When using system speex we therefore also need SpeexDSP.
+  # The bundled speex keeps the resampler in-tree so nothing extra is
+  # required there.
+  get_target_property(_pj_speex_provider Pj::Dep::Speex PJ_DEP_PROVIDER)
+  if(_pj_speex_provider STREQUAL "system")
+    find_package(SpeexDSP REQUIRED)
+    set(_pj_resample_speex_needs_speexdsp TRUE)
+  endif()
+  unset(_pj_speex_provider)
 endif()
 
 #
@@ -540,6 +550,7 @@ target_link_libraries(pjmedia
     $<$<STREQUAL:${PJMEDIA_WITH_RESAMPLE},libresample>:Pj::Dep::Resample>
     $<$<STREQUAL:${PJMEDIA_WITH_RESAMPLE},libsamplerate>:SampleRate::SampleRate>
     $<$<STREQUAL:${PJMEDIA_WITH_RESAMPLE},speex>:Pj::Dep::Speex>
+    $<$<BOOL:${_pj_resample_speex_needs_speexdsp}>:SpeexDSP::SpeexDSP>
 
     # aec
     $<$<BOOL:${PJMEDIA_WITH_SPEEX_AEC}>:Pj::Dep::Speex;SpeexDSP::SpeexDSP>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -90,6 +90,16 @@ foreach(dep IN LISTS DEPS)
       else()
         set(dep_target ${DEP_${dep}_PACKAGE}::${DEP_${dep}_PACKAGE})
       endif()
+      # Promote the IMPORTED target to GLOBAL so the `Pj::Dep::${dep}`
+      # ALIAS created below is visible across subdirectories. An ALIAS
+      # that backs a non-GLOBAL IMPORTED target is scope-local, which
+      # breaks `if(TARGET Pj::Dep::${dep})` checks in sibling modules
+      # (e.g. pjmedia checking for `Pj::Dep::Speex`).
+      get_target_property(_is_imported ${dep_target} IMPORTED)
+      if(_is_imported)
+        set_target_properties(${dep_target} PROPERTIES IMPORTED_GLOBAL TRUE)
+      endif()
+      unset(_is_imported)
     endif()
   endif()
 


### PR DESCRIPTION
Two issues prevented `PJ_DEP_SPEEX=system` with `PJMEDIA_WITH_RESAMPLE=speex`
from working out of the box on modern CMake builds:

1. `third_party/CMakeLists.txt` aliases `Pj::Dep::<dep>` from whatever
   target `find_package()` produced. For system deps the Find modules
   create non-GLOBAL IMPORTED targets, and an ALIAS backed by a
   non-GLOBAL IMPORTED target is scope-local — it isn't visible in
   sibling subdirectories. That broke `if(TARGET Pj::Dep::Speex)` in
   pjmedia, turning system-speex into a fatal configure error even when
   the library was found. Promote the IMPORTED target to GLOBAL right
   after find_package so the alias propagates.

2. Modern speex (1.2+) ships the resampler in libspeexdsp, separate
   from libspeex. pjmedia only links `Pj::Dep::Speex` for the speex
   resampler backend, which left `speex_resampler_*` symbols
   unresolved when linking against a system speex. Also require and
   link SpeexDSP when the resampler is selected and Speex is
   system-provided; the bundled speex keeps the resampler in-tree, so
   nothing extra is needed there.
