### PR TITLE
pjmedia: Fix T.140 RTT engine and RFC 2198 RED compliance

### DIFF
--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -846,21 +846,28 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
                     c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
 #endif
-                }
-            }
 
-            /* Shift the register: BOM becomes history for the next packet */
-            for (i = NUM_BUFFERS - 1; i > 0; i--) {
-                stream->tx_buf[i] = stream->tx_buf[i - 1];
+                    /* Shift the register: BOM becomes history for the next
+                     * packet */
+                    for (i = NUM_BUFFERS - 1; i > 0; i--) {
+                        stream->tx_buf[i] = stream->tx_buf[i - 1];
+                    }
+
+                    is_first_packet = PJ_FALSE;
+                    stream->is_idle = PJ_FALSE;
+                    rtp_ts_len =
+                        10; /* TS advance for the actual character packet */
+                }
             }
 
             /* Restore the user's typed character */
             stream->tx_buf[0].length = temp_len;
             pj_memcpy(stream->tx_buf[0].buf, temp_buf, temp_len);
 
-            is_first_packet = PJ_FALSE;
-            stream->is_idle = PJ_FALSE;
-            rtp_ts_len = 10; /* TS advance for the actual character packet */
+            /* If the BOM failed to send, abort */
+            if (status != PJ_SUCCESS) {
+                goto on_return;
+            }
         }
     }
 

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -1134,20 +1134,27 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
                                            &si->enc_fmtp) == PJ_SUCCESS) {
             si->tx_red_level = 0;
             for (i = 0; i < si->enc_fmtp.cnt; ++i) {
-                /* Check for 'redundancy=97/98' */
-                if (pj_strcmp(&si->enc_fmtp.param[i].name, &ID_RED_PARAM) ==
-                    0) {
-                    /* Count slashes or commas in value to determine depth */
-                    const char *p = si->enc_fmtp.param[i].val.ptr;
-                    for (r = 0; r < si->enc_fmtp.param[i].val.slen; ++r) {
-                        if (p[r] == '/')
-                            si->tx_red_level++;
-                    }
-                    break;
+                const char *p;
+                /* Accept either a non-standard named parameter (redundancy=)
+                 * or the standard RFC 2198 slash-separated PT list.
+                 */
+                if (si->enc_fmtp.param[i].name.slen != 0 &&
+                    pj_strcmp(&si->enc_fmtp.param[i].name, &ID_RED_PARAM) !=
+                        0) {
+                    continue;
                 }
-                /* Fallback: Nameless parameter count */
-                if (si->enc_fmtp.param[i].name.slen == 0)
-                    si->tx_red_level++;
+
+                p = si->enc_fmtp.param[i].val.ptr;
+                for (r = 0; r < si->enc_fmtp.param[i].val.slen; ++r) {
+                    if (p[r] == '/')
+                        si->tx_red_level++;
+                }
+                /* If fmtp was tokenized into multiple params (e.g. separated
+                 * by ';'), redundancy level is token count minus one.
+                 */
+                if (si->tx_red_level == 0 && si->enc_fmtp.cnt > 1)
+                    si->tx_red_level = (int) si->enc_fmtp.cnt - 1;
+                break;
             }
         }
     }

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -54,7 +54,7 @@
  * The default cps (character per second) is 30, but it's over a 10-second
  * interval, so we need a larger buffer to handle the burst.
  */
-#define BUFFER_SIZE             64
+#define BUFFER_SIZE             512
 
 /* The number of buffers must be the max redundancy we want to support +
  * plus one more to store the primary data.
@@ -152,10 +152,10 @@ PJ_DEF(pj_status_t) pjmedia_txt_stream_destroy( pjmedia_txt_stream *stream )
 #endif
     }
 
-    /* Unsubscribe from RTCP session events */
-    // Currently unused
-    //pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream,
-    //                          &c_strm->rtcp);
+    /* Unsubscribe from RTCP session events
+     * Currently unused
+     */
+    //pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream, &c_strm->rtcp);
 
     /* Detach from transport
      * MUST NOT hold stream mutex while detaching from transport, as
@@ -428,16 +428,16 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 
     char frm_type;
     int next_seq;
+    char frm_buf[BUFFER_SIZE];
+    pj_size_t frm_size = sizeof(frm_buf);
+    pj_uint32_t ts;
+    int popped_seq;
+    char *text_ptr = NULL;
 
     pj_mutex_lock(c_strm->jb_mutex);
 
     stream->is_waiting = PJ_FALSE;
     do {
-        char frm_buf[512];
-        pj_size_t frm_size = sizeof(frm_buf);
-        pj_uint32_t ts;
-        int popped_seq;
-
         /* Check if we have a packet with the next sequence number. */
         pjmedia_jbuf_peek_frame(c_strm->jb, 0, NULL, NULL, &frm_type, NULL,
                                 NULL, &next_seq);
@@ -470,7 +470,7 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
         }
 
         /* Strip the UTF-8 BOM if it exists at the start of the frame */
-        char *text_ptr = frm_buf;
+        text_ptr = frm_buf;
         if (frm_size >= 3 && (unsigned char) text_ptr[0] == 0xEF &&
             (unsigned char) text_ptr[1] == 0xBB &&
             (unsigned char) text_ptr[2] == 0xBF) {
@@ -491,6 +491,8 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 
         } else if (!stream->cb && frm_size > 0) {
             /* Debug trace if callback isn't set */
+            TRACE_((THIS_FILE, "Text frame popped: %.*s", (int) frm_size,
+                    text_ptr));
         }
         pj_mutex_lock(c_strm->jb_mutex);
 
@@ -504,14 +506,22 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
                               unsigned *red_len)
 {
     pj_uint32_t hdr[NUM_BUFFERS];
+    const char *payload_ptr = NULL;
+    const char *data_ptr = NULL;
     int i, level = 0;
     unsigned consumed = 0;
+    unsigned length = 0;
+    unsigned data_len = 0;
+    unsigned primary_len = 0;
+    pj_uint16_t block_seq = 0;
+    pj_int16_t diff = 0;
+    pj_uint8_t b = 0;
 
     /* Parse headers */
     while (1) {
         if (consumed + 1 > buflen)
             return PJ_ETOOBIG;
-        pj_uint8_t b = (pj_uint8_t) buf[consumed];
+        b = (pj_uint8_t) buf[consumed];
         if ((b & 0x7F) != (pj_uint8_t) pt)
             return PJMEDIA_EINVALIDPT;
         if ((b & 0x80) == 0) {
@@ -527,13 +537,13 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
     }
 
     /* Parse redundant history blocks */
-    const char *payload_ptr = buf + consumed;
+    payload_ptr = buf + consumed;
     for (i = 0; i < level; i++) {
-        unsigned length = (hdr[i] & 0x3FF);
-        pj_uint16_t block_seq = (pj_uint16_t) (seq - (level - i));
+        length = (hdr[i] & 0x3FF);
+        block_seq = (pj_uint16_t) (seq - (level - i));
 
-        const char *data_ptr = payload_ptr;
-        unsigned data_len = length;
+        data_ptr = payload_ptr;
+        data_len = length;
 
         if (length > 0) {
             if (consumed + length > buflen)
@@ -549,8 +559,8 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
         }
 
         /* Inject everything we missed, even length=0 frames! */
-        pj_int16_t diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
-        if (stream->rx_last_seq == 0 || diff > 0) {
+        diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
+        if (stream->rx_last_seq == -1 || diff > 0) {
             pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                    block_seq);
             stream->rx_last_seq = block_seq; /* Update tracker */
@@ -563,9 +573,9 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
     }
 
     /* Parse primary block */
-    unsigned primary_len = buflen - consumed;
-    const char *data_ptr = payload_ptr;
-    unsigned data_len = primary_len;
+    primary_len = buflen - consumed;
+    data_ptr = payload_ptr;
+    data_len = primary_len;
 
     if (primary_len > 0) {
         /* Strip native BOM if present */
@@ -578,8 +588,8 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
     }
 
     /* Detect gaps for primary */
-    pj_int16_t diff = (pj_int16_t) (seq - stream->rx_last_seq);
-    if (stream->rx_last_seq == 0 || diff > 0) {
+    diff = (pj_int16_t) (seq - stream->rx_last_seq);
+    if (stream->rx_last_seq == -1 || diff > 0) {
         pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                (pj_uint16_t) seq);
         stream->rx_last_seq = (pj_uint16_t) seq;
@@ -599,6 +609,7 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
     pjmedia_txt_stream *stream = (pjmedia_txt_stream *) c_strm;
     unsigned consumed = 0;
     pj_uint16_t seq = pj_ntohs(hdr->seq);
+    pj_int16_t diff = 0;
     pj_status_t status = PJ_SUCCESS;
 
     pj_mutex_lock(c_strm->jb_mutex);
@@ -610,23 +621,34 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
     if (hdr->pt == c_strm->si->rx_red_pt) {
         status = decode_red(stream, c_strm->si->rx_pt, seq,
                             (const char *) payload, payloadlen, &consumed);
+
+        if (status != PJ_SUCCESS) {
+            *pkt_discarded = PJ_TRUE;
+            pj_mutex_unlock(c_strm->jb_mutex);
+            return status;
+        }
+
     } else if (hdr->pt == c_strm->si->rx_pt) {
-        pj_int16_t diff = (pj_int16_t) (seq - stream->rx_last_seq);
+        /* Fallback: Route T.140 directly to Jitter Buffer */
+        diff = (pj_int16_t) (seq - stream->rx_last_seq);
         if (stream->rx_last_seq == -1 || diff > 0) {
             pjmedia_jbuf_put_frame(c_strm->jb, payload, payloadlen, seq);
+            stream->rx_last_seq = seq;
         } else {
             *pkt_discarded = PJ_TRUE;
         }
     } else {
+        /* Unknown Payload Type */
         status = PJMEDIA_EINVALIDPT;
         *pkt_discarded = PJ_TRUE;
     }
 
-    if (!(*pkt_discarded))
-        stream->rx_last_seq = seq;
     pj_mutex_unlock(c_strm->jb_mutex);
+
+    /* Trigger the UI callback if we got a packet */
     if (!(*pkt_discarded))
         call_cb(stream, PJ_FALSE);
+
     return status;
 }
 
@@ -636,7 +658,11 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
 {
     int i;
     unsigned len = 0;
+    unsigned hist_len = 0;
     pj_uint8_t *p_hdr = (pj_uint8_t *) buf;
+    pj_uint8_t *p_data = NULL;
+    pj_uint32_t offset = 0;
+    pj_uint32_t off = 0;
 
     unsigned level = stream->si.tx_red_level;
     if (level >= NUM_BUFFERS)
@@ -644,8 +670,8 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
 
     /* Write redundant headers */
     for (i = level; i > 0; i--) {
-        pj_uint32_t offset = 0;
-        unsigned hist_len = 0;
+        offset = 0;
+        hist_len = 0;
 
         /* Enforce empty history if requested */
         if (!force_empty_history) {
@@ -673,7 +699,7 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
     len += 1;
 
     /* Payloads */
-    pj_uint8_t *p_data = p_hdr;
+    p_data = p_hdr;
     for (i = level; i >= 0; i--) {
         unsigned payload_len =
             (force_empty_history && i > 0) ? 0 : stream->tx_buf[i].length;
@@ -682,8 +708,7 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
             continue;
 
         if (!force_empty_history && i > 0) {
-            pj_uint32_t off =
-                stream->tx_buf[0].timestamp - stream->tx_buf[i].timestamp;
+            off = stream->tx_buf[0].timestamp - stream->tx_buf[i].timestamp;
             if (off > 16383)
                 continue;
         }
@@ -704,17 +729,25 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 {
     pjmedia_stream_common *c_strm = &stream->base;
     pjmedia_channel *channel = c_strm->enc;
+    pjmedia_rtp_hdr *sent_hdr;
+    unsigned pt_to_use = 0;
     void *rtphdr;
     int size, i;
     pj_status_t status = PJ_SUCCESS;
     pj_bool_t is_keepalive = PJ_FALSE;
+    pj_bool_t is_first_packet = PJ_FALSE;
     pj_timestamp now;
+    void *bom_rtphdr;
+    int bom_size = 0;
+    pj_uint32_t bom_ts = 0;
+    char temp_buf[256];
+    unsigned temp_len = 0;
 
     /* Lock Jitter Buffer mutex to protect stream state during transmission */
     pj_mutex_lock(c_strm->jb_mutex);
     pj_get_timestamp(&now);
 
-    pj_bool_t is_first_packet =
+    is_first_packet =
         (stream->tx_last_ts.u32.hi == 0 && stream->tx_last_ts.u32.lo == 0);
 
     /* Calculate RTP timestamp increment based on actual elapsed time */
@@ -739,8 +772,7 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
         }
     }
 
-    unsigned pt_to_use =
-        (stream->si.tx_red_pt) ? stream->si.tx_red_pt : channel->pt;
+    pt_to_use = (stream->si.tx_red_pt) ? stream->si.tx_red_pt : channel->pt;
 
     /* Protect against application-layer BOMs leaking into the buffer */
     if (stream->tx_buf[0].length >= 3 &&
@@ -754,20 +786,16 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 
     /* BOM sent once per session to establish UTF-8 capability */
     if (is_first_packet && stream->tx_buf[0].length > 0) {
-        void *bom_rtphdr;
-        int bom_size;
-
         /* M=1 (Marker bit) for the first packet of a talkspurt */
         status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 1,
                                         (int) channel->buf_size, rtp_ts_len,
                                         (const void **) &bom_rtphdr, &bom_size);
         if (status == PJ_SUCCESS) {
             pj_memcpy(channel->buf, bom_rtphdr, sizeof(pjmedia_rtp_hdr));
-            pj_uint32_t bom_ts = pj_ntohl(((pjmedia_rtp_hdr *) bom_rtphdr)->ts);
+            bom_ts = pj_ntohl(((pjmedia_rtp_hdr *) bom_rtphdr)->ts);
 
             /* Back up the actual character the user typed */
-            char temp_buf[256];
-            unsigned temp_len = stream->tx_buf[0].length;
+            temp_len = stream->tx_buf[0].length;
             pj_memcpy(temp_buf, stream->tx_buf[0].buf, temp_len);
 
             /* Load the BOM into the active slot */
@@ -777,23 +805,46 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
             stream->tx_buf[0].length = 3;
             stream->tx_buf[0].timestamp = bom_ts;
 
-            for (i = 1; i < NUM_BUFFERS; i++) {
-                stream->tx_buf[i].length = 0;
-                stream->tx_buf[i].timestamp = bom_ts;
-            }
-
-            /* Encode the BOM with forced empty redundant headers */
             bom_size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
-            status =
-                encode_red(stream, (unsigned) stream->si.tx_pt,
-                           ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                           &bom_size, PJ_TRUE);
+
+            /* Encode the BOM */
+            if (stream->si.tx_red_pt > 0) {
+                /* RED Negotiated: Prime history slots and use RED encoder */
+                for (i = 1; i < NUM_BUFFERS; i++) {
+                    stream->tx_buf[i].length = 0;
+                    stream->tx_buf[i].timestamp = bom_ts;
+                }
+                status = encode_red(
+                    stream, (unsigned) stream->si.tx_pt,
+                    ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                    &bom_size, PJ_TRUE);
+            } else {
+                /* T.140 Negotiated: Send raw UTF-8 BOM bytes */
+                if (bom_size < 3) {
+                    status = PJ_ETOOBIG;
+                } else {
+                    pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                              stream->tx_buf[0].buf, 3);
+                    bom_size = 3;
+                    status = PJ_SUCCESS;
+                }
+            }
 
             if (status == PJ_SUCCESS) {
                 pj_mutex_unlock(c_strm->jb_mutex);
-                pjmedia_transport_send_rtp(c_strm->transport, channel->buf,
-                                           bom_size + sizeof(pjmedia_rtp_hdr));
+                status = pjmedia_transport_send_rtp(
+                    c_strm->transport, channel->buf,
+                    bom_size + sizeof(pjmedia_rtp_hdr));
                 pj_mutex_lock(c_strm->jb_mutex);
+                if (status == PJ_SUCCESS) {
+                    sent_hdr = (pjmedia_rtp_hdr *) channel->buf;
+                    pjmedia_rtcp_tx_rtp(&c_strm->rtcp, bom_size);
+                    c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(sent_hdr->ts);
+                    c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(sent_hdr->seq);
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
+                    c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
+#endif
+                }
             }
 
             /* Shift the register: BOM becomes history for the next packet */
@@ -834,13 +885,25 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
         ((pjmedia_rtp_hdr *) channel->buf)->m = 1;
     }
 
-    /* Encode character packet with normal redundancy */
+    /* Encode character packet */
     size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
-    status = encode_red(stream, (unsigned) stream->si.tx_pt,
-                        ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                        &size, PJ_FALSE);
-    if (status != PJ_SUCCESS)
-        goto on_return;
+    if (stream->si.tx_red_pt > 0) {
+        /* RED Negotiated: Use RFC 2198 wrapper */
+        status = encode_red(stream, (unsigned) stream->si.tx_pt,
+                            ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                            &size, PJ_FALSE);
+        if (status != PJ_SUCCESS)
+            goto on_return;
+    } else {
+        /* T.140 Negotiated: Send raw UTF-8 per RFC 4103 */
+        if (stream->tx_buf[0].length > size) {
+            status = PJ_ETOOBIG;
+            goto on_return;
+        }
+        pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                  stream->tx_buf[0].buf, stream->tx_buf[0].length);
+        size = stream->tx_buf[0].length;
+    }
 
     /* Linear shift register management */
     if (stream->tx_buf[0].length > 0) {
@@ -876,6 +939,14 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 
     if (status == PJ_SUCCESS) {
         pj_get_timestamp(&stream->tx_last_ts);
+
+        pjmedia_rtp_hdr *sent_hdr = (pjmedia_rtp_hdr *) channel->buf;
+        pjmedia_rtcp_tx_rtp(&c_strm->rtcp, size);
+        c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(sent_hdr->ts);
+        c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(sent_hdr->seq);
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
+        c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
+#endif
     }
 
 on_return:
@@ -891,14 +962,13 @@ static void check_tx_rtcp(pjmedia_txt_stream *stream)
 {
     pjmedia_stream_common *c_strm = &stream->base;
     pj_timestamp now;
+    pj_status_t status;
 
     pj_get_timestamp(&now);
     if (stream->rtcp_last_tx.u64 == 0) {
         stream->rtcp_last_tx = now;
     } else if (pj_elapsed_msec(&stream->rtcp_last_tx, &now) >=
                c_strm->rtcp_interval) {
-        pj_status_t status;
-
         status = send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled, PJ_FALSE,
                            PJ_FALSE, PJ_FALSE, PJ_FALSE, PJ_FALSE);
         if (status == PJ_SUCCESS) {
@@ -954,7 +1024,7 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
 
     pj_mutex_lock(c_strm->jb_mutex);
 
-    if (stream->tx_buf[stream->tx_buf_idx].length + text->slen > BUFFER_SIZE) {
+    if (stream->tx_buf[0].length + text->slen > BUFFER_SIZE) {
         pj_mutex_unlock(c_strm->jb_mutex);
         return PJ_ETOOMANY;
     }
@@ -1009,13 +1079,15 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
     static const pj_str_t ID_RTPMAP = {"rtpmap", 6};
     static const pj_str_t ID_REDUNDANCY = {"red", 3};
     const pjmedia_sdp_attr *attr;
+    int nameless = 0;
     unsigned i, fmti;
     unsigned rem_red_pt = 0;
     unsigned rem_t140_pt = 0;
+    unsigned pt = 0;
+    pjmedia_sdp_rtpmap r;
 
     /* Find Remote RED PT */
     for (i = 0; i < rem_m->desc.fmt_count; ++i) {
-        pjmedia_sdp_rtpmap r;
         attr =
             pjmedia_sdp_media_find_attr(rem_m, &ID_RTPMAP, &rem_m->desc.fmt[i]);
         if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
@@ -1028,11 +1100,9 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
 
     /* Find Remote T.140 PT (must not be RED) */
     for (i = 0; i < rem_m->desc.fmt_count; ++i) {
-        unsigned pt = (unsigned) pj_strtoul(&rem_m->desc.fmt[i]);
+        pt = (unsigned) pj_strtoul(&rem_m->desc.fmt[i]);
         if (pt == rem_red_pt)
             continue;
-
-        pjmedia_sdp_rtpmap r;
         attr =
             pjmedia_sdp_media_find_attr(rem_m, &ID_RTPMAP, &rem_m->desc.fmt[i]);
         if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
@@ -1046,7 +1116,6 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
 
     /* Get Local RX parameters... */
     for (fmti = 0; fmti < local_m->desc.fmt_count; ++fmti) {
-        pjmedia_sdp_rtpmap r;
         attr = pjmedia_sdp_media_find_attr(local_m, &ID_RTPMAP,
                                            &local_m->desc.fmt[fmti]);
         if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
@@ -1063,7 +1132,7 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
     if (rem_red_pt > 0) {
         if (pjmedia_stream_info_parse_fmtp(pool, rem_m, rem_red_pt,
                                            &si->enc_fmtp) == PJ_SUCCESS) {
-            int nameless = 0;
+            nameless = 0;
             for (i = 0; i < si->enc_fmtp.cnt; ++i) {
                 if (si->enc_fmtp.param[i].name.slen == 0)
                     nameless++;
@@ -1071,8 +1140,24 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
             si->tx_red_level = (nameless > 0) ? (nameless - 1) : 0;
         }
     }
-    /* Enforce T.140 clock rate */
-    si->fmt.clock_rate = 1000;
+
+    /* Restore downstream format tracking and fmtp parsing */
+    si->fmt.type = PJMEDIA_TYPE_TEXT;
+    si->fmt.pt = si->tx_pt;
+    pj_strset2(&si->fmt.encoding_name, "t140");
+    si->fmt.channel_cnt = 1;
+    si->fmt.clock_rate = 1000; /* Enforce standard T.140 clock rate */
+
+    /* Parse local fmtp for the decoder */
+    pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt, &si->dec_fmtp);
+
+    /* Re-parse remote fmtp for the T.140 encoder (in case RED overwrote it) */
+    pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt, &si->enc_fmtp);
+
+    /* Enforce dynamic PT range validation (PT >= 96) */
+    if (si->tx_pt < 96 || si->rx_pt < 96) {
+        return PJMEDIA_EINVALIDPT;
+    }
 
     return PJ_SUCCESS;
 }

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -270,8 +270,9 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
         goto err_cleanup;
 
     /* Create jitter buffer */
-    status = pjmedia_jbuf_create(pool, &c_strm->port.info.name, BUFFER_SIZE,
-                                 stream->buf_time, JBUF_MAX_COUNT, &c_strm->jb);
+    status =
+        pjmedia_jbuf_create(pool, &c_strm->port.info.name, MAX_TEXT_FRAME_SIZE,
+                            stream->buf_time, JBUF_MAX_COUNT, &c_strm->jb);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
 
@@ -417,6 +418,7 @@ pjmedia_txt_stream_get_info(const pjmedia_txt_stream *stream,
 static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 {
     pjmedia_stream_common *c_strm = &stream->base;
+    PJ_UNUSED_ARG(now);
 
     char frm_type;
     char frm_buf[MAX_TEXT_FRAME_SIZE];
@@ -601,6 +603,9 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
     pj_int16_t diff = 0;
     pj_status_t status = PJ_SUCCESS;
 
+    /* Initialize to prevent uninitialized memory reads on success paths */
+    *pkt_discarded = PJ_FALSE;
+
     pj_mutex_lock(c_strm->jb_mutex);
     if (seq_st.status.flag.restart) {
         stream->rx_last_seq = -1;
@@ -610,6 +615,12 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
     if (hdr->pt == c_strm->si->rx_red_pt) {
         status = decode_red(stream, c_strm->si->rx_pt, seq,
                             (const char *) payload, payloadlen, &consumed);
+
+        /* Mark packet as discarded if RED decoding fails */
+        if (status != PJ_SUCCESS) {
+            *pkt_discarded = PJ_TRUE;
+        }
+
     } else if (hdr->pt == c_strm->si->rx_pt) {
         /* Fallback: Route T.140 directly to Jitter Buffer */
         diff = (pj_int16_t) (seq - stream->rx_last_seq);
@@ -777,7 +788,7 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
         void *bom_rtphdr;
         int bom_size;
         pj_uint32_t bom_ts;
-        char temp_buf[256];
+        char temp_buf[BUFFER_SIZE];
         unsigned temp_len;
 
         /* M=1 (Marker bit) for the first packet of a talkspurt */
@@ -1014,7 +1025,7 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
 
     pj_mutex_lock(c_strm->jb_mutex);
 
-    if (stream->tx_buf[0].length + text->slen > MAX_TEXT_FRAME_SIZE) {
+    if (stream->tx_buf[0].length + text->slen > BUFFER_SIZE) {
         pj_mutex_unlock(c_strm->jb_mutex);
         return PJ_ETOOMANY;
     }
@@ -1130,11 +1141,19 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
         }
     }
 
+    if (si->rx_red_pt > 0) {
+        pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_red_pt,
+                                       &si->dec_fmtp);
+    }
+
     /* Set fmt */
     si->fmt.type = PJMEDIA_TYPE_TEXT;
     si->fmt.pt = si->rx_pt;
     pj_strset2(&si->fmt.encoding_name, "t140");
+    /*RFC 4103 recommends a clock frequency of 1000 Hz */
     si->fmt.clock_rate = 1000;
+    /* RFC 4103 defines the payload as a single, sequential stream of text */
+    si->fmt.channel_cnt = 1;
 
     return (si->tx_pt < 96 || si->rx_pt < 96) ? PJMEDIA_EINVALIDPT : PJ_SUCCESS;
 }

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -856,7 +856,7 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
                     c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(hdr->ts);
                     c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
-                    c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
+                    pj_gettimeofday(&c_strm->last_frm_ts_sent);
 #endif
 
                     /* Shift the register: BOM becomes history for the next
@@ -976,7 +976,7 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
         c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
-        c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
+        pj_gettimeofday(&c_strm->last_frm_ts_sent);
 #endif
     }
 

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -559,12 +559,13 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
             }
         }
 
-        /* Inject explicitly empty frames for tracking missing sequences */
+        /* Report sequences not covered by this RED packet as lost. */
         diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
         if (stream->rx_last_seq != -1 && diff > 1) {
             pj_uint16_t missing_seq = stream->rx_last_seq + 1;
             while (missing_seq != block_seq) {
-                pjmedia_jbuf_put_frame(stream->base.jb, "", 0, missing_seq);
+                pjmedia_jbuf_put_frame(stream->base.jb, "\xEF\xBF\xBD", 3,
+                                       missing_seq);
                 missing_seq++;
             }
         }
@@ -644,11 +645,12 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
         /* Fallback: Route T.140 directly to Jitter Buffer */
         diff = (pj_int16_t) (seq - stream->rx_last_seq);
 
-        /* Inject explicitly empty frames for tracking missing sequences */
+        /* Report missing T.140 packets as lost text. */
         if (stream->rx_last_seq != -1 && diff > 1) {
             pj_uint16_t missing_seq = stream->rx_last_seq + 1;
             while (missing_seq != seq) {
-                pjmedia_jbuf_put_frame(c_strm->jb, "", 0, missing_seq);
+                pjmedia_jbuf_put_frame(c_strm->jb, "\xEF\xBF\xBD", 3,
+                                       missing_seq);
                 missing_seq++;
             }
         }

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -746,12 +746,12 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
     pt_to_use = use_red ? stream->si.tx_red_pt : channel->pt;
 
     /* Calculate RTP timestamp increment based on actual elapsed time */
-    if (rtp_ts_len == 0) {
-        if (is_first_packet) {
-            rtp_ts_len = 20;
-        } else {
-            rtp_ts_len = pj_elapsed_msec(&stream->tx_last_ts, &now);
-        }
+    if (is_first_packet) {
+        /* Use a small initial increment; absolute RTP TS base is arbitrary */
+        rtp_ts_len = 20;
+    } else if (rtp_ts_len == 0) {
+        rtp_ts_len = pj_elapsed_msec(&stream->tx_last_ts, &now);
+
         if (rtp_ts_len == 0)
             rtp_ts_len = 1;
     }
@@ -1138,40 +1138,44 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
         }
     }
 
-    /* Parse Redundancy Level */
+    /* Parse Redundancy Level using a temporary struct */
     if (rem_red_pt > 0) {
+        pjmedia_codec_fmtp red_fmtp;
+        pj_bzero(&red_fmtp, sizeof(red_fmtp));
+
         if (pjmedia_stream_info_parse_fmtp(pool, rem_m, rem_red_pt,
-                                           &si->enc_fmtp) == PJ_SUCCESS) {
+                                           &red_fmtp) == PJ_SUCCESS) {
             si->tx_red_level = 0;
-            for (i = 0; i < si->enc_fmtp.cnt; ++i) {
+            for (i = 0; i < red_fmtp.cnt; ++i) {
                 const char *p;
                 /* Accept either a non-standard named parameter (redundancy=)
                  * or the standard RFC 2198 slash-separated PT list.
                  */
-                if (si->enc_fmtp.param[i].name.slen != 0 &&
-                    pj_strcmp(&si->enc_fmtp.param[i].name, &ID_RED_PARAM) !=
-                        0) {
+                if (red_fmtp.param[i].name.slen != 0 &&
+                    pj_strcmp(&red_fmtp.param[i].name, &ID_RED_PARAM) != 0) {
                     continue;
                 }
 
-                p = si->enc_fmtp.param[i].val.ptr;
-                for (r = 0; r < si->enc_fmtp.param[i].val.slen; ++r) {
+                p = red_fmtp.param[i].val.ptr;
+                for (r = 0; r < red_fmtp.param[i].val.slen; ++r) {
                     if (p[r] == '/')
                         si->tx_red_level++;
                 }
-                /* If fmtp was tokenized into multiple params (e.g. separated
-                 * by ';'), redundancy level is token count minus one.
-                 */
-                if (si->tx_red_level == 0 && si->enc_fmtp.cnt > 1)
-                    si->tx_red_level = (int) si->enc_fmtp.cnt - 1;
+
+                /* If fmtp was tokenized into multiple params */
+                if (si->tx_red_level == 0 && red_fmtp.cnt > 1)
+                    si->tx_red_level = (int) red_fmtp.cnt - 1;
                 break;
             }
         }
     }
 
-    if (si->rx_red_pt > 0) {
-        pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_red_pt,
-                                       &si->dec_fmtp);
+    /* Populate enc_fmtp/dec_fmtp with the BASE T.140 codec parameters */
+    if (si->tx_pt > 0) {
+        pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt, &si->enc_fmtp);
+    }
+    if (si->rx_pt > 0) {
+        pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt, &si->dec_fmtp);
     }
 
     /* Set fmt */

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -1121,8 +1121,8 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
         }
     }
 
-    si->tx_red_pt = (pj_uint8_t) rem_red_pt;
-    si->tx_pt = (pj_uint8_t) rem_t140_pt;
+si->tx_red_pt = 0;
+si->tx_pt = (pj_uint8_t) rem_t140_pt;
 
     /* Parse Local PTs */
     for (fmti = 0; fmti < local_m->desc.fmt_count; ++fmti) {

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -1121,8 +1121,8 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
         }
     }
 
-si->tx_red_pt = 0;
-si->tx_pt = (pj_uint8_t) rem_t140_pt;
+    si->tx_red_pt = 0;
+    si->tx_pt = (pj_uint8_t) rem_t140_pt;
 
     /* Parse Local PTs */
     for (fmti = 0; fmti < local_m->desc.fmt_count; ++fmti) {

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -421,7 +421,7 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 
     char frm_type;
     char frm_buf[MAX_TEXT_FRAME_SIZE];
-    pj_size_t frm_size = sizeof(frm_buf);
+    pj_size_t frm_size;
     pj_uint32_t ts;
     int popped_seq;
     char *text_ptr = NULL;
@@ -431,10 +431,12 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
     pj_mutex_lock(c_strm->jb_mutex);
 
     do {
-        /* Reset frm_size for every iteration to prevent truncation */
+        /* Initialize state to detect uninitialized returns */
+        popped_seq = -1;
+        ts = 0;
         frm_size = sizeof(frm_buf);
 
-        /* Pop the frame from the jitter buffer. */
+        /* Pop the frame from the jitter buffer */
         pjmedia_jbuf_get_frame3(c_strm->jb, frm_buf, &frm_size, &frm_type, NULL,
                                 &ts, &popped_seq);
 
@@ -446,17 +448,24 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 
         /* Handle missing frames */
         if (frm_type != PJMEDIA_JB_NORMAL_FRAME) {
-            if (frm_type == PJMEDIA_JB_MISSING_FRAME && stream->cb) {
-                /* Inject U+FFFD (replacement char) for lost packets */
-                pjmedia_txt_stream_data data;
-                data.seq = popped_seq;
-                data.ts = ts;
-                data.text.ptr = "\xEF\xBF\xBD";
-                data.text.slen = 3;
+            if (frm_type == PJMEDIA_JB_MISSING_FRAME) {
+                /* break if jitter buffer didn't provide a sequence */
+                if (popped_seq == -1) {
+                    break;
+                }
 
-                pj_mutex_unlock(c_strm->jb_mutex);
-                (*stream->cb)(stream, stream->cb_user_data, &data);
-                pj_mutex_lock(c_strm->jb_mutex);
+                if (stream->cb) {
+                    /* Inject U+FFFD (replacement char) for lost packets */
+                    pjmedia_txt_stream_data data;
+                    data.seq = popped_seq;
+                    data.ts = ts;
+                    data.text.ptr = "\xEF\xBF\xBD";
+                    data.text.slen = 3;
+
+                    pj_mutex_unlock(c_strm->jb_mutex);
+                    (*stream->cb)(stream, stream->cb_user_data, &data);
+                    pj_mutex_lock(c_strm->jb_mutex);
+                }
             }
             continue;
         }

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -720,7 +720,8 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
     return PJ_SUCCESS;
 }
 
-static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
+static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
+                                    unsigned rtp_ts_len)
 {
     pjmedia_stream_common *c_strm = &stream->base;
     pjmedia_channel *channel = c_strm->enc;
@@ -734,8 +735,6 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
     pjmedia_rtp_hdr *hdr;
     unsigned pt_to_use;
 
-    /* Lock Jitter Buffer mutex to protect stream state during transmission */
-    pj_mutex_lock(c_strm->jb_mutex);
     pj_get_timestamp(&now);
 
     is_first_packet =
@@ -963,7 +962,18 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
     }
 
 on_return:
+    return status;
+}
+
+static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
+{
+    pjmedia_stream_common *c_strm = &stream->base;
+    pj_status_t status;
+
+    pj_mutex_lock(c_strm->jb_mutex);
+    status = send_text_locked(stream, rtp_ts_len);
     pj_mutex_unlock(c_strm->jb_mutex);
+
     return status;
 }
 
@@ -1039,7 +1049,7 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
     pj_get_timestamp(&now);
     interval = pj_elapsed_msec(&stream->tx_last_ts, &now);
     if (interval >= stream->buf_time) {
-        status = send_text(stream, interval);
+        status = send_text_locked(stream, interval);
     }
 
     pj_mutex_unlock(c_strm->jb_mutex);

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -54,7 +54,7 @@
  * The default cps (character per second) is 30, but it's over a 10-second
  * interval, so we need a larger buffer to handle the burst.
  */
-#define BUFFER_SIZE             512
+#define BUFFER_SIZE             64
 
 /* The number of buffers must be the max redundancy we want to support +
  * plus one more to store the primary data.
@@ -428,7 +428,7 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 
     char frm_type;
     int next_seq;
-    char frm_buf[BUFFER_SIZE];
+    char frm_buf[512];
     pj_size_t frm_size = sizeof(frm_buf);
     pj_uint32_t ts;
     int popped_seq;
@@ -560,7 +560,7 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
 
         /* Inject everything we missed, even length=0 frames! */
         diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
-        if (stream->rx_last_seq == -1 || diff > 0) {
+        if (stream->rx_last_seq == 0 || diff > 0) {
             pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                    block_seq);
             stream->rx_last_seq = block_seq; /* Update tracker */
@@ -589,7 +589,7 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
 
     /* Detect gaps for primary */
     diff = (pj_int16_t) (seq - stream->rx_last_seq);
-    if (stream->rx_last_seq == -1 || diff > 0) {
+    if (stream->rx_last_seq == 0 || diff > 0) {
         pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                (pj_uint16_t) seq);
         stream->rx_last_seq = (pj_uint16_t) seq;
@@ -624,7 +624,7 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
 
         if (status != PJ_SUCCESS) {
             *pkt_discarded = PJ_TRUE;
-            pj_mutex_unlock(c_strm->jb_mutex);
+            pj_mutex_unlock(c_strm->jb_mutex); /* Unlock before error return */
             return status;
         }
 
@@ -643,6 +643,7 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
         *pkt_discarded = PJ_TRUE;
     }
 
+    /* Unlock mutex before calling the UI callback to prevent deadlocks */
     pj_mutex_unlock(c_strm->jb_mutex);
 
     /* Trigger the UI callback if we got a packet */
@@ -729,19 +730,15 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 {
     pjmedia_stream_common *c_strm = &stream->base;
     pjmedia_channel *channel = c_strm->enc;
-    pjmedia_rtp_hdr *sent_hdr;
-    unsigned pt_to_use = 0;
     void *rtphdr;
     int size, i;
     pj_status_t status = PJ_SUCCESS;
     pj_bool_t is_keepalive = PJ_FALSE;
-    pj_bool_t is_first_packet = PJ_FALSE;
     pj_timestamp now;
-    void *bom_rtphdr;
-    int bom_size = 0;
-    pj_uint32_t bom_ts = 0;
-    char temp_buf[256];
-    unsigned temp_len = 0;
+    pj_bool_t is_first_packet;
+    pj_bool_t use_red;
+    pjmedia_rtp_hdr *hdr;
+    unsigned pt_to_use;
 
     /* Lock Jitter Buffer mutex to protect stream state during transmission */
     pj_mutex_lock(c_strm->jb_mutex);
@@ -749,6 +746,8 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 
     is_first_packet =
         (stream->tx_last_ts.u32.hi == 0 && stream->tx_last_ts.u32.lo == 0);
+    use_red = (stream->si.tx_red_pt > 0) ? PJ_TRUE : PJ_FALSE;
+    pt_to_use = use_red ? stream->si.tx_red_pt : channel->pt;
 
     /* Calculate RTP timestamp increment based on actual elapsed time */
     if (rtp_ts_len == 0) {
@@ -772,8 +771,6 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
         }
     }
 
-    pt_to_use = (stream->si.tx_red_pt) ? stream->si.tx_red_pt : channel->pt;
-
     /* Protect against application-layer BOMs leaking into the buffer */
     if (stream->tx_buf[0].length >= 3 &&
         (pj_uint8_t) stream->tx_buf[0].buf[0] == 0xEF &&
@@ -786,6 +783,12 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 
     /* BOM sent once per session to establish UTF-8 capability */
     if (is_first_packet && stream->tx_buf[0].length > 0) {
+        void *bom_rtphdr;
+        int bom_size;
+        pj_uint32_t bom_ts;
+        char temp_buf[256];
+        unsigned temp_len;
+
         /* M=1 (Marker bit) for the first packet of a talkspurt */
         status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 1,
                                         (int) channel->buf_size, rtp_ts_len,
@@ -805,29 +808,24 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
             stream->tx_buf[0].length = 3;
             stream->tx_buf[0].timestamp = bom_ts;
 
-            bom_size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
+            for (i = 1; i < NUM_BUFFERS; i++) {
+                stream->tx_buf[i].length = 0;
+                stream->tx_buf[i].timestamp = bom_ts;
+            }
 
-            /* Encode the BOM */
-            if (stream->si.tx_red_pt > 0) {
-                /* RED Negotiated: Prime history slots and use RED encoder */
-                for (i = 1; i < NUM_BUFFERS; i++) {
-                    stream->tx_buf[i].length = 0;
-                    stream->tx_buf[i].timestamp = bom_ts;
-                }
+            if (use_red) {
+                /* Encode the BOM with forced empty redundant headers */
+                bom_size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
                 status = encode_red(
                     stream, (unsigned) stream->si.tx_pt,
                     ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
                     &bom_size, PJ_TRUE);
             } else {
-                /* T.140 Negotiated: Send raw UTF-8 BOM bytes */
-                if (bom_size < 3) {
-                    status = PJ_ETOOBIG;
-                } else {
-                    pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                              stream->tx_buf[0].buf, 3);
-                    bom_size = 3;
-                    status = PJ_SUCCESS;
-                }
+                /* Direct payload copy for non-redundant BOM */
+                bom_size = stream->tx_buf[0].length;
+                pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                          stream->tx_buf[0].buf, bom_size);
+                status = PJ_SUCCESS;
             }
 
             if (status == PJ_SUCCESS) {
@@ -837,10 +835,12 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
                     bom_size + sizeof(pjmedia_rtp_hdr));
                 pj_mutex_lock(c_strm->jb_mutex);
                 if (status == PJ_SUCCESS) {
-                    sent_hdr = (pjmedia_rtp_hdr *) channel->buf;
+                    hdr = (pjmedia_rtp_hdr *) channel->buf;
+
+                    /* Update RTCP TX stats */
                     pjmedia_rtcp_tx_rtp(&c_strm->rtcp, bom_size);
-                    c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(sent_hdr->ts);
-                    c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(sent_hdr->seq);
+                    c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(hdr->ts);
+                    c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
                     c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
 #endif
@@ -864,7 +864,7 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 
     /* If there's no data, no pending RED, and not a keepalive, we are done */
     if (stream->tx_buf[0].length == 0 && !is_keepalive &&
-        stream->tx_nred == 0) {
+        (!use_red || stream->tx_nred == 0)) {
         status = PJ_SUCCESS;
         goto on_return;
     }
@@ -885,36 +885,44 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
         ((pjmedia_rtp_hdr *) channel->buf)->m = 1;
     }
 
-    /* Encode character packet */
-    size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
-    if (stream->si.tx_red_pt > 0) {
-        /* RED Negotiated: Use RFC 2198 wrapper */
+    if (use_red) {
+        /* Encode character packet with normal redundancy */
+        size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
         status = encode_red(stream, (unsigned) stream->si.tx_pt,
                             ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
                             &size, PJ_FALSE);
         if (status != PJ_SUCCESS)
             goto on_return;
     } else {
-        /* T.140 Negotiated: Send raw UTF-8 per RFC 4103 */
-        if (stream->tx_buf[0].length > size) {
-            status = PJ_ETOOBIG;
-            goto on_return;
+        /* Raw copy for non-redundant encoding */
+        if (stream->tx_buf[0].length > 0) {
+            size = stream->tx_buf[0].length;
+            pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                      stream->tx_buf[0].buf, size);
+        } else {
+            /* Keep-alive with zero data */
+            size = 0;
         }
-        pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                  stream->tx_buf[0].buf, stream->tx_buf[0].length);
-        size = stream->tx_buf[0].length;
+        status = PJ_SUCCESS;
     }
 
     /* Linear shift register management */
     if (stream->tx_buf[0].length > 0) {
         /* We just sent a new character, reset the trailing packet counter */
-        stream->tx_nred = stream->si.tx_red_level;
+        if (use_red) {
+            stream->tx_nred = stream->si.tx_red_level;
+        } else {
+            stream->tx_nred = 0;
+            stream->is_idle =
+                PJ_TRUE; /* Idle immediately if no trailing packets */
+        }
+
         for (i = NUM_BUFFERS - 1; i > 0; i--) {
             stream->tx_buf[i] = stream->tx_buf[i - 1];
         }
         stream->tx_buf[0].length = 0;
 
-    } else if (stream->tx_nred > 0) {
+    } else if (use_red && stream->tx_nred > 0) {
         /* We are sending empty packets to fulfill redundancy requirements */
         stream->tx_nred--;
         if (stream->tx_nred == 0)
@@ -931,19 +939,21 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
         goto on_return;
     }
 
-    /* network transmission */
+    /* Network transmission */
     pj_mutex_unlock(c_strm->jb_mutex);
     status = pjmedia_transport_send_rtp(c_strm->transport, channel->buf,
                                         size + sizeof(pjmedia_rtp_hdr));
     pj_mutex_lock(c_strm->jb_mutex);
 
     if (status == PJ_SUCCESS) {
+        hdr = (pjmedia_rtp_hdr *) channel->buf;
         pj_get_timestamp(&stream->tx_last_ts);
 
-        pjmedia_rtp_hdr *sent_hdr = (pjmedia_rtp_hdr *) channel->buf;
+        /* Update RTCP TX stats */
         pjmedia_rtcp_tx_rtp(&c_strm->rtcp, size);
-        c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(sent_hdr->ts);
-        c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(sent_hdr->seq);
+        c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(hdr->ts);
+        c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
+
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
         c_strm->last_frm_ts_sent = c_strm->rtcp.stat.rtp_tx_last_ts;
 #endif
@@ -1078,88 +1088,76 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
 {
     static const pj_str_t ID_RTPMAP = {"rtpmap", 6};
     static const pj_str_t ID_REDUNDANCY = {"red", 3};
+    static const pj_str_t ID_RED_PARAM = {"redundancy", 10};
     const pjmedia_sdp_attr *attr;
-    int nameless = 0;
-    unsigned i, fmti;
+    unsigned i, fmti, r;
     unsigned rem_red_pt = 0;
     unsigned rem_t140_pt = 0;
     unsigned pt = 0;
-    pjmedia_sdp_rtpmap r;
+    pjmedia_sdp_rtpmap rtpmap;
 
-    /* Find Remote RED PT */
-    for (i = 0; i < rem_m->desc.fmt_count; ++i) {
-        attr =
-            pjmedia_sdp_media_find_attr(rem_m, &ID_RTPMAP, &rem_m->desc.fmt[i]);
-        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
-            if (pj_strcmp(&r.enc_name, &ID_REDUNDANCY) == 0) {
-                rem_red_pt = (unsigned) pj_strtoul(&rem_m->desc.fmt[i]);
-                break;
-            }
-        }
-    }
-
-    /* Find Remote T.140 PT (must not be RED) */
+    /* Parse Remote PTs */
     for (i = 0; i < rem_m->desc.fmt_count; ++i) {
         pt = (unsigned) pj_strtoul(&rem_m->desc.fmt[i]);
-        if (pt == rem_red_pt)
-            continue;
         attr =
             pjmedia_sdp_media_find_attr(rem_m, &ID_RTPMAP, &rem_m->desc.fmt[i]);
-        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
-            rem_t140_pt = pt;
-            break;
+        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &rtpmap) == PJ_SUCCESS) {
+            if (pj_strcmp(&rtpmap.enc_name, &ID_REDUNDANCY) == 0) {
+                rem_red_pt = pt;
+            } else {
+                rem_t140_pt = pt;
+            }
         }
     }
 
     si->tx_red_pt = (pj_uint8_t) rem_red_pt;
     si->tx_pt = (pj_uint8_t) rem_t140_pt;
 
-    /* Get Local RX parameters... */
+    /* Parse Local PTs */
     for (fmti = 0; fmti < local_m->desc.fmt_count; ++fmti) {
+        pt = (unsigned) pj_strtoul(&local_m->desc.fmt[fmti]);
         attr = pjmedia_sdp_media_find_attr(local_m, &ID_RTPMAP,
                                            &local_m->desc.fmt[fmti]);
-        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
-            if (pj_strcmp(&r.enc_name, &ID_REDUNDANCY) == 0) {
-                si->rx_red_pt =
-                    (pj_uint8_t) pj_strtoul(&local_m->desc.fmt[fmti]);
+        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &rtpmap) == PJ_SUCCESS) {
+            if (pj_strcmp(&rtpmap.enc_name, &ID_REDUNDANCY) == 0) {
+                si->rx_red_pt = (pj_uint8_t) pt;
             } else {
-                si->rx_pt = (pj_uint8_t) pj_strtoul(&local_m->desc.fmt[fmti]);
+                si->rx_pt = (pj_uint8_t) pt;
             }
         }
     }
 
-    /* Parse redundancy level */
+    /* Parse Redundancy Level */
     if (rem_red_pt > 0) {
         if (pjmedia_stream_info_parse_fmtp(pool, rem_m, rem_red_pt,
                                            &si->enc_fmtp) == PJ_SUCCESS) {
-            nameless = 0;
+            si->tx_red_level = 0;
             for (i = 0; i < si->enc_fmtp.cnt; ++i) {
+                /* Check for 'redundancy=97/98' */
+                if (pj_strcmp(&si->enc_fmtp.param[i].name, &ID_RED_PARAM) ==
+                    0) {
+                    /* Count slashes or commas in value to determine depth */
+                    const char *p = si->enc_fmtp.param[i].val.ptr;
+                    for (r = 0; r < si->enc_fmtp.param[i].val.slen; ++r) {
+                        if (p[r] == '/')
+                            si->tx_red_level++;
+                    }
+                    break;
+                }
+                /* Fallback: Nameless parameter count */
                 if (si->enc_fmtp.param[i].name.slen == 0)
-                    nameless++;
+                    si->tx_red_level++;
             }
-            si->tx_red_level = (nameless > 0) ? (nameless - 1) : 0;
         }
     }
 
-    /* Restore downstream format tracking and fmtp parsing */
+    /* Set fmt */
     si->fmt.type = PJMEDIA_TYPE_TEXT;
     si->fmt.pt = si->tx_pt;
     pj_strset2(&si->fmt.encoding_name, "t140");
-    si->fmt.channel_cnt = 1;
-    si->fmt.clock_rate = 1000; /* Enforce standard T.140 clock rate */
+    si->fmt.clock_rate = 1000;
 
-    /* Parse local fmtp for the decoder */
-    pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt, &si->dec_fmtp);
-
-    /* Re-parse remote fmtp for the T.140 encoder (in case RED overwrote it) */
-    pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt, &si->enc_fmtp);
-
-    /* Enforce dynamic PT range validation (PT >= 96) */
-    if (si->tx_pt < 96 || si->rx_pt < 96) {
-        return PJMEDIA_EINVALIDPT;
-    }
-
-    return PJ_SUCCESS;
+    return (si->tx_pt < 96 || si->rx_pt < 96) ? PJMEDIA_EINVALIDPT : PJ_SUCCESS;
 }
 
 /**

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -671,9 +671,12 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
         /* Enforce empty history if requested */
         if (!force_empty_history) {
             offset = stream->tx_buf[0].timestamp - stream->tx_buf[i].timestamp;
-            if (offset > 16383)
-                continue; /* Skip uninitialized */
-            hist_len = stream->tx_buf[i].length;
+            if (offset > 16383) {
+                offset = 0;
+                hist_len = 0;
+            } else {
+                hist_len = stream->tx_buf[i].length;
+            }
         }
 
         if (len + 4 > (unsigned) *size)

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -571,7 +571,7 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
         }
 
         /* Inject everything we missed, even length=0 frames! */
-        if (stream->rx_last_seq == -1 || diff > 0) {
+        if (stream->rx_last_seq != -1 && diff > 0) {
             pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                    block_seq);
             stream->rx_last_seq = block_seq; /* Update tracker */

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -307,7 +307,9 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
         rtcp_setting.name = c_strm->port.info.name.ptr;
         rtcp_setting.ssrc = info->ssrc;
         rtcp_setting.rtp_ts_base = pj_ntohl(c_strm->enc->rtp.out_hdr.ts);
-        rtcp_setting.clock_rate = info->fmt.clock_rate;
+        /* Fallback to T.140 standard */
+        rtcp_setting.clock_rate =
+            info->fmt.clock_rate > 0 ? info->fmt.clock_rate : 1000;
         rtcp_setting.samples_per_frame = 1;
 
         pjmedia_rtcp_init2(&c_strm->rtcp, &rtcp_setting);
@@ -423,6 +425,7 @@ pjmedia_txt_stream_get_info(const pjmedia_txt_stream *stream,
 static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 {
     pjmedia_stream_common *c_strm = &stream->base;
+
     char frm_type;
     int next_seq;
 
@@ -430,366 +433,449 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 
     stream->is_waiting = PJ_FALSE;
     do {
-        char frm_buf[BUFFER_SIZE];
+        char frm_buf[512];
         pj_size_t frm_size = sizeof(frm_buf);
         pj_uint32_t ts;
+        int popped_seq;
 
         /* Check if we have a packet with the next sequence number. */
         pjmedia_jbuf_peek_frame(c_strm->jb, 0, NULL, NULL, &frm_type, NULL,
                                 NULL, &next_seq);
 
-        /* Jitter buffer is empty, just return. */
-        if (frm_type == PJMEDIA_JB_ZERO_EMPTY_FRAME)
-            break;
-
-        if (!now && stream->rx_last_seq != -1 &&
-            next_seq != (pj_uint16_t)(stream->rx_last_seq + 1))
-        {
-            /* If analysis of a received packet reveals a gap in the sequence,
-             * we need to wait for the missing packet(s) to arrive.
-             * The waiting time is determined by MAX_RX_WAITING_TIME,
-             */
-            stream->is_waiting = PJ_TRUE;
-            pj_get_timestamp(&stream->rx_wait_ts);
+        /* PJSIP empty frame validation */
+        if (frm_type == PJMEDIA_JB_ZERO_EMPTY_FRAME ||
+            frm_type == PJMEDIA_JB_ZERO_PREFETCH_FRAME) {
             break;
         }
 
-        pjmedia_jbuf_get_frame3(c_strm->jb, frm_buf, &frm_size, &frm_type,
-                                NULL, &ts, &stream->rx_last_seq);
+        /* Pop the frame from the jitter buffer. */
+        pjmedia_jbuf_get_frame3(c_strm->jb, frm_buf, &frm_size, &frm_type, NULL,
+                                &ts, &popped_seq);
 
-        /* Call callback. */
+        /* Handle missing frames */
+        if (frm_type != PJMEDIA_JB_NORMAL_FRAME) {
+            if (frm_type == PJMEDIA_JB_MISSING_FRAME && stream->cb) {
+                /* Inject U+FFFD (replacement char) for lost packets */
+                pjmedia_txt_stream_data data;
+                data.seq = popped_seq;
+                data.ts = ts;
+                data.text.ptr = "\xEF\xBF\xBD";
+                data.text.slen = 3;
+
+                pj_mutex_unlock(c_strm->jb_mutex);
+                (*stream->cb)(stream, stream->cb_user_data, &data);
+                pj_mutex_lock(c_strm->jb_mutex);
+            }
+            continue;
+        }
+
+        /* Strip the UTF-8 BOM if it exists at the start of the frame */
+        char *text_ptr = frm_buf;
+        if (frm_size >= 3 && (unsigned char) text_ptr[0] == 0xEF &&
+            (unsigned char) text_ptr[1] == 0xBB &&
+            (unsigned char) text_ptr[2] == 0xBF) {
+            text_ptr += 3;
+            frm_size -= 3;
+        }
+
+        /* Prevent zero-length frames from waking up the UI */
         pj_mutex_unlock(c_strm->jb_mutex);
-        if (stream->cb) {
+        if (stream->cb && frm_size > 0) {
             pjmedia_txt_stream_data data;
 
-            data.seq = next_seq;
+            data.seq = popped_seq;
             data.ts = ts;
-            data.text.ptr = frm_buf;
+            data.text.ptr = text_ptr;
             data.text.slen = frm_size;
             (*stream->cb)(stream, stream->cb_user_data, &data);
-        } else {
-            TRACE_((c_strm->port.info.name.ptr, "Text data %zu: %.*s",
-                    frm_size, (int)frm_size, frm_buf));
+
+        } else if (!stream->cb && frm_size > 0) {
+            /* Debug trace if callback isn't set */
         }
         pj_mutex_lock(c_strm->jb_mutex);
+
     } while (1);
 
     pj_mutex_unlock(c_strm->jb_mutex);
 }
 
-static pj_status_t decode_red(pjmedia_txt_stream *stream,
-                              unsigned pt, int seq,
+static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
                               const char *buf, unsigned buflen,
                               unsigned *red_len)
 {
-    pjmedia_stream_common *c_strm = &stream->base;
-    pjmedia_rtp_add_hdr hdr[NUM_BUFFERS];
-    int i, len = 0, level = 0;
-    /* Acceptable seq delta for redundancy packets.
-     * The value is the same as the one used in rtp and jbuf
-     * for determining late packets.
-     */
-    enum { MAX_DELTA = 100 };
+    pj_uint32_t hdr[NUM_BUFFERS];
+    int i, level = 0;
+    unsigned consumed = 0;
 
-    /* Read the headers. */
-    do {
-        pjmedia_rtp_add_hdr_short shdr;
-
-        if (len + sizeof(shdr) > buflen)
+    /* Parse headers */
+    while (1) {
+        if (consumed + 1 > buflen)
             return PJ_ETOOBIG;
-
-        pj_memcpy(&shdr, buf, sizeof(shdr));
-        if (shdr.pt != (pj_uint8_t)pt) {
-            /* Bad PT, the PT is different from the expected media PT. */
+        pj_uint8_t b = (pj_uint8_t) buf[consumed];
+        if ((b & 0x7F) != (pj_uint8_t) pt)
             return PJMEDIA_EINVALIDPT;
-        }
-        if (shdr.f == 0) {
-            /* Zero F bit indicating final block. */
-            buf += sizeof(shdr);
-            len += sizeof(shdr);
+        if ((b & 0x80) == 0) {
+            consumed += 1;
             break;
         }
-
-        /* Redundancy level higher than what we can support. */
-        if (level >= c_strm->si->rx_red_level || level >= NUM_BUFFERS)
+        if (consumed + 4 > buflen || level >= NUM_BUFFERS)
             return PJ_ETOOBIG;
-        if (len + sizeof(hdr[level]) > buflen)
-            return PJ_ETOOBIG;
-
-        /* Store the headers. */
-        pj_memcpy(&hdr[level], buf, sizeof(hdr[level]));
+        pj_memcpy(&hdr[level], &buf[consumed], 4);
         hdr[level] = pj_ntohl(hdr[level]);
-        buf += sizeof(hdr[level]);
-        len += sizeof(hdr[level]);
-
+        consumed += 4;
         level++;
-    } while (1);
-
-    /* Read the redundant data. */
-    for (i = 0; i < level; i++) {
-        /* Bit 22-31 is block length. */
-        unsigned length = (hdr[i] & 0x3FF);
-        int ext_seq;
-        pj_uint16_t delta;
-
-        if (length == 0)
-            continue;
-        if (len + length > buflen)
-            return PJ_ETOOBIG;
-
-        ext_seq = (pj_uint16_t)(seq + i - level);
-        TRACE_((c_strm->port.info.name.ptr, "Received RTP red, seq: %d, "
-                "%.*s (%d bytes)", ext_seq, (int)length, buf, length));
-
-        delta = (pj_uint16_t) (stream->rx_last_seq - ext_seq);
-        if (delta < MAX_DELTA) {
-            /* Redundant packets that we already have in jbuf, do nothing. */
-        } else {
-            pjmedia_jbuf_put_frame(c_strm->jb, buf, length, ext_seq);
-        }
-
-        buf += length;
-        len += length;
     }
 
-    *red_len = len;
+    /* Parse redundant history blocks */
+    const char *payload_ptr = buf + consumed;
+    for (i = 0; i < level; i++) {
+        unsigned length = (hdr[i] & 0x3FF);
+        pj_uint16_t block_seq = (pj_uint16_t) (seq - (level - i));
 
+        const char *data_ptr = payload_ptr;
+        unsigned data_len = length;
+
+        if (length > 0) {
+            if (consumed + length > buflen)
+                return PJ_ETOOBIG;
+
+            /* Strip native BOM if it got trapped in history */
+            if (data_len >= 3 && (pj_uint8_t) data_ptr[0] == 0xEF &&
+                (pj_uint8_t) data_ptr[1] == 0xBB &&
+                (pj_uint8_t) data_ptr[2] == 0xBF) {
+                data_ptr += 3;
+                data_len -= 3;
+            }
+        }
+
+        /* Inject everything we missed, even length=0 frames! */
+        pj_int16_t diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
+        if (stream->rx_last_seq == 0 || diff > 0) {
+            pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
+                                   block_seq);
+            stream->rx_last_seq = block_seq; /* Update tracker */
+        }
+
+        if (length > 0) {
+            payload_ptr += length;
+            consumed += length;
+        }
+    }
+
+    /* Parse primary block */
+    unsigned primary_len = buflen - consumed;
+    const char *data_ptr = payload_ptr;
+    unsigned data_len = primary_len;
+
+    if (primary_len > 0) {
+        /* Strip native BOM if present */
+        if (data_len >= 3 && (pj_uint8_t) data_ptr[0] == 0xEF &&
+            (pj_uint8_t) data_ptr[1] == 0xBB &&
+            (pj_uint8_t) data_ptr[2] == 0xBF) {
+            data_ptr += 3;
+            data_len -= 3;
+        }
+    }
+
+    /* Detect gaps for primary */
+    pj_int16_t diff = (pj_int16_t) (seq - stream->rx_last_seq);
+    if (stream->rx_last_seq == 0 || diff > 0) {
+        pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
+                               (pj_uint16_t) seq);
+        stream->rx_last_seq = (pj_uint16_t) seq;
+    }
+
+    consumed += primary_len;
+    *red_len = consumed;
     return PJ_SUCCESS;
 }
 
 static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
                                     const pjmedia_rtp_hdr *hdr,
-                                    const void *payload,
-                                    unsigned payloadlen,
+                                    const void *payload, unsigned payloadlen,
                                     pjmedia_rtp_status seq_st,
                                     pj_bool_t *pkt_discarded)
 {
-    pjmedia_txt_stream *stream = (pjmedia_txt_stream *)c_strm;
-    unsigned red_len = 0;
-    int seq;
-    pj_status_t status;
+    pjmedia_txt_stream *stream = (pjmedia_txt_stream *) c_strm;
+    unsigned consumed = 0;
+    pj_uint16_t seq = pj_ntohs(hdr->seq);
+    pj_status_t status = PJ_SUCCESS;
 
     pj_mutex_lock(c_strm->jb_mutex);
-
     if (seq_st.status.flag.restart) {
         stream->rx_last_seq = -1;
         pjmedia_jbuf_reset(c_strm->jb);
-        PJ_LOG(4, (c_strm->port.info.name.ptr, "Jitter buffer reset"));
     }
-
-    seq = pj_ntohs(hdr->seq);
 
     if (hdr->pt == c_strm->si->rx_red_pt) {
         status = decode_red(stream, c_strm->si->rx_pt, seq,
-                            (const char *)payload, payloadlen, &red_len);
-        if (status != PJ_SUCCESS) {
+                            (const char *) payload, payloadlen, &consumed);
+    } else if (hdr->pt == c_strm->si->rx_pt) {
+        pj_int16_t diff = (pj_int16_t) (seq - stream->rx_last_seq);
+        if (stream->rx_last_seq == -1 || diff > 0) {
+            pjmedia_jbuf_put_frame(c_strm->jb, payload, payloadlen, seq);
+        } else {
             *pkt_discarded = PJ_TRUE;
-            pj_mutex_unlock(c_strm->jb_mutex);
-            return status;
         }
+    } else {
+        status = PJMEDIA_EINVALIDPT;
+        *pkt_discarded = PJ_TRUE;
     }
 
-    /* Put the primary data into jbuf. */
-    payload = ((pj_uint8_t*)payload) + red_len;
-    payloadlen -= red_len;
-    if (seq > stream->rx_last_seq) {
-        pjmedia_jbuf_put_frame(c_strm->jb, payload, payloadlen, seq);
-    }
-
+    if (!(*pkt_discarded))
+        stream->rx_last_seq = seq;
     pj_mutex_unlock(c_strm->jb_mutex);
-
-    /* Check if we need to call the callback. */
-    call_cb(stream, PJ_FALSE);
-
-    return PJ_SUCCESS;
+    if (!(*pkt_discarded))
+        call_cb(stream, PJ_FALSE);
+    return status;
 }
 
-static pj_status_t encode_red(unsigned level, unsigned pt,
-                              red_buf *rbuf, unsigned rbuf_idx,
-                              char *buf, int *size)
+static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
+                              char *buf, int *size,
+                              pj_bool_t force_empty_history)
 {
     int i;
     unsigned len = 0;
+    pj_uint8_t *p_hdr = (pj_uint8_t *) buf;
 
-    /* Encode RTP additional headers for redundancy. */
+    unsigned level = stream->si.tx_red_level;
+    if (level >= NUM_BUFFERS)
+        level = NUM_BUFFERS - 1;
+
+    /* Write redundant headers */
     for (i = level; i > 0; i--) {
-        pjmedia_rtp_add_hdr_short shdr;
-        pjmedia_rtp_add_hdr hdr = 0;
-        int past_idx, offset;
+        pj_uint32_t offset = 0;
+        unsigned hist_len = 0;
 
-        past_idx = (int)rbuf_idx - i;
-        if (past_idx < 0) past_idx += NUM_BUFFERS;
-
-        /* 1 means not final. */
-        shdr.f = 1;
-        shdr.pt = (pj_uint8_t)pt;
-
-        /* Timestamp is an offset, not absolute. */
-        offset = rbuf[rbuf_idx].timestamp - rbuf[past_idx].timestamp;
-        /* 4.1. Redundant data with timestamp offset > 16383 MUST NOT
-         * be included.
-         */
-        if (offset > 16383) {
-            offset = 0;
-            rbuf[past_idx].length = 0;
+        /* Enforce empty history if requested */
+        if (!force_empty_history) {
+            offset = stream->tx_buf[0].timestamp - stream->tx_buf[i].timestamp;
+            if (offset > 16383)
+                continue; /* Skip uninitialized */
+            hist_len = stream->tx_buf[i].length;
         }
-        hdr = offset << 10;
 
-        /* Block length. */
-        hdr |= rbuf[past_idx].length;
-
-        if (len + sizeof(hdr) > (unsigned)*size)
+        if (len + 4 > (unsigned) *size)
             return PJ_ETOOBIG;
-        hdr = pj_htonl(hdr);
-        pj_memcpy(buf, &hdr, sizeof(hdr));
-        pj_memcpy(buf, &shdr, sizeof(shdr));
-        buf += sizeof(hdr);
-        len += sizeof(hdr);
+
+        *p_hdr++ = (pj_uint8_t) (0x80 | (pt & 0x7F));
+        *p_hdr++ = (pj_uint8_t) ((offset >> 6) & 0xFF);
+        *p_hdr++ =
+            (pj_uint8_t) (((offset << 2) & 0xFC) | ((hist_len >> 8) & 0x03));
+        *p_hdr++ = (pj_uint8_t) (hist_len & 0xFF);
+        len += 4;
     }
 
-    if (level > 0) {
-        pjmedia_rtp_add_hdr_short hdr;
+    /* Primary header */
+    if (len + 1 > (unsigned) *size)
+        return PJ_ETOOBIG;
+    *p_hdr++ = (pj_uint8_t) (pt & 0x7F);
+    len += 1;
 
-        /* Last RTP additional header, for the primary data. */
-        hdr.f = 0;
-        hdr.pt = (pj_uint8_t)pt;
-        if (len + sizeof(hdr) > (unsigned)*size)
-            return PJ_ETOOBIG;
-        pj_memcpy(buf, &hdr, sizeof(hdr));
-        buf += sizeof(hdr);
-        len += sizeof(hdr);
-    }
-
-    /* Encode the redundant data placed in age order (with the most
-     * recent put last), and finally, the primary data.
-     */
+    /* Payloads */
+    pj_uint8_t *p_data = p_hdr;
     for (i = level; i >= 0; i--) {
-        int idx = (int)rbuf_idx - i;
-        if (idx < 0) idx += NUM_BUFFERS;
+        unsigned payload_len =
+            (force_empty_history && i > 0) ? 0 : stream->tx_buf[i].length;
 
-        if (rbuf[idx].length == 0)
+        if (payload_len == 0)
             continue;
-        if (len + rbuf[idx].length > (unsigned)*size)
+
+        if (!force_empty_history && i > 0) {
+            pj_uint32_t off =
+                stream->tx_buf[0].timestamp - stream->tx_buf[i].timestamp;
+            if (off > 16383)
+                continue;
+        }
+
+        if (len + payload_len > (unsigned) *size)
             return PJ_ETOOBIG;
-        pj_memcpy(buf, rbuf[idx].buf, rbuf[idx].length);
-        buf += rbuf[idx].length;
-        len += rbuf[idx].length;
+
+        pj_memcpy(p_data, stream->tx_buf[i].buf, payload_len);
+        p_data += payload_len;
+        len += payload_len;
     }
 
     *size = len;
     return PJ_SUCCESS;
 }
 
-
-static pj_status_t send_text(pjmedia_txt_stream *stream,
-                             unsigned rtp_ts_len)
+static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
 {
     pjmedia_stream_common *c_strm = &stream->base;
     pjmedia_channel *channel = c_strm->enc;
     void *rtphdr;
-    int size;
-    unsigned pt = 0;
+    int size, i;
     pj_status_t status = PJ_SUCCESS;
+    pj_bool_t is_keepalive = PJ_FALSE;
+    pj_timestamp now;
 
+    /* Lock Jitter Buffer mutex to protect stream state during transmission */
     pj_mutex_lock(c_strm->jb_mutex);
+    pj_get_timestamp(&now);
 
-    if (stream->is_idle &&
-        stream->tx_buf[stream->tx_buf_idx].length == 0)
-    {
-        /* Nothing to send. */
-        goto on_return;
-    }
+    pj_bool_t is_first_packet =
+        (stream->tx_last_ts.u32.hi == 0 && stream->tx_last_ts.u32.lo == 0);
 
-    pt = (stream->si.tx_red_pt && stream->tx_nred)?
-         stream->si.tx_red_pt: channel->pt;
-
-    status = pjmedia_rtp_encode_rtp( &channel->rtp,
-                                     pt, 0,
-                                     (int)channel->buf_size, rtp_ts_len,
-                                     (const void**)&rtphdr,
-                                     &size);
-
-    TRACE_((c_strm->port.info.name.ptr, "Sending text with seq %d, %.*s "
-            "(%d bytes), pt:%d red:%d",
-            pj_ntohs(channel->rtp.out_hdr.seq),
-            (int)stream->tx_buf[stream->tx_buf_idx].length,
-            stream->tx_buf[stream->tx_buf_idx].buf,
-            (int)stream->tx_buf[stream->tx_buf_idx].length,
-            pt, stream->tx_nred));
-
-    if (status != PJ_SUCCESS)
-        goto on_return;
-
-    /* Copy RTP header to the beginning of packet */
-    pj_memcpy(channel->buf, rtphdr, sizeof(pjmedia_rtp_hdr));
-
-    if (stream->is_idle) {
-        stream->is_idle = PJ_FALSE;
-        /* Set M-bit for the first packet in a session, and the first
-         * packet after an idle period.
-         */
-        ((pjmedia_rtp_hdr *)channel->buf)->m = 1;
-    }
-
-    size = channel->buf_size - sizeof(pjmedia_rtp_hdr);
-    status = encode_red(stream->tx_nred, channel->pt,
-                        stream->tx_buf, stream->tx_buf_idx,
-                        ((char*)channel->buf) + sizeof(pjmedia_rtp_hdr),
-                        &size);
-    if (status != PJ_SUCCESS)
-        goto on_return;
-
-    if (stream->tx_buf[stream->tx_buf_idx].length == 0) {
-        int i;
-
-        /* We are in idle if:
-         * - no new T.140 data is available for transmission, and
-         * - there's no more redundancy packet to send.
-         */
-        stream->is_idle = PJ_TRUE;
-        for (i = 0; i < stream->tx_nred - 1; i++) {
-            int idx = (int)stream->tx_buf_idx - 1 - i;
-            if (idx < 0) idx += NUM_BUFFERS;
-            if (stream->tx_buf[idx].length != 0) {
-                stream->is_idle = PJ_FALSE;
-                break;
-            }
+    /* Calculate RTP timestamp increment based on actual elapsed time */
+    if (rtp_ts_len == 0) {
+        if (is_first_packet) {
+            rtp_ts_len = 20;
+        } else {
+            rtp_ts_len = pj_elapsed_msec(&stream->tx_last_ts, &now);
         }
-
-        /* If idle, reset redundancy. */
-        if (stream->is_idle) stream->tx_nred = 0;
-    } else if (stream->tx_nred < stream->si.tx_red_level) {
-        /* We have data, increase the number of redundancies. */
-        stream->tx_nred++;
+        if (rtp_ts_len == 0)
+            rtp_ts_len = 1;
     }
 
-    stream->tx_buf_idx = (stream->tx_buf_idx + 1) % NUM_BUFFERS;
-    stream->tx_buf[stream->tx_buf_idx].length = 0;
+    /* Check for Keep-Alive condition (RFC 4103 recommends 10s of idle time) */
+    if (stream->is_idle && stream->tx_buf[0].length == 0) {
+        if (!is_first_packet &&
+            pj_elapsed_msec(&stream->tx_last_ts, &now) >= 10000) {
+            is_keepalive = PJ_TRUE;
+        } else {
+            status = PJ_SUCCESS;
+            goto on_return;
+        }
+    }
 
+    unsigned pt_to_use =
+        (stream->si.tx_red_pt) ? stream->si.tx_red_pt : channel->pt;
+
+    /* Protect against application-layer BOMs leaking into the buffer */
+    if (stream->tx_buf[0].length >= 3 &&
+        (pj_uint8_t) stream->tx_buf[0].buf[0] == 0xEF &&
+        (pj_uint8_t) stream->tx_buf[0].buf[1] == 0xBB &&
+        (pj_uint8_t) stream->tx_buf[0].buf[2] == 0xBF) {
+        stream->tx_buf[0].length -= 3;
+        pj_memmove(stream->tx_buf[0].buf, stream->tx_buf[0].buf + 3,
+                   stream->tx_buf[0].length);
+    }
+
+    /* BOM sent once per session to establish UTF-8 capability */
+    if (is_first_packet && stream->tx_buf[0].length > 0) {
+        void *bom_rtphdr;
+        int bom_size;
+
+        /* M=1 (Marker bit) for the first packet of a talkspurt */
+        status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 1,
+                                        (int) channel->buf_size, rtp_ts_len,
+                                        (const void **) &bom_rtphdr, &bom_size);
+        if (status == PJ_SUCCESS) {
+            pj_memcpy(channel->buf, bom_rtphdr, sizeof(pjmedia_rtp_hdr));
+            pj_uint32_t bom_ts = pj_ntohl(((pjmedia_rtp_hdr *) bom_rtphdr)->ts);
+
+            /* Back up the actual character the user typed */
+            char temp_buf[256];
+            unsigned temp_len = stream->tx_buf[0].length;
+            pj_memcpy(temp_buf, stream->tx_buf[0].buf, temp_len);
+
+            /* Load the BOM into the active slot */
+            stream->tx_buf[0].buf[0] = 0xEF;
+            stream->tx_buf[0].buf[1] = 0xBB;
+            stream->tx_buf[0].buf[2] = 0xBF;
+            stream->tx_buf[0].length = 3;
+            stream->tx_buf[0].timestamp = bom_ts;
+
+            for (i = 1; i < NUM_BUFFERS; i++) {
+                stream->tx_buf[i].length = 0;
+                stream->tx_buf[i].timestamp = bom_ts;
+            }
+
+            /* Encode the BOM with forced empty redundant headers */
+            bom_size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
+            status =
+                encode_red(stream, (unsigned) stream->si.tx_pt,
+                           ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                           &bom_size, PJ_TRUE);
+
+            if (status == PJ_SUCCESS) {
+                pj_mutex_unlock(c_strm->jb_mutex);
+                pjmedia_transport_send_rtp(c_strm->transport, channel->buf,
+                                           bom_size + sizeof(pjmedia_rtp_hdr));
+                pj_mutex_lock(c_strm->jb_mutex);
+            }
+
+            /* Shift the register: BOM becomes history for the next packet */
+            for (i = NUM_BUFFERS - 1; i > 0; i--) {
+                stream->tx_buf[i] = stream->tx_buf[i - 1];
+            }
+
+            /* Restore the user's typed character */
+            stream->tx_buf[0].length = temp_len;
+            pj_memcpy(stream->tx_buf[0].buf, temp_buf, temp_len);
+
+            is_first_packet = PJ_FALSE;
+            stream->is_idle = PJ_FALSE;
+            rtp_ts_len = 10; /* TS advance for the actual character packet */
+        }
+    }
+
+    /* If there's no data, no pending RED, and not a keepalive, we are done */
+    if (stream->tx_buf[0].length == 0 && !is_keepalive &&
+        stream->tx_nred == 0) {
+        status = PJ_SUCCESS;
+        goto on_return;
+    }
+
+    /* Standard character transmission */
+    status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 0,
+                                    (int) channel->buf_size, rtp_ts_len,
+                                    (const void **) &rtphdr, &size);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+
+    pj_memcpy(channel->buf, rtphdr, sizeof(pjmedia_rtp_hdr));
+    stream->tx_buf[0].timestamp = pj_ntohl(((pjmedia_rtp_hdr *) rtphdr)->ts);
+
+    /* Mid-session Talkspurt initialization (e.g., typing after a long pause) */
+    if (stream->is_idle && !is_keepalive) {
+        stream->is_idle = PJ_FALSE;
+        ((pjmedia_rtp_hdr *) channel->buf)->m = 1;
+    }
+
+    /* Encode character packet with normal redundancy */
+    size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
+    status = encode_red(stream, (unsigned) stream->si.tx_pt,
+                        ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                        &size, PJ_FALSE);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+
+    /* Linear shift register management */
+    if (stream->tx_buf[0].length > 0) {
+        /* We just sent a new character, reset the trailing packet counter */
+        stream->tx_nred = stream->si.tx_red_level;
+        for (i = NUM_BUFFERS - 1; i > 0; i--) {
+            stream->tx_buf[i] = stream->tx_buf[i - 1];
+        }
+        stream->tx_buf[0].length = 0;
+
+    } else if (stream->tx_nred > 0) {
+        /* We are sending empty packets to fulfill redundancy requirements */
+        stream->tx_nred--;
+        if (stream->tx_nred == 0)
+            stream->is_idle = PJ_TRUE;
+        for (i = NUM_BUFFERS - 1; i > 0; i--) {
+            stream->tx_buf[i] = stream->tx_buf[i - 1];
+        }
+        stream->tx_buf[0].length = 0;
+
+    } else if (is_keepalive) {
+        /* Keepalives do not advance the shift register */
+        stream->is_idle = PJ_TRUE;
+    } else {
+        goto on_return;
+    }
+
+    /* network transmission */
     pj_mutex_unlock(c_strm->jb_mutex);
-
-    /* Send the RTP packet to the transport. */
     status = pjmedia_transport_send_rtp(c_strm->transport, channel->buf,
                                         size + sizeof(pjmedia_rtp_hdr));
-
     pj_mutex_lock(c_strm->jb_mutex);
+
     if (status == PJ_SUCCESS) {
         pj_get_timestamp(&stream->tx_last_ts);
-
-        /* Update stat */
-        pjmedia_rtcp_tx_rtp(&c_strm->rtcp, (unsigned)size);
-        c_strm->rtcp.stat.rtp_tx_last_ts =
-            pj_ntohl(c_strm->enc->rtp.out_hdr.ts);
-        c_strm->rtcp.stat.rtp_tx_last_seq =
-            pj_ntohs(c_strm->enc->rtp.out_hdr.seq);
-
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
-        /* Update time of last sending packet. */
-        pj_gettimeofday(&c_strm->last_frm_ts_sent);
-#endif
-
-    } else {
-        TRACE_((c_strm->port.info.name.ptr, "Failed sending text %d", status));
     }
 
 on_return:
@@ -810,8 +896,7 @@ static void check_tx_rtcp(pjmedia_txt_stream *stream)
     if (stream->rtcp_last_tx.u64 == 0) {
         stream->rtcp_last_tx = now;
     } else if (pj_elapsed_msec(&stream->rtcp_last_tx, &now) >=
-               c_strm->rtcp_interval)
-    {
+               c_strm->rtcp_interval) {
         pj_status_t status;
 
         status = send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled, PJ_FALSE,
@@ -825,7 +910,7 @@ static void check_tx_rtcp(pjmedia_txt_stream *stream)
 /* Clock callback */
 static void clock_cb(const pj_timestamp *ts, void *user_data)
 {
-    pjmedia_txt_stream *stream = (pjmedia_txt_stream *)user_data;
+    pjmedia_txt_stream *stream = (pjmedia_txt_stream *) user_data;
     pj_timestamp now;
     unsigned interval;
 
@@ -838,8 +923,7 @@ static void clock_cb(const pj_timestamp *ts, void *user_data)
      * time, send the text now.
      */
     if (interval >= stream->buf_time ||
-        interval + stream->buf_time > MAX_BUFFERING_TIME)
-    {
+        interval + stream->buf_time > MAX_BUFFERING_TIME) {
         send_text(stream, interval);
     }
 
@@ -870,16 +954,15 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
 
     pj_mutex_lock(c_strm->jb_mutex);
 
-    if (stream->tx_buf[stream->tx_buf_idx].length + text->slen > BUFFER_SIZE)
-    {
+    if (stream->tx_buf[stream->tx_buf_idx].length + text->slen > BUFFER_SIZE) {
         pj_mutex_unlock(c_strm->jb_mutex);
         return PJ_ETOOMANY;
     }
 
     pj_memcpy(stream->tx_buf[stream->tx_buf_idx].buf +
-              stream->tx_buf[stream->tx_buf_idx].length,
+                  stream->tx_buf[stream->tx_buf_idx].length,
               text->ptr, text->slen);
-    stream->tx_buf[stream->tx_buf_idx].length += (unsigned)text->slen;
+    stream->tx_buf[stream->tx_buf_idx].length += (unsigned) text->slen;
 
     /* Decide if we should send the text immediately or just buffer it. */
     pj_get_timestamp(&now);
@@ -893,15 +976,14 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
     return status;
 }
 
-PJ_DEF(pj_status_t) pjmedia_txt_stream_set_rx_callback(
-                        pjmedia_txt_stream *stream,
-                        void (*cb)(pjmedia_txt_stream *,
-                                   void *user_data,
-                                   const pjmedia_txt_stream_data *data),
-                        void *user_data,
-                        unsigned option)
+PJ_DEF(pj_status_t)
+pjmedia_txt_stream_set_rx_callback(
+    pjmedia_txt_stream *stream,
+    void (*cb)(pjmedia_txt_stream *, void *user_data,
+               const pjmedia_txt_stream_data *data),
+    void *user_data, unsigned option)
 {
-    pjmedia_stream_common *c_strm = (pjmedia_stream_common *)stream;
+    pjmedia_stream_common *c_strm = (pjmedia_stream_common *) stream;
 
     PJ_ASSERT_RETURN(stream, PJ_EINVAL);
 
@@ -917,109 +999,95 @@ PJ_DEF(pj_status_t) pjmedia_txt_stream_set_rx_callback(
     return PJ_SUCCESS;
 }
 
-/*
+/**
  * Internal function for collecting codec info from the SDP media.
  */
-static pj_status_t get_codec_info(pjmedia_txt_stream_info *si,
-                                  pj_pool_t *pool,
+static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
                                   const pjmedia_sdp_media *local_m,
                                   const pjmedia_sdp_media *rem_m)
 {
-    static const pj_str_t ID_RTPMAP = { "rtpmap", 6 };
-    static const pj_str_t ID_REDUNDANCY = { "red", 3 };
+    static const pj_str_t ID_RTPMAP = {"rtpmap", 6};
+    static const pj_str_t ID_REDUNDANCY = {"red", 3};
     const pjmedia_sdp_attr *attr;
-    pjmedia_sdp_rtpmap *rtpmap;
-    unsigned i, fmti, pt = 0;
-    pj_status_t status = PJ_SUCCESS;
+    unsigned i, fmti;
+    unsigned rem_red_pt = 0;
+    unsigned rem_t140_pt = 0;
 
-    /* Find the first pt which is not redundancy */
-    for (fmti = 0; fmti < local_m->desc.fmt_count; ++fmti) {
+    /* Find Remote RED PT */
+    for (i = 0; i < rem_m->desc.fmt_count; ++i) {
         pjmedia_sdp_rtpmap r;
-
-        if (!pj_isdigit(*local_m->desc.fmt[fmti].ptr))
-            return PJMEDIA_EINVALIDPT;
-
-        attr = pjmedia_sdp_media_find_attr(local_m, &ID_RTPMAP,
-                                           &local_m->desc.fmt[fmti]);
-        if (attr == NULL)
-            continue;
-
-        status = pjmedia_sdp_attr_get_rtpmap(attr, &r);
-        if (status != PJ_SUCCESS)
-            continue;
-
-        if (pj_strcmp(&r.enc_name, &ID_REDUNDANCY) != 0)
-            break;
+        attr =
+            pjmedia_sdp_media_find_attr(rem_m, &ID_RTPMAP, &rem_m->desc.fmt[i]);
+        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
+            if (pj_strcmp(&r.enc_name, &ID_REDUNDANCY) == 0) {
+                rem_red_pt = (unsigned) pj_strtoul(&rem_m->desc.fmt[i]);
+                break;
+            }
+        }
     }
-    if (fmti >= local_m->desc.fmt_count)
-        return PJMEDIA_EINVALIDPT;
 
-    pt = pj_strtoul(&local_m->desc.fmt[fmti]);
-    if (pt < 96)
-        return PJMEDIA_EINVALIDPT;
+    /* Find Remote T.140 PT (must not be RED) */
+    for (i = 0; i < rem_m->desc.fmt_count; ++i) {
+        unsigned pt = (unsigned) pj_strtoul(&rem_m->desc.fmt[i]);
+        if (pt == rem_red_pt)
+            continue;
 
-    /* Get payload type for receiving direction */
-    si->rx_pt = pt;
-
-    /* Get codec info. */
-    attr = pjmedia_sdp_media_find_attr(local_m, &ID_RTPMAP,
-                                       &local_m->desc.fmt[fmti]);
-    if (attr == NULL)
-        return PJMEDIA_EMISSINGRTPMAP;
-
-    status = pjmedia_sdp_attr_to_rtpmap(pool, attr, &rtpmap);
-    if (status != PJ_SUCCESS)
-        return status;
-
-    /* Build codec format info: */
-    si->fmt.type = si->type;
-    si->fmt.pt = pj_strtoul(&local_m->desc.fmt[fmti]);
-    si->fmt.encoding_name = rtpmap->enc_name;
-    si->fmt.clock_rate = rtpmap->clock_rate;
-    si->fmt.channel_cnt = 1;
-
-    /* Determine payload type for outgoing channel, by finding
-     * dynamic payload type in remote SDP that matches the answer.
-     */
-    si->tx_pt = 0xFFFF;
-    for (i=0; i<rem_m->desc.fmt_count; ++i) {
-        if (pjmedia_sdp_neg_fmt_match(pool,
-                                      (pjmedia_sdp_media*)local_m, fmti,
-                                      (pjmedia_sdp_media*)rem_m, i, fmti) ==
-            PJ_SUCCESS)
-        {
-            /* Found matched codec. */
-            si->tx_pt = pj_strtoul(&rem_m->desc.fmt[i]);
+        pjmedia_sdp_rtpmap r;
+        attr =
+            pjmedia_sdp_media_find_attr(rem_m, &ID_RTPMAP, &rem_m->desc.fmt[i]);
+        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
+            rem_t140_pt = pt;
             break;
         }
     }
 
-    if (si->tx_pt == 0xFFFF)
-        return PJMEDIA_EMISSINGRTPMAP;
+    si->tx_red_pt = (pj_uint8_t) rem_red_pt;
+    si->tx_pt = (pj_uint8_t) rem_t140_pt;
 
-    /* Get remote fmtp for our encoder. */
-    pjmedia_stream_info_parse_fmtp(pool, rem_m, si->tx_pt,
-                                   &si->enc_fmtp);
+    /* Get Local RX parameters... */
+    for (fmti = 0; fmti < local_m->desc.fmt_count; ++fmti) {
+        pjmedia_sdp_rtpmap r;
+        attr = pjmedia_sdp_media_find_attr(local_m, &ID_RTPMAP,
+                                           &local_m->desc.fmt[fmti]);
+        if (attr && pjmedia_sdp_attr_get_rtpmap(attr, &r) == PJ_SUCCESS) {
+            if (pj_strcmp(&r.enc_name, &ID_REDUNDANCY) == 0) {
+                si->rx_red_pt =
+                    (pj_uint8_t) pj_strtoul(&local_m->desc.fmt[fmti]);
+            } else {
+                si->rx_pt = (pj_uint8_t) pj_strtoul(&local_m->desc.fmt[fmti]);
+            }
+        }
+    }
 
-    /* Get local fmtp for our decoder. */
-    pjmedia_stream_info_parse_fmtp(pool, local_m, si->rx_pt,
-                                   &si->dec_fmtp);
+    /* Parse redundancy level */
+    if (rem_red_pt > 0) {
+        if (pjmedia_stream_info_parse_fmtp(pool, rem_m, rem_red_pt,
+                                           &si->enc_fmtp) == PJ_SUCCESS) {
+            int nameless = 0;
+            for (i = 0; i < si->enc_fmtp.cnt; ++i) {
+                if (si->enc_fmtp.param[i].name.slen == 0)
+                    nameless++;
+            }
+            si->tx_red_level = (nameless > 0) ? (nameless - 1) : 0;
+        }
+    }
+    /* Enforce T.140 clock rate */
+    si->fmt.clock_rate = 1000;
 
     return PJ_SUCCESS;
 }
 
-/*
+/**
  * Create stream info from SDP media line.
  */
-PJ_DEF(pj_status_t) pjmedia_txt_stream_info_from_sdp(
-                                           pjmedia_txt_stream_info *si,
-                                           pj_pool_t *pool,
-                                           pjmedia_endpt *endpt,
-                                           const pjmedia_sdp_session *local,
-                                           const pjmedia_sdp_session *remote,
-                                           unsigned stream_idx)
+PJ_DEF(pj_status_t)
+pjmedia_txt_stream_info_from_sdp(pjmedia_txt_stream_info *si, pj_pool_t *pool,
+                                 pjmedia_endpt *endpt,
+                                 const pjmedia_sdp_session *local,
+                                 const pjmedia_sdp_session *remote,
+                                 unsigned stream_idx)
 {
-    pjmedia_stream_info_common *csi = (pjmedia_stream_info_common *)si;
+    pjmedia_stream_info_common *csi = (pjmedia_stream_info_common *) si;
     const pjmedia_sdp_media *local_m;
     const pjmedia_sdp_media *rem_m;
     pj_bool_t active;

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -74,6 +74,8 @@
  */
 #define JBUF_MAX_COUNT          8
 
+/* Maximum size of a single text frame in bytes */
+#define MAX_TEXT_FRAME_SIZE      512
 
 /* Buffer to store redundancy and primary data. */
 typedef struct red_buf
@@ -83,32 +85,26 @@ typedef struct red_buf
     char     buf[BUFFER_SIZE];
 } red_buf;
 
-typedef struct pjmedia_txt_stream
-{
-    pjmedia_stream_common       base;
-    pjmedia_txt_stream_info     si;             /**< Creation parameter.    */
+typedef struct pjmedia_txt_stream {
+    pjmedia_stream_common base;
+    pjmedia_txt_stream_info si; /**< Creation parameter.    */
 
-    pjmedia_clock              *clock;          /**< Clock.                 */
-    unsigned                    buf_time;       /**< Buffering time.        */
-    pj_bool_t                   is_idle;        /**< Is idle?               */
+    pjmedia_clock *clock; /**< Clock.                 */
+    unsigned buf_time;    /**< Buffering time.        */
+    pj_bool_t is_idle;    /**< Is idle?               */
 
-    pj_timestamp                rtcp_last_tx;   /**< Last RTCP tx time.     */
-    pj_timestamp                tx_last_ts;     /**< Timestamp of last tx.  */
-    red_buf                     tx_buf[NUM_BUFFERS];/**< Tx buffer.         */
-    int                         tx_buf_idx;     /**< Index to current buffer*/
-    int                         tx_nred;        /**< Num of redundant data. */
+    pj_timestamp rtcp_last_tx;   /**< Last RTCP tx time.     */
+    pj_timestamp tx_last_ts;     /**< Timestamp of last tx.  */
+    red_buf tx_buf[NUM_BUFFERS]; /**< Tx buffer.         */
+    int tx_nred;                 /**< Num of redundant data. */
 
-    int                         rx_last_seq;    /**< Sequence of last rx.   */
-    pj_bool_t                   is_waiting;     /**< Is waiting?            */
-    pj_timestamp                rx_wait_ts;     /**< Ts of waiting start.   */
+    int rx_last_seq; /**< Sequence of last rx.   */
 
     /* Incoming text callback. */
-    void                      (*cb)(pjmedia_txt_stream *, void *,
-                                    const pjmedia_txt_stream_data *);
-    void                       *cb_user_data;
+    void (*cb)(pjmedia_txt_stream *, void *, const pjmedia_txt_stream_data *);
+    void *cb_user_data;
 
 } pjmedia_txt_stream;
-
 
 static void clock_cb(const pj_timestamp *ts, void *user_data);
 
@@ -427,30 +423,27 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
     pjmedia_stream_common *c_strm = &stream->base;
 
     char frm_type;
-    int next_seq;
-    char frm_buf[512];
+    char frm_buf[MAX_TEXT_FRAME_SIZE];
     pj_size_t frm_size = sizeof(frm_buf);
     pj_uint32_t ts;
     int popped_seq;
     char *text_ptr = NULL;
-
+    
     pj_mutex_lock(c_strm->jb_mutex);
 
-    stream->is_waiting = PJ_FALSE;
     do {
-        /* Check if we have a packet with the next sequence number. */
-        pjmedia_jbuf_peek_frame(c_strm->jb, 0, NULL, NULL, &frm_type, NULL,
-                                NULL, &next_seq);
+        /* Reset frm_size for every iteration to prevent truncation */
+        frm_size = sizeof(frm_buf);
+
+        /* Pop the frame from the jitter buffer. */
+        pjmedia_jbuf_get_frame3(c_strm->jb, frm_buf, &frm_size, &frm_type, NULL,
+                                &ts, &popped_seq);
 
         /* PJSIP empty frame validation */
         if (frm_type == PJMEDIA_JB_ZERO_EMPTY_FRAME ||
             frm_type == PJMEDIA_JB_ZERO_PREFETCH_FRAME) {
             break;
         }
-
-        /* Pop the frame from the jitter buffer. */
-        pjmedia_jbuf_get_frame3(c_strm->jb, frm_buf, &frm_size, &frm_type, NULL,
-                                &ts, &popped_seq);
 
         /* Handle missing frames */
         if (frm_type != PJMEDIA_JB_NORMAL_FRAME) {
@@ -560,7 +553,7 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
 
         /* Inject everything we missed, even length=0 frames! */
         diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
-        if (stream->rx_last_seq == 0 || diff > 0) {
+        if (stream->rx_last_seq == -1 || diff > 0) {
             pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                    block_seq);
             stream->rx_last_seq = block_seq; /* Update tracker */
@@ -589,7 +582,7 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
 
     /* Detect gaps for primary */
     diff = (pj_int16_t) (seq - stream->rx_last_seq);
-    if (stream->rx_last_seq == 0 || diff > 0) {
+    if (stream->rx_last_seq == -1 || diff > 0) {
         pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                (pj_uint16_t) seq);
         stream->rx_last_seq = (pj_uint16_t) seq;
@@ -621,13 +614,6 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
     if (hdr->pt == c_strm->si->rx_red_pt) {
         status = decode_red(stream, c_strm->si->rx_pt, seq,
                             (const char *) payload, payloadlen, &consumed);
-
-        if (status != PJ_SUCCESS) {
-            *pkt_discarded = PJ_TRUE;
-            pj_mutex_unlock(c_strm->jb_mutex); /* Unlock before error return */
-            return status;
-        }
-
     } else if (hdr->pt == c_strm->si->rx_pt) {
         /* Fallback: Route T.140 directly to Jitter Buffer */
         diff = (pj_int16_t) (seq - stream->rx_last_seq);
@@ -1007,17 +993,6 @@ static void clock_cb(const pj_timestamp *ts, void *user_data)
         send_text(stream, interval);
     }
 
-    /* If we are waiting for the packet gap, and the next clock cb
-     * occurs past the maximum waiting time, call the rx callback
-     * now.
-     */
-    if (stream->is_waiting) {
-        interval = pj_elapsed_msec(&stream->rx_wait_ts, &now);
-        if (interval + stream->buf_time > MAX_RX_WAITING_TIME) {
-            call_cb(stream, PJ_TRUE);
-        }
-    }
-
     /* Check if now is the time to transmit RTCP SR/RR report. */
     check_tx_rtcp(stream);
 }
@@ -1034,15 +1009,14 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
 
     pj_mutex_lock(c_strm->jb_mutex);
 
-    if (stream->tx_buf[0].length + text->slen > BUFFER_SIZE) {
+    if (stream->tx_buf[0].length + text->slen > MAX_TEXT_FRAME_SIZE) {
         pj_mutex_unlock(c_strm->jb_mutex);
         return PJ_ETOOMANY;
     }
 
-    pj_memcpy(stream->tx_buf[stream->tx_buf_idx].buf +
-                  stream->tx_buf[stream->tx_buf_idx].length,
-              text->ptr, text->slen);
-    stream->tx_buf[stream->tx_buf_idx].length += (unsigned) text->slen;
+    pj_memcpy(stream->tx_buf[0].buf + stream->tx_buf[0].length,
+            text->ptr, text->slen);
+    stream->tx_buf[0].length += (unsigned) text->slen;
 
     /* Decide if we should send the text immediately or just buffer it. */
     pj_get_timestamp(&now);
@@ -1153,7 +1127,7 @@ static pj_status_t get_codec_info(pjmedia_txt_stream_info *si, pj_pool_t *pool,
 
     /* Set fmt */
     si->fmt.type = PJMEDIA_TYPE_TEXT;
-    si->fmt.pt = si->tx_pt;
+    si->fmt.pt = si->rx_pt;
     pj_strset2(&si->fmt.encoding_name, "t140");
     si->fmt.clock_rate = 1000;
 

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -75,7 +75,7 @@
 #define JBUF_MAX_COUNT 8
 
 /* Maximum size of a single text frame in bytes */
-#define MAX_TEXT_FRAME_SIZE 512
+#define MAX_TEXT_FRAME_SIZE PJMEDIA_MAX_MTU
 
 /* Buffer to store redundancy and primary data. */
 typedef struct red_buf {
@@ -286,8 +286,8 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
     if (status != PJ_SUCCESS)
         goto err_cleanup;
 
-    /* Create encoder channel: */
-    buf_size = BUFFER_SIZE;
+    /* Create encoder channel: accommodate full RED headers and history */
+    buf_size = PJMEDIA_MAX_MTU;
     status = create_channel(pool, c_strm, PJMEDIA_DIR_ENCODING, info->tx_pt,
                             buf_size, c_strm->si, &c_strm->enc);
     if (status != PJ_SUCCESS)
@@ -559,8 +559,17 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
             }
         }
 
-        /* Inject everything we missed, even length=0 frames! */
+        /* Inject explicitly empty frames for tracking missing sequences */
         diff = (pj_int16_t) (block_seq - stream->rx_last_seq);
+        if (stream->rx_last_seq != -1 && diff > 1) {
+            pj_uint16_t missing_seq = stream->rx_last_seq + 1;
+            while (missing_seq != block_seq) {
+                pjmedia_jbuf_put_frame(stream->base.jb, "", 0, missing_seq);
+                missing_seq++;
+            }
+        }
+
+        /* Inject everything we missed, even length=0 frames! */
         if (stream->rx_last_seq == -1 || diff > 0) {
             pjmedia_jbuf_put_frame(stream->base.jb, data_ptr, data_len,
                                    block_seq);
@@ -634,6 +643,16 @@ static pj_status_t on_stream_rx_rtp(pjmedia_stream_common *c_strm,
     } else if (hdr->pt == c_strm->si->rx_pt) {
         /* Fallback: Route T.140 directly to Jitter Buffer */
         diff = (pj_int16_t) (seq - stream->rx_last_seq);
+
+        /* Inject explicitly empty frames for tracking missing sequences */
+        if (stream->rx_last_seq != -1 && diff > 1) {
+            pj_uint16_t missing_seq = stream->rx_last_seq + 1;
+            while (missing_seq != seq) {
+                pjmedia_jbuf_put_frame(c_strm->jb, "", 0, missing_seq);
+                missing_seq++;
+            }
+        }
+
         if (stream->rx_last_seq == -1 || diff > 0) {
             pjmedia_jbuf_put_frame(c_strm->jb, payload, payloadlen, seq);
             stream->rx_last_seq = seq;
@@ -800,8 +819,7 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
         void *bom_rtphdr;
         int bom_size;
         pj_uint32_t bom_ts;
-        char temp_buf[BUFFER_SIZE];
-        unsigned temp_len;
+        char bom_payload[3] = {(char) 0xEF, (char) 0xBB, (char) 0xBF};
 
         /* M=1 (Marker bit) for the first packet of a talkspurt */
         status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 1,
@@ -811,75 +829,65 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
             pj_memcpy(channel->buf, bom_rtphdr, sizeof(pjmedia_rtp_hdr));
             bom_ts = pj_ntohl(((pjmedia_rtp_hdr *) bom_rtphdr)->ts);
 
-            /* Back up the actual character the user typed */
-            temp_len = stream->tx_buf[0].length;
-            pj_memcpy(temp_buf, stream->tx_buf[0].buf, temp_len);
-
-            /* Load the BOM into the active slot */
-            stream->tx_buf[0].buf[0] = 0xEF;
-            stream->tx_buf[0].buf[1] = 0xBB;
-            stream->tx_buf[0].buf[2] = 0xBF;
-            stream->tx_buf[0].length = 3;
-            stream->tx_buf[0].timestamp = bom_ts;
-
-            for (i = 1; i < NUM_BUFFERS; i++) {
-                stream->tx_buf[i].length = 0;
-                stream->tx_buf[i].timestamp = bom_ts;
-            }
-
             if (use_red) {
-                /* Encode the BOM with forced empty redundant headers */
+                red_buf real_tx_buf[NUM_BUFFERS];
+                red_buf temp_tx_buf[NUM_BUFFERS];
+
+                /* Construct local RED history leaving stream->tx_buf untouched
+                 */
+                pj_bzero(temp_tx_buf, sizeof(temp_tx_buf));
+                temp_tx_buf[0].timestamp = bom_ts;
+                temp_tx_buf[0].length = 3;
+                pj_memcpy(temp_tx_buf[0].buf, bom_payload, 3);
+                for (i = 1; i < NUM_BUFFERS; i++)
+                    temp_tx_buf[i].timestamp = bom_ts;
+
+                /* Swap buffer context for encode_red */
+                pj_memcpy(real_tx_buf, stream->tx_buf, sizeof(real_tx_buf));
+                pj_memcpy(stream->tx_buf, temp_tx_buf, sizeof(temp_tx_buf));
+
                 bom_size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
                 status = encode_red(
                     stream, (unsigned) stream->si.tx_pt,
                     ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
                     &bom_size, PJ_TRUE);
+
+                /* Restore original state */
+                pj_memcpy(stream->tx_buf, real_tx_buf, sizeof(real_tx_buf));
             } else {
-                /* Direct payload copy for non-redundant BOM */
-                bom_size = stream->tx_buf[0].length;
+                bom_size = 3;
                 pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                          stream->tx_buf[0].buf, bom_size);
-                status = PJ_SUCCESS;
+                          bom_payload, 3);
             }
 
             if (status == PJ_SUCCESS) {
+                /* Allocate a local buffer for the BOM */
+                char bom_tx_pkt[PJMEDIA_MAX_MTU];
+                int bom_tx_size = bom_size + sizeof(pjmedia_rtp_hdr);
+
+                /* Copy the payload while the lock is still held */
+                pj_memcpy(bom_tx_pkt, channel->buf, bom_tx_size);
+
                 pj_mutex_unlock(c_strm->jb_mutex);
-                status = pjmedia_transport_send_rtp(
-                    c_strm->transport, channel->buf,
-                    bom_size + sizeof(pjmedia_rtp_hdr));
+                status = pjmedia_transport_send_rtp(c_strm->transport,
+                                                    bom_tx_pkt, bom_tx_size);
                 pj_mutex_lock(c_strm->jb_mutex);
+
                 if (status == PJ_SUCCESS) {
                     hdr = (pjmedia_rtp_hdr *) channel->buf;
-
-                    /* Update RTCP TX stats */
                     pjmedia_rtcp_tx_rtp(&c_strm->rtcp, bom_size);
                     c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(hdr->ts);
                     c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
                     pj_gettimeofday(&c_strm->last_frm_ts_sent);
 #endif
-
-                    /* Shift the register: BOM becomes history for the next
-                     * packet */
-                    for (i = NUM_BUFFERS - 1; i > 0; i--) {
-                        stream->tx_buf[i] = stream->tx_buf[i - 1];
-                    }
-
                     is_first_packet = PJ_FALSE;
                     stream->is_idle = PJ_FALSE;
-                    rtp_ts_len =
-                        10; /* TS advance for the actual character packet */
+                    rtp_ts_len = 10;
                 }
             }
-
-            /* Restore the user's typed character */
-            stream->tx_buf[0].length = temp_len;
-            pj_memcpy(stream->tx_buf[0].buf, temp_buf, temp_len);
-
-            /* If the BOM failed to send, abort */
-            if (status != PJ_SUCCESS) {
+            if (status != PJ_SUCCESS)
                 goto on_return;
-            }
         }
     }
 
@@ -960,24 +968,39 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
         goto on_return;
     }
 
-    /* Network transmission */
-    pj_mutex_unlock(c_strm->jb_mutex);
-    status = pjmedia_transport_send_rtp(c_strm->transport, channel->buf,
-                                        size + sizeof(pjmedia_rtp_hdr));
-    pj_mutex_lock(c_strm->jb_mutex);
+    /* Network transmission (applies to both BOM and standard payload) */
+    {
+        /* Allocate a local buffer */
+        char tx_pkt[PJMEDIA_MAX_MTU];
+        int tx_size = size + sizeof(pjmedia_rtp_hdr);
+        pj_uint32_t pkt_ts;
+        pj_uint16_t pkt_seq;
 
-    if (status == PJ_SUCCESS) {
+        /* Copy the payload while the lock is still held */
+        pj_memcpy(tx_pkt, channel->buf, tx_size);
+
+        /* Cache the headers to ensure RTCP stats remain accurate */
         hdr = (pjmedia_rtp_hdr *) channel->buf;
-        pj_get_timestamp(&stream->tx_last_ts);
+        pkt_ts = pj_ntohl(hdr->ts);
+        pkt_seq = pj_ntohs(hdr->seq);
 
-        /* Update RTCP TX stats */
-        pjmedia_rtcp_tx_rtp(&c_strm->rtcp, size);
-        c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(hdr->ts);
-        c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
+        /* Drop the lock and transmit the local copy */
+        pj_mutex_unlock(c_strm->jb_mutex);
+        status = pjmedia_transport_send_rtp(c_strm->transport, tx_pkt, tx_size);
+        pj_mutex_lock(c_strm->jb_mutex);
+
+        if (status == PJ_SUCCESS) {
+            pj_get_timestamp(&stream->tx_last_ts);
+
+            /* Update RTCP TX stats using the cached headers */
+            pjmedia_rtcp_tx_rtp(&c_strm->rtcp, size);
+            c_strm->rtcp.stat.rtp_tx_last_ts = pkt_ts;
+            c_strm->rtcp.stat.rtp_tx_last_seq = pkt_seq;
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
-        pj_gettimeofday(&c_strm->last_frm_ts_sent);
+            pj_gettimeofday(&c_strm->last_frm_ts_sent);
 #endif
+        }
     }
 
 on_return:

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -16,15 +16,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <pjmedia/txt_stream.h>
-#include <pjmedia/clock.h>
-#include <pjmedia/errno.h>
-#include <pjmedia/jbuf.h>
-#include <pjmedia/port.h>
-#include <pjmedia/rtp.h>
-#include <pjmedia/rtcp.h>
-#include <pjmedia/sdp_neg.h>
-#include <pjmedia/transport.h>
 #include <pj/assert.h>
 #include <pj/ctype.h>
 #include <pj/errno.h>
@@ -32,57 +23,65 @@
 #include <pj/os.h>
 #include <pj/pool.h>
 #include <pj/rand.h>
+#include <pjmedia/clock.h>
+#include <pjmedia/errno.h>
+#include <pjmedia/jbuf.h>
+#include <pjmedia/port.h>
+#include <pjmedia/rtcp.h>
+#include <pjmedia/rtp.h>
+#include <pjmedia/sdp_neg.h>
+#include <pjmedia/transport.h>
+#include <pjmedia/txt_stream.h>
 
-#define THIS_FILE                       "txt_stream.c"
-#define LOGERR_(expr)                   PJ_PERROR(4,expr)
-#define TRC_(expr)                      PJ_LOG(5,expr)
+#define THIS_FILE "txt_stream.c"
+#define LOGERR_(expr) PJ_PERROR(4, expr)
+#define TRC_(expr) PJ_LOG(5, expr)
 
 #if 0
-#   define TRACE_(log)  PJ_LOG(3, log)
+#define TRACE_(log) PJ_LOG(3, log)
 #else
-#   define TRACE_(log)
+#define TRACE_(log)
 #endif
 
 /* Default and max buffering time if not specified.
  * The RFC recommends a buffering time of 300 ms. Note that the maximum
  * according to the RFC is 500 ms.
  */
-#define BUFFERING_TIME          300
-#define MAX_BUFFERING_TIME      500
+#define BUFFERING_TIME 300
+#define MAX_BUFFERING_TIME 500
 
 /* Buffer size to store the characters buffered during BUFFERING_TIME.
  * The default cps (character per second) is 30, but it's over a 10-second
  * interval, so we need a larger buffer to handle the burst.
  */
-#define BUFFER_SIZE             64
+#define BUFFER_SIZE 64
 
 /* The number of buffers must be the max redundancy we want to support +
  * plus one more to store the primary data.
  */
-#define NUM_BUFFERS             PJMEDIA_TXT_STREAM_MAX_RED_LEVELS + 1
+#define NUM_BUFFERS PJMEDIA_TXT_STREAM_MAX_RED_LEVELS + 1
 
 /* 5.4. Compensation for Packets Out of Order:
  * If analysis of a received packet reveals a gap in the sequence,
  * we need to wait for the missing packet(s) to arrive.  It is
  * RECOMMENDED the waiting time be limited to 1 second (1000 ms).
  */
-#define MAX_RX_WAITING_TIME     1000
+#define MAX_RX_WAITING_TIME 1000
 
 /* Maximum number of text packets that can be kept in the jitter buffer.
  * The value should be roughly our MAX_RX_WAITING_TIME over remote's
  * buffering time (which unfortunately we don't know).
  */
-#define JBUF_MAX_COUNT          8
+#define JBUF_MAX_COUNT 8
 
 /* Maximum size of a single text frame in bytes */
-#define MAX_TEXT_FRAME_SIZE      512
+#define MAX_TEXT_FRAME_SIZE 512
 
 /* Buffer to store redundancy and primary data. */
-typedef struct red_buf
-{
+typedef struct red_buf {
     unsigned timestamp;
     unsigned length;
-    char     buf[BUFFER_SIZE];
+    char buf[BUFFER_SIZE];
 } red_buf;
 
 typedef struct pjmedia_txt_stream {
@@ -108,12 +107,11 @@ typedef struct pjmedia_txt_stream {
 
 static void clock_cb(const pj_timestamp *ts, void *user_data);
 
-
 #include "stream_imp_common.c"
 
 static void on_stream_destroy(void *arg)
 {
-    pjmedia_txt_stream *stream = (pjmedia_txt_stream *)arg;
+    pjmedia_txt_stream *stream = (pjmedia_txt_stream *) arg;
 
     if (stream->clock) {
         pjmedia_clock_destroy(stream->clock);
@@ -124,13 +122,13 @@ static void on_stream_destroy(void *arg)
 /*
  * Destroy stream.
  */
-PJ_DEF(pj_status_t) pjmedia_txt_stream_destroy( pjmedia_txt_stream *stream )
+PJ_DEF(pj_status_t) pjmedia_txt_stream_destroy(pjmedia_txt_stream *stream)
 {
-    pjmedia_stream_common *c_strm = (pjmedia_stream_common *)stream;
+    pjmedia_stream_common *c_strm = (pjmedia_stream_common *) stream;
 
     PJ_ASSERT_RETURN(stream != NULL, PJ_EINVAL);
 
-    PJ_LOG(4,(c_strm->port.info.name.ptr, "Stream destroying"));
+    PJ_LOG(4, (c_strm->port.info.name.ptr, "Stream destroying"));
 
     stream->cb = NULL;
 
@@ -140,18 +138,18 @@ PJ_DEF(pj_status_t) pjmedia_txt_stream_destroy( pjmedia_txt_stream *stream )
     /* Send RTCP BYE (also SDES & XR) */
     if (c_strm->transport && !c_strm->rtcp_sdes_bye_disabled) {
 #if defined(PJMEDIA_HAS_RTCP_XR) && (PJMEDIA_HAS_RTCP_XR != 0)
-        send_rtcp(c_strm, PJ_TRUE, PJ_TRUE, c_strm->rtcp.xr_enabled,
-                  PJ_FALSE, PJ_FALSE, PJ_FALSE);
-#else
-        send_rtcp(c_strm, PJ_TRUE, PJ_TRUE, PJ_FALSE, PJ_FALSE,
+        send_rtcp(c_strm, PJ_TRUE, PJ_TRUE, c_strm->rtcp.xr_enabled, PJ_FALSE,
                   PJ_FALSE, PJ_FALSE);
+#else
+        send_rtcp(c_strm, PJ_TRUE, PJ_TRUE, PJ_FALSE, PJ_FALSE, PJ_FALSE,
+                  PJ_FALSE);
 #endif
     }
 
     /* Unsubscribe from RTCP session events
      * Currently unused
      */
-    //pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream, &c_strm->rtcp);
+    // pjmedia_event_unsubscribe(NULL, &stream_event_cb, stream, &c_strm->rtcp);
 
     /* Detach from transport
      * MUST NOT hold stream mutex while detaching from transport, as
@@ -159,7 +157,7 @@ PJ_DEF(pj_status_t) pjmedia_txt_stream_destroy( pjmedia_txt_stream *stream )
      */
     if (c_strm->transport) {
         pjmedia_transport_detach(c_strm->transport, c_strm);
-        //c_strm->transport = NULL;
+        // c_strm->transport = NULL;
     }
 
     if (c_strm->grp_lock) {
@@ -172,12 +170,10 @@ PJ_DEF(pj_status_t) pjmedia_txt_stream_destroy( pjmedia_txt_stream *stream )
 }
 
 PJ_DEF(pj_status_t)
-pjmedia_txt_stream_create( pjmedia_endpt *endpt,
-                           pj_pool_t *pool,
-                           const pjmedia_txt_stream_info *info,
-                           pjmedia_transport *tp,
-                           void *user_data,
-                           pjmedia_txt_stream **p_stream)
+pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
+                          const pjmedia_txt_stream_info *info,
+                          pjmedia_transport *tp, void *user_data,
+                          pjmedia_txt_stream **p_stream)
 
 {
     enum { M = 32 };
@@ -194,8 +190,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     PJ_ASSERT_RETURN(endpt && info && tp && p_stream, PJ_EINVAL);
 
     if (pool == NULL) {
-        own_pool = pjmedia_endpt_create_pool( endpt, "tstrm%p",
-                                              2000, 2000);
+        own_pool = pjmedia_endpt_create_pool(endpt, "tstrm%p", 2000, 2000);
         PJ_ASSERT_RETURN(own_pool != NULL, PJ_ENOMEM);
         pool = own_pool;
     }
@@ -208,7 +203,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
 
     /* Duplicate stream info */
     pj_memcpy(&stream->si, info, sizeof(*info));
-    c_strm->si = (pjmedia_stream_info_common *)&stream->si;
+    c_strm->si = (pjmedia_stream_info_common *) &stream->si;
     pj_strdup(pool, &stream->si.fmt.encoding_name, &info->fmt.encoding_name);
     pjmedia_rtcp_fb_info_dup(pool, &c_strm->si->loc_rtcp_fb,
                              &info->loc_rtcp_fb);
@@ -216,7 +211,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
                              &info->rem_rtcp_fb);
 
     /* Init stream/port name */
-    name.ptr = (char*) pj_pool_alloc(pool, M);
+    name.ptr = (char *) pj_pool_alloc(pool, M);
     name.slen = pj_ansi_snprintf(name.ptr, M, "tstrm%p", stream);
     c_strm->port.info.name = name;
 
@@ -224,7 +219,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     c_strm->endpt = endpt;
     c_strm->dir = info->dir;
     c_strm->user_data = user_data;
-    c_strm->rtcp_interval = (PJMEDIA_RTCP_INTERVAL-500 + (pj_rand()%1000)) *
+    c_strm->rtcp_interval = (PJMEDIA_RTCP_INTERVAL - 500 + (pj_rand() % 1000)) *
                             info->fmt.clock_rate / 1000;
     c_strm->rtcp_sdes_bye_disabled = info->rtcp_sdes_bye_disabled;
 
@@ -233,7 +228,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     stream->rx_last_seq = -1;
     stream->is_idle = PJ_TRUE;
 
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
     c_strm->use_ka = info->use_ka;
     c_strm->ka_interval = info->ka_cfg.ka_interval;
     c_strm->start_ka_count = info->ka_cfg.start_count;
@@ -243,13 +238,18 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     c_strm->cname = info->cname;
     if (c_strm->cname.slen == 0) {
         /* Build random RTCP CNAME. CNAME has user@host format */
-        c_strm->cname.ptr = p = (char*) pj_pool_alloc(pool, 20);
+        c_strm->cname.ptr = p = (char *) pj_pool_alloc(pool, 20);
         pj_create_random_string(p, 5);
         p += 5;
-        *p++ = '@'; *p++ = 'p'; *p++ = 'j';
+        *p++ = '@';
+        *p++ = 'p';
+        *p++ = 'j';
         pj_create_random_string(p, 6);
         p += 6;
-        *p++ = '.'; *p++ = 'o'; *p++ = 'r'; *p++ = 'g';
+        *p++ = '.';
+        *p++ = 'o';
+        *p++ = 'r';
+        *p++ = 'g';
         c_strm->cname.slen = p - c_strm->cname.ptr;
     }
 
@@ -259,8 +259,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
         stream->buf_time = BUFFERING_TIME;
     cparam.usec_interval = stream->buf_time * 1000;
     cparam.clock_rate = 1000;
-    status = pjmedia_clock_create2(pool, &cparam,
-                                   PJMEDIA_CLOCK_NO_HIGHEST_PRIO,
+    status = pjmedia_clock_create2(pool, &cparam, PJMEDIA_CLOCK_NO_HIGHEST_PRIO,
                                    clock_cb, stream, &stream->clock);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
@@ -271,10 +270,8 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
         goto err_cleanup;
 
     /* Create jitter buffer */
-    status = pjmedia_jbuf_create(pool, &c_strm->port.info.name,
-                                 BUFFER_SIZE,
-                                 stream->buf_time,
-                                 JBUF_MAX_COUNT, &c_strm->jb);
+    status = pjmedia_jbuf_create(pool, &c_strm->port.info.name, BUFFER_SIZE,
+                                 stream->buf_time, JBUF_MAX_COUNT, &c_strm->jb);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
 
@@ -283,15 +280,15 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     pjmedia_jbuf_set_discard(c_strm->jb, PJMEDIA_JB_DISCARD_NONE);
 
     /* Create decoder channel: */
-    status = create_channel( pool, c_strm, PJMEDIA_DIR_DECODING,
-                             info->rx_pt, 0, c_strm->si, &c_strm->dec);
+    status = create_channel(pool, c_strm, PJMEDIA_DIR_DECODING, info->rx_pt, 0,
+                            c_strm->si, &c_strm->dec);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
 
     /* Create encoder channel: */
     buf_size = BUFFER_SIZE;
-    status = create_channel( pool, c_strm, PJMEDIA_DIR_ENCODING,
-                             info->tx_pt, buf_size, c_strm->si, &c_strm->enc);
+    status = create_channel(pool, c_strm, PJMEDIA_DIR_ENCODING, info->tx_pt,
+                            buf_size, c_strm->si, &c_strm->enc);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
 
@@ -317,17 +314,16 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
 
         /* Subscribe to RTCP events */
         // Currently not needed, perhaps for future use.
-        //pjmedia_event_subscribe(NULL, &stream_event_cb, stream,
+        // pjmedia_event_subscribe(NULL, &stream_event_cb, stream,
         //                        &c_strm->rtcp);
     }
 
     /* Allocate outgoing RTCP buffer, should be enough to hold SR/RR, SDES,
      * BYE, and XR.
      */
-    c_strm->out_rtcp_pkt_size =  sizeof(pjmedia_rtcp_sr_pkt) +
-                                 sizeof(pjmedia_rtcp_common) +
-                                 (4 + (unsigned)c_strm->cname.slen) +
-                                 32;
+    c_strm->out_rtcp_pkt_size = sizeof(pjmedia_rtcp_sr_pkt) +
+                                sizeof(pjmedia_rtcp_common) +
+                                (4 + (unsigned) c_strm->cname.slen) + 32;
 
     if (c_strm->out_rtcp_pkt_size > PJMEDIA_MAX_MTU)
         c_strm->out_rtcp_pkt_size = PJMEDIA_MAX_MTU;
@@ -350,8 +346,7 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     att_param.rtcp_cb = &on_rx_rtcp;
 
     /* Create group lock & attach handler */
-    status = pj_grp_lock_create_w_handler(pool, NULL, stream,
-                                          &on_destroy,
+    status = pj_grp_lock_create_w_handler(pool, NULL, stream, &on_destroy,
                                           &c_strm->grp_lock);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
@@ -372,10 +367,10 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
 
     /* Send RTCP SDES */
     if (!c_strm->rtcp_sdes_bye_disabled) {
-       pjmedia_stream_common_send_rtcp_sdes(c_strm);
+        pjmedia_stream_common_send_rtcp_sdes(c_strm);
     }
 
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA!=0
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
     /* NAT hole punching by sending KA packet via RTP transport. */
     if (c_strm->use_ka)
         send_keep_alive_packet(c_strm);
@@ -384,7 +379,8 @@ pjmedia_txt_stream_create( pjmedia_endpt *endpt,
     /* Success! */
     *p_stream = stream;
 
-    PJ_LOG(3, (THIS_FILE, "Text stream %s created", c_strm->port.info.name.ptr));
+    PJ_LOG(3,
+           (THIS_FILE, "Text stream %s created", c_strm->port.info.name.ptr));
 
     return PJ_SUCCESS;
 
@@ -395,7 +391,7 @@ err_cleanup:
 
 PJ_DEF(pj_status_t) pjmedia_txt_stream_start(pjmedia_txt_stream *stream)
 {
-    pjmedia_stream_common *c_strm = (pjmedia_stream_common *)stream;
+    pjmedia_stream_common *c_strm = (pjmedia_stream_common *) stream;
     pj_status_t status;
 
     pjmedia_stream_common_start(c_strm);
@@ -428,7 +424,7 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
     pj_uint32_t ts;
     int popped_seq;
     char *text_ptr = NULL;
-    
+
     pj_mutex_lock(c_strm->jb_mutex);
 
     do {
@@ -746,7 +742,16 @@ static pj_status_t send_text(pjmedia_txt_stream *stream, unsigned rtp_ts_len)
             rtp_ts_len = 1;
     }
 
-    /* Check for Keep-Alive condition (RFC 4103 recommends 10s of idle time) */
+    /* Check for Keep-Alive condition */
+    /*
+       RFC 9071 (Section 4.2.2) suggests 10 seconds as the threshold for
+       detecting a "long pause" from an idle RTT source. RFC 6263 (Section 7)
+       suggests a minimum transmission interval (Tr) of 15 seconds for UDP
+       keep-alives to maintain NAT bindings. Using a 10-second timer provides a
+       safe 5-second margin to ensure the keep-alive traverses the network
+       before a firewall drops the connection.
+    */
+
     if (stream->is_idle && stream->tx_buf[0].length == 0) {
         if (!is_first_packet &&
             pj_elapsed_msec(&stream->tx_last_ts, &now) >= 10000) {
@@ -1014,8 +1019,8 @@ pjmedia_txt_stream_send_text(pjmedia_txt_stream *stream, const pj_str_t *text)
         return PJ_ETOOMANY;
     }
 
-    pj_memcpy(stream->tx_buf[0].buf + stream->tx_buf[0].length,
-            text->ptr, text->slen);
+    pj_memcpy(stream->tx_buf[0].buf + stream->tx_buf[0].length, text->ptr,
+              text->slen);
     stream->tx_buf[0].length += (unsigned) text->slen;
 
     /* Decide if we should send the text immediately or just buffer it. */

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -769,7 +769,6 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
     pj_timestamp now;
     pj_bool_t is_first_packet;
     pj_bool_t use_red;
-    pjmedia_rtp_hdr *hdr;
     pj_bool_t has_deferred_char = PJ_FALSE;
 
     void *rtphdr;

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -517,6 +517,7 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
     pj_uint16_t block_seq = 0;
     pj_int16_t diff = 0;
     pj_uint8_t b = 0;
+    unsigned total_red_len = 0;
 
     /* Parse headers */
     while (1) {
@@ -537,6 +538,13 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
         level++;
     }
 
+    for (i = 0; i < level; i++) {
+        total_red_len += (hdr[i] & 0x3FF);
+    }
+    if (consumed + total_red_len > buflen) {
+        return PJ_ETOOBIG;
+    }
+
     /* Parse redundant history blocks */
     payload_ptr = buf + consumed;
     for (i = 0; i < level; i++) {
@@ -547,9 +555,6 @@ static pj_status_t decode_red(pjmedia_txt_stream *stream, unsigned pt, int seq,
         data_len = length;
 
         if (length > 0) {
-            if (consumed + length > buflen)
-                return PJ_ETOOBIG;
-
             /* Strip native BOM if it got trapped in history */
             if (data_len >= 3 && (pj_uint8_t) data_ptr[0] == 0xEF &&
                 (pj_uint8_t) data_ptr[1] == 0xBB &&
@@ -756,16 +761,23 @@ static pj_status_t encode_red(pjmedia_txt_stream *stream, unsigned pt,
 static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
                                     unsigned rtp_ts_len)
 {
+    /* C90 compliant: All declarations must be at the top */
     pjmedia_stream_common *c_strm = &stream->base;
     pjmedia_channel *channel = c_strm->enc;
-    void *rtphdr;
-    int size, i;
     pj_status_t status = PJ_SUCCESS;
     pj_bool_t is_keepalive = PJ_FALSE;
     pj_timestamp now;
     pj_bool_t is_first_packet;
     pj_bool_t use_red;
     pjmedia_rtp_hdr *hdr;
+    pj_bool_t has_deferred_char = PJ_FALSE;
+
+    void *rtphdr;
+    char deferred_char_buf[PJMEDIA_MAX_MTU];
+    int deferred_char_len = 0;
+    int size, i;
+    int pass = 0;
+    int max_pass = 1;
     unsigned pt_to_use;
 
     pj_get_timestamp(&now);
@@ -775,38 +787,26 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
     use_red = (stream->si.tx_red_pt > 0) ? PJ_TRUE : PJ_FALSE;
     pt_to_use = use_red ? stream->si.tx_red_pt : channel->pt;
 
-    /* Calculate RTP timestamp increment based on actual elapsed time */
+    /* RTP timestamp calculation */
     if (is_first_packet) {
-        /* Use a small initial increment; absolute RTP TS base is arbitrary */
         rtp_ts_len = 20;
     } else if (rtp_ts_len == 0) {
         rtp_ts_len = pj_elapsed_msec(&stream->tx_last_ts, &now);
-
         if (rtp_ts_len == 0)
             rtp_ts_len = 1;
     }
 
-    /* Check for Keep-Alive condition */
-    /*
-       RFC 9071 (Section 4.2.2) suggests 10 seconds as the threshold for
-       detecting a "long pause" from an idle RTT source. RFC 6263 (Section 7)
-       suggests a minimum transmission interval (Tr) of 15 seconds for UDP
-       keep-alives to maintain NAT bindings. Using a 10-second timer provides a
-       safe 5-second margin to ensure the keep-alive traverses the network
-       before a firewall drops the connection.
-    */
-
+    /* Keep-alive check */
     if (stream->is_idle && stream->tx_buf[0].length == 0) {
         if (!is_first_packet &&
             pj_elapsed_msec(&stream->tx_last_ts, &now) >= 10000) {
             is_keepalive = PJ_TRUE;
         } else {
-            status = PJ_SUCCESS;
-            goto on_return;
+            return PJ_SUCCESS; /* Clean return */
         }
     }
 
-    /* Protect against application-layer BOMs leaking into the buffer */
+    /* BOM logic */
     if (stream->tx_buf[0].length >= 3 &&
         (pj_uint8_t) stream->tx_buf[0].buf[0] == 0xEF &&
         (pj_uint8_t) stream->tx_buf[0].buf[1] == 0xBB &&
@@ -816,196 +816,106 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
                    stream->tx_buf[0].length);
     }
 
-    /* BOM sent once per session to establish UTF-8 capability */
     if (is_first_packet && stream->tx_buf[0].length > 0) {
-        void *bom_rtphdr;
-        int bom_size;
-        pj_uint32_t bom_ts;
-        char bom_payload[3] = {(char) 0xEF, (char) 0xBB, (char) 0xBF};
+        deferred_char_len = stream->tx_buf[0].length;
+        pj_memcpy(deferred_char_buf, stream->tx_buf[0].buf, deferred_char_len);
 
-        /* M=1 (Marker bit) for the first packet of a talkspurt */
-        status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 1,
+        stream->tx_buf[0].buf[0] = (char) 0xEF;
+        stream->tx_buf[0].buf[1] = (char) 0xBB;
+        stream->tx_buf[0].buf[2] = (char) 0xBF;
+        stream->tx_buf[0].length = 3;
+        has_deferred_char = PJ_TRUE;
+        max_pass = 2; /* Need a second pass for the user data */
+    }
+
+    /* Loop for passes (1: BOM, 2: User Data) */
+    while (pass < max_pass) {
+        /* Check if we have data to send */
+        if (stream->tx_buf[0].length == 0 && !is_keepalive &&
+            (!use_red || stream->tx_nred == 0)) {
+            status = PJ_SUCCESS;
+            break;
+        }
+
+        /* Encode RTP */
+        status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 0,
                                         (int) channel->buf_size, rtp_ts_len,
-                                        (const void **) &bom_rtphdr, &bom_size);
-        if (status == PJ_SUCCESS) {
-            pj_memcpy(channel->buf, bom_rtphdr, sizeof(pjmedia_rtp_hdr));
-            bom_ts = pj_ntohl(((pjmedia_rtp_hdr *) bom_rtphdr)->ts);
-
-            if (use_red) {
-                red_buf real_tx_buf[NUM_BUFFERS];
-                red_buf temp_tx_buf[NUM_BUFFERS];
-
-                /* Construct local RED history leaving stream->tx_buf untouched
-                 */
-                pj_bzero(temp_tx_buf, sizeof(temp_tx_buf));
-                temp_tx_buf[0].timestamp = bom_ts;
-                temp_tx_buf[0].length = 3;
-                pj_memcpy(temp_tx_buf[0].buf, bom_payload, 3);
-                for (i = 1; i < NUM_BUFFERS; i++)
-                    temp_tx_buf[i].timestamp = bom_ts;
-
-                /* Swap buffer context for encode_red */
-                pj_memcpy(real_tx_buf, stream->tx_buf, sizeof(real_tx_buf));
-                pj_memcpy(stream->tx_buf, temp_tx_buf, sizeof(temp_tx_buf));
-
-                bom_size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
-                status = encode_red(
-                    stream, (unsigned) stream->si.tx_pt,
-                    ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                    &bom_size, PJ_TRUE);
-
-                /* Restore original state */
-                pj_memcpy(stream->tx_buf, real_tx_buf, sizeof(real_tx_buf));
-            } else {
-                bom_size = 3;
-                pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                          bom_payload, 3);
-            }
-
-            if (status == PJ_SUCCESS) {
-                /* Allocate a local buffer for the BOM */
-                char bom_tx_pkt[PJMEDIA_MAX_MTU];
-                int bom_tx_size = bom_size + sizeof(pjmedia_rtp_hdr);
-
-                /* Copy the payload while the lock is still held */
-                pj_memcpy(bom_tx_pkt, channel->buf, bom_tx_size);
-
-                pj_mutex_unlock(c_strm->jb_mutex);
-                status = pjmedia_transport_send_rtp(c_strm->transport,
-                                                    bom_tx_pkt, bom_tx_size);
-                pj_mutex_lock(c_strm->jb_mutex);
-
-                if (status == PJ_SUCCESS) {
-                    hdr = (pjmedia_rtp_hdr *) channel->buf;
-                    pjmedia_rtcp_tx_rtp(&c_strm->rtcp, bom_size);
-                    c_strm->rtcp.stat.rtp_tx_last_ts = pj_ntohl(hdr->ts);
-                    c_strm->rtcp.stat.rtp_tx_last_seq = pj_ntohs(hdr->seq);
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
-                    pj_gettimeofday(&c_strm->last_frm_ts_sent);
-#endif
-                    is_first_packet = PJ_FALSE;
-                    stream->is_idle = PJ_FALSE;
-                    rtp_ts_len = 10;
-                }
-            }
-            if (status != PJ_SUCCESS)
-                goto on_return;
-        }
-    }
-
-    /* If there's no data, no pending RED, and not a keepalive, we are done */
-    if (stream->tx_buf[0].length == 0 && !is_keepalive &&
-        (!use_red || stream->tx_nred == 0)) {
-        status = PJ_SUCCESS;
-        goto on_return;
-    }
-
-    /* Standard character transmission */
-    status = pjmedia_rtp_encode_rtp(&channel->rtp, pt_to_use, 0,
-                                    (int) channel->buf_size, rtp_ts_len,
-                                    (const void **) &rtphdr, &size);
-    if (status != PJ_SUCCESS)
-        goto on_return;
-
-    pj_memcpy(channel->buf, rtphdr, sizeof(pjmedia_rtp_hdr));
-    stream->tx_buf[0].timestamp = pj_ntohl(((pjmedia_rtp_hdr *) rtphdr)->ts);
-
-    /* Mid-session Talkspurt initialization (e.g., typing after a long pause) */
-    if (stream->is_idle && !is_keepalive) {
-        stream->is_idle = PJ_FALSE;
-        ((pjmedia_rtp_hdr *) channel->buf)->m = 1;
-    }
-
-    if (use_red) {
-        /* Encode character packet with normal redundancy */
-        size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
-        status = encode_red(stream, (unsigned) stream->si.tx_pt,
-                            ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                            &size, PJ_FALSE);
+                                        (const void **) &rtphdr, &size);
         if (status != PJ_SUCCESS)
-            goto on_return;
-    } else {
-        /* Raw copy for non-redundant encoding */
-        if (stream->tx_buf[0].length > 0) {
-            size = stream->tx_buf[0].length;
-            pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
-                      stream->tx_buf[0].buf, size);
-        } else {
-            /* Keep-alive with zero data */
-            size = 0;
-        }
-        status = PJ_SUCCESS;
-    }
+            break;
 
-    /* Linear shift register management */
-    if (stream->tx_buf[0].length > 0) {
-        /* We just sent a new character, reset the trailing packet counter */
+        pj_memcpy(channel->buf, rtphdr, sizeof(pjmedia_rtp_hdr));
+        stream->tx_buf[0].timestamp =
+            pj_ntohl(((pjmedia_rtp_hdr *) rtphdr)->ts);
+
+        if (stream->is_idle && !is_keepalive) {
+            stream->is_idle = PJ_FALSE;
+            ((pjmedia_rtp_hdr *) channel->buf)->m = 1;
+        }
+
+        /* Redundancy and Copy */
         if (use_red) {
-            stream->tx_nred = stream->si.tx_red_level;
+            size = (int) channel->buf_size - sizeof(pjmedia_rtp_hdr);
+            status =
+                encode_red(stream, (unsigned) stream->si.tx_pt,
+                           ((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                           &size, PJ_FALSE);
+            if (status != PJ_SUCCESS)
+                break;
         } else {
-            stream->tx_nred = 0;
-            stream->is_idle =
-                PJ_TRUE; /* Idle immediately if no trailing packets */
+            if (stream->tx_buf[0].length > 0) {
+                size = stream->tx_buf[0].length;
+                pj_memcpy(((char *) channel->buf) + sizeof(pjmedia_rtp_hdr),
+                          stream->tx_buf[0].buf, size);
+            } else {
+                size = 0;
+            }
         }
 
-        for (i = NUM_BUFFERS - 1; i > 0; i--) {
-            stream->tx_buf[i] = stream->tx_buf[i - 1];
-        }
-        stream->tx_buf[0].length = 0;
-
-    } else if (use_red && stream->tx_nred > 0) {
-        /* We are sending empty packets to fulfill redundancy requirements */
-        stream->tx_nred--;
-        if (stream->tx_nred == 0)
+        /* Shift Buffer */
+        if (stream->tx_buf[0].length > 0) {
+            if (use_red)
+                stream->tx_nred = stream->si.tx_red_level;
+            else {
+                stream->tx_nred = 0;
+                stream->is_idle = PJ_TRUE;
+            }
+            for (i = NUM_BUFFERS - 1; i > 0; i--)
+                stream->tx_buf[i] = stream->tx_buf[i - 1];
+            stream->tx_buf[0].length = 0;
+        } else if (use_red && stream->tx_nred > 0) {
+            stream->tx_nred--;
+            if (stream->tx_nred == 0)
+                stream->is_idle = PJ_TRUE;
+            for (i = NUM_BUFFERS - 1; i > 0; i--)
+                stream->tx_buf[i] = stream->tx_buf[i - 1];
+            stream->tx_buf[0].length = 0;
+        } else if (is_keepalive) {
             stream->is_idle = PJ_TRUE;
-        for (i = NUM_BUFFERS - 1; i > 0; i--) {
-            stream->tx_buf[i] = stream->tx_buf[i - 1];
         }
-        stream->tx_buf[0].length = 0;
 
-    } else if (is_keepalive) {
-        /* Keepalives do not advance the shift register */
-        stream->is_idle = PJ_TRUE;
-    } else {
-        goto on_return;
-    }
+        /* Network Transmission */
+        {
+            char tx_pkt[PJMEDIA_MAX_MTU];
+            int tx_size = size + sizeof(pjmedia_rtp_hdr);
+            pj_memcpy(tx_pkt, channel->buf, tx_size);
 
-    /* Network transmission (applies to both BOM and standard payload) */
-    {
-        /* Allocate a local buffer */
-        char tx_pkt[PJMEDIA_MAX_MTU];
-        int tx_size = size + sizeof(pjmedia_rtp_hdr);
-        pj_uint32_t pkt_ts;
-        pj_uint16_t pkt_seq;
+            pj_mutex_unlock(c_strm->jb_mutex);
+            status =
+                pjmedia_transport_send_rtp(c_strm->transport, tx_pkt, tx_size);
+            pj_mutex_lock(c_strm->jb_mutex);
+        }
 
-        /* Copy the payload while the lock is still held */
-        pj_memcpy(tx_pkt, channel->buf, tx_size);
-
-        /* Cache the headers to ensure RTCP stats remain accurate */
-        hdr = (pjmedia_rtp_hdr *) channel->buf;
-        pkt_ts = pj_ntohl(hdr->ts);
-        pkt_seq = pj_ntohs(hdr->seq);
-
-        /* Drop the lock and transmit the local copy */
-        pj_mutex_unlock(c_strm->jb_mutex);
-        status = pjmedia_transport_send_rtp(c_strm->transport, tx_pkt, tx_size);
-        pj_mutex_lock(c_strm->jb_mutex);
-
-        if (status == PJ_SUCCESS) {
-            pj_get_timestamp(&stream->tx_last_ts);
-
-            /* Update RTCP TX stats using the cached headers */
-            pjmedia_rtcp_tx_rtp(&c_strm->rtcp, size);
-            c_strm->rtcp.stat.rtp_tx_last_ts = pkt_ts;
-            c_strm->rtcp.stat.rtp_tx_last_seq = pkt_seq;
-
-#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
-            pj_gettimeofday(&c_strm->last_frm_ts_sent);
-#endif
+        /* Prepare second pass if needed */
+        pass++;
+        if (pass == 1 && has_deferred_char) {
+            stream->tx_buf[0].length = deferred_char_len;
+            pj_memcpy(stream->tx_buf[0].buf, deferred_char_buf,
+                      deferred_char_len);
+            rtp_ts_len = 10;
         }
     }
 
-on_return:
     return status;
 }
 

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -418,7 +418,6 @@ pjmedia_txt_stream_get_info(const pjmedia_txt_stream *stream,
 static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
 {
     pjmedia_stream_common *c_strm = &stream->base;
-    PJ_UNUSED_ARG(now);
 
     char frm_type;
     char frm_buf[MAX_TEXT_FRAME_SIZE];
@@ -426,6 +425,8 @@ static void call_cb(pjmedia_txt_stream *stream, pj_bool_t now)
     pj_uint32_t ts;
     int popped_seq;
     char *text_ptr = NULL;
+
+    PJ_UNUSED_ARG(now);
 
     pj_mutex_lock(c_strm->jb_mutex);
 


### PR DESCRIPTION
This PR resolves protocol compliance failures within the PJSIP Real-Time Text (txt_stream.c) implementation.

Core Stream & RTCP:
- Enforce the 1000 Hz clock rate for T.140 during SDP parsing.
- Correctly merge the primary T.140 payload and the RED payload into a single pjmedia_txt_stream context.

Transmitter (send_text & encode_red):
- Implement a linear shift-register for encode_red, generating zero-length RED headers for empty history to maintain sequence.
- Inject compliant UTF-8 BOM using empty RED headers to ensure compatibility with strict RTT implementations.

Receiver (decode_red):
- Add gap detection via rx_last_seq. Redundant history blocks are only injected if actually dropped by the network.
- Feed zero-length frames to the Jitter Buffer to preserve sequence tracking.
- Implement automated BOM stripping for primary/redundant payloads.

Fixes #4956: Prevents PJSIP from creating two media streams for RTT and RED.
Fixes #4957: Fixes the bug where pjsua fails to send RED data when negotiated.