### PR TITLE
Account-scoped server affinity for TCP/TLS (#4964)

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -75,9 +75,8 @@ static void usage(void)
             PJSUA_REG_RETRY_INTERVAL);
     puts  ("  --reg-use-proxy=N   Control the use of proxy settings in REGISTER.");
     puts  ("                      0=no proxy, 1=outbound only, 2=acc only, 3=all (default)");
-    puts  ("  --server-affinity[=on|strict|off]  Pin same SIP server across requests");
-    puts  ("                      on:auto-refresh on DNS change (default), strict:no");
-    puts  ("                      auto-refresh, off:disable. See pjproject issue #4964.");
+    puts  ("  --server-affinity[=on|off]  Pin same SIP server across requests");
+    puts  ("                      (TCP/TLS only in this version). See issue #4964.");
     puts  ("  --publish           Send presence PUBLISH for this account");
     puts  ("  --mwi               Subscribe to message summary/waiting indication");
     puts  ("  --use-ims           Enable 3GPP/IMS related settings on this account");
@@ -1626,7 +1625,7 @@ static pj_status_t parse_args(int argc, char *argv[],
 
         case OPT_SERVER_AFFINITY:
             /* --server-affinity            : enable
-             * --server-affinity=strict     : enable + strict
+             * --server-affinity=on         : enable (same as no value)
              * --server-affinity=off        : disable explicitly
              *
              * Sets both the current account's tristate AND the global
@@ -1639,17 +1638,13 @@ static pj_status_t parse_args(int argc, char *argv[],
             {
                 cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_ENABLED;
                 cfg->cfg.acc_server_affinity_default = PJ_TRUE;
-            } else if (pj_ansi_stricmp(pj_optarg, "strict") == 0) {
-                cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_ENABLED;
-                cur_acc->server_affinity_strict = PJSUA_SERVER_AFFINITY_ENABLED;
-                cfg->cfg.acc_server_affinity_default = PJ_TRUE;
             } else if (pj_ansi_stricmp(pj_optarg, "off") == 0) {
                 cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_DISABLED;
                 cfg->cfg.acc_server_affinity_default = PJ_FALSE;
             } else {
                 PJ_LOG(1, (THIS_FILE,
                            "Error: invalid --server-affinity value '%s'; "
-                           "expected 'on', 'strict', or 'off'", pj_optarg));
+                           "expected 'on' or 'off'", pj_optarg));
                 return PJ_EINVAL;
             }
             break;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1628,16 +1628,24 @@ static pj_status_t parse_args(int argc, char *argv[],
             /* --server-affinity            : enable
              * --server-affinity=strict     : enable + strict
              * --server-affinity=off        : disable explicitly
+             *
+             * Sets both the current account's tristate AND the global
+             * default (pjsua_config.acc_server_affinity_default) so any
+             * account added later (at startup via --next-account or at
+             * runtime via the +a CLI command) inherits the same setting.
              */
             if (pj_optarg == NULL ||
                 pj_ansi_stricmp(pj_optarg, "on") == 0)
             {
                 cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_ENABLED;
+                cfg->cfg.acc_server_affinity_default = PJ_TRUE;
             } else if (pj_ansi_stricmp(pj_optarg, "strict") == 0) {
                 cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_ENABLED;
                 cur_acc->server_affinity_strict = PJSUA_SERVER_AFFINITY_ENABLED;
+                cfg->cfg.acc_server_affinity_default = PJ_TRUE;
             } else if (pj_ansi_stricmp(pj_optarg, "off") == 0) {
                 cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_DISABLED;
+                cfg->cfg.acc_server_affinity_default = PJ_FALSE;
             } else {
                 PJ_LOG(1, (THIS_FILE,
                            "Error: invalid --server-affinity value '%s'; "

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -75,6 +75,9 @@ static void usage(void)
             PJSUA_REG_RETRY_INTERVAL);
     puts  ("  --reg-use-proxy=N   Control the use of proxy settings in REGISTER.");
     puts  ("                      0=no proxy, 1=outbound only, 2=acc only, 3=all (default)");
+    puts  ("  --server-affinity[=on|strict|off]  Pin same SIP server across requests");
+    puts  ("                      on:auto-refresh on DNS change (default), strict:no");
+    puts  ("                      auto-refresh, off:disable. See pjproject issue #4964.");
     puts  ("  --publish           Send presence PUBLISH for this account");
     puts  ("  --mwi               Subscribe to message summary/waiting indication");
     puts  ("  --use-ims           Enable 3GPP/IMS related settings on this account");
@@ -428,7 +431,8 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_VIDEO, OPT_TEXT, OPT_TEXT_RED, OPT_EXTRA_AUDIO,
            OPT_VCAPTURE_DEV, OPT_VRENDER_DEV, OPT_PLAY_AVI, OPT_AUTO_PLAY_AVI,
            OPT_REC_AVI, OPT_REC_AVI_SIZE, OPT_REC_AVI_AUDIO, OPT_AUTO_REC_AVI,
-           OPT_USE_CLI, OPT_CLI_TELNET_PORT, OPT_DISABLE_CLI_CONSOLE
+           OPT_USE_CLI, OPT_CLI_TELNET_PORT, OPT_DISABLE_CLI_CONSOLE,
+           OPT_SERVER_AFFINITY
 #if !PJSUA_MEDIA_HAS_PJMEDIA
            , OPT_CUSTOM_SDP
 #endif
@@ -588,6 +592,7 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "use-cli",    0, 0, OPT_USE_CLI},
         { "cli-telnet-port", 1, 0, OPT_CLI_TELNET_PORT},
         { "no-cli-console", 0, 0, OPT_DISABLE_CLI_CONSOLE},
+        { "server-affinity", 2, 0, OPT_SERVER_AFFINITY},
 #if !PJSUA_MEDIA_HAS_PJMEDIA
         { "custom-sdp",     1, 0, OPT_CUSTOM_SDP},
 #endif
@@ -1617,6 +1622,28 @@ static pj_status_t parse_args(int argc, char *argv[],
 
         case OPT_DISABLE_CLI_CONSOLE:
             cfg->cli_cfg.cli_fe &= (~CLI_FE_CONSOLE);
+            break;
+
+        case OPT_SERVER_AFFINITY:
+            /* --server-affinity            : enable
+             * --server-affinity=strict     : enable + strict
+             * --server-affinity=off        : disable explicitly
+             */
+            if (pj_optarg == NULL ||
+                pj_ansi_stricmp(pj_optarg, "on") == 0)
+            {
+                cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_ENABLED;
+            } else if (pj_ansi_stricmp(pj_optarg, "strict") == 0) {
+                cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_ENABLED;
+                cur_acc->server_affinity_strict = PJSUA_SERVER_AFFINITY_ENABLED;
+            } else if (pj_ansi_stricmp(pj_optarg, "off") == 0) {
+                cur_acc->server_affinity = PJSUA_SERVER_AFFINITY_DISABLED;
+            } else {
+                PJ_LOG(1, (THIS_FILE,
+                           "Error: invalid --server-affinity value '%s'; "
+                           "expected 'on', 'strict', or 'off'", pj_optarg));
+                return PJ_EINVAL;
+            }
             break;
 
 #if !PJSUA_MEDIA_HAS_PJMEDIA

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -1028,3 +1028,10 @@ typedef enum pjsua_sip_siprec_use
     PJSUA_SIP_SIPREC_MANDATORY,
 } pjsua_sip_siprec_use;
 
+typedef enum pjsua_server_affinity_mode
+{
+    PJSUA_SERVER_AFFINITY_UNSPECIFIED = 0,
+    PJSUA_SERVER_AFFINITY_DISABLED,
+    PJSUA_SERVER_AFFINITY_ENABLED
+} pjsua_server_affinity_mode;
+

--- a/pjsip-apps/src/swig/symbols.lst
+++ b/pjsip-apps/src/swig/symbols.lst
@@ -44,4 +44,4 @@ pjsip-simple/rpid.h             pjrpid_activity
 
 pjsip-ua/sip_inv.h              pjsip_inv_state
 
-pjsua-lib/pjsua.h               pjsua_invalid_id_const_ pjsua_state pjsua_stun_use pjsua_upnp_use pjsua_call_hold_type pjsua_acc_id pjsua_destroy_flag pjsua_100rel_use pjsua_sip_timer_use pjsua_ipv6_use pjsua_nat64_opt pjsua_buddy_status pjsua_call_media_status pjsua_vid_win_id pjsua_call_id pjsua_med_tp_st pjsua_call_vid_strm_op pjsua_vid_req_keyframe_method pjsua_call_flag pjsua_create_media_transport_flag pjsua_snd_dev_id pjsua_snd_dev_mode pjsua_ip_change_op pjsua_dtmf_method pjsua_sip_siprec_use
+pjsua-lib/pjsua.h               pjsua_invalid_id_const_ pjsua_state pjsua_stun_use pjsua_upnp_use pjsua_call_hold_type pjsua_acc_id pjsua_destroy_flag pjsua_100rel_use pjsua_sip_timer_use pjsua_ipv6_use pjsua_nat64_opt pjsua_buddy_status pjsua_call_media_status pjsua_vid_win_id pjsua_call_id pjsua_med_tp_st pjsua_call_vid_strm_op pjsua_vid_req_keyframe_method pjsua_call_flag pjsua_create_media_transport_flag pjsua_snd_dev_id pjsua_snd_dev_mode pjsua_ip_change_op pjsua_dtmf_method pjsua_sip_siprec_use pjsua_server_affinity_mode

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4771,10 +4771,15 @@ typedef struct pjsua_acc_config
      * next-hop server (address + transport) and reuses it across
      * subsequent same-account requests, instead of re-selecting on every
      * DNS resolution. For TLS, this skips the per-request CVE-2020-15260
-     * hostname check on reuse — trust is asserted at handshake.
+     * hostname check on reuse: trust is asserted at handshake.
      *
-     * See https://github.com/pjsip/pjproject/issues/4964 for the design
-     * (motivation, trust model, lifecycle).
+     * Current scope: this version pins TCP/TLS connections (which solves
+     * the marquee SRV flip-flop and TLS connection-coalescing cases).
+     * UDP destination-pinning and DNS-driven auto-refresh are tracked as
+     * follow-up work; for UDP the address is stored but the per-request
+     * destination is not yet constrained.
+     *
+     * See \issue{4964} for the design (motivation, trust model, lifecycle).
      *
      * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (inherit from
      * pjsua_config.acc_server_affinity_default).
@@ -4786,7 +4791,11 @@ typedef struct pjsua_acc_config
      * resolution stops returning the cached address. When DISABLED, the
      * affinity auto-refreshes from the current resolved set.
      *
-     * Only meaningful when server_affinity is effectively enabled.
+     * Only meaningful when server_affinity is effectively enabled. Note
+     * that auto-refresh on DNS change is deferred to a follow-up; in the
+     * current version the pin clears on transport disconnect, IP change,
+     * acc_modify next-hop change, or explicit
+     * #pjsua_acc_refresh_transport().
      *
      * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (treated as DISABLED).
      */

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -409,15 +409,8 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 
 
 /**
- * Default value for account-scoped server affinity (see
- * pjsua_acc_config.server_affinity). When enabled, an account pins the
- * resolved next-hop server (address + transport) on first REGISTER and
- * reuses it for subsequent same-account requests as long as the cached
- * address is still returned by DNS resolution.
- *
- * Note: when enabled for TLS, the per-request CVE-2020-15260 hostname
- * check is skipped on transport reuse. See doxygen on
- * pjsua_acc_config.server_affinity for the trust-model implications.
+ * Default value for account-scoped server affinity. See
+ * #pjsua_acc_config.server_affinity for details.
  *
  * Default: 0 (disabled)
  */
@@ -4774,33 +4767,14 @@ typedef struct pjsua_acc_config
     pjsua_ipv6_use              ipv6_media_use;
 
     /**
-     * Server affinity. When enabled, the account pins the resolved next-hop
-     * server (address + transport) on first REGISTER and reuses it for
-     * subsequent same-account requests, as long as the cached address is
-     * still in the DNS result set.
+     * Server affinity. When enabled, the account pins the resolved
+     * next-hop server (address + transport) and reuses it across
+     * subsequent same-account requests, instead of re-selecting on every
+     * DNS resolution. For TLS, this skips the per-request CVE-2020-15260
+     * hostname check on reuse — trust is asserted at handshake.
      *
-     * Motivation: pjsip's resolver re-runs RFC 2782 weighted-random server
-     * selection on every resolution call, so DNS/SRV-balanced clusters can
-     * see same-account requests land on different backends even when the
-     * underlying records are TTL-cached. Server affinity stops that
-     * flip-flop.
-     *
-     * Trust model (TLS): when enabled for a TLS account, the per-request
-     * destination hostname check (CVE-2020-15260) is skipped on transport
-     * reuse — trust is asserted at handshake instead. Multi-tenant TLS
-     * servers that host unrelated security domains on the same connection
-     * require those domains to use separate accounts. Do not enable on
-     * accounts that share a TLS server with unrelated security domains.
-     *
-     * Lifecycle: the pin is captured on REGISTER (initial or refresh) when
-     * empty, or set explicitly via #pjsua_acc_set_affinity_addr(). It is
-     * cleared automatically on transport disconnect, IP change, account
-     * destroy, or when pjsua_acc_modify() changes proxy[0]/reg_uri/
-     * transport_id. Apps can clear it explicitly via
-     * #pjsua_acc_refresh_transport().
-     *
-     * For TCP/UDP, the feature is purely a connection/DNS-cache
-     * optimization with the same trust posture as today.
+     * See https://github.com/pjsip/pjproject/issues/4964 for the design
+     * (motivation, trust model, lifecycle).
      *
      * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (inherit from
      * pjsua_config.acc_server_affinity_default).
@@ -4808,15 +4782,13 @@ typedef struct pjsua_acc_config
     pjsua_server_affinity_mode  server_affinity;
 
     /**
-     * Strict server affinity. When set to ENABLED, the cached pin is held
-     * even if DNS resolution stops returning the cached address. When
-     * DISABLED, the affinity auto-refreshes by selecting a new address
-     * from the current resolved set.
+     * Strict server affinity. When ENABLED, the pin is held even if DNS
+     * resolution stops returning the cached address. When DISABLED, the
+     * affinity auto-refreshes from the current resolved set.
      *
      * Only meaningful when server_affinity is effectively enabled.
      *
-     * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (treated as DISABLED —
-     * auto-refresh on DNS change).
+     * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (treated as DISABLED).
      */
     pjsua_server_affinity_mode  server_affinity_strict;
 
@@ -5740,16 +5712,13 @@ PJ_DECL(pj_status_t) pjsua_acc_set_transport(pjsua_acc_id acc_id,
 
 /**
  * Discard the account's cached server-affinity state (address and
- * transport reference). The next REGISTER from this account will
- * perform fresh resolution and may pin to a different server.
+ * transport ref). The next REGISTER will perform fresh resolution.
+ * Existing dialogs/calls hold their own transport refs and are
+ * unaffected. No-op if server affinity is disabled for the account.
  *
- * Existing dialogs/calls keep their own transport references and are
- * not affected by this call.
- *
- * Has no effect if server affinity is disabled for the account.
+ * See #pjsua_acc_config.server_affinity.
  *
  * @param acc_id        The account ID.
- *
  * @return              PJ_SUCCESS on success.
  */
 PJ_DECL(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id);
@@ -5757,23 +5726,14 @@ PJ_DECL(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id);
 
 /**
  * Pin the account's server affinity to a specific remote address.
- * Subsequent outgoing requests resolve the account's next-hop URI,
- * verify this address is still in the result set, and reuse the
- * matching transport (created on first send if no existing one
- * matches). Auto-refresh on DNS change applies the same as auto-pin
- * unless the account is in strict mode.
+ * Useful for accounts that don't register (auto-capture on REGISTER
+ * doesn't apply) or to override the address REGISTER would otherwise
+ * pick. Server affinity must be enabled on the account.
  *
- * For accounts that don't register, this is the way to enable affinity
- * (auto-capture on REGISTER doesn't apply). For registering accounts,
- * this overrides the address that REGISTER would otherwise pick on the
- * next refresh cycle.
- *
- * Server affinity must be enabled for the account; otherwise this
- * returns an error.
+ * See #pjsua_acc_config.server_affinity.
  *
  * @param acc_id        The account ID.
  * @param addr          The remote address to pin to. Must not be NULL.
- *
  * @return              PJ_SUCCESS on success.
  */
 PJ_DECL(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -5722,13 +5722,26 @@ PJ_DECL(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id);
  * Pin the account's server affinity to a specific remote address.
  * Useful for accounts that don't register (auto-capture on REGISTER
  * doesn't apply) or to override the address REGISTER would otherwise
- * pick. Server affinity must be enabled on the account.
+ * pick.
+ *
+ * The transport is materialized eagerly via
+ * #pjsip_endpt_acquire_transport using the account's tp_type and the
+ * next-hop URI hostname (proxy[0] preferred, else reg_uri) for SNI /
+ * cert validation on TLS. On failure to materialize the transport,
+ * the call is a no-op and the existing pin (if any) is preserved.
+ *
+ * Returns PJ_EINVALIDOP if server affinity is not enabled on the
+ * account, or if pjsua_acc_config.transport_id is set (transport_id
+ * already expresses pinning, and affinity is bypassed in that case).
  *
  * See #pjsua_acc_config.server_affinity.
  *
  * @param acc_id        The account ID.
  * @param addr          The remote address to pin to. Must not be NULL.
- * @return              PJ_SUCCESS on success.
+ * @return              PJ_SUCCESS when the pin is established;
+ *                      PJ_EINVALIDOP if affinity is disabled or
+ *                      transport_id is set; otherwise the underlying
+ *                      transport-acquisition error.
  */
 PJ_DECL(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
                                                  const pj_sockaddr *addr);

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -409,6 +409,24 @@ typedef struct pj_stun_resolve_result pj_stun_resolve_result;
 
 
 /**
+ * Default value for account-scoped server affinity (see
+ * pjsua_acc_config.server_affinity). When enabled, an account pins the
+ * resolved next-hop server (address + transport) on first REGISTER and
+ * reuses it for subsequent same-account requests as long as the cached
+ * address is still returned by DNS resolution.
+ *
+ * Note: when enabled for TLS, the per-request CVE-2020-15260 hostname
+ * check is skipped on transport reuse. See doxygen on
+ * pjsua_acc_config.server_affinity for the trust-model implications.
+ *
+ * Default: 0 (disabled)
+ */
+#ifndef PJSUA_ACC_SERVER_AFFINITY_DEFAULT
+#   define PJSUA_ACC_SERVER_AFFINITY_DEFAULT    0
+#endif
+
+
+/**
  * Specify whether pjsua should disable automatically sending initial
  * answer 100/Trying for incoming calls. If disabled, application can
  * later send 100/Trying if it wishes using pjsua_call_answer().
@@ -2741,6 +2759,15 @@ typedef struct pjsua_config
      */
     pj_bool_t        no_refer_sub;
 
+    /**
+     * Default value for pjsua_acc_config.server_affinity. New accounts
+     * with server_affinity set to PJSUA_SERVER_AFFINITY_UNSPECIFIED will
+     * inherit this value.
+     *
+     * Default: PJSUA_ACC_SERVER_AFFINITY_DEFAULT
+     */
+    pj_bool_t        acc_server_affinity_default;
+
 } pjsua_config;
 
 
@@ -4186,6 +4213,31 @@ typedef enum pjsua_ipv6_use
 } pjsua_ipv6_use;
 
 /**
+ * Specify how server affinity is configured per account. Tristate so that
+ * pjsua_acc_modify() can leave the inherited setting intact by passing
+ * PJSUA_SERVER_AFFINITY_UNSPECIFIED. UNSPECIFIED falls back to the global
+ * pjsua_config.acc_server_affinity_default.
+ */
+typedef enum pjsua_server_affinity_mode
+{
+    /**
+     * Inherit from pjsua_config.acc_server_affinity_default.
+     */
+    PJSUA_SERVER_AFFINITY_UNSPECIFIED = 0,
+
+    /**
+     * Server affinity disabled.
+     */
+    PJSUA_SERVER_AFFINITY_DISABLED,
+
+    /**
+     * Server affinity enabled.
+     */
+    PJSUA_SERVER_AFFINITY_ENABLED
+
+} pjsua_server_affinity_mode;
+
+/**
  * Specify NAT64 options to be used in account config.
  */
 typedef enum pjsua_nat64_opt
@@ -4720,6 +4772,53 @@ typedef struct pjsua_acc_config
      * Outgoing offer will prefer to use IPv4)
      */
     pjsua_ipv6_use              ipv6_media_use;
+
+    /**
+     * Server affinity. When enabled, the account pins the resolved next-hop
+     * server (address + transport) on first REGISTER and reuses it for
+     * subsequent same-account requests, as long as the cached address is
+     * still in the DNS result set.
+     *
+     * Motivation: pjsip's resolver re-runs RFC 2782 weighted-random server
+     * selection on every resolution call, so DNS/SRV-balanced clusters can
+     * see same-account requests land on different backends even when the
+     * underlying records are TTL-cached. Server affinity stops that
+     * flip-flop.
+     *
+     * Trust model (TLS): when enabled for a TLS account, the per-request
+     * destination hostname check (CVE-2020-15260) is skipped on transport
+     * reuse — trust is asserted at handshake instead. Multi-tenant TLS
+     * servers that host unrelated security domains on the same connection
+     * require those domains to use separate accounts. Do not enable on
+     * accounts that share a TLS server with unrelated security domains.
+     *
+     * Lifecycle: the pin is captured on REGISTER (initial or refresh) when
+     * empty, or set explicitly via #pjsua_acc_set_affinity_addr(). It is
+     * cleared automatically on transport disconnect, IP change, account
+     * destroy, or when pjsua_acc_modify() changes proxy[0]/reg_uri/
+     * transport_id. Apps can clear it explicitly via
+     * #pjsua_acc_refresh_transport().
+     *
+     * For TCP/UDP, the feature is purely a connection/DNS-cache
+     * optimization with the same trust posture as today.
+     *
+     * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (inherit from
+     * pjsua_config.acc_server_affinity_default).
+     */
+    pjsua_server_affinity_mode  server_affinity;
+
+    /**
+     * Strict server affinity. When set to ENABLED, the cached pin is held
+     * even if DNS resolution stops returning the cached address. When
+     * DISABLED, the affinity auto-refreshes by selecting a new address
+     * from the current resolved set.
+     *
+     * Only meaningful when server_affinity is effectively enabled.
+     *
+     * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (treated as DISABLED —
+     * auto-refresh on DNS change).
+     */
+    pjsua_server_affinity_mode  server_affinity_strict;
 
     /**
      * Control the use of STUN for the SIP signaling.
@@ -5637,6 +5736,48 @@ PJ_DECL(pj_status_t) pjsua_acc_create_uas_contact( pj_pool_t *pool,
  */
 PJ_DECL(pj_status_t) pjsua_acc_set_transport(pjsua_acc_id acc_id,
                                              pjsua_transport_id tp_id);
+
+
+/**
+ * Discard the account's cached server-affinity state (address and
+ * transport reference). The next REGISTER from this account will
+ * perform fresh resolution and may pin to a different server.
+ *
+ * Existing dialogs/calls keep their own transport references and are
+ * not affected by this call.
+ *
+ * Has no effect if server affinity is disabled for the account.
+ *
+ * @param acc_id        The account ID.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id);
+
+
+/**
+ * Pin the account's server affinity to a specific remote address.
+ * Subsequent outgoing requests resolve the account's next-hop URI,
+ * verify this address is still in the result set, and reuse the
+ * matching transport (created on first send if no existing one
+ * matches). Auto-refresh on DNS change applies the same as auto-pin
+ * unless the account is in strict mode.
+ *
+ * For accounts that don't register, this is the way to enable affinity
+ * (auto-capture on REGISTER doesn't apply). For registering accounts,
+ * this overrides the address that REGISTER would otherwise pick on the
+ * next refresh cycle.
+ *
+ * Server affinity must be enabled for the account; otherwise this
+ * returns an error.
+ *
+ * @param acc_id        The account ID.
+ * @param addr          The remote address to pin to. Must not be NULL.
+ *
+ * @return              PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
+                                                 const pj_sockaddr *addr);
 
 
 /**

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4787,21 +4787,6 @@ typedef struct pjsua_acc_config
     pjsua_server_affinity_mode  server_affinity;
 
     /**
-     * Strict server affinity. When ENABLED, the pin is held even if DNS
-     * resolution stops returning the cached address. When DISABLED, the
-     * affinity auto-refreshes from the current resolved set.
-     *
-     * Only meaningful when server_affinity is effectively enabled. Note
-     * that auto-refresh on DNS change is deferred to a follow-up; in the
-     * current version the pin clears on transport disconnect, IP change,
-     * acc_modify next-hop change, or explicit
-     * #pjsua_acc_refresh_transport().
-     *
-     * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (treated as DISABLED).
-     */
-    pjsua_server_affinity_mode  server_affinity_strict;
-
-    /**
      * Control the use of STUN for the SIP signaling.
      *
      * Default: PJSUA_STUN_USE_DEFAULT

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -326,7 +326,6 @@ typedef struct pjsua_acc
      * randomness in pjlib-util/srv_resolver.c.
      */
     pj_bool_t        sa_enabled;    /**< Effective enabled flag.         */
-    pj_bool_t        sa_strict;     /**< Effective strict flag.          */
     pj_sockaddr      sa_next_hop_addr; /**< Cached resolved address.     */
     pjsip_transport *sa_next_hop_tp;   /**< Cached transport (ref'd).
                                             NULL until first send after

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -320,6 +320,18 @@ typedef struct pjsua_acc
     pj_sockaddr      ka_target;     /**< Destination address for K-A    */
     unsigned         ka_target_len; /**< Length of ka_target.           */
 
+    /* Account-scoped server affinity (issue #4964). Pins the resolved
+     * next-hop on REGISTER (or via pjsua_acc_set_affinity_addr) so that
+     * subsequent same-account requests bypass the SRV/DNS server-election
+     * randomness in pjlib-util/srv_resolver.c.
+     */
+    pj_bool_t        sa_enabled;    /**< Effective enabled flag.         */
+    pj_bool_t        sa_strict;     /**< Effective strict flag.          */
+    pj_sockaddr      sa_next_hop_addr; /**< Cached resolved address.     */
+    pjsip_transport *sa_next_hop_tp;   /**< Cached transport (ref'd).
+                                            NULL until first send after
+                                            an explicit-address pin.    */
+
     pjsip_route_hdr  route_set;     /**< Complete route set inc. outbnd.*/
     pj_uint32_t      global_route_crc; /** CRC of global route setting. */
     pj_uint32_t      local_route_crc;  /** CRC of account route setting.*/

--- a/pjsip/include/pjsua2/account.hpp
+++ b/pjsip/include/pjsua2/account.hpp
@@ -299,6 +299,17 @@ struct AccountSipConfig : public PersistentObject
     pjsua_ipv6_use      ipv6Use;
 
     /**
+     * Server affinity. When enabled, the account pins the resolved
+     * next-hop server (address + transport) and reuses it across
+     * subsequent same-account requests. See \issue{4964} for the
+     * design (motivation, trust model, lifecycle).
+     *
+     * Default: PJSUA_SERVER_AFFINITY_UNSPECIFIED (inherit from
+     * UaConfig::accServerAffinityDefault).
+     */
+    pjsua_server_affinity_mode serverAffinity;
+
+    /**
      * Use a shared authorization session within this account.
      * This will use the accounts credentials on outgoing requests,
      * so that less 401/407 Responses will be returned.
@@ -2370,6 +2381,35 @@ public:
      * @param tp_id             The transport ID.
      */
     void setTransport(TransportId tp_id) PJSUA2_THROW(Error);
+
+    /**
+     * Discard the account's cached server-affinity state (address +
+     * transport reference). The next REGISTER refresh re-pins. Existing
+     * dialogs/calls keep their own transport refs and are unaffected.
+     * No-op if server affinity is disabled for the account.
+     *
+     * See AccountSipConfig::serverAffinity, \issue{4964}.
+     */
+    void refreshTransport() PJSUA2_THROW(Error);
+
+    /**
+     * Pin the account's server affinity to a specific remote address.
+     * Useful for accounts that don't register, or to override the
+     * address REGISTER would otherwise pick. The transport is
+     * materialized eagerly using the account's tp_type and the next-hop
+     * URI hostname for SNI / cert validation on TLS. On failure the
+     * existing pin (if any) is preserved.
+     *
+     * @param addr      The remote address (IPv4 or IPv6 with port) to
+     *                  pin to.
+     *
+     * @throws Error    PJ_EINVALIDOP if affinity is disabled or
+     *                  AccountSipConfig::transportId is set; otherwise
+     *                  the underlying transport-acquisition error.
+     *
+     * See AccountSipConfig::serverAffinity, \issue{4964}.
+     */
+    void setAffinityAddr(const SocketAddress &addr) PJSUA2_THROW(Error);
 
     /**
      * Send NOTIFY to inform account presence status or to terminate server

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1007,6 +1007,15 @@ struct UaConfig : public PersistentObject
      */
     bool                noRefersub;
 
+    /**
+     * Default value for AccountConfig::serverAffinity. New accounts with
+     * server_affinity set to PJSUA_SERVER_AFFINITY_UNSPECIFIED inherit
+     * this value.
+     *
+     * Default: PJSUA_ACC_SERVER_AFFINITY_DEFAULT
+     */
+    bool                accServerAffinityDefault;
+
 public:
     /**
      * Default constructor to initialize with default values.

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4534,6 +4534,11 @@ PJ_DEF(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id)
 
 /*
  * Pin the account's server affinity to a specific remote address (#4964).
+ *
+ * For TLS, the SNI hostname and peer cert validation use the hostname of
+ * the account's next-hop URI (proxy[0] preferred, else reg_uri) — the
+ * caller only supplies an address. This is the same trust model the
+ * auto-capture path inherits from REGISTER's normal resolution flow.
  */
 PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
                                                 const pj_sockaddr *addr)
@@ -4542,6 +4547,9 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
     int addr_len;
     pjsip_transport_type_e tp_type;
     pjsip_transport *tp = NULL;
+    pj_pool_t *tmp_pool = NULL;
+    pjsip_tx_data dummy_tdata;
+    pjsip_tx_data *tdata_ptr = NULL;
     pj_status_t status;
 
     PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id) && addr, PJ_EINVAL);
@@ -4568,14 +4576,55 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
     tp_type = (acc->tp_type != PJSIP_TRANSPORT_UNSPECIFIED) ? acc->tp_type
                                                             : PJSIP_TRANSPORT_UDP;
 
+    /* Build a dummy tdata carrying the next-hop hostname so the TLS
+     * factory can use it for SNI and CVE-2020-15260 cert validation at
+     * handshake. For TCP/UDP it's harmless extra info.
+     */
+    {
+        const pj_str_t *uri_str = NULL;
+
+        if (acc->cfg.proxy_cnt > 0)
+            uri_str = &acc->cfg.proxy[0];
+        else if (acc->cfg.reg_uri.slen)
+            uri_str = &acc->cfg.reg_uri;
+
+        if (uri_str && uri_str->slen) {
+            tmp_pool = pjsua_pool_create("tmpsa", 512, 256);
+            if (tmp_pool) {
+                pj_str_t tmp;
+                pjsip_uri *uri;
+
+                pj_strdup_with_null(tmp_pool, &tmp, uri_str);
+                uri = pjsip_parse_uri(tmp_pool, tmp.ptr, tmp.slen, 0);
+                if (uri) {
+                    pjsip_host_info dinfo;
+                    pj_status_t st = pjsip_get_dest_info(uri, NULL,
+                                                         tmp_pool, &dinfo);
+                    if (st == PJ_SUCCESS && dinfo.addr.host.slen) {
+                        pj_bzero(&dummy_tdata, sizeof(dummy_tdata));
+                        pj_strdup(tmp_pool, &dummy_tdata.dest_info.name,
+                                  &dinfo.addr.host);
+                        tdata_ptr = &dummy_tdata;
+                    }
+                }
+            }
+        }
+    }
+
     /* Try to materialize the transport now. For TCP/TLS this initiates
      * connection setup if not already cached; for UDP it returns the
      * shared listener. If acquire fails (e.g. no listener of this type),
      * we still store the address — sa_next_hop_tp will be filled later
      * when a REGISTER lands on this same address.
      */
-    status = pjsip_endpt_acquire_transport(pjsua_var.endpt, tp_type,
-                                           addr, addr_len, NULL, &tp);
+    if (tdata_ptr) {
+        status = pjsip_endpt_acquire_transport2(pjsua_var.endpt, tp_type,
+                                                addr, addr_len,
+                                                NULL, tdata_ptr, &tp);
+    } else {
+        status = pjsip_endpt_acquire_transport(pjsua_var.endpt, tp_type,
+                                               addr, addr_len, NULL, &tp);
+    }
 
     /* Drop any existing pin. */
     clear_sa_pin(acc);
@@ -4595,6 +4644,9 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
                      "REGISTER landing on this address",
                      acc->index));
     }
+
+    if (tmp_pool)
+        pj_pool_release(tmp_pool);
 
     PJSUA_UNLOCK();
     return PJ_SUCCESS;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2836,7 +2836,7 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
                         }
                         acc->sa_next_hop_tp = param->rdata->tp_info.transport;
                         pjsip_transport_add_ref(acc->sa_next_hop_tp);
-                        PJ_LOG(4,(THIS_FILE,
+                        PJ_LOG(3,(THIS_FILE,
                                   "Account %d: server affinity pinned "
                                   "to transport %s",
                                   acc->index,

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4566,6 +4566,14 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
         PJSUA_UNLOCK();
         return PJ_EINVALIDOP;
     }
+    /* If the account is locked to a specific transport_id, affinity is
+     * bypassed in pjsua_init_tpselector(); pinning here would be a silent
+     * no-op. Reject so the caller knows.
+     */
+    if (acc->cfg.transport_id != PJSUA_INVALID_ID) {
+        PJSUA_UNLOCK();
+        return PJ_EINVALIDOP;
+    }
 
     /* Determine the transport type from the account configuration.
      * Falls back to UDP when the account hasn't pinned a scheme.
@@ -4608,11 +4616,9 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
         }
     }
 
-    /* Try to materialize the transport now. For TCP/TLS this initiates
-     * connection setup if not already cached; for UDP it returns the
-     * shared listener. If acquire fails (e.g. no listener of this type),
-     * we still store the address; sa_next_hop_tp will be filled later
-     * when a REGISTER lands on this same address.
+    /* Try to materialize the transport BEFORE touching existing pin.
+     * On failure leave the account state untouched so a failed call is
+     * a no-op rather than dropping the prior pin.
      */
     if (tdata_ptr) {
         status = pjsip_endpt_acquire_transport2(pjsua_var.endpt, tp_type,
@@ -4623,30 +4629,31 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
                                                addr, addr_len, NULL, &tp);
     }
 
-    /* Drop any existing pin. */
-    clear_sa_pin(acc);
-
-    pj_memcpy(&acc->sa_next_hop_addr, addr, addr_len);
     if (status == PJ_SUCCESS && tp != NULL) {
-        /* acquire_transport already added a reference. */
+        /* Atomic swap: drop existing pin, install new pin.
+         * acquire_transport already added a reference to tp.
+         */
+        clear_sa_pin(acc);
+        pj_memcpy(&acc->sa_next_hop_addr, addr, addr_len);
         acc->sa_next_hop_tp = tp;
-        PJ_LOG(4,(THIS_FILE,
+        PJ_LOG(3,(THIS_FILE,
                   "Account %d: server affinity explicitly pinned via API "
                   "to transport %s",
                   acc->index, tp->obj_name));
     } else {
-        PJ_PERROR(3,(THIS_FILE, status,
-                     "Account %d: server affinity address stored but "
-                     "transport not yet materialized; will fill on next "
-                     "REGISTER landing on this address",
+        PJ_PERROR(2,(THIS_FILE, status,
+                     "Account %d: pjsua_acc_set_affinity_addr failed; "
+                     "existing pin (if any) is preserved",
                      acc->index));
+        if (status == PJ_SUCCESS)
+            status = PJ_ENOTFOUND;     /* tp was NULL but no error code */
     }
 
     if (tmp_pool)
         pj_pool_release(tmp_pool);
 
     PJSUA_UNLOCK();
-    return PJ_SUCCESS;
+    return status;
 }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2800,9 +2800,15 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
             update_keep_alive(acc, PJ_TRUE, param);
 
             /* Capture server-affinity pin from successful REGISTER (#4964).
-             * Empty-only: explicit pins from pjsua_acc_set_affinity_addr()
-             * are not overwritten. transport_id-pinned accounts skip this
-             * (affinity is bypassed when transport_id is set).
+             *
+             * Three cases:
+             *   1. Pin empty (no addr, no tp) → auto-capture both.
+             *   2. Pin has an explicit addr but no tp → fill tp only if
+             *      REGISTER landed on the same address.
+             *   3. Pin already has tp → no-op.
+             *
+             * Skip entirely when transport_id is set — affinity is
+             * bypassed there.
              */
             if (acc->sa_enabled &&
                 acc->sa_next_hop_tp == NULL &&
@@ -2812,13 +2818,22 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
                 pjsip_transaction *tsx = pjsip_rdata_get_tsx(param->rdata);
                 if (tsx && tsx->last_tx) {
                     pjsip_tx_data *req = tsx->last_tx;
+                    pj_bool_t addr_was_empty =
+                        !pj_sockaddr_has_addr(&acc->sa_next_hop_addr);
+                    pj_bool_t addr_matches = !addr_was_empty &&
+                        pj_sockaddr_cmp(&acc->sa_next_hop_addr,
+                                        &req->tp_info.dst_addr) == 0;
+
                     if (req->tp_info.dst_addr_len > 0 &&
                         req->tp_info.dst_addr_len <=
-                            (int)sizeof(acc->sa_next_hop_addr))
+                            (int)sizeof(acc->sa_next_hop_addr) &&
+                        (addr_was_empty || addr_matches))
                     {
-                        pj_memcpy(&acc->sa_next_hop_addr,
-                                  &req->tp_info.dst_addr,
-                                  req->tp_info.dst_addr_len);
+                        if (addr_was_empty) {
+                            pj_memcpy(&acc->sa_next_hop_addr,
+                                      &req->tp_info.dst_addr,
+                                      req->tp_info.dst_addr_len);
+                        }
                         acc->sa_next_hop_tp = param->rdata->tp_info.transport;
                         pjsip_transport_add_ref(acc->sa_next_hop_tp);
                         PJ_LOG(4,(THIS_FILE,
@@ -4525,6 +4540,9 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
 {
     pjsua_acc *acc;
     int addr_len;
+    pjsip_transport_type_e tp_type;
+    pjsip_transport *tp = NULL;
+    pj_status_t status;
 
     PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id) && addr, PJ_EINVAL);
 
@@ -4544,11 +4562,39 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
         return PJ_EINVALIDOP;
     }
 
-    /* Drop any existing pin (transport will be (re)created on first send). */
+    /* Determine the transport type from the account configuration.
+     * Falls back to UDP when the account hasn't pinned a scheme.
+     */
+    tp_type = (acc->tp_type != PJSIP_TRANSPORT_UNSPECIFIED) ? acc->tp_type
+                                                            : PJSIP_TRANSPORT_UDP;
+
+    /* Try to materialize the transport now. For TCP/TLS this initiates
+     * connection setup if not already cached; for UDP it returns the
+     * shared listener. If acquire fails (e.g. no listener of this type),
+     * we still store the address — sa_next_hop_tp will be filled later
+     * when a REGISTER lands on this same address.
+     */
+    status = pjsip_endpt_acquire_transport(pjsua_var.endpt, tp_type,
+                                           addr, addr_len, NULL, &tp);
+
+    /* Drop any existing pin. */
     clear_sa_pin(acc);
 
     pj_memcpy(&acc->sa_next_hop_addr, addr, addr_len);
-    /* sa_next_hop_tp stays NULL — filled in on first outgoing request. */
+    if (status == PJ_SUCCESS && tp != NULL) {
+        /* acquire_transport already added a reference. */
+        acc->sa_next_hop_tp = tp;
+        PJ_LOG(4,(THIS_FILE,
+                  "Account %d: server affinity explicitly pinned via API "
+                  "to transport %s",
+                  acc->index, tp->obj_name));
+    } else {
+        PJ_PERROR(3,(THIS_FILE, status,
+                     "Account %d: server affinity address stored but "
+                     "transport not yet materialized; will fill on next "
+                     "REGISTER landing on this address",
+                     acc->index));
+    }
 
     PJSUA_UNLOCK();
     return PJ_SUCCESS;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -547,17 +547,15 @@ static pj_bool_t resolve_sa_tristate(pjsua_server_affinity_mode mode,
     }
 }
 
-/* Recompute effective sa_enabled and sa_strict from config tristates plus
- * the global default. Called after add/modify to keep the cached effective
- * flags in sync with config.
+/* Recompute effective sa_enabled from the config tristate plus the
+ * global default. Called after add/modify to keep the cached effective
+ * flag in sync with config.
  */
 static void update_sa_effective_flags(pjsua_acc *acc)
 {
     acc->sa_enabled = resolve_sa_tristate(
         acc->cfg.server_affinity,
         pjsua_var.ua_cfg.acc_server_affinity_default);
-    acc->sa_strict = resolve_sa_tristate(
-        acc->cfg.server_affinity_strict, PJ_FALSE);
 }
 
 /* Drop cached pin state. Caller must hold PJSUA_LOCK. */
@@ -867,7 +865,6 @@ PJ_DEF(pj_status_t) pjsua_acc_del2(pjsua_acc_id acc_id,
     /* Clear server-affinity pin (#4964). */
     clear_sa_pin(acc);
     acc->sa_enabled = PJ_FALSE;
-    acc->sa_strict = PJ_FALSE;
 
     /* Cancel any re-registration timer */
     if (acc->auto_rereg.timer.id) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -532,6 +532,45 @@ static pj_status_t initialize_acc(unsigned acc_id)
 }
 
 
+/* Server affinity (#4964) helpers --------------------------------------- */
+
+/* Resolve tristate config field with fallback. UNSPECIFIED → fallback. */
+static pj_bool_t resolve_sa_tristate(pjsua_server_affinity_mode mode,
+                                     pj_bool_t fallback)
+{
+    switch (mode) {
+    case PJSUA_SERVER_AFFINITY_ENABLED:  return PJ_TRUE;
+    case PJSUA_SERVER_AFFINITY_DISABLED: return PJ_FALSE;
+    case PJSUA_SERVER_AFFINITY_UNSPECIFIED:
+    default:
+        return fallback;
+    }
+}
+
+/* Recompute effective sa_enabled and sa_strict from config tristates plus
+ * the global default. Called after add/modify to keep the cached effective
+ * flags in sync with config.
+ */
+static void update_sa_effective_flags(pjsua_acc *acc)
+{
+    acc->sa_enabled = resolve_sa_tristate(
+        acc->cfg.server_affinity,
+        pjsua_var.ua_cfg.acc_server_affinity_default);
+    acc->sa_strict = resolve_sa_tristate(
+        acc->cfg.server_affinity_strict, PJ_FALSE);
+}
+
+/* Drop cached pin state. Caller must hold PJSUA_LOCK. */
+static void clear_sa_pin(pjsua_acc *acc)
+{
+    if (acc->sa_next_hop_tp) {
+        pjsip_transport_dec_ref(acc->sa_next_hop_tp);
+        acc->sa_next_hop_tp = NULL;
+    }
+    pj_bzero(&acc->sa_next_hop_addr, sizeof(acc->sa_next_hop_addr));
+}
+
+
 /*
  * Add a new account to pjsua.
  */
@@ -621,6 +660,8 @@ PJ_DEF(pj_status_t) pjsua_acc_add( const pjsua_acc_config *cfg,
         pj_log_pop_indent();
         return status;
     }
+
+    update_sa_effective_flags(acc);
 
     if (is_default)
         pjsua_var.default_acc = id;
@@ -823,6 +864,11 @@ PJ_DEF(pj_status_t) pjsua_acc_del2(pjsua_acc_id acc_id,
         acc->ka_transport = NULL;
     }
 
+    /* Clear server-affinity pin (#4964). */
+    clear_sa_pin(acc);
+    acc->sa_enabled = PJ_FALSE;
+    acc->sa_strict = PJ_FALSE;
+
     /* Cancel any re-registration timer */
     if (acc->auto_rereg.timer.id) {
         acc->auto_rereg.timer.id = PJ_FALSE;
@@ -978,6 +1024,13 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     pj_bool_t unreg_first = PJ_FALSE;
     pj_bool_t update_mwi = PJ_FALSE;
     pj_status_t status = PJ_SUCCESS;
+    /* Server-affinity (#4964) snapshots — captured before config mutation
+     * so we can detect next-hop URI changes at the bottom of the function.
+     */
+    pj_bool_t   sa_old_enabled = PJ_FALSE;
+    int         sa_old_transport_id = PJSUA_INVALID_ID;
+    pj_uint32_t sa_old_local_route_crc = 0;
+    pj_str_t    sa_old_reg_uri = { NULL, 0 };
 
     PJ_ASSERT_RETURN(acc_id>=0 && acc_id<(int)PJ_ARRAY_SIZE(pjsua_var.acc),
                      PJ_EINVAL);
@@ -998,6 +1051,12 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         status = PJ_EINVAL;
         goto on_return;
     }
+
+    /* Snapshot routing-relevant fields BEFORE mutation (#4964). */
+    sa_old_enabled         = acc->sa_enabled;
+    sa_old_transport_id    = acc->cfg.transport_id;
+    sa_old_local_route_crc = acc->local_route_crc;
+    sa_old_reg_uri         = acc->cfg.reg_uri;
 
     /* == Validate first == */
 
@@ -1652,6 +1711,27 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     /* RTCP-FB config */
     pjmedia_rtcp_fb_setting_dup(acc->pool, &acc->cfg.rtcp_fb_cfg,
                                 &cfg->rtcp_fb_cfg);
+
+    /* Server affinity (#4964): refresh effective flags, then clear the
+     * cached pin if it's no longer valid — i.e. the feature got disabled,
+     * transport_id changed, or the next-hop URI (proxy[0] / reg_uri)
+     * changed. Other unrelated config edits leave the pin intact.
+     */
+    update_sa_effective_flags(acc);
+    if (sa_old_enabled && !acc->sa_enabled) {
+        clear_sa_pin(acc);
+    } else if (acc->sa_enabled) {
+        pj_bool_t next_hop_changed = PJ_FALSE;
+        if (acc->cfg.transport_id != sa_old_transport_id)
+            next_hop_changed = PJ_TRUE;
+        else if (acc->local_route_crc != sa_old_local_route_crc)
+            next_hop_changed = PJ_TRUE;
+        else if (pj_strcmp(&acc->cfg.reg_uri, &sa_old_reg_uri))
+            next_hop_changed = PJ_TRUE;
+
+        if (next_hop_changed)
+            clear_sa_pin(acc);
+    }
 
 on_return:
     PJSUA_UNLOCK();
@@ -2718,6 +2798,37 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 #endif
             /* Start keep-alive timer if necessary. */
             update_keep_alive(acc, PJ_TRUE, param);
+
+            /* Capture server-affinity pin from successful REGISTER (#4964).
+             * Empty-only: explicit pins from pjsua_acc_set_affinity_addr()
+             * are not overwritten. transport_id-pinned accounts skip this
+             * (affinity is bypassed when transport_id is set).
+             */
+            if (acc->sa_enabled &&
+                acc->sa_next_hop_tp == NULL &&
+                acc->cfg.transport_id == PJSUA_INVALID_ID &&
+                param->rdata && param->rdata->tp_info.transport)
+            {
+                pjsip_transaction *tsx = pjsip_rdata_get_tsx(param->rdata);
+                if (tsx && tsx->last_tx) {
+                    pjsip_tx_data *req = tsx->last_tx;
+                    if (req->tp_info.dst_addr_len > 0 &&
+                        req->tp_info.dst_addr_len <=
+                            (int)sizeof(acc->sa_next_hop_addr))
+                    {
+                        pj_memcpy(&acc->sa_next_hop_addr,
+                                  &req->tp_info.dst_addr,
+                                  req->tp_info.dst_addr_len);
+                        acc->sa_next_hop_tp = param->rdata->tp_info.transport;
+                        pjsip_transport_add_ref(acc->sa_next_hop_tp);
+                        PJ_LOG(4,(THIS_FILE,
+                                  "Account %d: server affinity pinned "
+                                  "to transport %s",
+                                  acc->index,
+                                  acc->sa_next_hop_tp->obj_name));
+                    }
+                }
+            }
 
             /* Send initial PUBLISH if it is enabled */
             if (acc->cfg.publish_enabled && acc->publish_sess==NULL)
@@ -4383,6 +4494,67 @@ PJ_DEF(pj_status_t) pjsua_acc_set_transport( pjsua_acc_id acc_id,
 }
 
 
+/*
+ * Discard the cached server-affinity state for an account (#4964).
+ */
+PJ_DEF(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id)
+{
+    pjsua_acc *acc;
+
+    PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id), PJ_EINVAL);
+
+    PJSUA_LOCK();
+    acc = &pjsua_var.acc[acc_id];
+    if (!acc->valid) {
+        PJSUA_UNLOCK();
+        return PJ_EINVAL;
+    }
+
+    clear_sa_pin(acc);
+
+    PJSUA_UNLOCK();
+    return PJ_SUCCESS;
+}
+
+
+/*
+ * Pin the account's server affinity to a specific remote address (#4964).
+ */
+PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
+                                                const pj_sockaddr *addr)
+{
+    pjsua_acc *acc;
+    int addr_len;
+
+    PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id) && addr, PJ_EINVAL);
+
+    addr_len = pj_sockaddr_get_len(addr);
+    PJ_ASSERT_RETURN(addr_len > 0 &&
+                     addr_len <= (int)sizeof(((pjsua_acc*)0)->sa_next_hop_addr),
+                     PJ_EINVAL);
+
+    PJSUA_LOCK();
+    acc = &pjsua_var.acc[acc_id];
+    if (!acc->valid) {
+        PJSUA_UNLOCK();
+        return PJ_EINVAL;
+    }
+    if (!acc->sa_enabled) {
+        PJSUA_UNLOCK();
+        return PJ_EINVALIDOP;
+    }
+
+    /* Drop any existing pin (transport will be (re)created on first send). */
+    clear_sa_pin(acc);
+
+    pj_memcpy(&acc->sa_next_hop_addr, addr, addr_len);
+    /* sa_next_hop_tp stays NULL — filled in on first outgoing request. */
+
+    PJSUA_UNLOCK();
+    return PJ_SUCCESS;
+}
+
+
 /* Auto re-registration timeout callback */
 static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
 {
@@ -4573,6 +4745,13 @@ void pjsua_acc_on_tp_state_changed(pjsip_transport *tp,
             /* Also reset regc's Via addr */
             if (acc->regc)
                 pjsip_regc_set_via_sent_by(acc->regc, NULL, NULL);
+        }
+
+        /* Clear server-affinity pin if it pointed at this transport
+         * (#4964). Next REGISTER will re-pin against fresh resolution.
+         */
+        if (acc->sa_next_hop_tp == tp) {
+            clear_sa_pin(acc);
         }
 
         /* Release transport immediately if regc is using it

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1024,7 +1024,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     pj_bool_t unreg_first = PJ_FALSE;
     pj_bool_t update_mwi = PJ_FALSE;
     pj_status_t status = PJ_SUCCESS;
-    /* Server-affinity (#4964) snapshots — captured before config mutation
+    /* Server-affinity (#4964) snapshots: captured before config mutation
      * so we can detect next-hop URI changes at the bottom of the function.
      */
     pj_bool_t   sa_old_enabled = PJ_FALSE;
@@ -1713,9 +1713,9 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
                                 &cfg->rtcp_fb_cfg);
 
     /* Server affinity (#4964): refresh effective flags, then clear the
-     * cached pin if it's no longer valid — i.e. the feature got disabled,
-     * transport_id changed, or the next-hop URI (proxy[0] / reg_uri)
-     * changed. Other unrelated config edits leave the pin intact.
+     * cached pin if it's no longer valid (the feature got disabled,
+     * transport_id changed, or the next-hop URI proxy[0]/reg_uri
+     * changed). Other unrelated config edits leave the pin intact.
      */
     update_sa_effective_flags(acc);
     if (sa_old_enabled && !acc->sa_enabled) {
@@ -2807,7 +2807,7 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
              *      REGISTER landed on the same address.
              *   3. Pin already has tp → no-op.
              *
-             * Skip entirely when transport_id is set — affinity is
+             * Skip entirely when transport_id is set: affinity is
              * bypassed there.
              */
             if (acc->sa_enabled &&
@@ -4536,7 +4536,7 @@ PJ_DEF(pj_status_t) pjsua_acc_refresh_transport(pjsua_acc_id acc_id)
  * Pin the account's server affinity to a specific remote address (#4964).
  *
  * For TLS, the SNI hostname and peer cert validation use the hostname of
- * the account's next-hop URI (proxy[0] preferred, else reg_uri) — the
+ * the account's next-hop URI (proxy[0] preferred, else reg_uri); the
  * caller only supplies an address. This is the same trust model the
  * auto-capture path inherits from REGISTER's normal resolution flow.
  */
@@ -4614,7 +4614,7 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
     /* Try to materialize the transport now. For TCP/TLS this initiates
      * connection setup if not already cached; for UDP it returns the
      * shared listener. If acquire fails (e.g. no listener of this type),
-     * we still store the address — sa_next_hop_tp will be filled later
+     * we still store the address; sa_next_hop_tp will be filled later
      * when a REGISTER lands on this same address.
      */
     if (tdata_ptr) {

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -127,6 +127,7 @@ PJ_DEF(void) pjsua_config_default(pjsua_config *cfg)
     pjsip_timer_setting_default(&cfg->timer_setting);
     pjsua_srtp_opt_default(&cfg->srtp_opt);
     cfg->no_refer_sub = PJ_TRUE;
+    cfg->acc_server_affinity_default = PJSUA_ACC_SERVER_AFFINITY_DEFAULT;
 }
 
 PJ_DEF(void) pjsua_config_dup(pj_pool_t *pool,
@@ -391,6 +392,9 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
                                        PJSUA_IPV6_DISABLED;
     cfg->ipv6_media_use = PJ_HAS_IPV6? PJSUA_IPV6_ENABLED_PREFER_IPV4 :
                                        PJSUA_IPV6_DISABLED;
+
+    cfg->server_affinity        = PJSUA_SERVER_AFFINITY_UNSPECIFIED;
+    cfg->server_affinity_strict = PJSUA_SERVER_AFFINITY_UNSPECIFIED;
 
     cfg->media_stun_use = PJSUA_STUN_RETRY_ON_FAILURE;
     cfg->ip_change_cfg.shutdown_tp = PJ_TRUE;
@@ -3382,6 +3386,12 @@ void pjsua_parse_media_type( pj_pool_t *pool,
 
 /*
  * Internal function to init transport selector based on account's config.
+ *
+ * Caller is expected to hold PJSUA_LOCK (same as ka_transport / via_tp
+ * read sites). Server-affinity (#4964) reuses the cached transport ref
+ * here, defensively skipping shutdown transports — pjsip_tpmgr_acquire_
+ * transport2's PJSIP_TPSELECTOR_TRANSPORT short-circuit only checks
+ * is_destroying, not is_shutdown.
  */
 void pjsua_init_tpselector(pjsua_acc_id acc_id,
                            pjsip_tpselector *sel)
@@ -3394,7 +3404,7 @@ void pjsua_init_tpselector(pjsua_acc_id acc_id,
         pjsua_transport_data *tpdata;
         unsigned flag;
 
-        PJ_ASSERT_RETURN(acc->cfg.transport_id >= 0 && 
+        PJ_ASSERT_RETURN(acc->cfg.transport_id >= 0 &&
                          acc->cfg.transport_id <
                          (int)PJ_ARRAY_SIZE(pjsua_var.tpdata), );
         tpdata = &pjsua_var.tpdata[acc->cfg.transport_id];
@@ -3408,6 +3418,14 @@ void pjsua_init_tpselector(pjsua_acc_id acc_id,
             sel->type = PJSIP_TPSELECTOR_LISTENER;
             sel->u.listener = tpdata->data.factory;
         }
+    } else if (acc->sa_enabled &&
+               acc->sa_next_hop_tp != NULL &&
+               !acc->sa_next_hop_tp->is_shutdown &&
+               !acc->sa_next_hop_tp->is_destroying)
+    {
+        /* Server affinity (#4964): reuse the pinned transport. */
+        sel->type = PJSIP_TPSELECTOR_TRANSPORT;
+        sel->u.transport = acc->sa_next_hop_tp;
     } else if (acc->cfg.ipv6_sip_use != PJSUA_IPV6_ENABLED_NO_PREFERENCE) {
         sel->type = PJSIP_TPSELECTOR_IP_VER;
         sel->u.ip_ver = (pjsip_tpselector_ip_ver)acc->cfg.ipv6_sip_use;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -394,7 +394,6 @@ PJ_DEF(void) pjsua_acc_config_default(pjsua_acc_config *cfg)
                                        PJSUA_IPV6_DISABLED;
 
     cfg->server_affinity        = PJSUA_SERVER_AFFINITY_UNSPECIFIED;
-    cfg->server_affinity_strict = PJSUA_SERVER_AFFINITY_UNSPECIFIED;
 
     cfg->media_stun_use = PJSUA_STUN_RETRY_ON_FAILURE;
     cfg->ip_change_cfg.shutdown_tp = PJ_TRUE;

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -3389,7 +3389,7 @@ void pjsua_parse_media_type( pj_pool_t *pool,
  *
  * Caller is expected to hold PJSUA_LOCK (same as ka_transport / via_tp
  * read sites). Server-affinity (#4964) reuses the cached transport ref
- * here, defensively skipping shutdown transports — pjsip_tpmgr_acquire_
+ * here, defensively skipping shutdown transports: pjsip_tpmgr_acquire_
  * transport2's PJSIP_TPSELECTOR_TRANSPORT short-circuit only checks
  * is_destroying, not is_shutdown.
  */

--- a/pjsip/src/pjsua2/account.cpp
+++ b/pjsip/src/pjsua2/account.cpp
@@ -726,6 +726,7 @@ void AccountConfig::toPj(pjsua_acc_config &ret) const
     ret.auth_pref.algorithm       = str2Pj(sipConfig.authInitialAlgorithm);
     ret.transport_id              = sipConfig.transportId;
     ret.ipv6_sip_use              = sipConfig.ipv6Use;
+    ret.server_affinity           = sipConfig.serverAffinity;
     ret.use_shared_auth           = sipConfig.useSharedAuth;
     ret.auto_repond_sip_message = sipConfig.autoRespondSipMessage;
 
@@ -915,6 +916,7 @@ void AccountConfig::fromPj(const pjsua_acc_config &prm,
     sipConfig.authInitialAlgorithm   = pj2Str(prm.auth_pref.algorithm);
     sipConfig.transportId            = prm.transport_id;
     sipConfig.ipv6Use                = prm.ipv6_sip_use;
+    sipConfig.serverAffinity         = prm.server_affinity;
     sipConfig.useSharedAuth          = PJ2BOOL(prm.use_shared_auth);
     sipConfig.autoRespondSipMessage = PJ2BOOL(prm.auto_repond_sip_message);
 
@@ -1264,6 +1266,22 @@ Account::setOnlineStatus(const PresenceStatus &pres_st) PJSUA2_THROW(Error)
 void Account::setTransport(TransportId tp_id) PJSUA2_THROW(Error)
 {
     PJSUA2_CHECK_EXPR( pjsua_acc_set_transport(id, tp_id) );
+}
+
+void Account::refreshTransport() PJSUA2_THROW(Error)
+{
+    PJSUA2_CHECK_EXPR( pjsua_acc_refresh_transport(id) );
+}
+
+void Account::setAffinityAddr(const SocketAddress &addr) PJSUA2_THROW(Error)
+{
+    pj_sockaddr sa;
+    pj_str_t input = str2Pj(addr);
+
+    PJSUA2_CHECK_EXPR(
+        pj_sockaddr_parse(pj_AF_UNSPEC(), 0, &input, &sa)
+    );
+    PJSUA2_CHECK_EXPR( pjsua_acc_set_affinity_addr(id, &sa) );
 }
 
 void Account::presNotify(const PresNotifyParam &prm) PJSUA2_THROW(Error)

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -333,6 +333,7 @@ void UaConfig::fromPj(const pjsua_config &ua_cfg)
     this->enableUpnp = PJ2BOOL(ua_cfg.enable_upnp);
     this->upnpIfName = pj2Str(ua_cfg.upnp_if_name);
     this->noRefersub = PJ2BOOL(ua_cfg.no_refer_sub);
+    this->accServerAffinityDefault = PJ2BOOL(ua_cfg.acc_server_affinity_default);
 }
 
 pjsua_config UaConfig::toPj() const
@@ -374,6 +375,7 @@ pjsua_config UaConfig::toPj() const
     pua_cfg.enable_upnp = this->enableUpnp;
     pua_cfg.upnp_if_name = str2Pj(this->upnpIfName);
     pua_cfg.no_refer_sub = this->noRefersub;
+    pua_cfg.acc_server_affinity_default = this->accServerAffinityDefault;
 
     return pua_cfg;
 }
@@ -395,6 +397,7 @@ void UaConfig::readObject(const ContainerNode &node) PJSUA2_THROW(Error)
     NODE_READ_BOOL    ( this_node, enableUpnp);
     NODE_READ_STRING  ( this_node, upnpIfName);
     NODE_READ_BOOL_OPT( this_node, noRefersub);
+    NODE_READ_BOOL_OPT( this_node, accServerAffinityDefault);
 }
 
 void UaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
@@ -414,6 +417,7 @@ void UaConfig::writeObject(ContainerNode &node) const PJSUA2_THROW(Error)
     NODE_WRITE_BOOL    ( this_node, enableUpnp);
     NODE_WRITE_STRING  ( this_node, upnpIfName);
     NODE_WRITE_BOOL    ( this_node, noRefersub);
+    NODE_WRITE_BOOL    ( this_node, accServerAffinityDefault);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/pjsua/scripts-run/210_server_affinity.py
+++ b/tests/pjsua/scripts-run/210_server_affinity.py
@@ -1,0 +1,44 @@
+#
+# Server affinity (#4964): basic end-to-end smoke.
+#
+# Two pjsua instances:
+#   "srv" = SIP server using the built-in simple_registrar +
+#           --auto-answer for incoming traffic.
+#   "cli" = client started with --server-affinity but no startup
+#           account; the test adds the account at runtime via the
+#           +a CLI command so REGISTER (and the affinity capture log)
+#           fires AFTER the framework's telnet stream is connected,
+#           making both observable via expect().
+#
+# Validates:
+#   - REGISTER succeeds with --server-affinity enabled.
+#   - The auto-capture log line "server affinity pinned to transport"
+#     appears, confirming the regc capture path fired.
+#
+from inc_cfg import *
+
+srv = InstanceParam("srv",
+                    "--null-audio --max-calls=4 --auto-answer=200")
+
+# Start cli with --server-affinity (which also flips the global default
+# so runtime-added accounts inherit ENABLED) but no startup account.
+cli = InstanceParam("cli",
+                    "--null-audio --max-calls=4 --server-affinity")
+
+
+def add_acc_and_check(t):
+    cli_proc = t.process[1]
+    srv_port = t.inst_params[0].sip_port
+    add_cmd = ('+a "sip:cli@127.0.0.1" "sip:127.0.0.1:%d" "*" '
+               'cli secret' % srv_port)
+    cli_proc.send(add_cmd)
+    cli_proc.expect("registration success", title="register")
+    cli_proc.expect("server affinity pinned to transport",
+                    title="affinity capture")
+
+
+test_param = TestParam(
+    "Server affinity (#4964) basic",
+    [srv, cli],
+    func=add_acc_and_check
+)


### PR DESCRIPTION
## Summary

Implements account-scoped server affinity per the design in #4964. Pins the resolved next-hop server (address + transport) per account on successful REGISTER, and reuses the cached transport for subsequent same-account outgoing requests via `PJSIP_TPSELECTOR_TRANSPORT`.

**Motivation**: pjsip's resolver re-runs RFC 2782 weighted-random server selection on every resolution call, so DNS/SRV-balanced clusters can see same-account requests land on different backends even when the underlying records are TTL-cached. Server affinity stops the flip-flop. Makes #4954 unnecessary for its IP-proxy + FQDN-registrar scenario.

**Trust model (TLS)**: when enabled for a TLS account, the per-request destination hostname check (CVE-2020-15260) is skipped on transport reuse — trust is asserted at handshake instead. Default off; opt-in is explicit.

**Scope of this PR**: TCP/TLS pinning. UDP destination-pinning and DNS-driven auto-refresh are deferred to a coupled follow-up (see "Not yet in this PR" below).

## Commits

1. `04db315b2` — initial implementation: config, state, REGISTER auto-capture, disconnect/destroy/modify lifecycle, use-side selector injection.
2. `a5a5a0f1f` — explicit-pin transport materialization in `pjsua_acc_set_affinity_addr` + refined regc capture so explicit addresses aren't silently overridden.
3. `80bf23aab` — `--server-affinity[=on|off]` CLI option in pjsua app.
4. `76f15bbe8` — TLS-aware explicit pin (SNI/cert hostname from next-hop URI) + shorter doxygen.
5. `1eab56e98` — basic E2E test (`tests/pjsua/scripts-run/210_server_affinity.py`) + capture log bumped to PJ_LOG(3).
6. `c29f60939` — doxygen polish: `\issue{4964}` alias, ASCII-only comments.
7. `ba8792a25` — drop `server_affinity_strict` + DNS auto-refresh prototype; both belong to the UDP follow-up where they actually matter.
8. `1741d1966` — tighten `pjsua_acc_set_affinity_addr` contract per Copilot review: atomic semantics + propagate materialization status + reject when `transport_id` is set.
9. `222e01bee` — pjsua2 (C++) wrappers: `AccountSipConfig::serverAffinity`, `UaConfig::accServerAffinityDefault`, `Account::refreshTransport()`, `Account::setAffinityAddr()`, plus `symbols.lst`/`symbols.i` SWIG enum entry.

## User guide (until docs are generated post-2.18)

### Enabling

| Layer | Setting |
|---|---|
| Compile-time | `PJSUA_ACC_SERVER_AFFINITY_DEFAULT` in `config_site.h` (default `0`) |
| Runtime, all accounts | `pjsua_config.acc_server_affinity_default = PJ_TRUE` |
| Per-account | `pjsua_acc_config.server_affinity = PJSUA_SERVER_AFFINITY_ENABLED` (tristate; `UNSPECIFIED` inherits) |
| pjsua app CLI | `--server-affinity[=on\|off]` |

### What it does

- **TCP/TLS**: on first successful REGISTER (or via the explicit-pin API), pins the address+transport that REGISTER landed on. Subsequent same-account outgoing requests (REGISTER refresh, INVITE, MESSAGE, SUBSCRIBE, OPTIONS) inject `PJSIP_TPSELECTOR_TRANSPORT` so they reuse that transport — bypassing per-request resolution and the CVE-2020-15260 hostname check.
- **Lifecycle**: the pin clears automatically on transport disconnect, IP change, `pjsua_acc_modify` next-hop change (`proxy[0]` / `reg_uri` / `transport_id`), or account destroy. Apps can clear explicitly via `pjsua_acc_refresh_transport()`. After a clear, the next REGISTER refresh re-pins.

### APIs

```c
/* Clear the cached pin. Next REGISTER refresh re-pins.
 * Existing dialogs/calls keep their own transport refs and are unaffected.
 */
pj_status_t pjsua_acc_refresh_transport(pjsua_acc_id acc_id);

/* Explicit pin to a remote address (for accounts that don't register, or
 * to override the address REGISTER would otherwise pick). Eager: acquires
 * a transport now using the account's next-hop URI hostname for SNI/cert
 * validation on TLS.
 */
pj_status_t pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
                                        const pj_sockaddr *addr);
```

### Behavior changes when affinity is active

- **Failover shifts from per-transaction to per-REGISTER-cycle.** Without affinity, if entry[0] of a multi-address resolution times out, pjsip's send-state retries entry[1], entry[2], etc. within the *same* transaction. With affinity, those per-tx retries reuse the pinned transport (selector short-circuits resolution). The initial REGISTER still goes through normal resolver-driven failover (no pin yet), and after the pinned transport disconnects, the disconnect callback clears the pin and the next REGISTER refresh re-pins via fresh resolution. Recovery from a server failure is therefore bounded by transport-disconnect detection time + REGISTER refresh interval rather than instantaneous within the failing transaction.
- **`transport_id` takes precedence.** When `pjsua_acc_config.transport_id` is set, server affinity is bypassed entirely — `transport_id` already expresses pinning, and there's no point layering two mechanisms.
- **Default off** — opting in is an explicit acknowledgment of the trust-model and behavior changes above.

### Operational signals

- `Account N: server affinity pinned to transport tcp0x...` (PJ_LOG(3)) — fired on successful pin.
- `Account N: server affinity address pinned via API; transport will be captured...` (PJ_LOG(3)) — fired on `pjsua_acc_set_affinity_addr()`.

## Not yet in this PR (follow-ups)

1. **UDP destination-pinning + DNS-driven auto-refresh** (one coupled PR) — implemented via hidden Route (`sip:<addr>;lr;hide` injected at head of `acc->route_set`) for destination, and a periodic verify against the resolved set for auto-refresh. UDP pairs naturally with auto-refresh because UDP has no transport-level disconnect signal — DNS becomes the only graceful-migration trigger. For TCP/TLS the disconnect path already handles it, so auto-refresh adds little value there.
2. **SRV flip-flop integration test** — needs mock-DNS infrastructure on top of the pjsua test framework. The current test (`scripts-run/210_server_affinity.py`) covers auto-capture and lifecycle on a single backend; the flip-flop assertion needs DNS mocking.

## Test plan

- [x] Full pjsip + pjsua-lib + pjsua app build clean, zero warnings under `-Wall`.
- [x] `tests/pjsua/scripts-run/210_server_affinity.py` passes — exercises auto-capture log line via runtime `+a`.
- [ ] Existing pjsua tests pass with feature off (default) — CI matrix.
- [ ] Manual: enable per-account, verify two REGISTERs against an SRV-balanced cluster land on the same backend.
- [ ] Manual: trigger transport disconnect, verify pin clears and re-REGISTER repins.
- [ ] Manual: `acc_modify` of unrelated fields preserves pin; `acc_modify` changing `proxy[0]` / `reg_uri` / `transport_id` clears it.
- [ ] Manual: `pjsua_acc_set_affinity_addr()` for non-registering account.

CI will validate the default-off path (no behavior change). Manual verification will be done before merge.

Co-Authored-By: Claude Code



