### PR TITLE
Fix SDP negotiation media overflow

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -477,6 +477,12 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
             if (!found) {
                 pjmedia_sdp_media *m;
 
+                if (new_offer->media_count >= PJMEDIA_MAX_SDP_MEDIA) {
+                    PJ_LOG(3,(THIS_FILE, "Too many media in SDP, "
+                                         "modify local offer failed"));
+                    return PJ_ETOOMANY;
+                }
+
                 m = sdp_media_clone_deactivate(pool, om, om, local);
 
                 pj_array_insert(new_offer->media, sizeof(new_offer->media[0]),
@@ -490,6 +496,12 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
          */
         for (oi = new_offer->media_count; oi < old_offer->media_count; ++oi) {
             pjmedia_sdp_media *m;
+
+            if (new_offer->media_count >= PJMEDIA_MAX_SDP_MEDIA) {
+                PJ_LOG(3,(THIS_FILE, "Too many media in SDP, "
+                                     "modify local offer failed"));
+                return PJ_ETOOMANY;
+            }
 
             m = sdp_media_clone_deactivate(pool, old_offer->media[oi],
                                            old_offer->media[oi], local);

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -480,6 +480,7 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
                 if (new_offer->media_count >= PJMEDIA_MAX_SDP_MEDIA) {
                     PJ_LOG(3,(THIS_FILE, "Too many media in SDP, "
                                          "modify local offer failed"));
+                    neg->state = PJMEDIA_SDP_NEG_STATE_DONE;
                     return PJ_ETOOMANY;
                 }
 
@@ -500,6 +501,7 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
             if (new_offer->media_count >= PJMEDIA_MAX_SDP_MEDIA) {
                 PJ_LOG(3,(THIS_FILE, "Too many media in SDP, "
                                      "modify local offer failed"));
+                neg->state = PJMEDIA_SDP_NEG_STATE_DONE;
                 return PJ_ETOOMANY;
             }
 


### PR DESCRIPTION
`pjmedia_sdp_neg_modify_local_offer2` fills in missing media lines from the active local SDP into the new offer, but does not enforce `PJMEDIA_MAX_SDP_MEDIA` checking. When the previously negotiated SDP has medias disjoint from the new local SDP, the combined count can exceed 16, overflowing the fixed-size array and causing a follow-on OOB read. This PR add checkings and early exit to avoid this OOB read discovered by the new fuzzer fixes with UBSAN in #4969 .