### PR TITLE
Fix YV12 U/V swap in Android Camera2 OnGetFrame2

### DIFF
--- a/pjmedia/src/pjmedia-videodev/android_dev.c
+++ b/pjmedia/src/pjmedia-videodev/android_dev.c
@@ -1272,7 +1272,12 @@ static void JNICALL OnGetFrame2(JNIEnv *env, jobject obj,
     }
     
     /* The buffer may be originally YV12, i.e: U & V planes are swapped.
-     * We also need to strip out padding, if any.
+     * In memory the order is Y, V, U. After in-place rearrangement to
+     * I420:
+     *   - U_out address coincides with V's source (p2)
+     *   - V_out address coincides with U's source (p1)
+     * so we must save V (plane[2]) into convert_buf before moving U
+     * (plane[1]) into U_out, which would otherwise overwrite V at p2.
      */
     else if (pixStride1==1 && pixStride2==1 && p1 > p2 && p2 > p0)
     {
@@ -1287,19 +1292,19 @@ static void JNICALL OnGetFrame2(JNIEnv *env, jobject obj,
 
             /* No padding, note Y plane should be no padding too! */
             pj_assert(rowStride0 == strm->cam_size.w);
-            pj_memcpy(strm->convert_buf, p1, strm->vafp.plane_bytes[1]);
+            pj_memcpy(strm->convert_buf, p2, strm->vafp.plane_bytes[2]);
             pj_memmove(U, p1, strm->vafp.plane_bytes[1]);
-            pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[1]);
+            pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[2]);
 
         } else if (rowStride1 > strm->cam_size.w/2) {
 
-            /* Strip padding */
-            strip_padding(strm->convert_buf, p1, strm->cam_size.w/2,
-                          strm->cam_size.h/2, rowStride1);
-            strip_padding(V, p2, strm->cam_size.w/2, strm->cam_size.h/2,
-                          rowStride2);
-
-            /* Get V plane data from conversion buffer */
+            /* Strip padding: save V via convert_buf (its source location
+             * overlaps U_out), then strip U into U_out, then write V.
+             */
+            strip_padding(strm->convert_buf, p2, strm->cam_size.w/2,
+                          strm->cam_size.h/2, rowStride2);
+            strip_padding(U, p1, strm->cam_size.w/2, strm->cam_size.h/2,
+                          rowStride1);
             pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[2]);
 
         }

--- a/pjmedia/src/pjmedia-videodev/android_dev.c
+++ b/pjmedia/src/pjmedia-videodev/android_dev.c
@@ -1272,12 +1272,11 @@ static void JNICALL OnGetFrame2(JNIEnv *env, jobject obj,
     }
     
     /* The buffer may be originally YV12, i.e: U & V planes are swapped.
-     * In memory the order is Y, V, U. After in-place rearrangement to
-     * I420:
-     *   - U_out address coincides with V's source (p2)
-     *   - V_out address coincides with U's source (p1)
-     * so we must save V (plane[2]) into convert_buf before moving U
-     * (plane[1]) into U_out, which would otherwise overwrite V at p2.
+     * In memory the order is Y, V, U. During in-place rearrangement to
+     * I420, U_out may overlap V's source (p2) in the no-padding case,
+     * and more generally writing U_out first may overwrite V data that
+     * is still needed. So save V (plane[2]) into convert_buf before
+     * moving/stripping U (plane[1]) into U_out, then write V_out.
      */
     else if (pixStride1==1 && pixStride2==1 && p1 > p2 && p2 > p0)
     {


### PR DESCRIPTION
Fixes #4980

## The problem

`pjmedia/src/pjmedia-videodev/android_dev.c`'s `OnGetFrame2` mis-handles
YV12-backed `YUV_420_888` Camera2 frames (chroma `pixStride == 1` with
`p1 > p2 > p0`, i.e. in-memory order Y, V, U). The existing code:

```c
/* Swap U & V planes */
pj_memcpy(strm->convert_buf, p1, strm->vafp.plane_bytes[1]);   // saves U
pj_memmove(U, p1, strm->vafp.plane_bytes[1]);                   // U_out := U  ✓
pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[1]);    // V_out := U  ✗
```

saves U (`plane[1]`) into `convert_buf` and then writes that saved U back
into `V_out`. So `V_out` ends up containing U data and the real V (Cr)
plane is lost — after the in-place U move `V_out`'s address is the same as
the **input U source**, not V's, so V is never read.

Same shape of bug in the with-padding sub-branch, which additionally never
writes anything into `U_out` (the original code stripped U into
`convert_buf`, stripped V into `V_out`, then overwrote `V_out` with the
stripped U).

Symptom: heavy purple/magenta cast on every video call from devices whose
Camera2 surfaces frames over a YV12 backing — typically Camera2 `LEGACY`
hardware level. Observed on Rockchip RK3368 / Android 8 with
`CameraHal_Marvin`. Devices that take the NV12/NV21 path
(`pixStride1 == 2`) or the standard I420-with-padding path
(`p2 > p1 > p0`) are unaffected.

## The fix

Save **V** (`plane[2]`) into `convert_buf` first instead — its source
address coincides with where `U_out` will land, so it must be preserved
before the U move. Then move U from `p1` into `U_out`, then write the
saved V into `V_out`. Same correction in the with-padding sub-branch,
which now strips V into `convert_buf` and strips U directly into `U_out`.

```c
pj_memcpy(strm->convert_buf, p2, strm->vafp.plane_bytes[2]);   /* save V */
pj_memmove(U, p1, strm->vafp.plane_bytes[1]);                   /* U_out := U */
pj_memcpy(V, strm->convert_buf, strm->vafp.plane_bytes[2]);    /* V_out := saved V */
```

15 insertions, 10 deletions. No API change. Only the YV12 branch is
touched; NV12/NV21/I420 paths and the "Unrecognized image format"
fallthrough are unchanged.

## Testing

- **Reproduces & verifies on real hardware:** Rockchip RK3368, Android 8
  (Camera2 `LEGACY`, `CameraHal_Marvin`) — purple cast before, natural
  colours after.
- **Negative test:** Same app/branch on Rockchip Android 10 (Camera2
  `LIMITED`, NV12 path with `pixStride == 2`) — no change, identical
  output before/after the patch, confirming the NV12/NV21 path is
  untouched.
- `make -j` clean against `master` (`8f067eb`); no new warnings.

## Notes

The "I420 no-pad" and "I420 with padding" branches above already correctly
handle the I420 → I420 case (planes ordered `p0 < p1 < p2`). Only the YV12
branch (planes ordered `p0 < p2 < p1`) needed correction.

I have a follow-up diagnostic patch that adds one-shot per-branch logging
plus a per-frame plane-address dump in the first 3 frames — happy to PR it
separately if useful; it was the only thing that made the root cause
obvious quickly. Not included here to keep this PR minimal.