### PR TITLE
Add on_uac_tsx_terminate_session callback for in-dialog 408/481

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -164,6 +164,25 @@ static void call_timeout_callback(pj_timer_heap_t *timer_heap,
 }
 
 /*
+ * Handler that lets the application veto the library's automatic
+ * teardown of the call after an in-dialog UAC 408/481.
+ * Enabled via --keep-call-on-tsx-fail; emits a marker log so tests
+ * can detect that suppression actually took effect.
+ */
+static pj_bool_t on_call_tsx_terminate_session(pjsua_call_id call_id,
+                                               pjsip_transaction *tsx,
+                                               pjsip_event *e)
+{
+    PJ_UNUSED_ARG(e);
+    PJ_LOG(3, (THIS_FILE,
+               "Call %d: suppressing termination after %.*s %d",
+               call_id,
+               (int)tsx->method.name.slen, tsx->method.name.ptr,
+               tsx->status_code));
+    return PJ_TRUE;
+}
+
+/*
  * Handler when invite state has changed.
  */
 static void on_call_state(pjsua_call_id call_id, pjsip_event *e)
@@ -1685,6 +1704,10 @@ static pj_status_t app_init(void)
     app_config.cfg.cb.on_mwi_info = &on_mwi_info;
     app_config.cfg.cb.on_transport_state = &on_transport_state;
     app_config.cfg.cb.on_ice_transport_error = &on_ice_transport_error;
+    if (app_config.keep_call_on_tsx_fail) {
+        app_config.cfg.cb.on_call_tsx_terminate_session =
+                                            &on_call_tsx_terminate_session;
+    }
     app_config.cfg.cb.on_snd_dev_operation = &on_snd_dev_operation;
     app_config.cfg.cb.on_call_media_event = &on_call_media_event;
     app_config.cfg.cb.on_ip_change_progress = &on_ip_change_progress;

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -82,6 +82,7 @@ typedef struct pjsua_app_config
     pj_bool_t               no_tcp;
     pj_bool_t               no_udp;
     pj_bool_t               use_tls;
+    pj_bool_t               keep_call_on_tsx_fail;
     pjsua_transport_config  udp_cfg;
     pjsua_transport_config  rtp_cfg;
     pjsip_redirect_op       redir_op;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -254,6 +254,8 @@ static void usage(void)
     puts  ("  --accept-redirect=N Specify how to handle call redirect (3xx) response.");
     puts  ("                      0: reject, 1: follow automatically,");
     puts  ("                      2: follow + replace To header (default), 3: ask");
+    puts  ("  --keep-call-on-tsx-fail");
+    puts  ("                      Keep call on in-dialog UAC tsx 408/481");
 
     puts  ("");
     puts  ("CLI options:");
@@ -415,6 +417,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_NEXT_ACCOUNT, OPT_NEXT_CRED, OPT_MAX_CALLS,
            OPT_DURATION, OPT_NO_TCP, OPT_NO_UDP, OPT_THREAD_CNT,
            OPT_NOREFERSUB, OPT_NO_SUPPORTED_NOREFERSUB, OPT_ACCEPT_REDIRECT,
+           OPT_KEEP_CALL_ON_TSX_FAIL,
            OPT_USE_TLS, OPT_TLS_CA_FILE, OPT_TLS_CERT_FILE, OPT_TLS_PRIV_FILE,
            OPT_TLS_PASSWORD, OPT_TLS_VERIFY_SERVER, OPT_TLS_VERIFY_CLIENT,
            OPT_TLS_NEG_TIMEOUT, OPT_TLS_CIPHER,
@@ -459,6 +462,7 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "no-udp",     0, 0, OPT_NO_UDP},
         { "norefersub", 0, 0, OPT_NOREFERSUB},
         { "no-supported-norefersub", 0, 0, OPT_NO_SUPPORTED_NOREFERSUB},
+        { "keep-call-on-tsx-fail", 0, 0, OPT_KEEP_CALL_ON_TSX_FAIL},
         { "proxy",      1, 0, OPT_PROXY},
         { "outbound",   1, 0, OPT_OUTBOUND_PROXY},
         { "registrar",  1, 0, OPT_REGISTRAR},
@@ -769,6 +773,10 @@ static pj_status_t parse_args(int argc, char *argv[],
 
         case OPT_NO_SUPPORTED_NOREFERSUB: /* no-supported-norefersub */
             cfg->cfg.no_refer_sub = PJ_FALSE;
+            break;
+
+        case OPT_KEEP_CALL_ON_TSX_FAIL: /* keep-call-on-tsx-fail */
+            cfg->keep_call_on_tsx_fail = PJ_TRUE;
             break;
 
         case OPT_NO_TCP: /* no-tcp */

--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -324,9 +324,61 @@ typedef struct pjsip_inv_callback
      *                    to either accept or reject the redirection upon
      *                    getting user decision.
      */
-    pjsip_redirect_op (*on_redirected)(pjsip_inv_session *inv, 
+    pjsip_redirect_op (*on_redirected)(pjsip_inv_session *inv,
                                        const pjsip_uri *target,
                                        const pjsip_event *e);
+
+    /**
+     * This callback is called when an in-dialog UAC transaction within the
+     * invite session is about to cause the session to be terminated due to
+     * an RFC 3261 #12.2.1.2 failure -- a 408 Request Timeout, transaction
+     * timeout, or 481 Call/Transaction Does Not Exist response. The
+     * library would otherwise send BYE (or end the session) automatically.
+     *
+     * Implementing this callback allows the application to override that
+     * behavior selectively, e.g. to keep the session alive when an INFO
+     * or MESSAGE request fails (RFC 5057 #5.2 noted that the RFC 3261
+     * rule should have been scoped to the invite usage), or for non-RFC
+     * profiles such as ETSI EN 16072 (eCall) which require that only the
+     * operator may tear down the call.
+     *
+     * Returning PJ_TRUE suppresses the BYE/end-session step and prevents
+     * inv->cause from being set to the failed status. The library still
+     * performs cleanup that is necessary to keep the session usable for
+     * later requests -- in particular, a pending SDP offer carried by a
+     * failed re-INVITE or UPDATE is cancelled and inv->invite_tsx is
+     * cleared. Anything else (timers the application armed, application
+     * state) remains the responsibility of the application.
+     *
+     * Interaction with pjsip_cfg()->endpt.keep_inv_after_tsx_timeout:
+     * when that global flag is set, the 408/timeout branch is short-
+     * circuited before the callback is reached, so the callback is not
+     * invoked for 408 -- the session is already kept by the global flag.
+     * The callback is still invoked for 481, since the global flag does
+     * not cover it. Applications that want this callback to be the sole
+     * authority for both 408 and 481 should leave the global flag at its
+     * default (PJ_FALSE).
+     *
+     * Threading: this callback is invoked synchronously while the dialog
+     * group lock is held. The application MUST NOT call any pjsua_* or
+     * pjsip_dlg_* / pjsip_inv_* API that would acquire a higher-order
+     * lock (PJSUA_LOCK > dialog grp_lock > tsx grp_lock) from inside the
+     * callback -- doing so risks AB-BA deadlock. Defer any such work to
+     * a timer or worker thread.
+     *
+     * This callback is optional.
+     *
+     * @param inv       The invite session.
+     * @param tsx       The failed UAC transaction.
+     * @param e         The event that caused the failure.
+     *
+     * @return          PJ_TRUE if the application has handled the failure
+     *                  and the session should NOT be terminated.
+     *                  PJ_FALSE (default) to keep current behavior.
+     */
+    pj_bool_t (*on_uac_tsx_terminate_session)(pjsip_inv_session *inv,
+                                              pjsip_transaction *tsx,
+                                              pjsip_event *e);
 
 } pjsip_inv_callback;
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1372,6 +1372,53 @@ typedef struct pjsua_callback
                               pjsip_event *e);
 
     /**
+     * Notification when an in-dialog UAC transaction within the call is
+     * about to cause the call to be terminated due to RFC 3261 #12.2.1.2
+     * failures: 408 Request Timeout, transaction timeout, or 481
+     * Call/Transaction Does Not Exist. The library would otherwise send
+     * BYE automatically.
+     *
+     * If implemented, the application can return PJ_TRUE to suppress the
+     * automatic termination and keep the call alive, e.g. when an INFO or
+     * MESSAGE request fails for application-level reasons (see RFC 5057
+     * #5.2; ETSI EN 16072 eCall, etc.). When suppressed, the library
+     * still cancels any pending SDP offer that the failed re-INVITE or
+     * UPDATE carried, so the call remains usable for subsequent
+     * renegotiation. inv->cause is not set to the failed status.
+     *
+     * Interaction with pjsip_cfg()->endpt.keep_inv_after_tsx_timeout:
+     * when that global flag is set, the 408/timeout branch is short-
+     * circuited before the callback is reached, so the callback is not
+     * invoked for 408 -- the session is already kept by the global flag.
+     * The callback is still invoked for 481. Applications that want this
+     * callback to be the sole authority for both should leave the global
+     * flag at its default (PJ_FALSE).
+     *
+     * Threading: invoked synchronously while the dialog group lock is
+     * held. The application MUST NOT call any pjsua, pjsip_dlg, or
+     * pjsip_inv API that would acquire a higher-order lock (PJSUA_LOCK
+     * > dialog grp_lock > tsx grp_lock) from inside this callback --
+     * doing so risks deadlock. Defer such work to a timer.
+     *
+     * Note: this callback must be set in pjsua_callback BEFORE
+     * pjsua_init(); installing it later has no effect because pjsua wires
+     * the underlying pjsip-ua hook only at init time.
+     *
+     * This callback is optional. When not set, the call is terminated as
+     * per the default behavior.
+     *
+     * @param call_id   The call identification.
+     * @param tsx       The failed UAC transaction.
+     * @param e         The event that caused the failure.
+     *
+     * @return          PJ_TRUE to suppress the automatic call termination.
+     *                  PJ_FALSE (default) to keep current behavior.
+     */
+    pj_bool_t (*on_call_tsx_terminate_session)(pjsua_call_id call_id,
+                                               pjsip_transaction *tsx,
+                                               pjsip_event *e);
+
+    /**
      * Notify application when a transaction started by pjsua_acc_send_request()
      * has been completed,i.e. when a response has been received.
      *

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -787,6 +787,30 @@ struct OnCallTsxStateParam
 };
 
 /**
+ * This structure contains parameters for Call::onCallTsxTerminateSession()
+ * callback.
+ */
+struct OnCallTsxTerminateSessionParam
+{
+    /**
+     * Transaction event that would otherwise cause the call to be terminated.
+     * Inspect e.body.tsxState.tsx for the failed transaction's method and
+     * status code.
+     */
+    SipEvent    e;
+
+    /**
+     * Output: application sets this to true to suppress the automatic
+     * session termination and keep the call alive. Default is false, i.e.
+     * the library will terminate the call as per default behavior.
+     */
+    bool        suppressTermination;
+
+    OnCallTsxTerminateSessionParam() : suppressTermination(false)
+    {}
+};
+
+/**
  * This structure contains parameters for Call::onCallMediaState() callback.
  */
 struct OnCallMediaStateParam
@@ -2002,6 +2026,40 @@ public:
      * @param prm       Callback parameter.
      */
     virtual void onCallTsxState(OnCallTsxStateParam &prm)
+    { PJ_UNUSED_ARG(prm); }
+
+    /**
+     * Notification when an in-dialog UAC transaction within the call is
+     * about to cause the call to be terminated due to RFC 3261 #12.2.1.2
+     * failures: 408 Request Timeout, transaction timeout, or 481
+     * Call/Transaction Does Not Exist response.
+     *
+     * Application can inspect prm.e (e.g. e.body.tsxState.tsx.method and
+     * tsx.statusCode) to determine the failed request, and set
+     * prm.suppressTermination to true to keep the call alive instead of
+     * letting the library terminate it. This is useful for application
+     * level requests such as INFO/MESSAGE where the failure should not
+     * teardown the call (see RFC 5057 #5.2 and e.g. ETSI EN 16072 eCall).
+     *
+     * When suppressed, the library still cancels any pending SDP offer
+     * that the failed re-INVITE or UPDATE carried, so the call remains
+     * usable for subsequent renegotiation.
+     *
+     * Interaction with pjsip_cfg()->endpt.keep_inv_after_tsx_timeout:
+     * when that global flag is set, the 408/timeout branch is short-
+     * circuited before this callback is reached, so it is not invoked
+     * for 408. It is still invoked for 481.
+     *
+     * Threading: invoked synchronously while the dialog group lock is
+     * held. Do not call any Call or Endpoint API from this callback
+     * that would acquire a higher-order lock; defer such work via a
+     * timer or by posting to your own queue.
+     *
+     * Default implementation does nothing (call is terminated as before).
+     *
+     * @param prm       Callback parameter.
+     */
+    virtual void onCallTsxTerminateSession(OnCallTsxTerminateSessionParam &prm)
     { PJ_UNUSED_ARG(prm); }
     
     /**

--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -2367,6 +2367,9 @@ private:
     static void on_call_tsx_state(pjsua_call_id call_id,
                                   pjsip_transaction *tsx,
                                   pjsip_event *e);
+    static pj_bool_t on_call_tsx_terminate_session(pjsua_call_id call_id,
+                                                   pjsip_transaction *tsx,
+                                                   pjsip_event *e);
     static void on_call_media_state(pjsua_call_id call_id);
     static void on_call_sdp_created(pjsua_call_id call_id,
                                     pjmedia_sdp_session *sdp,

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -4318,14 +4318,29 @@ static pj_bool_t inv_handle_update_response( pjsip_inv_session *inv,
           !pjsip_cfg()->endpt.keep_inv_after_tsx_timeout)))
     {
         pjsip_tx_data *bye = NULL;
+        pj_bool_t suppress = PJ_FALSE;
 
-        /* End session */
-        status = pjsip_inv_end_session(inv, tsx->status_code,
-                                       &tsx->status_text, &bye);
-        if (status == PJ_SUCCESS && bye) {
-            status = pjsip_inv_send_msg(inv, bye);
+        /* Allow application to override the automatic session termination. */
+        if (mod_inv.cb.on_uac_tsx_terminate_session) {
+            suppress = (*mod_inv.cb.on_uac_tsx_terminate_session)(inv, tsx,
+                                                                  e);
         }
 
+        if (!suppress) {
+            /* End session */
+            status = pjsip_inv_end_session(inv, tsx->status_code,
+                                           &tsx->status_text, &bye);
+            if (status == PJ_SUCCESS && bye) {
+                status = pjsip_inv_send_msg(inv, bye);
+            }
+        }
+
+        /* Mark handled either way: when suppressed, the caller must not
+         * fall through to handle_uac_tsx_response() and invoke the
+         * callback a second time for the same transaction. The tail SDP
+         * cleanup below still runs so the negotiator does not stay in
+         * LOCAL_OFFER for a kept-alive session.
+         */
         handled =  PJ_TRUE;
     }
 
@@ -4825,6 +4840,20 @@ static pj_bool_t handle_uac_tsx_response(pjsip_inv_session *inv,
     {
         pjsip_tx_data *bye;
         pj_status_t status;
+
+        /* Allow application to override the automatic session termination.
+         * Return PJ_FALSE so the caller (e.g. inv_on_state_confirmed for
+         * a re-INVITE) still runs its post-failure cleanup branch --
+         * cancelling a pending SDP offer and clearing inv->invite_tsx --
+         * which would otherwise be skipped on PJ_TRUE. The session is
+         * kept alive but the failed transaction must not leave stale
+         * negotiation state behind.
+         */
+        if (mod_inv.cb.on_uac_tsx_terminate_session &&
+            (*mod_inv.cb.on_uac_tsx_terminate_session)(inv, tsx, e))
+        {
+            return PJ_FALSE;
+        }
 
         inv_set_cause(inv, tsx->status_code, &tsx->status_text);
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -116,6 +116,14 @@ static pjsip_redirect_op pjsua_call_on_redirected(pjsip_inv_session *inv,
                                                   const pjsip_uri *target,
                                                   const pjsip_event *e);
 
+/*
+ * UAC transaction termination override handler.
+ */
+static pj_bool_t pjsua_call_on_uac_tsx_terminate_session(
+                                            pjsip_inv_session *inv,
+                                            pjsip_transaction *tsx,
+                                            pjsip_event *e);
+
 
 /* Create SDP for call hold. */
 static pj_status_t create_sdp_of_call_hold(pjsua_call *call,
@@ -245,6 +253,10 @@ pj_status_t pjsua_call_subsys_init(const pjsua_config *cfg)
     inv_cb.on_redirected = &pjsua_call_on_redirected;
     if (pjsua_var.ua_cfg.cb.on_call_rx_reinvite) {
         inv_cb.on_rx_reinvite = &pjsua_call_on_rx_reinvite;
+    }
+    if (pjsua_var.ua_cfg.cb.on_call_tsx_terminate_session) {
+        inv_cb.on_uac_tsx_terminate_session =
+                                    &pjsua_call_on_uac_tsx_terminate_session;
     }
 
     /* Initialize invite session module: */
@@ -6987,6 +6999,28 @@ static pjsip_redirect_op pjsua_call_on_redirected(pjsip_inv_session *inv,
     pj_log_pop_indent();
 
     return op;
+}
+
+/*
+ * UAC tsx termination override: ask the app whether to keep the call alive
+ * when the invite session is about to be terminated due to 408/481 on an
+ * in-dialog UAC request.
+ */
+static pj_bool_t pjsua_call_on_uac_tsx_terminate_session(
+                                            pjsip_inv_session *inv,
+                                            pjsip_transaction *tsx,
+                                            pjsip_event *e)
+{
+    pjsua_call *call = (pjsua_call*) inv->dlg->mod_data[pjsua_var.mod.id];
+
+    if (!call || call->hanging_up ||
+        !pjsua_var.ua_cfg.cb.on_call_tsx_terminate_session)
+    {
+        return PJ_FALSE;
+    }
+
+    return (*pjsua_var.ua_cfg.cb.on_call_tsx_terminate_session)(call->index,
+                                                                tsx, e);
 }
 
 #if defined(PJSUA_MEDIA_HAS_PJMEDIA) && PJSUA_MEDIA_HAS_PJMEDIA != 0

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1510,8 +1510,27 @@ void Endpoint::on_call_tsx_state(pjsua_call_id call_id,
     
     OnCallTsxStateParam prm;
     prm.e.fromPj(*e);
-    
+
     call->onCallTsxState(prm);
+}
+
+pj_bool_t Endpoint::on_call_tsx_terminate_session(pjsua_call_id call_id,
+                                                  pjsip_transaction *tsx,
+                                                  pjsip_event *e)
+{
+    PJ_UNUSED_ARG(tsx);
+
+    Call *call = Call::lookup(call_id);
+    if (!call) {
+        return PJ_FALSE;
+    }
+
+    OnCallTsxTerminateSessionParam prm;
+    prm.e.fromPj(*e);
+
+    call->onCallTsxTerminateSession(prm);
+
+    return prm.suppressTermination ? PJ_TRUE : PJ_FALSE;
 }
 
 void Endpoint::on_call_media_state(pjsua_call_id call_id)
@@ -2325,6 +2344,8 @@ void Endpoint::libInit(const EpConfig &prmEpConfig) PJSUA2_THROW(Error)
     /* Call callbacks */
     ua_cfg.cb.on_call_state             = &Endpoint::on_call_state;
     ua_cfg.cb.on_call_tsx_state         = &Endpoint::on_call_tsx_state;
+    ua_cfg.cb.on_call_tsx_terminate_session
+                                        = &Endpoint::on_call_tsx_terminate_session;
     ua_cfg.cb.on_call_media_state       = &Endpoint::on_call_media_state;
     ua_cfg.cb.on_call_sdp_created       = &Endpoint::on_call_sdp_created;
     ua_cfg.cb.on_stream_precreate       = &Endpoint::on_stream_precreate;

--- a/tests/pjsua/scripts-sipp/uas-keep-call-on-tsx-fail.py
+++ b/tests/pjsua/scripts-sipp/uas-keep-call-on-tsx-fail.py
@@ -1,0 +1,28 @@
+#
+# Driver for uas-keep-call-on-tsx-fail.xml. pjsua dials SIPp, presses
+# 'H' to send a re-INVITE that SIPp rejects with 481. With the
+# --keep-call-on-tsx-fail flag, pjsua's on_call_tsx_terminate_session
+# returns PJ_TRUE so the library must NOT send BYE; the call must
+# stay in CONFIRMED state until pjsua itself hangs up via 'h'.
+#
+import inc_const as const
+
+PJSUA = ["--null-audio --max-calls=1 --no-tcp "
+         "--keep-call-on-tsx-fail sip:127.0.0.1:$SIPP_PORT"]
+
+PJSUA_EXPECTS = [
+    # Call connected -- send hold (re-INVITE).
+    [0, const.STATE_CONFIRMED, "H"],
+    # The suppression log line proves the callback fired and returned
+    # PJ_TRUE; only then send the hangup so the BYE is ours, not the
+    # library's auto-BYE.
+    [0, "suppressing termination after INVITE 481", "h"],
+    # Disconnect via our explicit BYE.
+    [0, const.STATE_DISCONNECTED, ""]
+]
+
+PJSUA_CLI_EXPECTS = [
+    [0, const.STATE_CONFIRMED, "H"],
+    [0, "suppressing termination after INVITE 481", "call hangup"],
+    [0, const.STATE_DISCONNECTED, ""]
+]

--- a/tests/pjsua/scripts-sipp/uas-keep-call-on-tsx-fail.xml
+++ b/tests/pjsua/scripts-sipp/uas-keep-call-on-tsx-fail.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Verifies pjsua's on_call_tsx_terminate_session callback: when the
+  application returns PJ_TRUE, an in-dialog UAC re-INVITE that gets
+  481 must NOT cause the call to be terminated by the library. The
+  paired pjsua driver runs with the keep-call-on-tsx-fail flag; the
+  call must stay alive until pjsua itself sends BYE in response to
+  the hangup command, not as a side effect of the failed re-INVITE.
+-->
+
+<scenario name="uas-keep-call-on-tsx-fail">
+
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=- 1 1 IN IP4 [local_ip]
+      s=-
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 4444 RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+
+    ]]>
+  </send>
+
+  <recv request="ACK">
+  </recv>
+
+  <!-- Wait for pjsua's hold re-INVITE, respond 481. -->
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 481 Call/Transaction Does Not Exist
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv request="ACK">
+  </recv>
+
+  <!--
+    With suppression in effect, pjsua-lib must NOT auto-BYE here. The
+    BYE that follows is the one pjsua sends after the test driver
+    issues the 'h' (hangup) command on stdin. If suppression failed,
+    the BYE would arrive immediately and SIPp would still accept it,
+    but the driver's expect for the suppression log line would have
+    timed out first.
+  -->
+  <recv request="BYE">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>


### PR DESCRIPTION
By RFC 3261 §12.2.1.2, an in-dialog UAC transaction that fails with 408 Request Timeout or 481 Call/Transaction Does Not Exist causes the invite usage to be torn down via BYE. RFC 5057 §5.2 noted that this rule should have been scoped to the invite usage, and some profiles (e.g. ETSI EN 16072 eCall) require that only the operator may tear down the call. The existing `endpt.keep_inv_after_tsx_timeout` flag is global, binary, and only covers 408 — not 481 — so it cannot discriminate by method or per call.

This adds a new `on_uac_tsx_terminate_session` callback to `pjsip_inv_callback` that fires inside `handle_uac_tsx_response()` and `inv_handle_update_response()` just before BYE / end-session, letting the application return `PJ_TRUE` to keep the session alive. Bridged through `pjsua_callback` as `on_call_tsx_terminate_session`, and through pjsua2 as `Call::onCallTsxTerminateSession` with `OnCallTsxTerminateSessionParam::suppressTermination`.

On suppress, the library still cancels any pending SDP offer carried by a failed re-INVITE or UPDATE and clears `inv->invite_tsx` so the kept-alive session remains usable for subsequent renegotiation. `inv->cause` is not set to the failed status.

Interaction with `endpt.keep_inv_after_tsx_timeout`: when that global flag is set, the 408/timeout branch is short-circuited before the callback is reached. 481 always reaches the callback. Applications that want the callback to be the sole authority should leave the global flag at its default.

Threading: callback runs synchronously while the dialog group lock is held. The header doc warns applications not to call back into pjsua/pjsip APIs that acquire higher-order locks (PJSUA_LOCK > dialog grp_lock > tsx grp_lock) — defer such work to a timer.

Closes #4936.

## Test plan
- [x] Builds cleanly on Linux with `make -j3` (zero warnings beyond the existing `PJ_TODO` ones).
- [ ] Manual test: send an INFO that times out (peer drops the request), set the callback to return `PJ_TRUE`, verify the call stays in CONFIRMED state and no BYE is sent.
- [ ] Manual test: same as above but for a re-INVITE with a local SDP offer; verify `pjmedia_sdp_neg` returns to `DONE` (offer cancelled) and a subsequent re-INVITE succeeds.
- [ ] Manual test: leave the callback unimplemented; verify pre-PR behavior is preserved (BYE is sent on 408/481).

Co-Authored-By Claude Code