### PR TITLE
Fix Win32 thread stack overflow with default stack size; clarify 0 == OS default

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -614,12 +614,18 @@
 
 
 /**
- * Specify this as \a stack_size argument in #pj_thread_create() to specify
- * that thread should use default stack size for the current platform.
+ * Numeric default stack size used by pjlib in legacy code paths and on
+ * platforms that require an explicit per-thread stack size. Historically
+ * intended as a small embedded-friendly default.
  *
- * Default: 8192
+ * IMPORTANT: this is NOT a sentinel for "OS default" -- pass 0 (zero)
+ * for that. To get the OS thread default stack size on every platform,
+ * pass 0 as the stack_size argument to #pj_thread_create(); the OS
+ * picks its default regardless of #PJ_THREAD_SET_STACK_SIZE.
+ *
+ * Default: 8192.
  */
-#ifndef PJ_THREAD_DEFAULT_STACK_SIZE 
+#ifndef PJ_THREAD_DEFAULT_STACK_SIZE
 #  define PJ_THREAD_DEFAULT_STACK_SIZE    8192
 #endif
 

--- a/pjlib/include/pj/os.h
+++ b/pjlib/include/pj/os.h
@@ -183,12 +183,18 @@ PJ_DECL(pj_uint32_t) pj_getpid(void);
  * @param thread_name   The optional name to be assigned to the thread.
  * @param proc          Thread entry function.
  * @param arg           Argument to be passed to the thread entry function.
- * @param stack_size    The size of the stack for the new thread, or ZERO or
- *                      PJ_THREAD_DEFAULT_STACK_SIZE to let the 
- *                      library choose the reasonable size for the stack. 
- *                      For some systems, the stack will be allocated from 
- *                      the pool, so the pool must have suitable capacity.
- * @param flags         Flags for thread creation, which is bitmask combination 
+ * @param stack_size    The size of the stack for the new thread, in bytes.
+ *                      Pass 0 to let the OS pick its default size; this is
+ *                      honored on every platform regardless of
+ *                      PJ_THREAD_SET_STACK_SIZE. Pass a non-zero value to
+ *                      request a specific size; that request is propagated
+ *                      to the OS thread API only when PJ_THREAD_SET_STACK_SIZE
+ *                      is non-zero (the default is 0 on Linux/Mac/Windows
+ *                      and 1 on rtems; can be enabled per-build via
+ *                      config_site.h on any platform). For some systems,
+ *                      the stack will be allocated from the pool, so the
+ *                      pool must have suitable capacity.
+ * @param flags         Flags for thread creation, which is bitmask combination
  *                      from enum pj_thread_create_flags.
  * @param thread        Pointer to hold the newly created thread.
  *
@@ -211,9 +217,15 @@ PJ_DECL(pj_status_t) pj_thread_create(  pj_pool_t *pool,
  * @param thread_name   The optional name to be assigned to the thread.
  * @param proc          Thread entry function.
  * @param arg           Argument to be passed to the thread entry function.
- * @param stack_size    The size of the stack for the new thread, or ZERO or
- *                      PJ_THREAD_DEFAULT_STACK_SIZE to let the 
- *                      library choose the reasonable size for the stack. 
+ * @param stack_size    The size of the stack for the new thread, in bytes.
+ *                      Pass 0 to let the OS pick its default size; this is
+ *                      honored on every platform regardless of
+ *                      PJ_THREAD_SET_STACK_SIZE. Pass a non-zero value to
+ *                      request a specific size; that request is propagated
+ *                      to the OS thread API only when PJ_THREAD_SET_STACK_SIZE
+ *                      is non-zero (the default is 0 on Linux/Mac/Windows
+ *                      and 1 on rtems; can be enabled per-build via
+ *                      config_site.h on any platform).
  * @param stack_addr    Preallocated space of size stack_size for the stack
  *                      for the new thread, used if PJ_THREAD_ALLOCATE_STACK
  *                      macro defined and is not 0. Otherwise ignored.

--- a/pjlib/include/pj/os.h
+++ b/pjlib/include/pj/os.h
@@ -226,6 +226,10 @@ PJ_DECL(pj_status_t) pj_thread_create(  pj_pool_t *pool,
  *                      is non-zero (the default is 0 on Linux/Mac/Windows
  *                      and 1 on rtems; can be enabled per-build via
  *                      config_site.h on any platform).
+ *                      Note: on platforms where PJ_THREAD_ALLOCATE_STACK is
+ *                      non-zero (e.g. rtems), the caller must provide a
+ *                      non-zero stack_size matching the size of stack_addr;
+ *                      passing 0 is not valid in that case.
  * @param stack_addr    Preallocated space of size stack_size for the stack
  *                      for the new thread, used if PJ_THREAD_ALLOCATE_STACK
  *                      macro defined and is not 0. Otherwise ignored.

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -800,12 +800,12 @@ static pj_status_t create_thread(const char *thread_name,
         pj_ansi_strxcpy(rec->obj_name, thread_name, PJ_MAX_OBJ_NAME);
     }
 
-    /* Set default stack size */
-    if (stack_size == 0)
-        stack_size = PJ_THREAD_DEFAULT_STACK_SIZE;
-
 #if defined(PJ_OS_HAS_CHECK_STACK) && PJ_OS_HAS_CHECK_STACK!=0
-    rec->stk_size = stack_size;
+#   if defined(PJ_THREAD_SET_STACK_SIZE) && PJ_THREAD_SET_STACK_SIZE!=0
+    rec->stk_size = stack_size ? stack_size : 0xFFFFFFFFUL;
+#   else
+    rec->stk_size = 0xFFFFFFFFUL;
+#   endif
     rec->stk_max_usage = 0;
 #endif
 
@@ -813,11 +813,15 @@ static pj_status_t create_thread(const char *thread_name,
     pthread_attr_init(&thread_attr);
 
 #if defined(PJ_THREAD_SET_STACK_SIZE) && PJ_THREAD_SET_STACK_SIZE!=0
-    /* Set thread's stack size */
-    rc = pthread_attr_setstacksize(&thread_attr, stack_size);
-    if (rc != 0) {
-        pthread_attr_destroy(&thread_attr);
-        return PJ_RETURN_OS_ERROR(rc);
+    /* Set thread's stack size if caller specified one;
+     * 0 means let OS pick the default.
+     */
+    if (stack_size != 0) {
+        rc = pthread_attr_setstacksize(&thread_attr, stack_size);
+        if (rc != 0) {
+            pthread_attr_destroy(&thread_attr);
+            return PJ_RETURN_OS_ERROR(rc);
+        }
     }
 #endif  /* PJ_THREAD_SET_STACK_SIZE */
 

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -882,6 +882,11 @@ PJ_DEF(pj_status_t) pj_thread_create( pj_pool_t *pool,
     PJ_ASSERT_RETURN(rec, PJ_ENOMEM);
 
 #if defined(PJ_THREAD_ALLOCATE_STACK) && PJ_THREAD_ALLOCATE_STACK!=0
+    /* When pjlib allocates the stack from the pool, 0 is not
+     * meaningful; fall back to PJ_THREAD_DEFAULT_STACK_SIZE.
+     */
+    if (stack_size == 0)
+        stack_size = PJ_THREAD_DEFAULT_STACK_SIZE;
     /* Allocate memory for the stack */
     stack_addr = pj_pool_alloc(pool, stack_size);
     PJ_ASSERT_RETURN(stack_addr, PJ_ENOMEM);

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -722,6 +722,13 @@ static pj_status_t create_thread(const char *thread_name,
 
     PJ_LOG(6, (rec->obj_name, "Thread created"));
 
+#if !defined(PJ_THREAD_SET_STACK_SIZE) || PJ_THREAD_SET_STACK_SIZE==0
+    /* Don't propagate caller's stack_size to the OS thread API;
+     * let the OS pick its default size.
+     */
+    stack_size = 0;
+#endif
+
 #if defined(PJ_OS_HAS_CHECK_STACK) && PJ_OS_HAS_CHECK_STACK!=0
     rec->stk_size = stack_size ? (pj_uint32_t)stack_size : 0xFFFFFFFFUL;
     rec->stk_max_usage = 0;


### PR DESCRIPTION
## Background
A user migrating from 2.14 to 2.17 hit immediate stack overflow on Windows x64 in `pj_log` when creating a thread via `pj_thread_create(..., PJ_THREAD_DEFAULT_STACK_SIZE, ...)`. The same code worked on Linux. Two issues exposed by PR #4626 (`CreateThread` -> `_beginthreadex`):

1. `PJ_THREAD_DEFAULT_STACK_SIZE` is hardcoded to 8192 -- too small for a Windows thread that runs the MSVC CRT shim plus `vsnprintf`. `CreateThread` historically masked this; `_beginthreadex` does not.
2. The `PJ_THREAD_SET_STACK_SIZE` toggle was honored on the Unix path but ignored on Win32, so the small value was always pushed to the OS API.

The deeper issue is a mismatched contract: the doc claimed `0` and `PJ_THREAD_DEFAULT_STACK_SIZE` are equivalent, but the macro expanded to a numeric value that may or may not be honored depending on platform.

## New contract
Pass `0` to get the OS thread default size on every platform, regardless of `PJ_THREAD_SET_STACK_SIZE`. A non-zero value is propagated to the OS thread API only when the toggle is on. `PJ_THREAD_DEFAULT_STACK_SIZE` is now a numeric default (8192), not a sentinel.

## Changes
- Win32 `create_thread()` now honors `PJ_THREAD_SET_STACK_SIZE` the same way the Unix path does.
- Unix `create_thread()` no longer normalizes `0` to `PJ_THREAD_DEFAULT_STACK_SIZE`; `pthread_attr_setstacksize()` is skipped when caller passes `0`.
- `rec->stk_size` accounting for `PJ_OS_HAS_CHECK_STACK` records `0xFFFFFFFFUL` ("unknown") whenever the OS picks the size, so the stack checker doesn't fire spurious warnings.
- Documentation in `config.h` and `os.h` updated to reflect the new contract.

## Behavior change
- rtems with `caller_stack_size == 0`: now gets rtems pthread default instead of pjlib's forced 8192. rtems users who relied on the 8 KB default should pass `8192` (or `PJ_THREAD_DEFAULT_STACK_SIZE`) explicitly.
- All other platforms / call patterns: no change in observable OS behavior.

## Test plan
- [ ] Linux build (default config) -- `pjlib-test`
- [ ] Windows build (MSVC, `_beginthreadex`) -- thread test, user's `EventQueue` repro
- [ ] macOS build

## Credits
Reported and analyzed by Pirmin Walthert.
