### PR TITLE
Account-scoped server affinity: UDP destination-pinning (#4964)

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4783,10 +4783,10 @@ typedef struct pjsua_acc_config
      *
      * Limitation: when #reg_use_proxy is set to 0 (REGISTER bypasses
      * both outbound and account proxies) and UDP affinity is enabled,
-     * the proxy entries from acc->route_set may still be pushed to the
-     * registration client alongside the hidden Route, partially
-     * defeating the reg_use_proxy=0 intent. Use the default
-     * #PJSUA_REG_USE_ALL_PROXY with UDP affinity if this matters.
+     * the configured proxies may still appear in REGISTER routing
+     * alongside the affinity pin, partially defeating the
+     * reg_use_proxy=0 intent. Use the default #PJSUA_REG_USE_ALL_PROXY
+     * with UDP affinity if this matters.
      *
      * See \issue{4964} for the design (motivation, trust model, lifecycle).
      *

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -4773,11 +4773,20 @@ typedef struct pjsua_acc_config
      * DNS resolution. For TLS, this skips the per-request CVE-2020-15260
      * hostname check on reuse: trust is asserted at handshake.
      *
-     * Current scope: this version pins TCP/TLS connections (which solves
-     * the marquee SRV flip-flop and TLS connection-coalescing cases).
-     * UDP destination-pinning and DNS-driven auto-refresh are tracked as
-     * follow-up work; for UDP the address is stored but the per-request
-     * destination is not yet constrained.
+     * TCP/TLS pinning is via the transport selector. UDP pinning is via
+     * a hidden Route header (suppressed from the wire) since the UDP
+     * listener is shared. Pin recovery on graceful migration is driven
+     * by the auto-rereg retry path: a retry-eligible REGISTER failure
+     * drops the auto-captured pin so the retry can pick a different
+     * address from the resolved set. Pins set explicitly via
+     * #pjsua_acc_set_affinity_addr are preserved across retries.
+     *
+     * Limitation: when #reg_use_proxy is set to 0 (REGISTER bypasses
+     * both outbound and account proxies) and UDP affinity is enabled,
+     * the proxy entries from acc->route_set may still be pushed to the
+     * registration client alongside the hidden Route, partially
+     * defeating the reg_use_proxy=0 intent. Use the default
+     * #PJSUA_REG_USE_ALL_PROXY with UDP affinity if this matters.
      *
      * See \issue{4964} for the design (motivation, trust model, lifecycle).
      *

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -331,8 +331,10 @@ typedef struct pjsua_acc
                                             auto-rereg pin drop.        */
     pj_sockaddr      sa_next_hop_addr; /**< Cached resolved address.     */
     pjsip_transport *sa_next_hop_tp;   /**< Cached transport (ref'd).
-                                            NULL until first send after
-                                            an explicit-address pin.    */
+                                            NULL when pin is empty; set
+                                            on regc_cb auto-capture or
+                                            pjsua_acc_set_affinity_addr
+                                            success.                    */
     pjsip_route_hdr *sa_route_hdr;     /**< Hidden Route injected at the
                                             head of route_set when pin
                                             is active. Constrains UDP

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -326,6 +326,9 @@ typedef struct pjsua_acc
      * randomness in pjlib-util/srv_resolver.c.
      */
     pj_bool_t        sa_enabled;    /**< Effective enabled flag.         */
+    pj_bool_t        sa_pin_explicit;  /**< Pin was set by API call (not
+                                            auto-captured). Survives
+                                            auto-rereg pin drop.        */
     pj_sockaddr      sa_next_hop_addr; /**< Cached resolved address.     */
     pjsip_transport *sa_next_hop_tp;   /**< Cached transport (ref'd).
                                             NULL until first send after

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -330,6 +330,26 @@ typedef struct pjsua_acc
     pjsip_transport *sa_next_hop_tp;   /**< Cached transport (ref'd).
                                             NULL until first send after
                                             an explicit-address pin.    */
+    pjsip_route_hdr *sa_route_hdr;     /**< Hidden Route injected at the
+                                            head of route_set when pin
+                                            is active. Constrains UDP
+                                            destination via loose-route.
+                                            Suppressed from wire by the
+                                            ;hide URI param. NULL when
+                                            pin is empty.               */
+    pj_sockaddr      sa_route_hdr_addr;/**< The address sa_route_hdr was
+                                            built for. Used to skip
+                                            pjsip_parse_hdr() rebuild
+                                            when the cached header is
+                                            still valid (e.g., on the
+                                            acc_modify detach/reattach
+                                            path).                      */
+    pjsip_route_hdr  sa_pushed_route;  /**< Mirror of what we last
+                                            pushed to regc. Diffed
+                                            against acc->route_set
+                                            before each push so we
+                                            skip the regc clone when
+                                            nothing actually changed.   */
 
     pjsip_route_hdr  route_set;     /**< Complete route set inc. outbnd.*/
     pj_uint32_t      global_route_crc; /** CRC of global route setting. */

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -355,6 +355,12 @@ typedef struct pjsua_acc
                                             before each push so we
                                             skip the regc clone when
                                             nothing actually changed.   */
+    pj_pool_t       *sa_mirror_pool;   /**< Sub-pool for sa_pushed_route
+                                            clones. Reset on each
+                                            mirror rebuild so memory
+                                            does not grow with each
+                                            sync (acc->pool has no
+                                            reset point).               */
 
     pjsip_route_hdr  route_set;     /**< Complete route set inc. outbnd.*/
     pj_uint32_t      global_route_crc; /** CRC of global route setting. */

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -574,6 +574,7 @@ static pj_bool_t update_hdr_list(pj_pool_t *pool, pjsip_hdr *dst,
 static void sa_sync_route_set(pjsua_acc *acc)
 {
     pj_bool_t need_route;
+    pj_bool_t hdr_rebuilt = PJ_FALSE;
 
     if (acc->sa_route_hdr)
         pj_list_erase(acc->sa_route_hdr);
@@ -619,6 +620,7 @@ static void sa_sync_route_set(pjsua_acc *acc)
                     acc->sa_route_hdr = hdr;
                     pj_sockaddr_cp(&acc->sa_route_hdr_addr,
                                    &acc->sa_next_hop_addr);
+                    hdr_rebuilt = PJ_TRUE;
                 } else {
                     PJ_LOG(2,(THIS_FILE, "Account %d: failed to parse "
                                          "hidden Route '%.*s' (#4964)",
@@ -632,17 +634,20 @@ static void sa_sync_route_set(pjsua_acc *acc)
             pj_list_push_front(&acc->route_set, acc->sa_route_hdr);
     }
 
-    /* Push to regc only if it actually differs from what we pushed
-     * last time. update_hdr_list both detects the diff and keeps
-     * acc->sa_pushed_route in sync as our mirror of regc's view.
-     * Skipping avoids the regc->pool clone that
-     * pjsip_regc_set_route_set does unconditionally.
+    /* Push to regc when the route_set diffs from sa_pushed_route, OR
+     * when we rebuilt the hidden hdr. The rebuild case is force-pushed
+     * because pjsip_hdr_cmp (used by update_hdr_list) compares headers
+     * by printed form, and ;hide entries print empty — so a stale
+     * hidden Route clone in the mirror would falsely match a fresh
+     * hidden Route built for a different address. (#4964)
      */
-    if (acc->regc &&
-        update_hdr_list(acc->pool, (pjsip_hdr*)&acc->sa_pushed_route,
-                        (const pjsip_hdr*)&acc->route_set))
-    {
-        pjsip_regc_set_route_set(acc->regc, &acc->route_set);
+    if (acc->regc) {
+        pj_bool_t changed = update_hdr_list(
+                                acc->pool,
+                                (pjsip_hdr*)&acc->sa_pushed_route,
+                                (const pjsip_hdr*)&acc->route_set);
+        if (changed || hdr_rebuilt)
+            pjsip_regc_set_route_set(acc->regc, &acc->route_set);
     }
 }
 
@@ -655,6 +660,7 @@ static void clear_sa_pin(pjsua_acc *acc)
         acc->sa_next_hop_tp = NULL;
     }
     pj_bzero(&acc->sa_next_hop_addr, sizeof(acc->sa_next_hop_addr));
+    acc->sa_pin_explicit = PJ_FALSE;
     sa_sync_route_set(acc);
 }
 
@@ -2957,6 +2963,7 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
                         }
                         acc->sa_next_hop_tp = param->rdata->tp_info.transport;
                         pjsip_transport_add_ref(acc->sa_next_hop_tp);
+                        acc->sa_pin_explicit = PJ_FALSE;
                         /* Mirror the pin into route_set (UDP only —
                          * for TCP/TLS tp_sel covers destination).
                          */
@@ -4769,6 +4776,7 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
         clear_sa_pin(acc);
         pj_memcpy(&acc->sa_next_hop_addr, addr, addr_len);
         acc->sa_next_hop_tp = tp;
+        acc->sa_pin_explicit = PJ_TRUE;
         /* Inject hidden Route for UDP destination-pinning. */
         sa_sync_route_set(acc);
         PJ_LOG(3,(THIS_FILE,
@@ -4853,12 +4861,12 @@ static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
         pj_pool_release(pool);
     }
 
-    /* Drop affinity pin before retrying — if the pinned server is the
-     * one that misbehaved, fresh resolution gives the retry a chance
-     * at a different address from the resolved set. Re-pin happens
-     * naturally via regc_cb capture on a successful retry. (#4964)
+    /* Drop auto-captured affinity pin before retrying — if the pinned
+     * server is the one that misbehaved, fresh resolution gives the
+     * retry a chance at a different address. Explicit (API-set) pins
+     * are preserved per the set_affinity_addr contract. (#4964)
      */
-    if (acc->sa_enabled && acc->sa_next_hop_tp) {
+    if (acc->sa_enabled && acc->sa_next_hop_tp && !acc->sa_pin_explicit) {
         PJ_LOG(4,(THIS_FILE,
                   "Account %d: dropping server affinity pin before "
                   "re-registration retry", acc->index));

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -301,6 +301,10 @@ static pj_status_t destroy_regc(pjsua_acc *acc, pj_bool_t force)
     acc->reg_mapped_addr.slen = 0;
     acc->rfc5626_status = OUTBOUND_UNKNOWN;
     acc->rfc5626_flowtmr = 0;
+    /* New regc starts with an empty route_set; reset the mirror so the
+     * next sa_sync_route_set diff re-pushes the hidden Route. (#4964)
+     */
+    pj_list_init(&acc->sa_pushed_route);
 
     return PJ_SUCCESS;
 }
@@ -414,10 +418,11 @@ static pj_status_t initialize_acc(unsigned acc_id)
     //  acc_cfg->contact = acc_cfg->id;
     //}
 
-    /* Build account route-set from outbound proxies and route set from 
+    /* Build account route-set from outbound proxies and route set from
      * account configuration.
      */
     pj_list_init(&acc->route_set);
+    pj_list_init(&acc->sa_pushed_route);   /* mirror for diff (#4964) */
 
     if (!pj_list_empty(&pjsua_var.outbound_proxy)) {
         pjsip_route_hdr *r;
@@ -558,6 +563,90 @@ static void update_sa_effective_flags(pjsua_acc *acc)
         pjsua_var.ua_cfg.acc_server_affinity_default);
 }
 
+/* Forward decl. */
+static pj_bool_t update_hdr_list(pj_pool_t *pool, pjsip_hdr *dst,
+                                 const pjsip_hdr *src);
+
+/* Sync the hidden Route entry in acc->route_set with the current pin
+ * state, then push to regc if the result actually differs from what
+ * we pushed last time. UDP-only (TCP/TLS use tp_sel). See #4964.
+ */
+static void sa_sync_route_set(pjsua_acc *acc)
+{
+    pj_bool_t need_route;
+
+    if (acc->sa_route_hdr)
+        pj_list_erase(acc->sa_route_hdr);
+
+    /* Use sa_next_hop_tp->key.type rather than acc->tp_type because
+     * tp_type is only meaningful when transport_id is set, and
+     * affinity is bypassed in that case anyway.
+     */
+    need_route =
+        acc->sa_enabled && acc->sa_next_hop_tp != NULL &&
+        ((acc->sa_next_hop_tp->key.type & ~PJSIP_TRANSPORT_IPV6)
+         == PJSIP_TRANSPORT_UDP);
+
+    if (need_route) {
+        /* Reuse cached hdr when the address didn't change (skips parse
+         * + acc->pool alloc on the acc_modify detach/reattach path).
+         */
+        if (acc->sa_route_hdr == NULL ||
+            pj_sockaddr_cmp(&acc->sa_route_hdr_addr,
+                            &acc->sa_next_hop_addr) != 0)
+        {
+            /* Build "<sip:host:port;lr;hide>". The angle brackets are
+             * required so ;hide lands in URI params, where
+             * pjsip_routing_hdr_print() looks for it.
+             */
+            char host_port[PJ_INET6_ADDRSTRLEN + 16];
+            char buf[PJ_INET6_ADDRSTRLEN + 32];
+            pj_str_t hname = { "Route", 5 };
+            pj_str_t tmp;
+            pjsip_route_hdr *hdr;
+            int len;
+
+            pj_sockaddr_print(&acc->sa_next_hop_addr, host_port,
+                              sizeof(host_port),
+                              3 /* port + IPv6 brackets */);
+            len = pj_ansi_snprintf(buf, sizeof(buf),
+                                   "<sip:%s;lr;hide>", host_port);
+            if (len > 0 && len < (int)sizeof(buf)) {
+                pj_strdup2(acc->pool, &tmp, buf);
+                hdr = (pjsip_route_hdr*)pjsip_parse_hdr(
+                          acc->pool, &hname, tmp.ptr, tmp.slen, NULL);
+                if (hdr) {
+                    acc->sa_route_hdr = hdr;
+                    pj_sockaddr_cp(&acc->sa_route_hdr_addr,
+                                   &acc->sa_next_hop_addr);
+                } else {
+                    PJ_LOG(2,(THIS_FILE, "Account %d: failed to parse "
+                                         "hidden Route '%.*s' (#4964)",
+                              acc->index, (int)tmp.slen, tmp.ptr));
+                    acc->sa_route_hdr = NULL;
+                }
+            }
+        }
+
+        if (acc->sa_route_hdr)
+            pj_list_push_front(&acc->route_set, acc->sa_route_hdr);
+    }
+
+    /* Push to regc only if it actually differs from what we pushed
+     * last time. update_hdr_list both detects the diff and keeps
+     * acc->sa_pushed_route in sync as our mirror of regc's view.
+     * Skipping avoids the regc->pool clone that
+     * pjsip_regc_set_route_set does unconditionally.
+     */
+    if (acc->regc &&
+        update_hdr_list(acc->pool, (pjsip_hdr*)&acc->sa_pushed_route,
+                        (const pjsip_hdr*)&acc->route_set))
+    {
+        pjsip_regc_set_route_set(acc->regc, &acc->route_set);
+    }
+}
+
+
 /* Drop cached pin state. Caller must hold PJSUA_LOCK. */
 static void clear_sa_pin(pjsua_acc *acc)
 {
@@ -566,6 +655,7 @@ static void clear_sa_pin(pjsua_acc *acc)
         acc->sa_next_hop_tp = NULL;
     }
     pj_bzero(&acc->sa_next_hop_addr, sizeof(acc->sa_next_hop_addr));
+    sa_sync_route_set(acc);
 }
 
 
@@ -1054,6 +1144,14 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     sa_old_transport_id    = acc->cfg.transport_id;
     sa_old_local_route_crc = acc->local_route_crc;
     sa_old_reg_uri         = acc->cfg.reg_uri;
+
+    /* The route_set rebuild below iterates assuming the head structure
+     * is [outbound_proxies][acc.proxy[]]. Detach our hidden entry now;
+     * the bottom of this function reattaches it (cache-hit reuses
+     * the same node) or omits it if the pin was cleared. #4964.
+     */
+    if (acc->sa_route_hdr)
+        pj_list_erase(acc->sa_route_hdr);
 
     /* == Validate first == */
 
@@ -1709,10 +1807,12 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     pjmedia_rtcp_fb_setting_dup(acc->pool, &acc->cfg.rtcp_fb_cfg,
                                 &cfg->rtcp_fb_cfg);
 
-    /* Server affinity (#4964): refresh effective flags, then clear the
-     * cached pin if it's no longer valid (the feature got disabled,
-     * transport_id changed, or the next-hop URI proxy[0]/reg_uri
-     * changed). Other unrelated config edits leave the pin intact.
+    /* Server affinity (#4964): refresh effective flags. If the pin is
+     * no longer valid (feature disabled, transport_id changed, or
+     * next-hop URI proxy[0]/reg_uri changed), clear it. Otherwise
+     * re-attach the hidden Route entry that was detached at the top of
+     * this function (so the route_set rebuild iteration could run
+     * against the original structure).
      */
     update_sa_effective_flags(acc);
     if (sa_old_enabled && !acc->sa_enabled) {
@@ -1726,8 +1826,15 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         else if (pj_strcmp(&acc->cfg.reg_uri, &sa_old_reg_uri))
             next_hop_changed = PJ_TRUE;
 
-        if (next_hop_changed)
+        if (next_hop_changed) {
             clear_sa_pin(acc);
+        } else if (pj_sockaddr_has_addr(&acc->sa_next_hop_addr)) {
+            /* Pin still valid: re-attach hidden Route detached at the
+             * top. update_hdr_list inside will see no net change and
+             * skip the regc push.
+             */
+            sa_sync_route_set(acc);
+        }
     }
 
 on_return:
@@ -2833,6 +2940,10 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
                         }
                         acc->sa_next_hop_tp = param->rdata->tp_info.transport;
                         pjsip_transport_add_ref(acc->sa_next_hop_tp);
+                        /* Mirror the pin into route_set (UDP only —
+                         * for TCP/TLS tp_sel covers destination).
+                         */
+                        sa_sync_route_set(acc);
                         PJ_LOG(3,(THIS_FILE,
                                   "Account %d: server affinity pinned "
                                   "to transport %s",
@@ -4636,6 +4747,8 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
         clear_sa_pin(acc);
         pj_memcpy(&acc->sa_next_hop_addr, addr, addr_len);
         acc->sa_next_hop_tp = tp;
+        /* Inject hidden Route for UDP destination-pinning. */
+        sa_sync_route_set(acc);
         PJ_LOG(3,(THIS_FILE,
                   "Account %d: server affinity explicitly pinned via API "
                   "to transport %s",

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -564,8 +564,40 @@ static void update_sa_effective_flags(pjsua_acc *acc)
 }
 
 /* Forward decl. */
-static pj_bool_t update_hdr_list(pj_pool_t *pool, pjsip_hdr *dst,
-                                 const pjsip_hdr *src);
+static int pjsip_hdr_cmp(const pjsip_hdr *h1, const pjsip_hdr *h2);
+
+/* Order-sensitive Route-list sync. Returns PJ_TRUE if dst differs
+ * from src in content or order, and resyncs dst to match in that
+ * case. Used for the affinity mirror — Route order is semantically
+ * significant (RFC 3261 loose routing, RFC 3608 Service-Route), so a
+ * pure set-based diff would miss reorders. (#4964)
+ */
+static pj_bool_t sa_sync_mirror(pj_pool_t *pool, pjsip_hdr *dst,
+                                 const pjsip_hdr *src)
+{
+    pjsip_hdr *di = dst->next;
+    const pjsip_hdr *si = src->next;
+    pj_bool_t differs = PJ_FALSE;
+
+    while (di != dst && si != src) {
+        if (pjsip_hdr_cmp(di, si) != 0) {
+            differs = PJ_TRUE;
+            break;
+        }
+        di = di->next;
+        si = si->next;
+    }
+    if (!differs && (di != dst || si != src))
+        differs = PJ_TRUE;     /* different sizes */
+
+    if (differs) {
+        while (!pj_list_empty(dst))
+            pj_list_erase(dst->next);
+        for (si = src->next; si != src; si = si->next)
+            pj_list_push_back(dst, pjsip_hdr_clone(pool, si));
+    }
+    return differs;
+}
 
 /* Sync the hidden Route entry in acc->route_set with the current pin
  * state, then push to regc if the result actually differs from what
@@ -636,13 +668,13 @@ static void sa_sync_route_set(pjsua_acc *acc)
 
     /* Push to regc when the route_set diffs from sa_pushed_route, OR
      * when we rebuilt the hidden hdr. The rebuild case is force-pushed
-     * because pjsip_hdr_cmp (used by update_hdr_list) compares headers
-     * by printed form, and ;hide entries print empty — so a stale
-     * hidden Route clone in the mirror would falsely match a fresh
-     * hidden Route built for a different address. (#4964)
+     * because pjsip_hdr_cmp compares headers by printed form, and
+     * ;hide entries print empty — so a stale hidden Route clone in
+     * the mirror would falsely match a fresh hidden Route built for a
+     * different address. (#4964)
      */
     if (acc->regc) {
-        pj_bool_t changed = update_hdr_list(
+        pj_bool_t changed = sa_sync_mirror(
                                 acc->pool,
                                 (pjsip_hdr*)&acc->sa_pushed_route,
                                 (const pjsip_hdr*)&acc->route_set);
@@ -3260,8 +3292,8 @@ static pj_status_t pjsua_regc_init(int acc_id)
             /* Seed affinity mirror to match what we just pushed, so
              * the next sa_sync_route_set only pushes the delta. (#4964)
              */
-            update_hdr_list(acc->pool, (pjsip_hdr*)&acc->sa_pushed_route,
-                            (const pjsip_hdr*)&route_set);
+            sa_sync_mirror(acc->pool, (pjsip_hdr*)&acc->sa_pushed_route,
+                           (const pjsip_hdr*)&route_set);
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -302,9 +302,13 @@ static pj_status_t destroy_regc(pjsua_acc *acc, pj_bool_t force)
     acc->rfc5626_status = OUTBOUND_UNKNOWN;
     acc->rfc5626_flowtmr = 0;
     /* New regc starts with an empty route_set; reset the mirror so the
-     * next sa_sync_route_set diff re-pushes the hidden Route. (#4964)
+     * next sa_sync_route_set diff re-pushes the hidden Route. Also
+     * reset the sub-pool that held the previous mirror's clones to
+     * reclaim memory. (#4964)
      */
     pj_list_init(&acc->sa_pushed_route);
+    if (acc->sa_mirror_pool)
+        pj_pool_reset(acc->sa_mirror_pool);
 
     return PJ_SUCCESS;
 }
@@ -570,9 +574,11 @@ static int pjsip_hdr_cmp(const pjsip_hdr *h1, const pjsip_hdr *h2);
  * from src in content or order, and resyncs dst to match in that
  * case. Used for the affinity mirror — Route order is semantically
  * significant (RFC 3261 loose routing, RFC 3608 Service-Route), so a
- * pure set-based diff would miss reorders. (#4964)
+ * pure set-based diff would miss reorders. Clones go into a per-acc
+ * sub-pool reset on each rebuild so memory does not grow across
+ * Service-Route flaps. (#4964)
  */
-static pj_bool_t sa_sync_mirror(pj_pool_t *pool, pjsip_hdr *dst,
+static pj_bool_t sa_sync_mirror(pjsua_acc *acc, pjsip_hdr *dst,
                                  const pjsip_hdr *src)
 {
     pjsip_hdr *di = dst->next;
@@ -591,10 +597,18 @@ static pj_bool_t sa_sync_mirror(pj_pool_t *pool, pjsip_hdr *dst,
         differs = PJ_TRUE;     /* different sizes */
 
     if (differs) {
-        while (!pj_list_empty(dst))
-            pj_list_erase(dst->next);
+        if (acc->sa_mirror_pool)
+            pj_pool_reset(acc->sa_mirror_pool);
+        else
+            acc->sa_mirror_pool = pjsua_pool_create("sa_mirror%p",
+                                                   256, 256);
+        if (!acc->sa_mirror_pool)
+            return differs;
+
+        pj_list_init(dst);
         for (si = src->next; si != src; si = si->next)
-            pj_list_push_back(dst, pjsip_hdr_clone(pool, si));
+            pj_list_push_back(dst,
+                              pjsip_hdr_clone(acc->sa_mirror_pool, si));
     }
     return differs;
 }
@@ -675,7 +689,7 @@ static void sa_sync_route_set(pjsua_acc *acc)
      */
     if (acc->regc) {
         pj_bool_t changed = sa_sync_mirror(
-                                acc->pool,
+                                acc,
                                 (pjsip_hdr*)&acc->sa_pushed_route,
                                 (const pjsip_hdr*)&acc->route_set);
         if (changed || hdr_rebuilt)
@@ -1016,6 +1030,10 @@ PJ_DEF(pj_status_t) pjsua_acc_del2(pjsua_acc_id acc_id,
     pjsua_pres_delete_acc(acc_id, 0);
 
     /* Release & wipe account pool */
+    if (acc->sa_mirror_pool) {
+        pj_pool_release(acc->sa_mirror_pool);
+        acc->sa_mirror_pool = NULL;
+    }
     if (acc->pool) {
         pj_pool_secure_release(&acc->pool);
     }
@@ -3292,7 +3310,7 @@ static pj_status_t pjsua_regc_init(int acc_id)
             /* Seed affinity mirror to match what we just pushed, so
              * the next sa_sync_route_set only pushes the delta. (#4964)
              */
-            sa_sync_mirror(acc->pool, (pjsip_hdr*)&acc->sa_pushed_route,
+            sa_sync_mirror(acc, (pjsip_hdr*)&acc->sa_pushed_route,
                            (const pjsip_hdr*)&route_set);
         }
     }

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1838,6 +1838,13 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     }
 
 on_return:
+    /* Reattach hidden Route on early-exit paths (idempotent on success).
+     * Guarded by acc->valid since the very first early exit fires before
+     * acc is initialized. (#4964)
+     */
+    if (acc->valid)
+        sa_sync_route_set(acc);
+
     PJSUA_UNLOCK();
     pj_log_pop_indent();
     return status;
@@ -2477,16 +2484,22 @@ static void update_service_route(pjsua_acc *acc, pjsip_rx_data *rdata)
             break;
     }
 
-    /* 
-     * Update account's route set 
+    /*
+     * Update account's route set
      */
-    
+
+    /* Detach hidden affinity Route so strip-tail size accounting below
+     * operates on [outbound][acc.proxy][service-route] only. (#4964)
+     */
+    if (acc->sa_route_hdr)
+        pj_list_erase(acc->sa_route_hdr);
+
     /* First remove all routes which are not the outbound proxies */
     rcnt = pj_list_size(&acc->route_set);
     if (rcnt != pjsua_var.ua_cfg.outbound_proxy_cnt + acc->cfg.proxy_cnt) {
-        for (i=pjsua_var.ua_cfg.outbound_proxy_cnt + acc->cfg.proxy_cnt, 
-                hr=acc->route_set.prev; 
-             i<rcnt; 
+        for (i=pjsua_var.ua_cfg.outbound_proxy_cnt + acc->cfg.proxy_cnt,
+                hr=acc->route_set.prev;
+             i<rcnt;
              ++i)
          {
             pjsip_route_hdr *prev = hr->prev;
@@ -2502,7 +2515,11 @@ static void update_service_route(pjsua_acc *acc, pjsip_rx_data *rdata)
         pj_list_push_back(&acc->route_set, hr);
     }
 
-    /* Done */
+    /* Reattach hidden Route and push the post-update route_set diff
+     * to regc — Service-Route changes after first pin capture would
+     * otherwise never reach regc. (#4964)
+     */
+    sa_sync_route_set(acc);
 
     PJ_LOG(4,(THIS_FILE, "Service-Route updated for acc %d with %d URI(s)",
               acc->index, uri_cnt));
@@ -3233,6 +3250,11 @@ static pj_status_t pjsua_regc_init(int acc_id)
                              status);
                 goto on_return;
             }
+            /* Seed affinity mirror to match what we just pushed, so
+             * the next sa_sync_route_set only pushes the delta. (#4964)
+             */
+            update_hdr_list(acc->pool, (pjsip_hdr*)&acc->sa_pushed_route,
+                            (const pjsip_hdr*)&route_set);
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4831,6 +4831,18 @@ static void auto_rereg_timer_cb(pj_timer_heap_t *th, pj_timer_entry *te)
         pj_pool_release(pool);
     }
 
+    /* Drop affinity pin before retrying — if the pinned server is the
+     * one that misbehaved, fresh resolution gives the retry a chance
+     * at a different address from the resolved set. Re-pin happens
+     * naturally via regc_cb capture on a successful retry. (#4964)
+     */
+    if (acc->sa_enabled && acc->sa_next_hop_tp) {
+        PJ_LOG(4,(THIS_FILE,
+                  "Account %d: dropping server affinity pin before "
+                  "re-registration retry", acc->index));
+        clear_sa_pin(acc);
+    }
+
     status = pjsua_acc_set_registration(acc->index, PJ_TRUE);
     if (status != PJ_SUCCESS)
         schedule_reregistration(acc);


### PR DESCRIPTION
## Summary

Follow-up to #4966 (TCP/TLS account-scoped affinity). Pins the UDP destination per-account so REGISTERs and subsequent same-account requests stay on the same backend across SRV/DNS reroll, matching the TCP/TLS behavior shipped earlier.

Issue: https://github.com/pjsip/pjproject/issues/4964

## Why a different mechanism for UDP

TCP/TLS pins via the transport selector (`PJSIP_TPSELECTOR_TRANSPORT`) — each connection is its own destination. UDP can't use that because the UDP listener is shared across all peers. This PR pins UDP destination by injecting a hidden Route header `<sip:host:port;lr;hide>` at the head of `acc->route_set`. The `;hide` URI param suppresses the Route from the wire (handled in `pjsip_routing_hdr_print`), but loose-routing still uses it as the request destination — so REGISTER/INVITE go to the pinned address even though the listener is shared.

## How

- **Sync helper**: `sa_sync_route_set(acc)` is the single point that adds/removes the hidden Route in `acc->route_set` based on the current pin state (UDP-only — TCP/TLS continue to use tp_sel), and pushes the result to regc only if it differs from a mirror of the last push (`sa_pushed_route`). Force-pushes when the hidden hdr was rebuilt for a new address, since `pjsip_hdr_cmp` would otherwise falsely match two different hidden Routes by their empty printed form.
- **Lifecycle**: detach/reattach the hidden Route around `acc_modify`'s route_set rebuild, `update_service_route`'s strip-tail, and `pjsua_regc_init`'s direct push (mirror seeded after to keep the diff invariant).
- **Pin recovery**: `auto_rereg_timer_cb` drops auto-captured pins just before the retry REGISTER fires, so fresh resolution can pick a different address from the resolved set. This fills the graceful-migration gap for UDP (no transport disconnect signal). Explicit pins set via `pjsua_acc_set_affinity_addr` are preserved across retries (tracked by `sa_pin_explicit`).
- **Mirror reset on regc destroy**: `destroy_regc` resets `sa_pushed_route` so the post-recreate push diffs against an empty mirror and re-pushes the hidden Route correctly.

## Behavior changes / caveats

- DNS auto-refresh was considered and dropped in favor of the auto_rereg pin reset — same calculus as the original `server_affinity_strict` drop: the actual graceful-decomm trigger is when REGISTER starts failing, and the retry path is exactly where we'd want to re-resolve.
- `reg_use_proxy = 0` limitation: when REGISTER is configured to bypass both outbound and account proxies, enabling UDP affinity may still push those proxy entries to regc alongside the hidden Route. Niche config — documented in the `server_affinity` doxygen with a recommendation to use the default `PJSUA_REG_USE_ALL_PROXY` with UDP affinity.

## Test plan

- [x] Build clean (`make -C pjsip/build`, `-Wall` no warnings)
- [x] `tests/pjsua/scripts-run/210_server_affinity.py` passes (basic E2E with simple_registrar — verifies the auto-capture log line fires)
- [x] `tests/pjsua/scripts-run/100_simple.py` passes (smoke)
- [ ] SRV flip-flop assertion test — needs mock-DNS infrastructure on top of pjsua test framework, tracked as a separate follow-up

## Review history

This PR went through two adversarial review passes that surfaced 6 real bugs and 1 latent invariant, all fixed across the commit history:
- Detach/reattach gaps in `acc_modify` early-exit and `update_service_route` (commit `0c777934b`)
- Mirror divergence after Service-Route changes (commit `0c777934b`)
- `pjsua_regc_init` direct push leaving mirror stale (commit `0c777934b`)
- `auto_rereg` dropping explicit (API-set) pins (commit `e6052243a`)
- `pjsip_hdr_cmp` empty-print false-match on hidden Routes (commit `e6052243a` — latent today, defended via force-push on rebuild)

Co-Authored-By: Claude Code