### PR TITLE
Miscellaneous fixes in conference.c and vid_conf.c

### DIFF
--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -1107,6 +1107,11 @@ PJ_DEF(pj_status_t) pjmedia_conf_add_port( pjmedia_conf *conf,
         PJ_LOG(4,(THIS_FILE, "Add port %d (%.*s) queued",
                              index, (int)port_name->slen, port_name->ptr));
     } else {
+        /* Failed to queue ADD op: undo slot registration and release the
+         * conf_port reference taken by create_conf_port().
+         */
+        conf->ports[index] = NULL;
+        pj_grp_lock_dec_ref(strm_port->grp_lock);
         status = PJ_ENOMEM;
         goto on_return;
     }
@@ -1272,8 +1277,6 @@ PJ_DEF(pj_status_t) pjmedia_conf_configure_port( pjmedia_conf *conf,
         pj_mutex_unlock(conf->mutex);
         return PJ_EINVAL;
     }
-
-    conf_port = conf->ports[slot];
 
     if (tx != PJMEDIA_PORT_NO_CHANGE)
         conf_port->tx_setting = tx;
@@ -2816,18 +2819,11 @@ static pj_status_t get_frame(pjmedia_port *this_port,
                 continue;
             }
 
-            /* Check that the port is not removed when we call get_frame() */
-            if (conf->ports[i] == NULL) {
-                conf_port->rx_level = 0;
-                continue;
-            }
-                
-
             /* Ignore if we didn't get any frame */
             if (frame_type != PJMEDIA_FRAME_TYPE_AUDIO) {
                 conf_port->rx_level = 0;
                 continue;
-            }           
+            }
         }
 
         p_in = (pj_int16_t*) frame->buf;

--- a/pjmedia/src/pjmedia/vid_conf.c
+++ b/pjmedia/src/pjmedia/vid_conf.c
@@ -620,18 +620,21 @@ PJ_DEF(pj_status_t) pjmedia_vid_conf_add_port( pjmedia_vid_conf *vid_conf,
 
     /* Queue the operation */
     ope = get_free_op_entry(vid_conf);
-    if (ope) {
-        ope->type = PJMEDIA_VID_CONF_OP_ADD_PORT;
-        ope->param.add_port.port = index;
-        pj_list_push_back(vid_conf->op_queue, ope);
-        PJ_LOG(4,(THIS_FILE,"Add video port %d (%.*s) queued",
-                  index, (int)cport->name.slen, cport->name.ptr));
-    } else {
+    if (!ope) {
+        /* Failed to queue ADD op: undo slot registration and the port ref
+         * we took above, then fall through to on_error to release the pool.
+         */
+        vid_conf->ports[index] = NULL;
+        pjmedia_port_dec_ref(port);
         status = PJ_ENOMEM;
-        goto on_return;
+        goto on_error;
     }
+    ope->type = PJMEDIA_VID_CONF_OP_ADD_PORT;
+    ope->param.add_port.port = index;
+    pj_list_push_back(vid_conf->op_queue, ope);
+    PJ_LOG(4,(THIS_FILE,"Add video port %d (%.*s) queued",
+              index, (int)cport->name.slen, cport->name.ptr));
 
-on_return:
     pj_mutex_unlock(vid_conf->mutex);
 
     /* Done. */


### PR DESCRIPTION
Four small, independent fixes in the audio and video conference bridge implementations. The first one was reported by a user; the rest were found while auditing the surrounding code.

### conference.c

- **Remove dead `conf->ports[i] == NULL` check in `get_frame()`** after `read_port()`. The check dates back to 2006, when port removal could clear the slot synchronously from a user callback fired inside `pjmedia_port_get_frame()`. Modern conference bridges serialize port removal through `op_queue` (drained at the top of `get_frame()` via `handle_op_queue()`), so the slot cannot transition to NULL mid-frame. `is_new` ports are filtered out before reaching `read_port()`, so the only synchronous-removal path also doesn't apply. Even if the check ever did fire, dereferencing `conf_port->rx_level` afterwards would touch potentially-freed memory — exactly the unsafe pattern the equivalent comment in `conf_thread.c` warns against.

- **Drop redundant `conf_port = conf->ports[slot]` reassignment** in `pjmedia_conf_configure_port()` (already assigned three lines above).

- **Fix port leak in `pjmedia_conf_add_port()`** when `get_free_op_entry()` returns NULL. The slot registration and the `conf_port` reference taken by `create_conf_port()` were left dangling. Now matches the cleanup pattern already in `conf_thread.c:1502-1527`.

### vid_conf.c

- **Fix `pjmedia_vid_conf_add_port()` returning `PJ_SUCCESS` on op-queue allocation failure**. The previous code set `status = PJ_ENOMEM` then jumped to a label that hardcoded `return PJ_SUCCESS;`, so the caller saw success and a slot index even though the operation was never queued. The registered slot, the port ref taken via `pjmedia_port_add_ref()`, and the cport pool were all leaked. Restructured so the failure path releases all three and returns the actual status.

`conf_switch.c` and `conf_thread.c` were also reviewed; no equivalent issues found there.

## Test plan

- [ ] `make` builds without errors or warnings
- [ ] `make pjmedia-test` passes
- [ ] `make pjsua-test` passes (exercises conference bridge via PJSUA)
- [ ] Manual: video conference port add/remove cycle (vid_conf path)

Co-Authored-By: Claude Code