### PR TITLE
FIX: ipjsua CXProviderDelegate didDeactivate typo

### DIFF
--- a/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
+++ b/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
@@ -432,7 +432,7 @@ didActivateAudioSession:(AVAudioSession *) audioSession
 }
 
 - (void) provider:(CXProvider *) provider
-didDectivateAudioSession:(AVAudioSession *) audioSession
+didDeactivateAudioSession:(AVAudioSession *) audioSession
 {
     NSLog(@"Did deactivate Audio Session");
 }


### PR DESCRIPTION
## Summary

Fix a one-character typo in the CallKit `CXProviderDelegate` audio-session deactivation handler of the `ipjsua` iOS sample app:

```diff
 - (void) provider:(CXProvider *) provider
-didDectivateAudioSession:(AVAudioSession *) audioSession
+didDeactivateAudioSession:(AVAudioSession *) audioSession
 {
     NSLog(@"Did deactivate Audio Session");
 }
```

The selector Apple actually defines is `provider:didDeactivateAudioSession:` (Swift: [`provider(_:didDeactivate:)`](https://developer.apple.com/documentation/callkit/cxproviderdelegate/provider(_:diddeactivate:))). With the typo (`Dectivate`, missing the second "a") the system never matched the implementation, so the sample app silently stopped reacting when CallKit deactivated its `AVAudioSession`.

### Why it stayed hidden

`CXProviderDelegate` is a formal Objective-C protocol with all-`@optional` methods ([docs](https://developer.apple.com/documentation/callkit/cxproviderdelegate)). The runtime never *sends* the wrong selector — it asks `[delegate respondsToSelector:@selector(provider:didDeactivateAudioSession:)]` first ([NSObjectProtocol.responds(to:)](https://developer.apple.com/documentation/objectivec/nsobjectprotocol/responds(to:))) and silently skips when the answer is `NO`. So:

- no compile-time error — the method body is a syntactically valid Obj-C method;
- no `-Wprotocol` warning — the protocol method is *optional*, so the absent implementation is allowed;
- no `doesNotRecognizeSelector:` crash — that fires when a message is *sent* to an unrecognised selector; here no message is sent at all;
- no runtime log — `respondsToSelector:` returns `NO` and the framework moves on.

The Swift equivalent (`func provider(_:didDeactivate:)`) would have been a hard compile error on misspelling because the name is part of the typed protocol surface; the Obj-C side trades that compile-time safety for late-bound flexibility.

The typo was introduced in 472bda508 / upstream PR #3913 ("Support Push Notification in iOS sample app", 2024-04-23) when the deactivate handler was added next to the already-correct `didActivateAudioSession:` handler. It has been silently sleeping for ~2 years.