### PR TITLE
Preserve negotiated text PT across re-INVITE in sdp_neg

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -61,6 +61,8 @@ struct pjmedia_sdp_neg
     pj_int8_t             vid_dyn_codecs_cnt;
     pj_str_t              vid_dyn_codecs[PJMEDIA_CODEC_MGR_MAX_CODECS];
 #endif
+    pj_int8_t             txt_dyn_codecs_cnt;
+    pj_str_t              txt_dyn_codecs[2];     /**< "red", "t140"          */
 
     pjmedia_sdp_session *initial_sdp,       /**< Initial local SDP           */
                         *initial_sdp_tmp,   /**< Temporary initial local SDP */
@@ -128,6 +130,11 @@ static void init_mapping(pjmedia_sdp_neg *neg)
     pjmedia_vid_codec_mgr_get_dyn_codecs(NULL, &neg->vid_dyn_codecs_cnt,
                                          neg->vid_dyn_codecs);
 #endif
+
+    /* Text has no codec mgr; sort by pj_stricmp for binary search. */
+    neg->txt_dyn_codecs[0] = pj_str("red");
+    neg->txt_dyn_codecs[1] = pj_str("t140");
+    neg->txt_dyn_codecs_cnt = PJ_ARRAY_SIZE(neg->txt_dyn_codecs);
 
     pj_memset(neg->pt_to_codec, -1, PJ_ARRAY_SIZE(neg->pt_to_codec) *
               PJ_ARRAY_SIZE(neg->pt_to_codec[0]));
@@ -1877,6 +1884,9 @@ static pj_status_t assign_pt_and_update_map(pj_pool_t *pool,
             dyn_codecs = neg->vid_dyn_codecs;
             count = neg->vid_dyn_codecs_cnt;
 #endif
+        } else if (med_type == PJMEDIA_TYPE_TEXT) {
+            dyn_codecs = neg->txt_dyn_codecs;
+            count = neg->txt_dyn_codecs_cnt;
         } else {
             continue;
         }
@@ -2020,6 +2030,7 @@ static pj_status_t assign_pt_and_update_map(pj_pool_t *pool,
             const pjmedia_sdp_attr *attr;
             pjmedia_sdp_fmtp fmtp;
             unsigned pt, new_pt = 0;
+            pj_bool_t is_red = PJ_FALSE;
 
             attr = sdp_m->attr[j];
             if (pj_strcmp2(&attr->name, "fmtp") != 0)
@@ -2033,12 +2044,91 @@ static pj_status_t assign_pt_and_update_map(pj_pool_t *pool,
                 continue;
 
             new_pt = pt_change[pt - START_DYNAMIC_PT];
-            /* No PT change */
-            if (new_pt == 0 || new_pt == pt)
-                continue;
+            if (new_pt == 0)
+                new_pt = pt;
 
-            rewrite_pt2(pool, (pj_str_t *)&attr->value,
-                        pt, new_pt);
+            /* Detect RED so we can also rewrite its redundancy PT refs
+             * (the body, e.g. "100 98/98/98", references other PTs).
+             * Look up rtpmap by new_pt: the rtpmap loop above may have
+             * already rewritten the rtpmap value in place.
+             */
+            {
+                const pjmedia_sdp_attr *rtpmap_attr;
+                pjmedia_sdp_rtpmap r;
+                pj_str_t npt_str;
+                char npt_buf[8];
+
+                npt_str.ptr = npt_buf;
+                npt_str.slen = pj_utoa(new_pt, npt_buf);
+                rtpmap_attr = pjmedia_sdp_media_find_attr2(sdp_m, "rtpmap",
+                                                           &npt_str);
+                if (rtpmap_attr &&
+                    pjmedia_sdp_attr_get_rtpmap(rtpmap_attr, &r)==PJ_SUCCESS &&
+                    pj_stricmp2(&r.enc_name, "red") == 0)
+                {
+                    is_red = PJ_TRUE;
+                }
+            }
+
+            if (is_red) {
+                pjmedia_codec_fmtp parsed;
+
+                pj_bzero(&parsed, sizeof(parsed));
+                if (pjmedia_stream_info_parse_fmtp_data(pool, &fmtp.fmt_param,
+                                                        &parsed) == PJ_SUCCESS
+                    && parsed.cnt > 0)
+                {
+                    /* Same bound as create_redundancy_rtpmap() (producer)
+                     * and apply_answer_symmetric_pt().
+                     */
+                    enum { MAX_FMTP_STR_LEN = 32 };
+                    char buf[MAX_FMTP_STR_LEN];
+                    int buf_len, len;
+                    unsigned k;
+                    pj_bool_t modified = (new_pt != pt);
+                    pj_str_t new_val;
+
+                    buf_len = pj_ansi_snprintf(buf, MAX_FMTP_STR_LEN, "%u ",
+                                               new_pt);
+                    if (buf_len < 0 || buf_len >= MAX_FMTP_STR_LEN)
+                        continue;
+
+                    for (k = 0; k < parsed.cnt; ++k) {
+                        unsigned ref_pt = pj_strtoul(&parsed.param[k].val);
+                        unsigned new_ref = ref_pt;
+
+                        if (ref_pt >= START_DYNAMIC_PT &&
+                            pt_change[ref_pt - START_DYNAMIC_PT] != 0)
+                        {
+                            new_ref = pt_change[ref_pt - START_DYNAMIC_PT];
+                            if (new_ref != ref_pt)
+                                modified = PJ_TRUE;
+                        }
+                        len = pj_ansi_snprintf(buf + buf_len,
+                                               MAX_FMTP_STR_LEN - buf_len,
+                                               (k == 0)? "%u": "/%u",
+                                               new_ref);
+                        if (len < 0 || len >= MAX_FMTP_STR_LEN - buf_len) {
+                            buf_len = -1;
+                            break;
+                        }
+                        buf_len += len;
+                    }
+
+                    if (buf_len > 0 && modified) {
+                        new_val.ptr = buf;
+                        new_val.slen = buf_len;
+                        pj_strdup(pool, (pj_str_t *)&attr->value, &new_val);
+                    }
+                    continue;
+                }
+                /* Parse failed or empty body: fall through. */
+            }
+
+            /* Only the fmtp's own PT needs rewriting. */
+            if (new_pt == pt)
+                continue;
+            rewrite_pt2(pool, (pj_str_t *)&attr->value, pt, new_pt);
         }
 
         /* Modify format list */


### PR DESCRIPTION
`assign_pt_and_update_map()` handles audio and video but not text, so the per-stream `codec_to_pt` map is never populated for text. Each time PJSUA generates a re-INVITE (e.g. on hold/resume), the freshly built local text SDP uses default dynamic PTs (`t140=98`, `red=100`) regardless of what was negotiated earlier in the session.

## Reported scenario

Incoming RTT call from a remote endpoint, SRTP enabled. The remote offers `m=text RTP/SAVP 111` with `a=rtpmap:111 t140/1000`; PJSUA answers symmetrically with `pt=111`. Bidirectional RTT works.

After hold/resume, the re-INVITE we send drops back to `m=text RTP/SAVP 100 98` (red+t140 defaults). The remote answers with `pt=111` again — RFC 3264 allows asymmetric PT in the SDP, so that part is fine — and then transmits using its own answered PT (`pt=111`). That TX behavior is non-conformant: each side's `m=` line advertises the PT it expects to receive, so the remote should be transmitting with the PT we listed in our offer (`pt=98`), not its own answered PT. The decoder rejects every inbound packet:

```
tstrm... !Bad RTP pt 111 (expecting 98)
```

Outbound text still works (we use the remote's answered PT for TX); inbound text stops after the first hold/resume even though Wireshark shows the packets arriving.

Keeping the same dynamic PT across re-INVITEs avoids the asymmetric outcome entirely, which is what we already do for audio and video.

## Change

- Add a small text dynamic-codec list (`"red"`, `"t140"`) to `struct pjmedia_sdp_neg` and initialize it in `init_mapping()` (text has no codec manager).
- Route `PJMEDIA_TYPE_TEXT` through the existing codec lookup / PT preservation path in `assign_pt_and_update_map()` — same as video.
- When a `fmtp` attribute belongs to a `red` rtpmap, rebuild its value so the redundancy PT references inside the body (e.g. `100 98/98/98`) are also remapped when the referenced codec's PT changes. Rtpmap lookup is done by the **new** PT to handle the case where the rtpmap loop has already rewritten the rtpmap value in place.

## Trace through the reported scenario

After symmetric answer: `codec_to_pt[i][t140_idx] = 111` is recorded.

Hold re-INVITE flow with the change applied:
- rtpmap loop rewrites `a=rtpmap:98 t140/1000` → `a=rtpmap:111 t140/1000`; `pt_change[98-96] = 111`.
- fmtp loop sees `a=fmtp:100 98/98/98`. Lookup rtpmap by new PT `100` → encoding is `red` → rebuild: `100 111/111/111`.
- m-line fmt list rewrite: `100 98` → `100 111`.

Resulting SDP:
```
m=text 4004 RTP/SAVP 100 111
a=rtpmap:100 red/1000
a=fmtp:100 111/111/111
a=rtpmap:111 t140/1000
```

Both sides stay on `pt=111` for `t140`, so the asymmetric-PT outcome never arises and the remote's TX-side behavior no longer matters.

## Limitations

- Only `red` is special-cased in the fmtp body rewrite. Other inter-PT-reference fmtps (`apt=` for RTX, ULPFEC, etc.) are not handled by this patch — they'd need the same treatment if/when used.
- The text codec list is hardcoded at size 2. Adding a third text dynamic codec needs the array size and the `pj_stricmp` sort order both updated.

## Test plan
- [x] Full `make -j3` clean — no new warnings
- [x] `pjmedia-test sdp_neg_test` passes
- [ ] Manual repro of the reported scenario (RTT call + hold/resume) to confirm `Bad RTP pt` no longer logs
