### PR TITLE
Fixed Android Media Codec H264 read-only DMA buffer violation during packetization

### DIFF
--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1709,6 +1709,7 @@ static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
                 AMediaCodec_releaseOutputBuffer(and_media_data->enc,
                                         and_media_data->enc_output_buf_idx,
                                         0);
+                and_media_data->enc_output_buf_idx = -1;
                 return PJ_ENOMEM;
             }
             h264_data->enc_frame_buf_size = frame_size;

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1703,8 +1703,10 @@ static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
         unsigned frame_size = and_media_data->enc_buf_info.size;
 
         if (frame_size > h264_data->enc_frame_buf_size) {
+            /* Allocate 2x to reduce the frequency of future reallocations. */
             h264_data->enc_frame_buf = (pj_uint8_t *)pj_pool_alloc(
-                                            and_media_data->pool, frame_size);
+                                            and_media_data->pool,
+                                            frame_size * 2);
             if (!h264_data->enc_frame_buf) {
                 AMediaCodec_releaseOutputBuffer(and_media_data->enc,
                                         and_media_data->enc_output_buf_idx,
@@ -1712,7 +1714,7 @@ static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
                 and_media_data->enc_output_buf_idx = -1;
                 return PJ_ENOMEM;
             }
-            h264_data->enc_frame_buf_size = frame_size;
+            h264_data->enc_frame_buf_size = frame_size * 2;
         }
         pj_memcpy(h264_data->enc_frame_buf, and_media_data->enc_frame_whole,
                   frame_size);

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -176,6 +176,13 @@ typedef struct h264_codec_data {
     unsigned                     enc_sps_pps_len;
     pj_bool_t                    enc_sps_pps_ex;
 
+    /* Writable copy of encoder output buffer. Android 16+ may return read-only
+     * DMA buffers from AMediaCodec_getOutputBuffer, but the H264 packetizer
+     * writes FU-A headers directly into the input buffer, requiring write access.
+     */
+    pj_uint8_t                  *enc_frame_buf;
+    unsigned                     enc_frame_buf_size;
+
     pj_uint8_t                  *dec_sps_buf;
     unsigned                     dec_sps_len;
     pj_uint8_t                  *dec_pps_buf;
@@ -1685,6 +1692,25 @@ static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
         and_media_data->enc_frame_size = h264_data->enc_sps_pps_len;
     } else {
         h264_data->enc_sps_pps_ex = PJ_FALSE;
+    }
+
+    /* Android 16+ returns read-only DMA buffers from AMediaCodec_getOutputBuffer.
+     * The H264 packetizer writes FU-A headers back into the buffer, so we must
+     * work on a writable copy. Grow the buffer via pool when needed.
+     */
+    {
+        unsigned frame_size = and_media_data->enc_buf_info.size;
+
+        if (frame_size > h264_data->enc_frame_buf_size) {
+            h264_data->enc_frame_buf = (pj_uint8_t *)pj_pool_alloc(
+                                            and_media_data->pool, frame_size);
+            if (!h264_data->enc_frame_buf)
+                return PJ_ENOMEM;
+            h264_data->enc_frame_buf_size = frame_size;
+        }
+        pj_memcpy(h264_data->enc_frame_buf, and_media_data->enc_frame_whole,
+                  frame_size);
+        and_media_data->enc_frame_whole = h264_data->enc_frame_buf;
     }
 
     return status;

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1696,16 +1696,21 @@ static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
 
     /* Android 16+ returns read-only DMA buffers from AMediaCodec_getOutputBuffer.
      * The H264 packetizer writes FU-A headers back into the buffer, so we must
-     * work on a writable copy. Grow the buffer via pool when needed.
+     * work on a writable copy. Skip in whole mode — the frame is only read there.
+     * Grow the buffer via pool when needed.
      */
-    {
+    if (!and_media_data->whole) {
         unsigned frame_size = and_media_data->enc_buf_info.size;
 
         if (frame_size > h264_data->enc_frame_buf_size) {
             h264_data->enc_frame_buf = (pj_uint8_t *)pj_pool_alloc(
                                             and_media_data->pool, frame_size);
-            if (!h264_data->enc_frame_buf)
+            if (!h264_data->enc_frame_buf) {
+                AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+                                        and_media_data->enc_output_buf_idx,
+                                        0);
                 return PJ_ENOMEM;
+            }
             h264_data->enc_frame_buf_size = frame_size;
         }
         pj_memcpy(h264_data->enc_frame_buf, and_media_data->enc_frame_whole,

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1314,7 +1314,7 @@ static pj_status_t and_media_codec_encode_more(pjmedia_vid_codec *codec,
                                                             and_media_data,
                                                             out_size, output,
                                                             has_more);
-    if (!(*has_more)) {
+    if (!(*has_more) && and_media_data->enc_output_buf_idx >= 0) {
         AMediaCodec_releaseOutputBuffer(and_media_data->enc,
                                         and_media_data->enc_output_buf_idx,
                                         0);
@@ -1716,6 +1716,15 @@ static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
         pj_memcpy(h264_data->enc_frame_buf, and_media_data->enc_frame_whole,
                   frame_size);
         and_media_data->enc_frame_whole = h264_data->enc_frame_buf;
+
+        /* The MediaCodec output buffer is no longer needed; release it now
+         * so the codec is not starved of output buffers during packetization.
+         * Set enc_output_buf_idx to -1 so encode_more does not double-release.
+         */
+        AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+                                        and_media_data->enc_output_buf_idx,
+                                        0);
+        and_media_data->enc_output_buf_idx = -1;
     }
 
     return status;


### PR DESCRIPTION
To fix #4943.

## Root Cause

`pjmedia_h264_packetize()` performs in-place modification of its input buffer when producing FU-A (Fragmentation Unit) packets. It writes a 2-byte FU header directly into the source buffer, two bytes before the current NAL unit position:

```c
p = nal_start - HEADER_SIZE_FU_A;
*p = (NRI << 5) | NAL_TYPE_FU_A;  /* writes into input buffer */
```

This is intentional design — it reuses the space previously occupied by the H.264 start code bytes as scratch space for the FU indicator and FU header octets.

In the Android MediaCodec encoder path, the encoded output buffer is obtained via `AMediaCodec_getOutputBuffer()` and stored directly as `enc_frame_whole`, which is then passed to the packetizer:

```c
and_media_data->enc_frame_whole = output_buf;  /* points to DMA buffer */
...
pjmedia_h264_packetize(h264_data->pktz, data_buf, ...);  /* writes into it */
```

Starting with Android 16 (March 2026), `AMediaCodec_getOutputBuffer()` returns **read-only DMA-mapped memory** for encoded frames. Writing into it causes a segmentation fault:

```
signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr ... (write)
[0x00000070e5676000-0x00000070e5678000) r-- /dmabuf:system
```

## Fix

In `process_encode_h264()`, after the codec output buffer is obtained and before packetization begins, copy the encoder output into a private writable buffer kept in `h264_codec_data`. The pointer `enc_frame_whole` is then redirected to this writable copy, so the packetizer never touches the DMA buffer.

The writable buffer is allocated from the codec's `pj_pool_t` and grows on demand (via a new pool allocation) if a larger frame arrives. In practice the size stabilizes after the first few frames.

SPS/PPS config frames are unaffected — they are already copied into `enc_sps_pps_buf` and the function returns early before reaching this code path.

The VPX codec path does not require the same fix. `pjmedia_vpx_packetize()` writes the RTP payload descriptor into the *output* buffer supplied by the caller; it only reads from `enc_frame_whole` via `pj_memcpy()`.

