### PR TITLE
Fix race between RTP receive callback and transport_attach2 zeroing rtp_src_addr

### DIFF
--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -529,19 +529,25 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
     if (udp->base.grp_lock)
         pj_grp_lock_release(udp->base.grp_lock);
 
-    /* If a concurrent transport_attach2() zeroed rtp_src_addr between
-     * the recvfrom completion and this snapshot, the cb has no valid
-     * peer to act on; drop the packet rather than feeding sa_family=0
-     * downstream. The next recvfrom will repopulate the address.
-     */
-    if (src_addr->addr.sa_family != PJ_AF_INET &&
-        src_addr->addr.sa_family != PJ_AF_INET6)
-    {
-        return;
-    }
-
     if (cb2) {
         pjmedia_tp_cb_param param;
+
+        /* If a concurrent transport_attach2() zeroed rtp_src_addr
+         * between the recvfrom completion and this snapshot, the cb
+         * has no valid peer to act on; drop the packet rather than
+         * feeding sa_family=0 downstream. The next recvfrom will
+         * repopulate the address. Only relevant for real received
+         * packets (bytes_read > 0); error notifications (bytes_read
+         * < 0, e.g. PJ_ESOCKETSTOP from the restart paths) must
+         * still be delivered regardless of src_addr state, since
+         * they signal a fatal socket condition to the upper layer.
+         */
+        if (bytes_read > 0 &&
+            src_addr->addr.sa_family != PJ_AF_INET &&
+            src_addr->addr.sa_family != PJ_AF_INET6)
+        {
+            return;
+        }
 
         param.user_data = user_data;
         param.pkt = udp->rtp_pkt;
@@ -552,6 +558,7 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
         if (rem_switch)
             *rem_switch = param.rem_switch;
     } else if (cb) {
+        /* Legacy cb doesn't consume src_addr; deliver unconditionally. */
         (*cb)(user_data, udp->rtp_pkt, bytes_read);
     }
 }

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -494,14 +494,20 @@ static pj_status_t transport_destroy(pjmedia_transport *tp)
     return PJ_SUCCESS;
 }
 
-/* Call RTP cb. */
+/* Call RTP cb.
+ *
+ * src_addr is an out-param: on return, holds the snapshot of the RTP
+ * source address taken under grp_lock. Callers that need to act on the
+ * peer address (e.g. on_rx_rtp's rem_switch path) must use this snapshot
+ * rather than reading udp->rtp_src_addr directly, since the latter can
+ * be raced by transport_attach2().
+ */
 static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
-                        pj_bool_t *rem_switch)
+                        pj_bool_t *rem_switch, pj_sockaddr *src_addr)
 {
     void (*cb)(void*,void*,pj_ssize_t);
     void (*cb2)(pjmedia_tp_cb_param*);
     void *user_data;
-    pj_sockaddr src_addr;
 
     /* Snapshot callback pointers and the RTP source address under lock.
      * pj_ioqueue_lock_key() == pj_grp_lock_acquire() for the same group
@@ -518,7 +524,7 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
     cb = udp->rtp_cb;
     cb2 = udp->rtp_cb2;
     user_data = udp->user_data;
-    pj_memcpy(&src_addr, &udp->rtp_src_addr, sizeof(src_addr));
+    pj_memcpy(src_addr, &udp->rtp_src_addr, sizeof(*src_addr));
 
     if (udp->base.grp_lock)
         pj_grp_lock_release(udp->base.grp_lock);
@@ -528,8 +534,8 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
      * peer to act on; drop the packet rather than feeding sa_family=0
      * downstream. The next recvfrom will repopulate the address.
      */
-    if (src_addr.addr.sa_family != PJ_AF_INET &&
-        src_addr.addr.sa_family != PJ_AF_INET6)
+    if (src_addr->addr.sa_family != PJ_AF_INET &&
+        src_addr->addr.sa_family != PJ_AF_INET6)
     {
         return;
     }
@@ -540,7 +546,7 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
         param.user_data = user_data;
         param.pkt = udp->rtp_pkt;
         param.size = bytes_read;
-        param.src_addr = &src_addr;
+        param.src_addr = src_addr;
         param.rem_switch = PJ_FALSE;
         (*cb2)(&param);
         if (rem_switch)
@@ -578,6 +584,7 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
     struct transport_udp *udp;
     pj_status_t status;
     pj_bool_t rem_switch = PJ_FALSE;
+    pj_sockaddr src_addr;
     pj_bool_t transport_restarted = PJ_FALSE;
     unsigned num_err = 0;
     pj_status_t last_err = PJ_SUCCESS;
@@ -598,7 +605,7 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
         status = transport_restart(PJ_TRUE, udp);
         if (status != PJ_SUCCESS) {
             bytes_read = -PJ_ESOCKETSTOP;
-            call_rtp_cb(udp, bytes_read, NULL);
+            call_rtp_cb(udp, bytes_read, NULL, &src_addr);
         }
         return;
     }
@@ -609,7 +616,7 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
         /* Simulate packet lost on RX direction */
         if (udp->rx_drop_pct) {
             if ((pj_rand() % 100) <= (int)udp->rx_drop_pct) {
-                PJ_LOG(5,(udp->base.name, 
+                PJ_LOG(5,(udp->base.name,
                           "RX RTP packet dropped because of pkt lost "
                           "simulation"));
                 discard = PJ_TRUE;
@@ -617,10 +624,10 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
         }
 
         //if (!discard && udp->attached && cb)
-        if (!discard && 
-            (-bytes_read != PJ_STATUS_FROM_OS(PJ_BLOCKING_ERROR_VAL))) 
+        if (!discard &&
+            (-bytes_read != PJ_STATUS_FROM_OS(PJ_BLOCKING_ERROR_VAL)))
         {
-            call_rtp_cb(udp, bytes_read, &rem_switch);
+            call_rtp_cb(udp, bytes_read, &rem_switch, &src_addr);
         }
 
         /* Transport may be destroyed from the callback! */
@@ -634,12 +641,16 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
         {
             char addr_text[PJ_INET6_ADDRSTRLEN+10];
 
-            /* Set remote RTP address to source address */
-            pj_sockaddr_cp(&udp->rem_rtp_addr, &udp->rtp_src_addr);
+            /* Set remote RTP address to source address. Use the snapshot
+             * filled in by call_rtp_cb() rather than udp->rtp_src_addr,
+             * since the latter can be zeroed by a concurrent
+             * transport_attach2().
+             */
+            pj_sockaddr_cp(&udp->rem_rtp_addr, &src_addr);
 
             PJ_LOG(4,(udp->base.name,
                       "Remote RTP address switched to %s",
-                      pj_sockaddr_print(&udp->rtp_src_addr, addr_text,
+                      pj_sockaddr_print(&src_addr, addr_text,
                                         sizeof(addr_text), 3)));
 
             if (udp->use_rtcp_mux) {
@@ -674,11 +685,11 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
                                      &udp->rtp_src_addr,
                                      &udp->rtp_addrlen);
 
-        if (status != PJ_EPENDING && status != PJ_SUCCESS) {        
+        if (status != PJ_EPENDING && status != PJ_SUCCESS) {
             if (transport_restarted && last_err == status) {
                 /* Still the same error after restart */
                 bytes_read = -PJ_ESOCKETSTOP;
-                call_rtp_cb(udp, bytes_read, NULL);
+                call_rtp_cb(udp, bytes_read, NULL, &src_addr);
                 break;
             } else if (PJMEDIA_IGNORE_RECV_ERR_CNT) {
                 if (last_err == status) {
@@ -691,10 +702,10 @@ static void on_rx_rtp(pj_ioqueue_key_t *key,
                 if (status == PJ_ESOCKETSTOP ||
                     num_err > PJMEDIA_IGNORE_RECV_ERR_CNT)
                 {
-                    status = transport_restart(PJ_TRUE, udp);               
+                    status = transport_restart(PJ_TRUE, udp);
                     if (status != PJ_SUCCESS) {
                         bytes_read = -PJ_ESOCKETSTOP;
-                        call_rtp_cb(udp, bytes_read, NULL);
+                        call_rtp_cb(udp, bytes_read, NULL, &src_addr);
                         break;
                     }
                     transport_restarted = PJ_TRUE;

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -501,14 +501,16 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
     void (*cb)(void*,void*,pj_ssize_t);
     void (*cb2)(pjmedia_tp_cb_param*);
     void *user_data;
+    pj_sockaddr src_addr;
 
-    /* Snapshot callback pointers under lock to avoid race with
-     * transport_detach() clearing them. Note that
-     * pj_ioqueue_lock_key() == pj_grp_lock_acquire() for the same
-     * group lock, so the detach side is already synchronized via
-     * pj_ioqueue_lock_key(). The lock is needed here because
-     * PJ_IOQUEUE_CALLBACK_NO_LOCK causes this callback to be invoked
-     * without the key lock held.
+    /* Snapshot callback pointers and the RTP source address under lock.
+     * pj_ioqueue_lock_key() == pj_grp_lock_acquire() for the same group
+     * lock, so transport_attach2() (which zeroes rtp_src_addr under the
+     * ioqueue key lock) is serialized with us here. Snapshotting is
+     * necessary because PJ_IOQUEUE_CALLBACK_NO_LOCK causes this callback
+     * to be invoked without the key lock held — without the copy, a
+     * concurrent attach could bzero rtp_src_addr after we passed a
+     * pointer to it into the cb, and the cb would then see sa_family=0.
      */
     if (udp->base.grp_lock)
         pj_grp_lock_acquire(udp->base.grp_lock);
@@ -516,9 +518,21 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
     cb = udp->rtp_cb;
     cb2 = udp->rtp_cb2;
     user_data = udp->user_data;
+    pj_memcpy(&src_addr, &udp->rtp_src_addr, sizeof(src_addr));
 
     if (udp->base.grp_lock)
         pj_grp_lock_release(udp->base.grp_lock);
+
+    /* If a concurrent transport_attach2() zeroed rtp_src_addr between
+     * the recvfrom completion and this snapshot, the cb has no valid
+     * peer to act on; drop the packet rather than feeding sa_family=0
+     * downstream. The next recvfrom will repopulate the address.
+     */
+    if (src_addr.addr.sa_family != PJ_AF_INET &&
+        src_addr.addr.sa_family != PJ_AF_INET6)
+    {
+        return;
+    }
 
     if (cb2) {
         pjmedia_tp_cb_param param;
@@ -526,7 +540,7 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
         param.user_data = user_data;
         param.pkt = udp->rtp_pkt;
         param.size = bytes_read;
-        param.src_addr = &udp->rtp_src_addr;
+        param.src_addr = &src_addr;
         param.rem_switch = PJ_FALSE;
         (*cb2)(&param);
         if (rem_switch)


### PR DESCRIPTION
# Fix race between UDP RTP receive cb and `transport_attach2`

## Symptom

Under stress with many simultaneous media re-negotiations, pjsua
aborts:

```
pjsua-stress-aarch64-apple-darwin24.6.0 -n 32 -v 8 --log-level 4 --duration 30
Assertion failed: (a->addr.sa_family == PJ_AF_INET ||
                   a->addr.sa_family == PJ_AF_INET6),
                  function pj_sockaddr_get_len, file sock_common.c, line 394.
```

Reproduces within seconds at `-n 32 -v 8 --duration 30`. ASan stays
silent — the memory is alive, just been zeroed.

## Backtrace

```
pj_sockaddr_get_len(addr=0x…f10) at sock_common.c:393
pj_sockaddr_cp(dst=…, src=0x…f10)  at sock_common.c:416
on_rx_rtp(param=…)                 at stream_imp_common.c:504
srtp_rtp_cb(param=…)               at transport_srtp.c:1569
call_rtp_cb(udp=…, bytes_read=172) at transport_udp.c:531
on_rx_rtp(key=…, op_key=…)         at transport_udp.c:609
ioqueue_dispatch_read_event(…)     at ioqueue_common_abs.c:881
pj_ioqueue_poll(…)                 at ioqueue_select.c:1100
worker_proc(…)                     at endpoint.c:352
```

In lldb at the assertion the memory at `param->src_addr` is all zeros
(`sa_family=0`), while the destination `c_strm->rem_rtp_addr` has
`sa_family=AF_INET (2)` — i.e. the stream is fine, the UDP transport's
just-received source address has been zeroed out from underneath us.

## Cause

`transport_udp.c:call_rtp_cb()` passes the address of the UDP
transport's `rtp_src_addr` directly into the user RTP callback:

```c
param.src_addr = &udp->rtp_src_addr;     /* line 529 */
(*cb2)(&param);
```

The comment at the top of the function explains it acquires the
group-lock briefly to snapshot the cb pointers under
`PJ_IOQUEUE_CALLBACK_NO_LOCK` (lines 505-514), but it does **not**
snapshot the address — it hands out a pointer into the shared
`udp` struct.

`transport_udp.c:tp_attach()` / `transport_attach2()` zeros that
same field on every re-attach:

```c
pj_ioqueue_lock_key(udp->rtp_key);                              /* 893 */
pj_ioqueue_lock_key(udp->rtcp_key);                             /* 894 */
...
pj_bzero(&udp->rtp_src_addr, sizeof(udp->rtp_src_addr));        /* 948 */
pj_bzero(&udp->rtcp_src_addr, sizeof(udp->rtcp_src_addr));      /* 949 */
```

The intent (per the ticket #844 comment at 891) is that
`pj_ioqueue_lock_key()` blocks any pending read callback so the
bzero is safe. That holds when callbacks dispatch **with** the key
lock held. With `PJ_IOQUEUE_CALLBACK_NO_LOCK`,
`ioqueue_common_abs.c:867` explicitly releases the key lock right
before calling `on_read_complete` — at which point `attach2` is no
longer blocked.

The race window:

```
T_recv: recvfrom completes → udp->rtp_src_addr := <real peer>
T_recv: ioqueue releases key lock, prepares to call read cb
T_attach: pj_ioqueue_lock_key(rtp_key) succeeds (key lock free)
T_attach: pj_bzero(&udp->rtp_src_addr)
T_attach: pj_ioqueue_unlock_key(rtp_key)
T_recv:  call_rtp_cb() runs, param.src_addr = &udp->rtp_src_addr (now zeroed)
T_recv:  (*cb2)(&param) → stream's on_rx_rtp
T_recv:  pj_sockaddr_cp(&c_strm->rem_rtp_addr, param->src_addr)
T_recv:    → pj_sockaddr_get_len(zeros) → PJ_ASSERT_RETURN → abort
```

In the failing run, call 24 had a flurry of offer/answer/offer/answer
inside a few tens of milliseconds (visible in the log:
`Call 24: re-initializing media..` repeating). That churn gives
`attach2` ample chances to land between recvfrom completion and the
callback dereferencing `src_addr`. Smaller smoke tests rarely hit it.

## Fix

`call_rtp_cb()` is already the place that snapshots cb pointers under
the group lock. Snapshot the source address there too, into a stack
local, and hand the cb a pointer to the local instead of into shared
state:

```diff
 static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
                         pj_bool_t *rem_switch)
 {
     void (*cb)(void*,void*,pj_ssize_t);
     void (*cb2)(pjmedia_tp_cb_param*);
     void *user_data;
+    pj_sockaddr src_addr;

     if (udp->base.grp_lock)
         pj_grp_lock_acquire(udp->base.grp_lock);

     cb = udp->rtp_cb;
     cb2 = udp->rtp_cb2;
     user_data = udp->user_data;
+    pj_memcpy(&src_addr, &udp->rtp_src_addr, sizeof(src_addr));

     if (udp->base.grp_lock)
         pj_grp_lock_release(udp->base.grp_lock);

+    /* If a concurrent transport_attach2() zeroed rtp_src_addr between
+     * the recvfrom completion and this snapshot, the cb has no valid
+     * peer to act on; drop the packet rather than feeding sa_family=0
+     * downstream. The next recvfrom will repopulate the address.
+     */
+    if (src_addr.addr.sa_family != PJ_AF_INET &&
+        src_addr.addr.sa_family != PJ_AF_INET6)
+    {
+        return;
+    }
+
     if (cb2) {
         pjmedia_tp_cb_param param;
         param.user_data = user_data;
         param.pkt       = udp->rtp_pkt;
         param.size      = bytes_read;
-        param.src_addr  = &udp->rtp_src_addr;
+        param.src_addr  = &src_addr;
         param.rem_switch = PJ_FALSE;
         (*cb2)(&param);
         ...
     }
 }
```

Notes:

* `pj_memcpy` of `sizeof(pj_sockaddr)` is used instead of
  `pj_sockaddr_cp`. `pj_sockaddr_cp` calls `pj_sockaddr_get_len(src)`,
  which would itself trip the very assertion we are trying to avoid
  if `rtp_src_addr` had already been zeroed by the racing `attach2`.
* The post-snapshot family check covers the case where `attach2`
  zeroed `rtp_src_addr` *before* the snapshot grabbed it. We then
  drop one packet rather than feed sa_family=0 into the stream cb.
  The next recvfrom will refill `rtp_src_addr` and the next callback
  runs normally.
* The RTP path matters here; RTCP doesn't pass `&rtcp_src_addr` to
  user cbs the same way (it only hands `udp->rtcp_pkt` to the cb),
  so no parallel change is needed in `call_rtcp_cb()`.

## Why not fix it in `transport_attach2`

The natural alternative — acquire `udp->base.grp_lock` in `attach2`
in addition to the ioqueue key locks before zeroing — would also
close the race, but it widens the lock acquisition order at a
function that already takes two key locks, and risks a deadlock if
any peer also acquires grp_lock then a key lock. Snapshotting at the
cb site is the narrowest fix and matches the existing
"copy-cb-under-lock" pattern already in `call_rtp_cb`.

The third alternative — simply not zeroing `rtp_src_addr` in
`attach2` — changes observable behavior (`rem_switch` logic would
still see the previous peer's address after a re-attach to a
different peer), so it's not a drop-in.

## Verification

`pjsua-stress -n 32 -v 8 --log-level 4 --duration 30` on macOS, ASan
build:

| Metric                              | Before                                | After  |
|---                                  |---                                    |---     |
| `Assertion failed: …sa_family…`     | aborts within seconds                 | **0**  |
| Exit code                           | 134 (SIGABRT)                         | **0**  |
| Pool leak warnings                  | n/a (couldn't reach cleanup)          | **0**  |
| Stress phase ops (hangup/make/...)  | n/a (aborted mid-stress)              | ~6000 / run, ~30 s clean |

Verified across 3 consecutive 30-second runs (different UDP ports);
all 3 exited 0, no asserts, no pool leaks, full stress + cleanup
phases completed.

## Files

| Path                                  | Function          | Change |
|------|------|---|
| `pjmedia/src/pjmedia/transport_udp.c` | `call_rtp_cb`     | Snapshot `udp->rtp_src_addr` under grp_lock; drop packet if snapshot has invalid sa_family; pass `&local` to cb instead of `&udp->rtp_src_addr`. |
