### PR TITLE
Honor PJSUA_CONTACT_REWRITE_UNREGISTER in auto-rereg on transport drop

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4431,15 +4431,44 @@ static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
         }
 
         if (pj_strcmp(&tmp_contact, &acc->contact)) {
-            if (acc->contact.slen < tmp_contact.slen) {
-                pj_strdup_with_null(acc->pool, &acc->contact, &tmp_contact);
+            pj_bool_t need_unreg = ((acc->cfg.contact_rewrite_method &
+                                     PJSUA_CONTACT_REWRITE_UNREGISTER) != 0);
+
+            if (need_unreg && acc->regc) {
+                /* PJSUA_CONTACT_REWRITE_UNREGISTER is set: avoid bundling
+                 * the old (expires=0) and new Contact in a single REGISTER
+                 * (which is what pjsip_regc_update_contact() would produce).
+                 * Tear down the existing regc so the upcoming REGISTER
+                 * carries only the new Contact on the new transport. The
+                 * old binding will be replaced by the registrar (atomically
+                 * for SIP outbound via +sip.instance/reg-id, or by AOR
+                 * match) or expire on its own.
+                 */
+                destroy_regc(acc, PJ_TRUE);
+                update_keep_alive(acc, PJ_FALSE, NULL);
+                status = pjsua_regc_init(acc->index);
+                if (status != PJ_SUCCESS) {
+                    pjsua_perror(THIS_FILE,
+                                 "Unable to reinit client registration"
+                                 " for re-registration", status);
+                    pj_pool_release(pool);
+                    schedule_reregistration(acc);
+                    goto on_return;
+                }
             } else {
-                pj_strncpy_with_null(&acc->contact, &tmp_contact, 
-                                     PJSIP_MAX_URL_SIZE);
+                if (acc->contact.slen < tmp_contact.slen) {
+                    pj_strdup_with_null(acc->pool, &acc->contact,
+                                        &tmp_contact);
+                } else {
+                    pj_strncpy_with_null(&acc->contact, &tmp_contact,
+                                         PJSIP_MAX_URL_SIZE);
+                }
+                update_regc_contact(acc);
+                if (acc->regc) {
+                    pjsip_regc_update_contact(acc->regc, 1,
+                                              &acc->reg_contact);
+                }
             }
-            update_regc_contact(acc);
-            if (acc->regc)
-                pjsip_regc_update_contact(acc->regc, 1, &acc->reg_contact);
         }
         pj_pool_release(pool);
     }

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4435,15 +4435,15 @@ static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
                                      PJSUA_CONTACT_REWRITE_UNREGISTER) != 0);
 
             if (need_unreg && acc->regc) {
-                /* PJSUA_CONTACT_REWRITE_UNREGISTER is set: avoid bundling
-                 * the old (expires=0) and new Contact in a single REGISTER
-                 * (which is what pjsip_regc_update_contact() would produce).
-                 * Tear down the existing regc so the upcoming REGISTER
-                 * carries only the new Contact on the new transport. The
-                 * old binding will be replaced by the registrar (atomically
-                 * for SIP outbound via +sip.instance/reg-id, or by AOR
-                 * match) or expire on its own.
+                /* PJSUA_CONTACT_REWRITE_UNREGISTER is set. Mirror the
+                 * IP-change response path semantics (see
+                 * acc_check_nat_addr()): send an explicit unregister of
+                 * the old Contact, then tear down and recreate the regc
+                 * so the next REGISTER carries only the new Contact
+                 * under a fresh Call-ID. The unregister is best-effort
+                 * — the regc is destroyed before the response arrives.
                  */
+                pjsua_acc_set_registration(acc->index, PJ_FALSE);
                 destroy_regc(acc, PJ_TRUE);
                 update_keep_alive(acc, PJ_FALSE, NULL);
                 status = pjsua_regc_init(acc->index);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4437,13 +4437,26 @@ static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
             if (need_unreg && acc->regc) {
                 /* PJSUA_CONTACT_REWRITE_UNREGISTER is set. Mirror the
                  * IP-change response path semantics (see
-                 * acc_check_nat_addr()): send an explicit unregister of
-                 * the old Contact, then tear down and recreate the regc
-                 * so the next REGISTER carries only the new Contact
-                 * under a fresh Call-ID. The unregister is best-effort
-                 * — the regc is destroyed before the response arrives.
+                 * acc_check_nat_addr()): send an explicit unregister
+                 * of the old Contact, then tear down and recreate the
+                 * regc so the next REGISTER carries only the new
+                 * Contact under a fresh Call-ID. The unregister is
+                 * best-effort — the regc is destroyed before the
+                 * response arrives. If the old regc still has a
+                 * pending transaction (PJSIP_EBUSY), defer to the
+                 * next retry rather than abandon the in-flight tsx
+                 * and race a second REGISTER against it.
                  */
-                pjsua_acc_set_registration(acc->index, PJ_FALSE);
+                status = pjsua_acc_set_registration(acc->index,
+                                                   PJ_FALSE);
+                if (status != PJ_SUCCESS) {
+                    pjsua_perror(THIS_FILE,
+                                 "Unable to send unregister of old"
+                                 " Contact; deferring", status);
+                    pj_pool_release(pool);
+                    schedule_reregistration(acc);
+                    goto on_return;
+                }
                 destroy_regc(acc, PJ_TRUE);
                 update_keep_alive(acc, PJ_FALSE, NULL);
                 status = pjsua_regc_init(acc->index);


### PR DESCRIPTION
- When a TLS/TCP transport disconnects, `pjsua_acc_on_tp_state_changed()` schedules a 5s auto re-registration via `auto_rereg_timer_cb()`. On firing, if the new transport's local port differs from the prior Contact, the callback calls `pjsip_regc_update_contact()`, which pushes the old Contact onto the regc's removed-list with `expires=0` and serializes **both** old and new Contacts in the next REGISTER.
- This bundled-Contact behavior was forced regardless of `acc_cfg.contact_rewrite_method`. In particular, users who set `PJSUA_CONTACT_REWRITE_UNREGISTER` (intending separate REGISTERs with different Call-IDs, per the doc string) still saw a single REGISTER carrying old (`expires=0`) + new Contact on this path.
- This patch makes `auto_rereg_timer_cb()` consult `acc_cfg.contact_rewrite_method`. When `PJSUA_CONTACT_REWRITE_UNREGISTER` is set, it tears down the existing regc (`destroy_regc` + `update_keep_alive(FALSE)` + `pjsua_regc_init`) so the upcoming REGISTER carries only the new Contact on the new transport. The old binding is replaced by the registrar via `+sip.instance`/`reg-id` (SIP outbound) or AOR match, or expires on its own.
- Default behavior (`PJSUA_CONTACT_REWRITE_NO_UNREG | PJSUA_CONTACT_REWRITE_ALWAYS_UPDATE`) is preserved — no change for users who haven't opted in.
- Mirrors the semantics already in place on the IP-change response path (`acc_check_nat_addr()`, `pjsip/src/pjsua-lib/pjsua_acc.c:2137-2141`).

## Test plan

- [ ] Reproduce the original scenario (TLS transport drop → reconnect with new local port → 5s auto-rereg) with `acc_cfg.contact_rewrite_method = PJSUA_CONTACT_REWRITE_UNREGISTER | PJSUA_CONTACT_REWRITE_ALWAYS_UPDATE`. Verify the resulting REGISTER carries a single Contact (the new one).
- [ ] Verify the registrar accepts the new binding and routes inbound calls/requests to the new contact.
- [ ] Verify default `contact_rewrite_method` (NO_UNREG | ALWAYS_UPDATE) still produces the previous two-Contact REGISTER on this path — no regression for existing users.
- [ ] Verify the regular registration-failure auto-rereg path (no transport drop) still works — `tmp_contact == acc->contact` so the new branch isn't taken.
- [ ] Verify the IP-change response path (`acc_check_nat_addr()`) still behaves as before.