### PR TITLE
Reject re-INVITE / hold / UPDATE / vid-strm changes after hangup

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -3385,6 +3385,13 @@ PJ_DEF(pj_status_t) pjsua_call_set_hold2(pjsua_call_id call_id,
     if (status != PJ_SUCCESS)
         goto on_return;
 
+    if (call->hanging_up) {
+        PJ_LOG(3,(THIS_FILE, "Can not hold call %d while it is hanging up",
+                  call_id));
+        status = PJ_EINVALIDOP;
+        goto on_return;
+    }
+
     if (call->inv->state != PJSIP_INV_STATE_CONFIRMED) {
         PJ_LOG(3,(THIS_FILE, "Can not hold call that is not confirmed"));
         status = PJSIP_ESESSIONSTATE;
@@ -3508,6 +3515,14 @@ PJ_DEF(pj_status_t) pjsua_call_reinvite2(pjsua_call_id call_id,
     status = acquire_call("pjsua_call_reinvite2()", call_id, &call, &dlg);
     if (status != PJ_SUCCESS)
         goto on_return;
+
+    if (call->hanging_up) {
+        PJ_LOG(3,(THIS_FILE,
+                  "Can not re-INVITE call %d while it is hanging up",
+                  call_id));
+        status = PJ_EINVALIDOP;
+        goto on_return;
+    }
 
     if (pjsua_call_media_is_changing(call)) {
         PJ_LOG(1,(THIS_FILE, "Unable to reinvite" ERR_MEDIA_CHANGING));
@@ -3642,6 +3657,14 @@ PJ_DEF(pj_status_t) pjsua_call_update2(pjsua_call_id call_id,
     status = acquire_call("pjsua_call_update2()", call_id, &call, &dlg);
     if (status != PJ_SUCCESS)
         goto on_return;
+
+    if (call->hanging_up) {
+        PJ_LOG(3,(THIS_FILE,
+                  "Can not send UPDATE on call %d while it is hanging up",
+                  call_id));
+        status = PJ_EINVALIDOP;
+        goto on_return;
+    }
 
     /* Don't check media changing if UPDATE is sent without SDP */
     if (pjsua_call_media_is_changing(call) &&

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -3480,6 +3480,14 @@ PJ_DEF(pj_status_t) pjsua_call_reinvite( pjsua_call_id call_id,
     if (status != PJ_SUCCESS)
         goto on_return;
 
+    if (call->hanging_up) {
+        PJ_LOG(3,(THIS_FILE,
+                  "Can not re-INVITE call %d while it is hanging up",
+                  call_id));
+        status = PJ_EINVALIDOP;
+        goto on_return;
+    }
+
     if (options != call->opt.flag)
         call->opt.flag = options;
 
@@ -3622,6 +3630,14 @@ PJ_DEF(pj_status_t) pjsua_call_update( pjsua_call_id call_id,
     status = acquire_call("pjsua_call_update()", call_id, &call, &dlg);
     if (status != PJ_SUCCESS)
         goto on_return;
+
+    if (call->hanging_up) {
+        PJ_LOG(3,(THIS_FILE,
+                  "Can not send UPDATE on call %d while it is hanging up",
+                  call_id));
+        status = PJ_EINVALIDOP;
+        goto on_return;
+    }
 
     if (options != call->opt.flag)
         call->opt.flag = options;

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -2728,6 +2728,14 @@ PJ_DEF(pj_status_t) pjsua_call_set_vid_strm (
     if (status != PJ_SUCCESS)
         goto on_return;
 
+    if (call->hanging_up) {
+        PJ_LOG(3,(THIS_FILE,
+                  "Can not change video stream on call %d while it is "
+                  "hanging up", call_id));
+        status = PJ_EINVALIDOP;
+        goto on_return;
+    }
+
     if (param) {
         param_ = *param;
     } else {


### PR DESCRIPTION
## Description
Prevent public call-control APIs from issuing hold, re-INVITE, UPDATE, or video stream changes after a call has entered hangup.

This PR adds `call->hanging_up` guards to:
- `pjsua_call_set_hold2()`
- `pjsua_call_reinvite2()`
- `pjsua_call_update2()`
- `pjsua_call_set_vid_strm()`

Based on review feedback, it also adds wrapper-level guards in:
- `pjsua_call_reinvite()`
- `pjsua_call_update()`

so the legacy wrappers return `PJ_EINVALIDOP` before mutating `call->opt.flag` while hangup is already in progress.

## Motivation and Context
A race between `pjsua_call_hangup()` and re-INVITE/UPDATE/video-change APIs could trigger media reinitialization during teardown and leave provisional media transports orphaned.

The additional wrapper guards are needed because the legacy `pjsua_call_reinvite()` and `pjsua_call_update()` wrappers update `call->opt.flag` before delegating to the `*2()` variants. Without guarding the wrappers too, those calls can still mutate call state even when the lower-level API later rejects the operation.

## How Has This Been Tested?
- Ran `./configure`
- Ran `make -j2 lib`
- Ran `cd pjsip/build && make -j2 pjsip-test-x86_64-pc-linux-gnu && ../bin/pjsip-test-x86_64-pc-linux-gnu`

Test result:
- 25/26 `pjsip-test` tests passed
- `tsx_destroy_test` failed with `[Err: -20]`
- The affected `libpjsua` target rebuilt successfully with the wrapper changes

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.