### PR TITLE
Fix med_prov_cnt assertion under call-slot reuse race

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5466,6 +5466,26 @@ static void pjsua_call_on_media_update(pjsip_inv_session *inv,
 
     call = (pjsua_call*) inv->dlg->mod_data[pjsua_var.mod.id];
 
+    /* Stale callback guard. The inv that fired this callback may be a
+     * leftover from a dialog that the application has already hung up.
+     * If pjsua's call slot has since been reallocated to a different
+     * dialog (e.g. an outgoing make_call right after a hangup whose
+     * earlier re-INVITE is still pending a response), `call->inv` now
+     * points at the new dialog. Touching its media — in particular
+     * pjsua_media_prov_revert() below — would corrupt the new dialog's
+     * provisional state and trip the assertion in
+     * pjsua_media_channel_update() (`med_prov_cnt >= media_count`).
+     * Just drop the late event in that case.
+     */
+    if (!call || call->inv != inv) {
+        PJ_LOG(4, (THIS_FILE,
+                   "Ignoring stale media update on call %d "
+                   "(inv %p != current %p)",
+                   call ? call->index : -1, inv,
+                   call ? (void*)call->inv : NULL));
+        goto on_return;
+    }
+
     if (call->hanging_up)
         goto on_return;
 
@@ -6451,6 +6471,23 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 
     if (call->inv == NULL || call->hanging_up) {
         /* Call has been disconnected. */
+        goto on_return;
+    }
+
+    /* Stale callback guard (see comment in pjsua_call_on_media_update).
+     * The inv firing this tsx-state callback may belong to a dialog
+     * whose call slot has already been recycled into a new dialog.
+     * Acting on the slot's current state would corrupt the new dialog
+     * (e.g. pjsua_media_prov_revert further below would zero
+     * med_prov_cnt of the new dialog and trip the assertion in
+     * pjsua_media_channel_update). Drop the stale event.
+     */
+    if (call->inv != inv) {
+        PJ_LOG(4, (THIS_FILE,
+                   "Ignoring stale tsx-state event on call %d "
+                   "(inv %p != current %p, cseq=%d)",
+                   call->index, inv, (void*)call->inv,
+                   tsx ? (int)tsx->cseq : -1));
         goto on_return;
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5481,7 +5481,7 @@ static void pjsua_call_on_media_update(pjsip_inv_session *inv,
         PJ_LOG(4, (THIS_FILE,
                    "Ignoring stale media update on call %d "
                    "(inv %p != current %p)",
-                   call ? call->index : -1, inv,
+                   call ? (int)call->index : -1, inv,
                    call ? (void*)call->inv : NULL));
         goto on_return;
     }


### PR DESCRIPTION
# `med_prov_cnt` assertion under stress: root cause

```
Assertion failed: (call->med_prov_cnt >= local_sdp->media_count),
  function pjsua_media_channel_update, file pjsua_media.c, line 4438.
```

Reproducer: `pjsua_stress -n 8 -v 1 --log-level 4 --duration 15` on macOS,
ASan build. The assertion fires from thread `pjsua_0` while processing a
`200 OK` for an outgoing INVITE on call slot 5.

## Cause

Same-slot reuse race in PJSUA. **Call slot 5** is being shared by two
different dialogs at the same moment, and one dialog's late re-INVITE
response stomps on the other dialog's provisional-media state.

### Timeline for call slot 5

| Time | Event |
|------|-------|
| `36.046` | Slot 5 allocated for **dialog A** — Call-ID `273A9B99…`, outgoing INVITE `cseq=9654`, audio-only. Confirmed. |
| `36.071` | Worker fires **re-INVITE on call 5** → sends `cseq=9655` (audio + video + text, Content-Length 1546). Transaction in-flight. |
| `36.108` | Worker fires **HANGUP on call 5** → PJSUA sends `BYE cseq=9656` *without* waiting for the `cseq=9655` response. Media is cleaned up (`prov_med_cnt=3, med_cnt=1`). Dialog A is DISCONNECTING; the `cseq=9655` transaction is still alive. |
| `37.237` | Worker fires MAKE_AUDIO. **Slot 5 is reallocated** for **dialog B** — Call-ID `149B2A69…`, outgoing INVITE `cseq=15985`, audio-only. New media set up, `med_prov_cnt=1`. Dialog B is in CALLING. |
| `37.714` | The delayed **488 Not Acceptable Here for `cseq=9655`** (dialog A's re-INVITE) finally arrives, 1.6 s late under load. |
| `37.715` | PJSUA's failure handler for that 488 calls `pjsua_media_prov_revert(5)` → log line `Call 5: cleaning up provisional media, prov_med_cnt=1, med_cnt=0`. **This is operating on slot 5's current state, which belongs to dialog B.** `med_prov_cnt` is zeroed. |
| `37.715` | `RX 200 OK for cseq=9656` (BYE for dialog A) arrives. Dialog A is finally fully torn down. |
| `37.784` | Dialog B's `200 OK for cseq=15985` arrives. `inv_negotiate_sdp` runs, `local_sdp->media_count == 1`. `pjsua_media_channel_update(5, …)` asserts `med_prov_cnt(0) >= 1` → **abort**. |

### What's happening

PJSUA frees slot 5 from dialog A as soon as the application calls
`pjsua_call_hangup`, even though dialog A still has a pending INVITE
transaction (`cseq=9655`). When the late `488` response for that
transaction comes back, PJSUA processes the failure using the slot
index that was stored on dialog A's inv session, and reverts
provisional media on `pjsua_var.calls[5]` — which now points to
dialog B. From dialog B's perspective the assertion
`med_prov_cnt >= local_sdp->media_count` is then violated by an
external party.

The 1.6 s gap between sending the re-INVITE and getting the `488` is
the result of sustained worker-thread load (the `Temporary failure in
sending Request msg … Unsuitable transport selected` lines show pjsip
queueing transmissions). Without that load the response arrives before
slot reuse and the bug never triggers.

### Crash backtrace

```
frame #4: pjsua_media_channel_update(call_id=5,
                                     local_sdp=0x6190001a72a8,
                                     remote_sdp=0x619000081c30)
            at pjsua_media.c:4438
frame #5: pjsua_call_on_media_update(inv=0x62100046a150, status=0)
            at pjsua_call.c:5544
frame #6: inv_negotiate_sdp(inv=0x62100046a150)        at sip_inv.c:2357
frame #7: inv_check_sdp_in_incoming_msg(inv=0x62100046a150, …)
            at sip_inv.c:2600
frame #8: inv_on_state_calling(inv=0x62100046a150, …)  at sip_inv.c:5199
```

The `inv` pointer in frame #5 belongs to **dialog B** (the new
outgoing call). `call_id=5` is correct for dialog B. The corruption
happened earlier, when dialog A's `488` handler ran
`pjsua_media_prov_revert(5)` on the slot that now hosts dialog B.

### Why the stress test exposes it

Three things have to line up:

1. A re-INVITE is sent on a call (worker's HOLD / UNHOLD).
2. The call is hung up before the re-INVITE response arrives (worker's
   HANGUP racing the prior op on the same call).
3. The re-INVITE response is delayed long enough that the slot is
   recycled into a new call (worker's MAKE_AUDIO).

All three are generated by the random ops on the same `call_id`, and
load makes (3) easy.

## Where the fix belongs (PJSUA, not the test)

Two reasonable approaches in PJSUA:

- **Don't reuse a call slot until all its outstanding non-INVITE /
  non-INVITE-response transactions are cleared.** That's the strict
  correctness fix; it requires `make_call` to skip slots that still
  hold a transaction reference.
- **Tag responses with a dialog generation counter.** When the late
  `488` for `cseq=9655` arrives, check that the slot's current `inv`
  is the same one that originated the transaction; if not, ignore it
  (just send the ACK). This is a smaller, more local change in
  `pjsua_call_on_media_update` / `pjsua_media_prov_revert` — verify
  `pjsua_var.calls[call_id].inv == captured_inv` before touching
  media.

## Workarounds available in the stress test (not a real fix)

If we want the test to keep running without tripping this specific
bug while the PJSIP fix is pending:

- Don't issue HANGUP on a call that has an in-flight re-INVITE.
  Track "reinvite pending" in the per-call registry, set it in
  `do_hold` / `do_unhold` and clear it from `on_call_state` when the
  call returns to CONFIRMED (or DISCONNECTED).
- Or, more bluntly, drop HANGUP from the worker op set entirely — but
  that defeats much of the point.

The first option is the cheap version that lets the test keep running
while leaving the PJSIP bug visible and fixable separately.

# Fix for `med_prov_cnt` assertion: stale inv-callback guard

See `pjsua_stress_med_prov_cnt_bug.md` for the root-cause analysis.

The patch implements the "tag responses with a dialog generation
counter" approach from that document: rather than introduce a new
counter, we use `pjsua_var.calls[slot].inv` as the dialog identity.
If a SIP-layer callback fires with an `inv` that no longer matches
the slot's current inv, the slot has been recycled into a new dialog
and the event is dropped.

## Diff

Both changes are in `pjsip/src/pjsua-lib/pjsua_call.c`.

### 1. `pjsua_call_on_media_update`

This is the direct path that asserted in the original reproducer — a
delayed `488` for a previous dialog's re-INVITE drove
`pjsua_media_prov_revert(call->index)`, zeroing the new dialog's
`med_prov_cnt`. Added after the existing `call = inv->dlg->mod_data[…]`
lookup:

```c
/* Stale callback guard. The inv that fired this callback may be a
 * leftover from a dialog that the application has already hung up.
 * If pjsua's call slot has since been reallocated to a different
 * dialog (e.g. an outgoing make_call right after a hangup whose
 * earlier re-INVITE is still pending a response), `call->inv` now
 * points at the new dialog. Touching its media — in particular
 * pjsua_media_prov_revert() below — would corrupt the new dialog's
 * provisional state and trip the assertion in
 * pjsua_media_channel_update() (`med_prov_cnt >= media_count`).
 * Just drop the late event in that case.
 */
if (!call || call->inv != inv) {
    PJ_LOG(4, (THIS_FILE,
               "Ignoring stale media update on call %d "
               "(inv %p != current %p)",
               call ? call->index : -1, inv,
               call ? (void*)call->inv : NULL));
    goto on_return;
}
```

### 2. `pjsua_call_on_tsx_state_changed`

The same race exists in transaction-state events (which also call
`pjsua_media_prov_revert` on non-2xx INVITE results around line 6636).
The existing checks (`call == NULL`, `call->inv == NULL`,
`call->hanging_up`) don't catch slot recycling, since the slot's
`call->inv` is non-NULL but points at the *new* dialog. Added after
those checks:

```c
/* Stale callback guard (see comment in pjsua_call_on_media_update).
 * The inv firing this tsx-state callback may belong to a dialog
 * whose call slot has already been recycled into a new dialog.
 * Acting on the slot's current state would corrupt the new dialog
 * (e.g. pjsua_media_prov_revert further below would zero
 * med_prov_cnt of the new dialog and trip the assertion in
 * pjsua_media_channel_update). Drop the stale event.
 */
if (call->inv != inv) {
    PJ_LOG(4, (THIS_FILE,
               "Ignoring stale tsx-state event on call %d "
               "(inv %p != current %p, cseq=%d)",
               call->index, inv, (void*)call->inv,
               tsx ? (int)tsx->cseq : -1));
    goto on_return;
}
```

## Why this works

Both callbacks receive an `inv` pointer that pjsip's transaction /
dialog layer dispatched the event to. They resolve `call` via
`inv->dlg->mod_data` — that gives a pointer to
`&pjsua_var.calls[slot]`, but the slot may have been reallocated to
a different dialog in the meantime. The current dialog's inv is
stored in `call->inv`. If `call->inv != inv`, this callback is firing
for a previous dialog whose slot has been recycled; acting on it
(especially calling `pjsua_media_prov_revert(call->index)`) would
corrupt the new dialog. The guard drops the late event harmlessly.

## Verification

`pjsua_stress -n 8 -v 1 -t 4 --duration 15` on macOS, ASan build —
6 iterations:

```
run 1: exit=0 med_prov_cnt_asserts=0 stale_guards=39
run 2: exit=0 med_prov_cnt_asserts=0 stale_guards=47
run 3: exit=0 med_prov_cnt_asserts=0 stale_guards=66
run 4: exit=0 med_prov_cnt_asserts=0 stale_guards=37
run 5: exit=0 med_prov_cnt_asserts=0 stale_guards=47
run 6: exit=0 med_prov_cnt_asserts=0 stale_guards=36
---total: 6 runs, 0 asserts, 272 stale guards
```

- **0 `med_prov_cnt` assertions** across 6 runs (vs. the original
  reproducer which aborted within ~1 s).
- **272 stale-guard triggers in total** — i.e. the race condition
  itself is firing ~45 times per 15-second run; each one was
  previously a potential crash. The guard catches and drops them
  cleanly.

`--log-level 3` runs initially appeared to "not trigger the guard"
because the `Ignoring stale …` lines log at level 4. Re-running at
`--log-level 4` revealed that the guard is doing real work; it just
doesn't surface at the default log level.

## Caveats / follow-up

- This is a defensive fix: it stops the corruption at the two
  callbacks that have shown up in stress. Other places that resolve
  `call` from a stored inv pointer and then touch `pjsua_var.calls[slot]`
  may have similar latent issues (e.g. other `pjsua_media_prov_revert`
  callers in `pjsua_vid.c` and `pjsua_media.c`). Consider auditing
  each.
- A more principled fix would be to delay slot reuse until all
  outstanding transactions for the previous dialog are torn down.
  That's a larger change in `alloc_call_id()` / make-call path and
  needs careful thought about deadlock and dialog timer
  interactions. The stale-callback guard is cheap, local, and
  sufficient for the failure modes the stress test surfaces.
