### PR TITLE
Fixes build when older version present on system by promoting APP_LDFLAGS above OS_LDFLAGS

### DIFF
--- a/pjlib-util/build/Makefile
+++ b/pjlib-util/build/Makefile
@@ -28,8 +28,8 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 		   $(CFLAGS) $(CC_INC)../include $(CC_INC)../../pjlib/include
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
-export _LDFLAGS := $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS)
+export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 ###############################################################################
 # Defines for building PJLIB-UTIL library

--- a/pjlib-util/build/Makefile
+++ b/pjlib-util/build/Makefile
@@ -29,7 +29,7 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS) 
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 ###############################################################################
 # Defines for building PJLIB-UTIL library

--- a/pjlib-util/build/Makefile
+++ b/pjlib-util/build/Makefile
@@ -29,7 +29,7 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 ###############################################################################
 # Defines for building PJLIB-UTIL library

--- a/pjlib/build/Makefile
+++ b/pjlib/build/Makefile
@@ -22,8 +22,8 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 		   $(CFLAGS) $(CC_INC)../include
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
-export _LDFLAGS := $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS) 
+export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 
 ###############################################################################

--- a/pjlib/build/Makefile
+++ b/pjlib/build/Makefile
@@ -23,7 +23,7 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 
 ###############################################################################

--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -50,8 +50,8 @@ export _CXXFLAGS:= $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 
 export _LDFLAGS := $(APP_THIRD_PARTY_LIBS) \
 		   $(APP_THIRD_PARTY_EXT) \
-		   $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS) 
+		   $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 ###############################################################################
 # Defines for building PJMEDIA library

--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -51,7 +51,7 @@ export _CXXFLAGS:= $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 export _LDFLAGS := $(APP_THIRD_PARTY_LIBS) \
 		   $(APP_THIRD_PARTY_EXT) \
 		   $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 ###############################################################################
 # Defines for building PJMEDIA library

--- a/pjnath/build/Makefile
+++ b/pjnath/build/Makefile
@@ -31,7 +31,7 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 ###############################################################################
 # Defines for building PJNATH library

--- a/pjnath/build/Makefile
+++ b/pjnath/build/Makefile
@@ -30,8 +30,8 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 		   $(CC_INC)../../pjlib-util/include
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
-export _LDFLAGS := $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS) 
+export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 ###############################################################################
 # Defines for building PJNATH library

--- a/pjsip-apps/build/Makefile
+++ b/pjsip-apps/build/Makefile
@@ -18,8 +18,8 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 		   $(CC_INC)../../pjmedia/include
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
-export _LDFLAGS := $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(APP_LDLIBS) $(LDFLAGS) 
+export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(APP_LDLIBS) $(LDFLAGS)
 
 ###############################################################################
 # Defines for building PJSUA

--- a/pjsip-apps/build/Makefile
+++ b/pjsip-apps/build/Makefile
@@ -19,7 +19,7 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(APP_LDLIBS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(APP_LDLIBS) $(LDFLAGS) 
 
 ###############################################################################
 # Defines for building PJSUA

--- a/pjsip/build/Makefile
+++ b/pjsip/build/Makefile
@@ -50,8 +50,8 @@ export _CXXFLAGS:= $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS) $(_CFLAGS)
 export _LDFLAGS := $(APP_THIRD_PARTY_LIBS) \
 		   $(APP_THIRD_PARTY_EXT) \
-		   $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS) 
+		   $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 ###############################################################################
 # Defines for building PJSIP core library

--- a/pjsip/build/Makefile
+++ b/pjsip/build/Makefile
@@ -51,7 +51,7 @@ export _CXXFLAGS:= $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 export _LDFLAGS := $(APP_THIRD_PARTY_LIBS) \
 		   $(APP_THIRD_PARTY_EXT) \
 		   $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 ###############################################################################
 # Defines for building PJSIP core library

--- a/third_party/build/speex/Makefile
+++ b/third_party/build/speex/Makefile
@@ -23,7 +23,7 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 export SPEEX_SRCDIR = ../../speex/libspeex
 export SPEEX_OBJS = 	bits.o cb_search.o exc_10_16_table.o  \

--- a/third_party/build/speex/Makefile
+++ b/third_party/build/speex/Makefile
@@ -22,8 +22,8 @@ export _CFLAGS 	:= $(CC_CFLAGS) $(OS_CFLAGS) $(HOST_CFLAGS) $(M_CFLAGS) \
 		   $(CC_INC)../../../pjlib/include
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
-export _LDFLAGS := $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS) 
+export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 export SPEEX_SRCDIR = ../../speex/libspeex
 export SPEEX_OBJS = 	bits.o cb_search.o exc_10_16_table.o  \

--- a/third_party/build/srtp/Makefile
+++ b/third_party/build/srtp/Makefile
@@ -24,8 +24,8 @@ export _CFLAGS 	:= $(CC_INC). $(CC_INC)../../srtp/crypto/include \
 		   $(CFLAGS) 
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
-export _LDFLAGS := $(CC_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) $(HOST_LDFLAGS) \
-		   $(APP_LDFLAGS) $(LDFLAGS) 
+export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
+		   $(HOST_LDFLAGS) $(LDFLAGS)
 
 # libcrypt.a (the crypto engine) 
 ciphers = crypto/cipher/cipher.o crypto/cipher/null_cipher.o crypto/cipher/cipher_test_cases.o     \

--- a/third_party/build/srtp/Makefile
+++ b/third_party/build/srtp/Makefile
@@ -25,7 +25,7 @@ export _CFLAGS 	:= $(CC_INC). $(CC_INC)../../srtp/crypto/include \
 export _CXXFLAGS:= $(_CFLAGS) $(CC_CXXFLAGS) $(OS_CXXFLAGS) $(M_CXXFLAGS) \
 		   $(HOST_CXXFLAGS) $(CXXFLAGS)
 export _LDFLAGS := $(CC_LDFLAGS) $(APP_LDFLAGS) $(OS_LDFLAGS) $(M_LDFLAGS) \
-		   $(HOST_LDFLAGS) $(LDFLAGS)
+		   $(HOST_LDFLAGS) $(LDFLAGS) 
 
 # libcrypt.a (the crypto engine) 
 ciphers = crypto/cipher/cipher.o crypto/cipher/null_cipher.o crypto/cipher/cipher_test_cases.o     \


### PR DESCRIPTION
This fixes an issue I had in building on Arch Linux. Essentially, the linker was trying to find definitions for some recently added functions related to websock. However, it was resolving against an older version of `libpjlib-util.so.2` that was previously installed on my machine under `/usr/lib`. The older version did not have the recently defined functions.

The `APP_LDFLAGS` seem to be defined here: https://github.com/pjsip/pjproject/blob/8c1c9de9733feb01b140345f4b4fd8d87fe43526/build.mak.in#L243-L250

...They are mostly `-L` library directory switches that refer the linker to directories within this project/repository. Placing them earlier in the concatenated/compounded `_LDFLAGS` declarations (that end up being the effective declarations), ahead of `OS_LDFLAGS`, ensures they take precedence over any ambient files that happen to be on the build system.

FWIW, on my system in particular, the following line was interrogating the SDL2 config:
https://github.com/pjsip/pjproject/blob/8c1c9de9733feb01b140345f4b4fd8d87fe43526/aconfigure.ac#L1545

...which responded like this:
```
$ /usr/bin/sdl2-config --libs
-L/usr/lib -lSDL2
```

The changes in this PR makes sure the `-L/usr/lib` (from SDL2), that ends up baked into `$(OS_LDFLAGS)` comes after `-L$(PJDIR)/pjlib-util/lib` (from `APP_LDFLAGS`) and not before.