### PR TITLE
Add PJSIP_INV_ABSORB_RETRANS_AFTER_ACK macro to opt out of #4765

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1560,7 +1560,7 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #   define PJSIP_INV_ACCEPT_UNKNOWN_BODY    PJ_FALSE
 #endif
 
-/** 
+/**
  * Specify whether to check if UPDATE sent in EARLY state has already
  * completed SDP negotiation using reliable provisional responses, as
  * specified in RFC3311 section 5.1.
@@ -1572,6 +1572,23 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  */
 #ifndef PJSIP_INV_UPDATE_EARLY_CHECK_RELIABLE
 #   define PJSIP_INV_UPDATE_EARLY_CHECK_RELIABLE    0
+#endif
+
+/**
+ * Specify whether to absorb INVITE request retransmissions arriving after
+ * an ACK has been received for a 2xx response. When enabled (default), the
+ * INVITE transaction termination is delayed for about 64*T1 (~32 seconds)
+ * so retransmitted INVITEs are matched to the existing transaction and
+ * silently dropped, rather than being treated as new requests.
+ *
+ * Set this to 0 to revert to the legacy behavior, where the INVITE
+ * transaction is terminated immediately after ACK and any subsequent
+ * retransmission is treated as a new request. See also \pr{4765}.
+ *
+ * Default: 1 (enabled)
+ */
+#ifndef PJSIP_INV_ABSORB_RETRANS_AFTER_ACK
+#   define PJSIP_INV_ABSORB_RETRANS_AFTER_ACK   1
 #endif
 
 /**

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -1577,9 +1577,10 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 /**
  * Specify whether to absorb INVITE request retransmissions arriving after
  * an ACK has been received for a 2xx response. When enabled (default), the
- * INVITE transaction termination is delayed for about 64*T1 (~32 seconds)
- * so retransmitted INVITEs are matched to the existing transaction and
- * silently dropped, rather than being treated as new requests.
+ * INVITE transaction termination is delayed for about ~32 seconds
+ * (configurable via pjsip_cfg()->tsx.td) so retransmitted INVITEs are
+ * matched to the existing transaction and answered by the cached 2xx
+ * retransmission, rather than being treated as new requests.
  *
  * Set this to 0 to revert to the legacy behavior, where the INVITE
  * transaction is terminated immediately after ACK and any subsequent

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -763,6 +763,7 @@ static pj_bool_t mod_inv_on_rx_request(pjsip_rx_data *rdata)
 
             /* Now we can terminate the INVITE transaction */
             if (inv->invite_tsx->status_code/100 == 2) {
+#if PJSIP_INV_ABSORB_RETRANS_AFTER_ACK
                 /* Stop retransmissions of 200 response */
                 pjsip_tsx_stop_retransmit(inv->invite_tsx);
 
@@ -774,6 +775,10 @@ static pj_bool_t mod_inv_on_rx_request(pjsip_rx_data *rdata)
                                            inv->invite_tsx->status_code,
                                            NULL,
                                            pjsip_cfg()->tsx.td);
+#else
+                pjsip_tsx_terminate(inv->invite_tsx,
+                                    inv->invite_tsx->status_code);
+#endif
             } else {
                 /* If the response was not 2xx, the ACK is considered part of
                  * the INVITE transaction, so should have been handled by

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -3718,19 +3718,22 @@ static pj_status_t tsx_on_state_completed_uas( pjsip_transaction *tsx,
             tsx_cancel_timer( tsx, &tsx->timeout_timer );
 
             /* Schedule tsx termination */
+#if PJSIP_INV_ABSORB_RETRANS_AFTER_ACK
             if (tsx->status_code/100 == 2) {
                 /* Normally 2xx response is handled by TU (not considered
                  * part of the INVITE tsx), anyway if it comes here, let's
                  * delay the tsx termination to absorb INVITE retransmission
                  * for about 64*T1 (~32 seconds). See also #4765.
                  */
-                timeout = td_timer_val; 
-            } else {
+                timeout = td_timer_val;
+            } else
+#endif
+            {
                 /* Timer I is T4 timer for unreliable transports, and
                  * zero seconds for reliable transports.
                  */
                 if (tsx->is_reliable) {
-                    timeout.sec = 0; 
+                    timeout.sec = 0;
                     timeout.msec = 0;
                 } else {
                     timeout.sec = t4_timer_val.sec;


### PR DESCRIPTION
## Summary
- Adds compile-time macro `PJSIP_INV_ABSORB_RETRANS_AFTER_ACK` (default `1`) in `pjsip/include/pjsip/sip_config.h` to opt out of the delayed-termination behavior introduced by #4765.
- When set to `0`, the UAS INVITE transaction terminates immediately after ACK (legacy behavior) instead of being delayed by `pjsip_cfg()->tsx.td` (~32 s, default) to absorb INVITE retransmissions.
- Guards both code paths affected by the delay: the async `pjsip_tsx_terminate_async2` call in `sip_inv.c` and the 2xx branch using `td_timer_val` in `tsx_on_state_completed_uas` (`sip_transaction.c`).
- The same-branch-different-CSeq → 400 Bad Request handling in `mod_tsx_layer_on_rx_request` remains unconditional and is not affected by this macro.

## Test plan
- [x] Build with default config (`PJSIP_INV_ABSORB_RETRANS_AFTER_ACK=1`) — CI matrix passing, no regressions vs master.
- [x] Build with `-DPJSIP_INV_ABSORB_RETRANS_AFTER_ACK=0` locally — clean build, legacy 2xx-INVITE termination path restored.
- [x] Ran `tests/pjsua/scripts-sipp/uac-inv-retrans-after-ack.xml` locally with the macro disabled (`=0`) — fails as expected ("At least one call failed"), confirming the legacy path no longer absorbs the post-ACK INVITE retransmission.
- [x] Default-config (`=1`) still passes the same scenario via existing CI coverage.

Co-Authored-By: Claude Code