### PR TITLE
Fix assertion in pjsua_vid_conf_remove_port when add-port failed

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -946,14 +946,16 @@ static void free_vid_win(pjsua_vid_win_id wid)
     num_locks = PJSUA_RELEASE_LOCK();
 
     if (w->vp_cap) {
-        pjsua_vid_conf_remove_port(w->cap_slot);
+        if (w->cap_slot != PJSUA_INVALID_ID)
+            pjsua_vid_conf_remove_port(w->cap_slot);
         pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL,
                                   w->vp_cap);
         pjmedia_vid_port_stop(w->vp_cap);
         pjmedia_vid_port_destroy(w->vp_cap);
     }
     if (w->vp_rend) {
-        pjsua_vid_conf_remove_port(w->rend_slot);
+        if (w->rend_slot != PJSUA_INVALID_ID)
+            pjsua_vid_conf_remove_port(w->rend_slot);
         pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL,
                                   w->vp_rend);
         pjmedia_vid_port_stop(w->vp_rend);


### PR DESCRIPTION
# Fix assertion in `pjsua_vid_conf_remove_port` when add-port failed

## Symptom

Under stress with many simultaneous video calls (more than the video
conference bridge can hold), pjsua aborts:

```
vid_conf.c    Add video port Metal failed: Too many objects of the
              specified type (PJ_ETOOMANY)
pjsua_vid.c   Window 12: destroying..
Assertion failed: (id >= 0), function pjsua_vid_conf_remove_port,
                  file pjsua_vid.c, line 2988.
zsh: abort    pjsua-stress -n 16 -v 4 --log-level 4 --duration 30
```

Reproduces reliably with `pjsua-stress -n 16 -v 4 --duration 30` on
the default `PJMEDIA_VID_CONF_MAX_PORTS`: about 16 simultaneous video
legs each need their own pair of video-conf ports, the bridge limit
is hit, the next `add_port` fails, and the failure-recovery path
trips the `id >= 0` assertion in `pjsua_vid_conf_remove_port` within
a few seconds.

## Cause

In `pjsua_vid.c`, the window setup path inside `create_vid_win()` runs
in this order for the renderer side:

1. Open the renderer device — `pjmedia_vid_port_create(... &w->vp_rend)`.
   On success `w->vp_rend` is non-NULL.
2. Register the renderer port with the video conf bridge —
   `pjsua_vid_conf_add_port(... &w->rend_slot)`.

If step 2 fails (typically `PJ_ETOOMANY` because the bridge has
`PJMEDIA_VID_CONF_MAX_PORTS` ports already), `pjsua_vid_conf_add_port`
correctly sets `w->rend_slot = PJSUA_INVALID_ID` (`= -1`) and returns
the error. The caller propagates it; the window then goes through the
normal teardown path `free_vid_win()`:

```c
if (w->vp_rend) {                    /* TRUE: vp_rend was created OK */
    pjsua_vid_conf_remove_port(w->rend_slot);   /* slot is -1 !! */
    ...
}
```

`pjsua_vid_conf_remove_port()` is:

```c
PJ_DEF(pj_status_t) pjsua_vid_conf_remove_port(pjsua_conf_port_id id)
{
    PJ_ASSERT_RETURN(id >= 0, PJ_EINVAL);   /* aborts here */
    return pjmedia_vid_conf_remove_port(pjsua_var.vid_conf, (unsigned)id);
}
```

Same race exists for the capture side (`w->vp_cap` + `w->cap_slot`).

The interesting bit is that the rest of the file already knows how to
handle this — the strm-enc / strm-dec teardown a couple of hundred
lines lower checks the slot ID before calling remove:

```c
/* Unregister video stream ports (encode+decode) from conference */
if (call_med->strm.v.strm_enc_slot != PJSUA_INVALID_ID) {
    pjsua_vid_conf_remove_port(call_med->strm.v.strm_enc_slot);
    call_med->strm.v.strm_enc_slot = PJSUA_INVALID_ID;
}
if (call_med->strm.v.strm_dec_slot != PJSUA_INVALID_ID) {
    pjsua_vid_conf_remove_port(call_med->strm.v.strm_dec_slot);
    call_med->strm.v.strm_dec_slot = PJSUA_INVALID_ID;
}
```

`free_vid_win()` is the only path missing that guard.

## Fix

Add the same `slot != PJSUA_INVALID_ID` guard to both remove calls in
`free_vid_win()`:

```diff
 if (w->vp_cap) {
-    pjsua_vid_conf_remove_port(w->cap_slot);
+    if (w->cap_slot != PJSUA_INVALID_ID)
+        pjsua_vid_conf_remove_port(w->cap_slot);
     pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL,
                               w->vp_cap);
     pjmedia_vid_port_stop(w->vp_cap);
     pjmedia_vid_port_destroy(w->vp_cap);
 }
 if (w->vp_rend) {
-    pjsua_vid_conf_remove_port(w->rend_slot);
+    if (w->rend_slot != PJSUA_INVALID_ID)
+        pjsua_vid_conf_remove_port(w->rend_slot);
     pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL,
                               w->vp_rend);
     pjmedia_vid_port_stop(w->vp_rend);
     pjmedia_vid_port_destroy(w->vp_rend);
 }
```

4 lines added, 2 deleted. No behavioural change for the happy path
(both slots are valid → both removes still run). On the failure path
the assert is replaced by a no-op for the slot that was never added,
and the rest of the window teardown (event unsubscribe, port stop,
port destroy) proceeds unchanged — so the renderer / capture device
that *was* opened still gets closed properly.

## Verification

| Reproducer | Before | After |
|---|---|---|
| `pjsua-stress -n 16 -v 4 --duration 30` | aborts within a few seconds at first PJ_ETOOMANY | runs the full 30 s, exit 0, no aborts; `PJ_ETOOMANY` is logged 10+ times per run as expected |

The `PJ_ETOOMANY` itself is still a signal — application code may
want to either raise `PJMEDIA_VID_CONF_MAX_PORTS` for very-many-call
scenarios, or back off when the bridge is full. The fix here is
strictly about not aborting on the cleanup path; it does not change
the bridge's capacity.

## Files

* `pjsip/src/pjsua-lib/pjsua_vid.c` — `free_vid_win()`: guard
  `pjsua_vid_conf_remove_port` calls with
  `if (slot != PJSUA_INVALID_ID)`.
