### PR TITLE
[support-2.15.1] Backport SIP multipart boundary checks for CVE-2026-33069

### DIFF
--- a/pjsip/src/pjsip/sip_multipart.c
+++ b/pjsip/src/pjsip/sip_multipart.c
@@ -833,7 +833,7 @@ PJ_DEF(pjsip_msg_body*) pjsip_multipart_parse(pj_pool_t *pool,
 
         /* Eat the boundary */
         curptr += delim.slen;
-        if (*curptr=='-' && curptr<endptr-1 && *(curptr+1)=='-') {
+        if (curptr+1 < endptr && *curptr=='-' && *(curptr+1)=='-') {
             /* Found the closing delimiter */
             curptr += 2;
             break;
@@ -841,8 +841,12 @@ PJ_DEF(pjsip_msg_body*) pjsip_multipart_parse(pj_pool_t *pool,
         /* Optional whitespace after delimiter */
         while (curptr!=endptr && IS_SPACE(*curptr)) ++curptr;
         /* Mandatory CRLF */
+        if (curptr == endptr) {
+            PJ_LOG(2, (THIS_FILE, "Unexpected end of buffer after boundary"));
+            return NULL;
+        }
         if (*curptr=='\r') ++curptr;
-        if (*curptr!='\n') {
+        if (curptr == endptr || *curptr!='\n') {
             /* Expecting a newline here */
             PJ_LOG(2, (THIS_FILE, "Failed to find newline"));
 


### PR DESCRIPTION
Backport of the public CVE-2026-33069 fix to `support-2.15.1`.

I cherry-picked `f0fa32a226df` from upstream with `git cherry-pick -x`, so the original author and upstream commit reference are preserved. The change touches `pjsip/src/pjsip/sip_multipart.c`.

Upstream commit: https://github.com/pjsip/pjproject/commit/f0fa32a226df5f87a9903093e5d145ebb69734db
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2026-33069

This applied cleanly on my local checkout of the target branch. I have not run the full project test suite locally.