### PR TITLE
docs: pjsua.h — \warning on audio stream port substitution callbacks

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1432,7 +1432,7 @@ typedef struct pjsua_callback
      * port wraps the original audio stream port, the wrapper must pin
      * the inner port via pj_grp_lock_add_ref() on (*p_port)->grp_lock at
      * construction and release it from on_destroy(). This callback has
-     * no #pjsua_on_stream_created_param::destroy_port equivalent — the
+     * no #pjsua_on_stream_created_param::destroy_port equivalent, so the
      * application must call pjmedia_port_destroy() on the substituted
      * port itself (e.g. from on_stream_destroyed()) so the destroy
      * chain fires. Prefer on_stream_created2() for new code. See

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -710,9 +710,10 @@ typedef struct pjsua_on_stream_created_param
      * pjmedia_stream_destroy(), which PJSUA calls unconditionally at
      * call teardown, may free the inner port while the conference bridge
      * is still iterating over the wrapper. The substituted port also
-     * needs its own pool released from on_destroy(); set #destroy_port
-     * to PJ_TRUE so PJSUA fires the destroy chain. See "Customizing the
-     * Audio Stream Port" in the docs guide for the full contract.
+     * needs its own pool released from on_destroy(); set
+     * #pjsua_on_stream_created_param::destroy_port to PJ_TRUE so PJSUA
+     * fires the destroy chain. See "Customizing the Audio Stream Port"
+     * in the docs guide for the full contract.
      */
     pjmedia_port        *port;
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -700,6 +700,19 @@ typedef struct pjsua_on_stream_created_param
      * On input, it specifies the audio media port of the stream. Application
      * may modify this pointer to point to different media port to be
      * registered to the conference bridge.
+     *
+     * \warning
+     * If the substituted port retains a pointer to the original audio
+     * stream port (e.g. a DSP wrapper around it), the application must
+     * take a reference on the inner port's group lock at construction
+     * (pj_grp_lock_add_ref() on the original port->grp_lock) and release
+     * it from the wrapper's on_destroy(). Otherwise
+     * pjmedia_stream_destroy(), which PJSUA calls unconditionally at
+     * call teardown, may free the inner port while the conference bridge
+     * is still iterating over the wrapper. The substituted port also
+     * needs its own pool released from on_destroy(); set #destroy_port
+     * to PJ_TRUE so PJSUA fires the destroy chain. See "Customizing the
+     * Audio Stream Port" in the docs guide for the full contract.
      */
     pjmedia_port        *port;
 
@@ -1411,7 +1424,18 @@ typedef struct pjsua_callback
      * This media port then will be added to the conference bridge instead.
      *
      * Note: if implemented, on_stream_created2() callback will be called
-     * instead of this one. 
+     * instead of this one.
+     *
+     * \warning
+     * Same lifetime contract as on_stream_created2(): if the substituted
+     * port wraps the original audio stream port, the wrapper must pin
+     * the inner port via pj_grp_lock_add_ref() on (*p_port)->grp_lock at
+     * construction and release it from on_destroy(). This callback has
+     * no #pjsua_on_stream_created_param::destroy_port equivalent — the
+     * application must call pjmedia_port_destroy() on the substituted
+     * port itself (e.g. from on_stream_destroyed()) so the destroy
+     * chain fires. Prefer on_stream_created2() for new code. See
+     * "Customizing the Audio Stream Port" in the docs guide.
      *
      * @param call_id       Call identification.
      * @param strm          Audio media stream.
@@ -1431,6 +1455,20 @@ typedef struct pjsua_callback
      * registered to the conference bridge. Application may return different
      * audio media port if it has added media processing port to the stream.
      * This media port then will be added to the conference bridge instead.
+     *
+     * \warning
+     * If the substituted port retains a pointer to the original audio
+     * stream port (e.g. a DSP wrapper around it), the application must
+     * take a reference on the inner port's group lock at construction
+     * (pj_grp_lock_add_ref() on the original param->port->grp_lock) and
+     * release it from the wrapper's on_destroy(). Otherwise
+     * pjmedia_stream_destroy(), which PJSUA calls unconditionally at
+     * call teardown, may free the inner port while the conference bridge
+     * is still iterating over the wrapper. The substituted port also
+     * needs its own pool released from on_destroy(); set
+     * #pjsua_on_stream_created_param::destroy_port to PJ_TRUE so PJSUA
+     * fires the destroy chain. See "Customizing the Audio Stream Port"
+     * in the docs guide for the full contract.
      *
      * @param call_id       Call identification.
      * @param param         The on stream created callback parameter.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -856,6 +856,20 @@ struct OnStreamCreatedParam
      * On input, it specifies the audio media port of the stream. Application
      * may modify this pointer to point to different media port to be
      * registered to the conference bridge.
+     *
+     * \warning
+     * If the substituted port retains a pointer to the original audio
+     * stream port (e.g. a DSP wrapper around it), the application must
+     * take a reference on the inner port's group lock at construction
+     * (pj_grp_lock_add_ref() on the original port's grp_lock — MediaPort
+     * is a void* alias of pjmedia_port*, so a cast is needed) and
+     * release it from the wrapper's on_destroy(). Otherwise
+     * pjmedia_stream_destroy(), which PJSUA calls unconditionally at
+     * call teardown, may free the inner port while the conference bridge
+     * is still iterating over the wrapper. The substituted port also
+     * needs its own pool released from on_destroy(); set #destroyPort
+     * to true so PJSUA fires the destroy chain. See "Customizing the
+     * Audio Stream Port" in the docs guide for the full contract.
      */
     MediaPort   pPort;
 };
@@ -2032,6 +2046,17 @@ public:
      * registered to the conference bridge. Application may return different
      * audio media port if it has added media processing port to the stream.
      * This media port then will be added to the conference bridge instead.
+     *
+     * \warning
+     * Same lifetime contract as the C-side on_stream_created2(): if the
+     * substituted port wraps the original audio stream port, the wrapper
+     * must pin the inner port via pj_grp_lock_add_ref() on its grp_lock
+     * at construction and release it from on_destroy() — otherwise
+     * pjmedia_stream_destroy() at call teardown may free it while the
+     * conference bridge still references the wrapper. The substituted
+     * port also needs its own pool released from on_destroy(); set
+     * #OnStreamCreatedParam::destroyPort to true so the destroy chain
+     * fires. See "Customizing the Audio Stream Port" in the docs guide.
      *
      * @param prm       Callback parameter.
      */

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -861,9 +861,9 @@ struct OnStreamCreatedParam
      * If the substituted port retains a pointer to the original audio
      * stream port (e.g. a DSP wrapper around it), the application must
      * take a reference on the inner port's group lock at construction
-     * (pj_grp_lock_add_ref() on the original port's grp_lock — MediaPort
-     * is a void* alias of pjmedia_port*, so a cast is needed) and
-     * release it from the wrapper's on_destroy(). Otherwise
+     * (pj_grp_lock_add_ref() on the original port's grp_lock; note that
+     * MediaPort is a void* alias of pjmedia_port*, so a cast is needed)
+     * and release it from the wrapper's on_destroy(). Otherwise
      * pjmedia_stream_destroy(), which PJSUA calls unconditionally at
      * call teardown, may free the inner port while the conference bridge
      * is still iterating over the wrapper. The substituted port also
@@ -2051,7 +2051,7 @@ public:
      * Same lifetime contract as the C-side on_stream_created2(): if the
      * substituted port wraps the original audio stream port, the wrapper
      * must pin the inner port via pj_grp_lock_add_ref() on its grp_lock
-     * at construction and release it from on_destroy() — otherwise
+     * at construction and release it from on_destroy(); otherwise
      * pjmedia_stream_destroy() at call teardown may free it while the
      * conference bridge still references the wrapper. The substituted
      * port also needs its own pool released from on_destroy(); set


### PR DESCRIPTION
## Summary

Adds doxygen `\warning` blocks to the three header symbols involved in substituting the default audio stream port for a call:

- `pjsua_on_stream_created_param::port` (struct field where the substitution happens)
- `pjsua_callback::on_stream_created` (older callback)
- `pjsua_callback::on_stream_created2` (recommended callback)

The warning flags the lifetime contract a substituted port must satisfy when it retains a pointer to the original audio stream port — typically a DSP wrapper, recorder/forker, or any layer that delegates frames to the inner stream port:

- Take a reference on the inner port's group lock at construction (`pj_grp_lock_add_ref()` on the original `port->grp_lock`) and release it from the wrapper's `on_destroy()`.
- Otherwise `pjmedia_stream_destroy()` — which PJSUA calls unconditionally at call teardown in `pjsua_aud.c` `stop_media_session` — drops the stream's group-lock refcount, frees the inner port, and the conference bridge then iterates over the wrapper one more clock tick before its queued remove runs. Use-after-free on the clock thread.
- The substituted port also needs its own pool released from `on_destroy()`, and `destroy_port=PJ_TRUE` (or an application-side `pjmedia_port_destroy()` for the older `on_stream_created` which has no `destroy_port` mechanism) so the destroy chain fires.

Each warning closes with a pointer to *Customizing the Audio Stream Port* in the docs guide, where the full contract — including the patterns A (wrap) / B (replace) split and the refcount walk-through — is laid out.

## Origin

Customer crash report: wrapper outliving inner stream port across PJSUA's teardown sequence; the application-side fix was implicit in the PJMEDIA / PJSUA-LIB source. Companion docs PR is pjproject_docs#56.

## Code-claim audit

- `pjsip/src/pjsua-lib/pjsua_aud.c` `stop_media_session` — `pjsua_conf_remove_port` is asynchronous (queued); `pjmedia_stream_destroy` is unconditional and runs on the calling thread; `destroy_port` is honoured only on the `on_stream_created2` path (lines 778, 559).
- `pjmedia/src/pjmedia/stream.c` 2317–2325 — group-lock setup; `c_strm->port.grp_lock = c_strm->grp_lock` so the audio stream port shares the stream's group lock.
- `pjmedia/src/pjmedia/stream.c` 2594–2598 — `pjmedia_stream_destroy()` is just `pj_grp_lock_dec_ref(c_strm->grp_lock)`.

## Verification

- `make` proceeds past `pjsua.h` parsing without warnings or errors. (Local build environment hits an unrelated `sip_auth_aka.c` `f1` link issue, unrelated to this change.)

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the `\warning` text reads naturally alongside the existing prose on each of the three sites and doesn't conflict with the existing `Note:` recommendation on `on_stream_created` to prefer `on_stream_created2`.
- [ ] Companion docs guide (pjproject_docs#56) merges so the cross-reference target is live.

Co-Authored-By: Claude Code