### PR TITLE
Fix heap-use-after-free in shared video preview hangup races and harden clock stop/destroy serialization

### DIFF
--- a/pjmedia/include/pjmedia/clock.h
+++ b/pjmedia/include/pjmedia/clock.h
@@ -327,7 +327,7 @@ PJ_DECL(pj_bool_t) pjmedia_clock_wait(pjmedia_clock *clock,
  * The caller must also ensure no concurrent #pjmedia_clock_stop() or
  * #pjmedia_clock_destroy() is in flight on the same clock when the
  * destroy proceeds past its internal join; the lock that serializes
- * stop/destroy is torn down at the tail of a successful destroy.
+ * stop/destroy stays valid for the clock object's lifetime.
  *
  * @param clock             The media clock.
  *

--- a/pjmedia/include/pjmedia/clock.h
+++ b/pjmedia/include/pjmedia/clock.h
@@ -327,7 +327,7 @@ PJ_DECL(pj_bool_t) pjmedia_clock_wait(pjmedia_clock *clock,
  * The caller must also ensure no concurrent #pjmedia_clock_stop() or
  * #pjmedia_clock_destroy() is in flight on the same clock when the
  * destroy proceeds past its internal join; the lock that serializes
- * stop/destroy stays valid for the clock object's lifetime.
+ * stop/destroy is torn down at the tail of a successful destroy.
  *
  * @param clock             The media clock.
  *

--- a/pjmedia/include/pjmedia/clock.h
+++ b/pjmedia/include/pjmedia/clock.h
@@ -317,16 +317,15 @@ PJ_DECL(pj_bool_t) pjmedia_clock_wait(pjmedia_clock *clock,
 
 
 /**
- * Destroy the clock. The caller must not invoke this from inside the
- * clock callback itself — the function joins the clock thread, and a
- * self-join is not recoverable here (it returns #PJ_EBUSY without
- * tearing the clock down, leaving the caller to retry from a
- * different thread). Use #pjmedia_clock_stop() to signal stop from
- * within the callback, and destroy from outside.
+ * Destroy the clock. If called from inside the clock callback
+ * (self-join), the function cannot complete the destroy: it returns
+ * #PJ_EBUSY without tearing the clock down. The caller must arrange
+ * a retry from a different thread. Use #pjmedia_clock_stop() to
+ * signal stop from within the callback, and destroy from outside.
  *
  * The caller must also ensure no concurrent #pjmedia_clock_stop() or
- * #pjmedia_clock_destroy() is in flight on the same clock when the
- * destroy proceeds past its internal join; the lock that serializes
+ * #pjmedia_clock_destroy() runs on the same clock once the destroy
+ * proceeds past its internal join; the lock that serializes
  * stop/destroy is torn down at the tail of a successful destroy.
  *
  * @param clock             The media clock.

--- a/pjmedia/include/pjmedia/clock.h
+++ b/pjmedia/include/pjmedia/clock.h
@@ -317,11 +317,24 @@ PJ_DECL(pj_bool_t) pjmedia_clock_wait(pjmedia_clock *clock,
 
 
 /**
- * Destroy the clock.
+ * Destroy the clock. The caller must not invoke this from inside the
+ * clock callback itself — the function joins the clock thread, and a
+ * self-join is not recoverable here (it returns #PJ_EBUSY without
+ * tearing the clock down, leaving the caller to retry from a
+ * different thread). Use #pjmedia_clock_stop() to signal stop from
+ * within the callback, and destroy from outside.
+ *
+ * The caller must also ensure no concurrent #pjmedia_clock_stop() or
+ * #pjmedia_clock_destroy() is in flight on the same clock when the
+ * destroy proceeds past its internal join; the lock that serializes
+ * stop/destroy is torn down at the tail of a successful destroy.
  *
  * @param clock             The media clock.
  *
- * @return                  PJ_SUCCES on success.
+ * @return                  PJ_SUCCESS on success, #PJ_EBUSY if
+ *                          called from inside the clock callback
+ *                          (self-join), or another error code if
+ *                          the OS-level join failed.
  */
 PJ_DECL(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock);
 

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -511,17 +511,10 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
         clock->lock = NULL;
     }
 
-    /* Release destroy_lock and tear down its OS resources together
-     * with the pool that backs its memory. The lock and the memory
-     * it guards share one lifetime — both go away here, under one
-     * owner. Safe because the higher layer (e.g. pjsua_vid's
-     * is_destroying flag + dec_vid_win under PJSUA_LOCK) guarantees
-     * no concurrent destroy/stop on the same clock; any in-flight
-     * concurrent caller has already drained against destroy_lock
-     * above. */
+    /* Keep destroy_lock valid for the clock object's lifetime.
+     * This avoids late stop/destroy callers touching a destroyed/NULL
+     * mutex after another thread has already completed destroy(). */
     pj_mutex_unlock(clock->destroy_lock);
-    pj_mutex_destroy(clock->destroy_lock);
-    clock->destroy_lock = NULL;
 
     pj_pool_safe_release(&clock->pool);
 

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -207,10 +207,17 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
      * rejects the second one with EINVAL, but on Windows the
      * underlying WaitForSingleObject() permits multiple waiters and
      * *both* return success, leading to double pj_thread_destroy()
-     * and double pj_pool_reset(). Allocated from the caller's pool so
-     * it outlives clock->pool's release in pjmedia_clock_destroy().
-     */
-    status = pj_mutex_create_recursive(pool, "clockdestroy",
+     * and double pj_pool_reset().
+     *
+     * Allocated from clock->pool — not the caller's pool — so the
+     * lock and the memory it guards share one lifetime and are torn
+     * down together in pjmedia_clock_destroy() by a single owner.
+     * pj_mutex_destroy(destroy_lock) runs immediately before
+     * pj_pool_safe_release(&clock->pool) there. This relies on the
+     * caller not issuing concurrent destroy on the same handle —
+     * which the higher-layer is_destroying flag + dec_vid_win under
+     * PJSUA_LOCK guarantees for the pjsua video path. */
+    status = pj_mutex_create_recursive(clock->pool, "clockdestroy",
                                        &clock->destroy_lock);
     if (status != PJ_SUCCESS) {
         pj_lock_destroy(clock->lock);
@@ -504,14 +511,19 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
         clock->lock = NULL;
     }
 
-    pj_pool_safe_release(&clock->pool);
-
-    /* Keep destroy_lock valid for the lifetime of this clock object.
-     * Unlocking and immediately destroying it can race with concurrent
-     * stop/destroy callers currently blocked on the same mutex.
-     */
+    /* Release destroy_lock and tear down its OS resources together
+     * with the pool that backs its memory. The lock and the memory
+     * it guards share one lifetime — both go away here, under one
+     * owner. Safe because the higher layer (e.g. pjsua_vid's
+     * is_destroying flag + dec_vid_win under PJSUA_LOCK) guarantees
+     * no concurrent destroy/stop on the same clock; any in-flight
+     * concurrent caller has already drained against destroy_lock
+     * above. */
     pj_mutex_unlock(clock->destroy_lock);
+    pj_mutex_destroy(clock->destroy_lock);
+    clock->destroy_lock = NULL;
+
+    pj_pool_safe_release(&clock->pool);
 
     return ret;
 }
-

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -123,6 +123,12 @@ struct pjmedia_clock
     pj_bool_t                running;
     pj_bool_t                quitting;
     pj_lock_t               *lock;
+    /* Serializes pjmedia_clock_stop() and pjmedia_clock_destroy()
+     * across concurrent callers. Cannot be the same as `lock` above,
+     * because `lock` is held by the clock thread inside the callback
+     * (see clock_thread()), and stop/destroy must be allowed to run
+     * while the thread is mid-callback. */
+    pj_mutex_t              *destroy_lock;
 };
 
 
@@ -186,9 +192,26 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
     clock->thread = NULL;
     clock->running = PJ_FALSE;
     clock->quitting = PJ_FALSE;
-    
+    clock->destroy_lock = NULL;
+
     /* I don't think we need a mutex, so we'll use null. */
     status = pj_lock_create_null_mutex(pool, "clock", &clock->lock);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* But we *do* need a real mutex to serialize stop/destroy: under
+     * stress, multiple threads can land in pjmedia_clock_stop() on the
+     * same clock concurrently (e.g. cbar_stream_stop reached from both
+     * vid_port handle_format_change and free_vid_win). Without this,
+     * two pthread_join() calls race the same descriptor — POSIX
+     * rejects the second one with EINVAL, but on Windows the
+     * underlying WaitForSingleObject() permits multiple waiters and
+     * *both* return success, leading to double pj_thread_destroy()
+     * and double pj_pool_reset(). Allocated from the caller's pool so
+     * it outlives clock->pool's release in pjmedia_clock_destroy().
+     */
+    status = pj_mutex_create_recursive(pool, "clockdestroy",
+                                       &clock->destroy_lock);
     if (status != PJ_SUCCESS)
         return status;
 
@@ -245,7 +268,19 @@ PJ_DEF(pj_status_t) pjmedia_clock_start(pjmedia_clock *clock)
  */
 PJ_DEF(pj_status_t) pjmedia_clock_stop(pjmedia_clock *clock)
 {
+    pj_status_t ret = PJ_SUCCESS;
+
     PJ_ASSERT_RETURN(clock != NULL, PJ_EINVAL);
+
+    /* Serialize against concurrent stop/destroy on the same clock.
+     * The first caller does the join + descriptor destroy; subsequent
+     * callers acquire the mutex, find clock->thread == NULL, and
+     * return PJ_SUCCESS without touching the thread handle. This is
+     * portable across POSIX (where pthread_join would reject the
+     * second joiner with EINVAL) and Windows (where the underlying
+     * wait would otherwise allow multiple successful waiters).
+     */
+    pj_mutex_lock(clock->destroy_lock);
 
     clock->running = PJ_FALSE;
     clock->quitting = PJ_TRUE;
@@ -257,28 +292,23 @@ PJ_DEF(pj_status_t) pjmedia_clock_stop(pjmedia_clock *clock)
             clock->thread = NULL;
             pj_pool_reset(clock->pool);
         } else if (status == PJ_ECANCELLED) {
-            /* We are probably called from the clock thread itself.
-             * Do not cancel the thread's quitting though, since it
-             * may cause the clock thread to run indefinitely.
-             */
-            // clock->quitting = PJ_FALSE;
-            return PJ_EBUSY;
+            /* We are called from the clock thread itself; we cannot
+             * join ourselves. Leave clock->quitting set so the thread
+             * will exit on the next loop iteration. The caller must
+             * NOT release the clock's owning pool — the thread is
+             * still alive. */
+            ret = PJ_EBUSY;
         } else {
-            /* pthread_join() returned an OS error (e.g. EINVAL on
-             * macOS). The usual cause is another thread already
-             * joining this same descriptor concurrently — POSIX
-             * forbids two simultaneous joiners. The actual joiner
-             * will set clock->thread = NULL once the underlying
-             * thread has exited; spin-wait here so the caller's
-             * follow-up pj_pool_release() doesn't pull the rug out
-             * from under the still-running clock thread.
-             */
-            while (clock->thread != NULL)
-                pj_thread_sleep(1);
+            /* Any other OS error from pj_thread_join(): clock->thread
+             * is still alive and the descriptor was not freed.
+             * Propagate the error so the caller doesn't release the
+             * owning pool out from under the running thread. */
+            ret = status;
         }
     }
 
-    return PJ_SUCCESS;
+    pj_mutex_unlock(clock->destroy_lock);
+    return ret;
 }
 
 
@@ -435,7 +465,13 @@ static int clock_thread(void *arg)
  */
 PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
 {
+    pj_status_t ret = PJ_SUCCESS;
+
     PJ_ASSERT_RETURN(clock != NULL, PJ_EINVAL);
+
+    /* Serialize against concurrent stop/destroy. See the same
+     * pattern in pjmedia_clock_stop() above. */
+    pj_mutex_lock(clock->destroy_lock);
 
     clock->running = PJ_FALSE;
     clock->quitting = PJ_TRUE;
@@ -445,15 +481,17 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
         if (status == PJ_SUCCESS) {
             pj_thread_destroy(clock->thread);
             clock->thread = NULL;
-        } else if (status != PJ_ECANCELLED) {
-            /* Another thread is already joining the same descriptor
-             * (see pjmedia_clock_stop() for details). Wait for it
-             * to clear clock->thread before we release clock->pool
-             * (which would free the thread descriptor underneath
-             * the joiner).
-             */
-            while (clock->thread != NULL)
-                pj_thread_sleep(1);
+        } else {
+            /* PJ_ECANCELLED (self-join) or another OS error: the
+             * clock thread is still alive and may still touch
+             * clock->lock and clock->pool from inside the callback
+             * loop. Tearing them down here would be a UAF. Skip the
+             * cleanup, propagate the error, and let the caller
+             * (which still owns the backing pool) retry once the
+             * thread has actually exited. */
+            ret = (status == PJ_ECANCELLED) ? PJ_EBUSY : status;
+            pj_mutex_unlock(clock->destroy_lock);
+            return ret;
         }
     }
 
@@ -464,7 +502,19 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
 
     pj_pool_safe_release(&clock->pool);
 
-    return PJ_SUCCESS;
+    /* Release destroy_lock and free its OS resources. pjmedia_clock
+     * is documented as single-owner for stop/destroy, and the higher
+     * layer (e.g. pjsua_vid window refcounting) is responsible for
+     * not calling destroy concurrently; the destroy_lock only guards
+     * against the in-progress stop/destroy on the same clock that
+     * we've already drained by holding it through the join above.
+     * After this unlock there must be no further callers.
+     */
+    pj_mutex_unlock(clock->destroy_lock);
+    pj_mutex_destroy(clock->destroy_lock);
+    clock->destroy_lock = NULL;
+
+    return ret;
 }
 
 

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -283,14 +283,9 @@ PJ_DEF(pj_status_t) pjmedia_clock_stop(pjmedia_clock *clock)
 
     PJ_ASSERT_RETURN(clock != NULL, PJ_EINVAL);
 
-    /* Serialize against concurrent stop/destroy on the same clock.
-     * The first caller does the join + descriptor destroy; subsequent
-     * callers acquire the mutex, find clock->thread == NULL, and
-     * return PJ_SUCCESS without touching the thread handle. This is
-     * portable across POSIX (where pthread_join would reject the
-     * second joiner with EINVAL) and Windows (where the underlying
-     * wait would otherwise allow multiple successful waiters).
-     */
+    /* Serialize in-flight stop/destroy calls within the clock's
+     * lifetime. The caller contract in clock.h bars stop/destroy
+     * after a successful destroy (which tears down this lock). */
     pj_mutex_lock(clock->destroy_lock);
 
     clock->running = PJ_FALSE;

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -251,18 +251,30 @@ PJ_DEF(pj_status_t) pjmedia_clock_stop(pjmedia_clock *clock)
     clock->quitting = PJ_TRUE;
 
     if (clock->thread) {
-        if (pj_thread_join(clock->thread) == PJ_SUCCESS) {
+        pj_status_t status = pj_thread_join(clock->thread);
+        if (status == PJ_SUCCESS) {
             pj_thread_destroy(clock->thread);
             clock->thread = NULL;
             pj_pool_reset(clock->pool);
-        } else {
+        } else if (status == PJ_ECANCELLED) {
             /* We are probably called from the clock thread itself.
              * Do not cancel the thread's quitting though, since it
              * may cause the clock thread to run indefinitely.
-             */ 
+             */
             // clock->quitting = PJ_FALSE;
-            
             return PJ_EBUSY;
+        } else {
+            /* pthread_join() returned an OS error (e.g. EINVAL on
+             * macOS). The usual cause is another thread already
+             * joining this same descriptor concurrently — POSIX
+             * forbids two simultaneous joiners. The actual joiner
+             * will set clock->thread = NULL once the underlying
+             * thread has exited; spin-wait here so the caller's
+             * follow-up pj_pool_release() doesn't pull the rug out
+             * from under the still-running clock thread.
+             */
+            while (clock->thread != NULL)
+                pj_thread_sleep(1);
         }
     }
 
@@ -429,9 +441,20 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
     clock->quitting = PJ_TRUE;
 
     if (clock->thread) {
-        pj_thread_join(clock->thread);
-        pj_thread_destroy(clock->thread);
-        clock->thread = NULL;
+        pj_status_t status = pj_thread_join(clock->thread);
+        if (status == PJ_SUCCESS) {
+            pj_thread_destroy(clock->thread);
+            clock->thread = NULL;
+        } else if (status != PJ_ECANCELLED) {
+            /* Another thread is already joining the same descriptor
+             * (see pjmedia_clock_stop() for details). Wait for it
+             * to clear clock->thread before we release clock->pool
+             * (which would free the thread descriptor underneath
+             * the joiner).
+             */
+            while (clock->thread != NULL)
+                pj_thread_sleep(1);
+        }
     }
 
     if (clock->lock) {

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -212,8 +212,12 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
      */
     status = pj_mutex_create_recursive(pool, "clockdestroy",
                                        &clock->destroy_lock);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+        pj_lock_destroy(clock->lock);
+        clock->lock = NULL;
+        pj_pool_safe_release(&clock->pool);
         return status;
+    }
 
     *p_clock = clock;
 
@@ -502,19 +506,12 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
 
     pj_pool_safe_release(&clock->pool);
 
-    /* Release destroy_lock and free its OS resources. pjmedia_clock
-     * is documented as single-owner for stop/destroy, and the higher
-     * layer (e.g. pjsua_vid window refcounting) is responsible for
-     * not calling destroy concurrently; the destroy_lock only guards
-     * against the in-progress stop/destroy on the same clock that
-     * we've already drained by holding it through the join above.
-     * After this unlock there must be no further callers.
+    /* Keep destroy_lock valid for the lifetime of this clock object.
+     * Unlocking and immediately destroying it can race with concurrent
+     * stop/destroy callers currently blocked on the same mutex.
      */
     pj_mutex_unlock(clock->destroy_lock);
-    pj_mutex_destroy(clock->destroy_lock);
-    clock->destroy_lock = NULL;
 
     return ret;
 }
-
 

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -511,10 +511,12 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
         clock->lock = NULL;
     }
 
-    /* Keep destroy_lock valid for the clock object's lifetime.
-     * This avoids late stop/destroy callers touching a destroyed/NULL
-     * mutex after another thread has already completed destroy(). */
+    /* destroy_lock memory lives in clock->pool, so tear it down here
+     * before pool release. Caller must not race stop/destroy past
+     * this point. */
     pj_mutex_unlock(clock->destroy_lock);
+    pj_mutex_destroy(clock->destroy_lock);
+    clock->destroy_lock = NULL;
 
     pj_pool_safe_release(&clock->pool);
 

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -537,6 +537,9 @@ typedef struct pjsua_vid_win
     pjsua_vid_win_type           type;          /**< Type.              */
     pj_pool_t                   *pool;          /**< Own pool.          */
     unsigned                     ref_cnt;       /**< Reference counter. */
+    pj_bool_t                    is_destroying; /**< Currently being torn
+                                                     down (free_vid_win()
+                                                     in progress).      */
     pjmedia_vid_port            *vp_cap;        /**< Capture vidport.   */
     pjmedia_vid_port            *vp_rend;       /**< Renderer vidport   */
     pjsua_conf_port_id           cap_slot;      /**< Capturer conf slot */

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1843,11 +1843,13 @@ PJ_DEF(pj_status_t) pjsua_vid_enum_wins( pjsua_vid_win_id wids[],
 
     cnt = 0;
 
+    PJSUA_LOCK();
     for (i=0; i<PJSUA_MAX_VID_WINS && cnt <*count; ++i) {
         pjsua_vid_win *w = &pjsua_var.win[i];
         if (w->type != PJSUA_WND_TYPE_NONE && !w->is_destroying)
             wids[cnt++] = i;
     }
+    PJSUA_UNLOCK();
 
     *count = cnt;
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -597,7 +597,9 @@ static pjsua_vid_win_id vid_preview_get_win(pjmedia_vid_dev_index id,
 
     for (i=0; i<PJSUA_MAX_VID_WINS; ++i) {
         pjsua_vid_win *w = &pjsua_var.win[i];
-        if (w->type == PJSUA_WND_TYPE_PREVIEW && w->preview_cap_id == id) {
+        if (w->type == PJSUA_WND_TYPE_PREVIEW && !w->is_destroying &&
+            w->preview_cap_id == id)
+        {
             wid = i;
             break;
         }
@@ -944,15 +946,24 @@ static void free_vid_win(pjsua_vid_win_id wid)
     PJ_LOG(4,(THIS_FILE, "Window %d: destroying..", wid));
     pj_log_push_indent();
 
-    /* Snapshot the underlying vid_ports and conf slots under PJSUA_LOCK,
-     * then clear them out of the window so that anything else reading
-     * pjsua_var.win[wid] concurrently (e.g. another call's
-     * pjsua_vid_stop_stream() that shares this preview window) sees
-     * vp_cap == NULL / vp_rend == NULL and skips the stop, instead of
+    /* Mark the window as being torn down and snapshot the underlying
+     * vid_ports / conf slots under PJSUA_LOCK, then clear them out
+     * of the window so that anything else reading pjsua_var.win[wid]
+     * concurrently (e.g. another call's pjsua_vid_stop_stream() that
+     * shares this preview window, or vid_preview_get_win() about to
+     * inc_vid_win() this slot) sees is_destroying == PJ_TRUE and
+     * vp_cap == NULL / vp_rend == NULL and skips the slot, instead of
      * dereferencing a vid_port whose underlying cbar stream is about
      * to be freed by the destroy calls below.
+     *
+     * dec_vid_win() already sets is_destroying before calling us, but
+     * free_vid_win() is also reached from create_vid_win()'s on_error
+     * path and from pjsua_vid_subsys_destroy() — those don't go
+     * through dec_vid_win(), so we set the flag here too. Idempotent
+     * either way.
      */
     PJSUA_LOCK();
+    w->is_destroying = PJ_TRUE;
     vp_cap    = w->vp_cap;
     vp_rend   = w->vp_rend;
     cap_slot  = w->cap_slot;
@@ -997,7 +1008,7 @@ static void inc_vid_win(pjsua_vid_win_id wid)
 
     PJSUA_LOCK();
     w = &pjsua_var.win[wid];
-    pj_assert(w->type != PJSUA_WND_TYPE_NONE);
+    pj_assert(w->type != PJSUA_WND_TYPE_NONE && !w->is_destroying);
     ++w->ref_cnt;
     PJSUA_UNLOCK();
 }
@@ -1011,7 +1022,9 @@ static void dec_vid_win(pjsua_vid_win_id wid)
 
     PJSUA_LOCK();
     w = &pjsua_var.win[wid];
-    if (w->type == PJSUA_WND_TYPE_NONE || w->ref_cnt == 0) {
+    if (w->type == PJSUA_WND_TYPE_NONE || w->is_destroying ||
+        w->ref_cnt == 0)
+    {
         /* A concurrent dec on a shared preview window has already
          * driven ref_cnt to 0 and is inside free_vid_win() (which
          * releases PJSUA_LOCK to destroy its vid_ports), or the
@@ -1020,12 +1033,21 @@ static void dec_vid_win(pjsua_vid_win_id wid)
         return;
     }
     if (--w->ref_cnt == 0) {
-        /* Mark the window dead *before* we release PJSUA_LOCK inside
-         * free_vid_win(): a concurrent inc/dec on the same wid (e.g.
-         * another call sharing this Colorbar preview) would otherwise
-         * touch half-destroyed state and double-destroy the cbar
-         * stream, racing the cbar clock thread vs pool release. */
-        w->type = PJSUA_WND_TYPE_NONE;
+        /* Mark the window as being destroyed *before* we release
+         * PJSUA_LOCK inside free_vid_win(): a concurrent inc/dec on
+         * the same wid (e.g. another call sharing this Colorbar
+         * preview) would otherwise touch half-destroyed state and
+         * double-destroy the cbar stream, racing the cbar clock
+         * thread vs pool release.
+         *
+         * The flag is cleared (via pj_bzero) only by the final
+         * pjsua_vid_win_reset() at the tail of free_vid_win(),
+         * which is also what returns the slot to the allocator.
+         * Until then, the slot stays "not selectable" in
+         * vid_preview_get_win(), the create_vid_win() slot
+         * allocator, the enumeration, and another inc/dec.
+         */
+        w->is_destroying = PJ_TRUE;
         need_free = PJ_TRUE;
     }
     PJSUA_UNLOCK();
@@ -1818,7 +1840,7 @@ PJ_DEF(pj_status_t) pjsua_vid_enum_wins( pjsua_vid_win_id wids[],
 
     for (i=0; i<PJSUA_MAX_VID_WINS && cnt <*count; ++i) {
         pjsua_vid_win *w = &pjsua_var.win[i];
-        if (w->type != PJSUA_WND_TYPE_NONE)
+        if (w->type != PJSUA_WND_TYPE_NONE && !w->is_destroying)
             wids[cnt++] = i;
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -937,29 +937,48 @@ on_error:
 static void free_vid_win(pjsua_vid_win_id wid)
 {
     pjsua_vid_win *w = &pjsua_var.win[wid];
+    pjmedia_vid_port *vp_cap, *vp_rend;
+    pjsua_conf_port_id cap_slot, rend_slot;
     unsigned num_locks = 0;
-    
+
     PJ_LOG(4,(THIS_FILE, "Window %d: destroying..", wid));
     pj_log_push_indent();
+
+    /* Snapshot the underlying vid_ports and conf slots under PJSUA_LOCK,
+     * then clear them out of the window so that anything else reading
+     * pjsua_var.win[wid] concurrently (e.g. another call's
+     * pjsua_vid_stop_stream() that shares this preview window) sees
+     * vp_cap == NULL / vp_rend == NULL and skips the stop, instead of
+     * dereferencing a vid_port whose underlying cbar stream is about
+     * to be freed by the destroy calls below.
+     */
+    PJSUA_LOCK();
+    vp_cap    = w->vp_cap;
+    vp_rend   = w->vp_rend;
+    cap_slot  = w->cap_slot;
+    rend_slot = w->rend_slot;
+    w->vp_cap    = NULL;
+    w->vp_rend   = NULL;
+    w->cap_slot  = PJSUA_INVALID_ID;
+    w->rend_slot = PJSUA_INVALID_ID;
+    PJSUA_UNLOCK();
 
     /* Release locks before unsubscribing/destroying, to avoid deadlock. */
     num_locks = PJSUA_RELEASE_LOCK();
 
-    if (w->vp_cap) {
-        if (w->cap_slot != PJSUA_INVALID_ID)
-            pjsua_vid_conf_remove_port(w->cap_slot);
-        pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL,
-                                  w->vp_cap);
-        pjmedia_vid_port_stop(w->vp_cap);
-        pjmedia_vid_port_destroy(w->vp_cap);
+    if (vp_cap) {
+        if (cap_slot != PJSUA_INVALID_ID)
+            pjsua_vid_conf_remove_port(cap_slot);
+        pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL, vp_cap);
+        pjmedia_vid_port_stop(vp_cap);
+        pjmedia_vid_port_destroy(vp_cap);
     }
-    if (w->vp_rend) {
-        if (w->rend_slot != PJSUA_INVALID_ID)
-            pjsua_vid_conf_remove_port(w->rend_slot);
-        pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL,
-                                  w->vp_rend);
-        pjmedia_vid_port_stop(w->vp_rend);
-        pjmedia_vid_port_destroy(w->vp_rend);
+    if (vp_rend) {
+        if (rend_slot != PJSUA_INVALID_ID)
+            pjsua_vid_conf_remove_port(rend_slot);
+        pjmedia_event_unsubscribe(NULL, &call_media_on_event, NULL, vp_rend);
+        pjmedia_vid_port_stop(vp_rend);
+        pjmedia_vid_port_destroy(vp_rend);
     }
     /* Re-acquire the locks. */
     PJSUA_RELOCK(num_locks);
@@ -973,23 +992,45 @@ static void free_vid_win(pjsua_vid_win_id wid)
 static void inc_vid_win(pjsua_vid_win_id wid)
 {
     pjsua_vid_win *w;
-    
+
     pj_assert(wid >= 0 && wid < PJSUA_MAX_VID_WINS);
 
+    PJSUA_LOCK();
     w = &pjsua_var.win[wid];
     pj_assert(w->type != PJSUA_WND_TYPE_NONE);
     ++w->ref_cnt;
+    PJSUA_UNLOCK();
 }
 
 static void dec_vid_win(pjsua_vid_win_id wid)
 {
     pjsua_vid_win *w;
-    
+    pj_bool_t need_free = PJ_FALSE;
+
     pj_assert(wid >= 0 && wid < PJSUA_MAX_VID_WINS);
 
+    PJSUA_LOCK();
     w = &pjsua_var.win[wid];
-    pj_assert(w->type != PJSUA_WND_TYPE_NONE);
-    if (--w->ref_cnt == 0)
+    if (w->type == PJSUA_WND_TYPE_NONE || w->ref_cnt == 0) {
+        /* A concurrent dec on a shared preview window has already
+         * driven ref_cnt to 0 and is inside free_vid_win() (which
+         * releases PJSUA_LOCK to destroy its vid_ports), or the
+         * caller is unbalanced. Either way, nothing more to do. */
+        PJSUA_UNLOCK();
+        return;
+    }
+    if (--w->ref_cnt == 0) {
+        /* Mark the window dead *before* we release PJSUA_LOCK inside
+         * free_vid_win(): a concurrent inc/dec on the same wid (e.g.
+         * another call sharing this Colorbar preview) would otherwise
+         * touch half-destroyed state and double-destroy the cbar
+         * stream, racing the cbar clock thread vs pool release. */
+        w->type = PJSUA_WND_TYPE_NONE;
+        need_free = PJ_TRUE;
+    }
+    PJSUA_UNLOCK();
+
+    if (need_free)
         free_vid_win(wid);
 }
 
@@ -1430,32 +1471,56 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
 
     /* Unsubscribe events first, otherwise the event callbacks
      * can be called and access already destroyed objects.
+     *
+     * Both branches read pjsua_var.win[wid] after we released
+     * PJSUA_LOCK above. A racing dec_vid_win() on a shared preview
+     * window or on a renderer window whose call_med peer was just
+     * torn down (prov_med <-> call_med sync in pjsua_media.c) can
+     * have already freed the window — its vp_cap / vp_rend are NULL
+     * and re-stopping or unsubscribing would dereference NULL.
      */
     if (call_med->strm.v.cap_win_id != PJSUA_INVALID_ID) {
         pjsua_vid_win *w = &pjsua_var.win[call_med->strm.v.cap_win_id];
+        pjmedia_vid_port *vp_cap;
 
-        /* Unsubscribe event */
-        pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med,
-                                  w->vp_cap);
+        /* Snapshot vp_cap so a racing free_vid_win() that clears
+         * w->vp_cap mid-flight can't NULL it out from under us
+         * between the check and the use. */
+        PJSUA_LOCK();
+        vp_cap = w->vp_cap;
+        PJSUA_UNLOCK();
+
+        if (vp_cap) {
+            /* Unsubscribe event */
+            pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med,
+                                      vp_cap);
+        }
     }
     if (call_med->strm.v.rdr_win_id != PJSUA_INVALID_ID) {
         pj_status_t status;
         pjmedia_port *media_port;
         pjsua_vid_win *w = &pjsua_var.win[call_med->strm.v.rdr_win_id];
+        pjmedia_vid_port *vp_rend;
 
-        /* Unsubscribe event, but stop the render first */
-        pjmedia_vid_port_stop(w->vp_rend);
-        pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med,
-                                  w->vp_rend);
+        PJSUA_LOCK();
+        vp_rend = w->vp_rend;
+        PJSUA_UNLOCK();
 
-        /* Retrieve stream decoding port */
-        status = pjmedia_vid_stream_get_port(strm, PJMEDIA_DIR_DECODING,
-                                             &media_port);
-        if (status == PJ_SUCCESS) {
-            pjmedia_event_unsubscribe(NULL, &call_media_on_event,
-                                    call_med, media_port);
+        if (vp_rend) {
+            /* Unsubscribe event, but stop the render first */
+            pjmedia_vid_port_stop(vp_rend);
+            pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med,
+                                      vp_rend);
 
-            pjmedia_vid_port_unsubscribe_event(w->vp_rend, media_port);
+            /* Retrieve stream decoding port */
+            status = pjmedia_vid_stream_get_port(strm, PJMEDIA_DIR_DECODING,
+                                                 &media_port);
+            if (status == PJ_SUCCESS) {
+                pjmedia_event_unsubscribe(NULL, &call_media_on_event,
+                                        call_med, media_port);
+
+                pjmedia_vid_port_unsubscribe_event(vp_rend, media_port);
+            }
         }
     }
     /* Unsubscribe from video stream events */

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -1528,19 +1528,24 @@ void pjsua_vid_stop_stream(pjsua_call_media *call_med)
         vp_rend = w->vp_rend;
         PJSUA_UNLOCK();
 
+        /* Retrieve stream decoding port and always remove the
+         * call-specific subscription from it, even when the renderer
+         * has already been torn down.
+         */
+        status = pjmedia_vid_stream_get_port(strm, PJMEDIA_DIR_DECODING,
+                                             &media_port);
+        if (status == PJ_SUCCESS) {
+            pjmedia_event_unsubscribe(NULL, &call_media_on_event,
+                                      call_med, media_port);
+        }
+
         if (vp_rend) {
             /* Unsubscribe event, but stop the render first */
             pjmedia_vid_port_stop(vp_rend);
             pjmedia_event_unsubscribe(NULL, &call_media_on_event, call_med,
                                       vp_rend);
 
-            /* Retrieve stream decoding port */
-            status = pjmedia_vid_stream_get_port(strm, PJMEDIA_DIR_DECODING,
-                                                 &media_port);
             if (status == PJ_SUCCESS) {
-                pjmedia_event_unsubscribe(NULL, &call_media_on_event,
-                                        call_med, media_port);
-
                 pjmedia_vid_port_unsubscribe_event(vp_rend, media_port);
             }
         }


### PR DESCRIPTION
## Description
This PR fixes a heap-use-after-free that occurs when concurrent call
hangups race on a shared video preview window (notably with
`Colorbar-active`), and hardens the clock stop/destroy path against
concurrent callers.

Main updates in the final state of this PR:

- **Serialized video window refcount transitions and made teardown
  idempotent** for concurrent decrements. `inc_vid_win` /
  `dec_vid_win` now run under `PJSUA_LOCK`. A new `pj_bool_t
  is_destroying` field on `pjsua_vid_win` marks the slot dead before
  `free_vid_win()` releases the lock to destroy its vid_ports, so
  racing inc/dec/preview-lookup/enumeration on the same wid see the
  flag and bail. The flag is cleared (via `pj_bzero`) by
  `pjsua_vid_win_reset()` at the tail of `free_vid_win()`.
- **Prevented teardown races by snapshotting `vp_cap`/`vp_rend` under
  `PJSUA_LOCK`** in both `free_vid_win()` and `pjsua_vid_stop_stream()`
  before any destroy/unsubscribe work, so a racing free can't NULL
  them out mid-call. `free_vid_win()` also clears the window's slot
  pointers under the lock so concurrent readers see NULL and skip.
- **Updated stop-stream cleanup** to always unsubscribe the
  `call_media_on_event` subscription from the stream's decoding port
  even when the renderer port has already been torn down.
- **Serialized `pjmedia_clock_stop()` / `pjmedia_clock_destroy()` join
  paths** via a recursive `destroy_lock` on `pjmedia_clock`, and
  propagated join errors so callers don't free backing memory while
  the clock thread is still alive. Distinguishes `PJ_ECANCELLED`
  (self-join) from other OS errors — both early-return with the clock
  state preserved for a future retry.
- **Co-owned `destroy_lock` with `clock->pool`**: allocated from
  `clock->pool`, `pj_mutex_destroy()`-ed at the tail of
  `pjmedia_clock_destroy()` immediately before
  `pj_pool_safe_release(&clock->pool)`. Lock and the memory it guards
  share one lifetime, torn down together by the single owner. No
  OS-resource leak on any platform (the Windows `CRITICAL_SECTION`
  global-list entry is properly freed). Relies on the higher-layer
  `is_destroying` guarantee that no concurrent stop/destroy can race
  past a successful destroy.
- **Documented the `pjmedia_clock_destroy()` caller contract** in the
  public header: must not be called from within the clock callback
  (self-join returns `PJ_EBUSY`); the caller must also ensure no
  concurrent stop/destroy is in flight on the same clock when the
  destroy proceeds past its internal join (the lock that serializes
  stop/destroy is torn down at the tail of a successful destroy).

## Motivation and Context
Concurrent hangup and teardown paths could race across shared preview
windows and clock thread shutdown, leading to UAF crashes under
stress. The fix combines per-window serialization (pjsua_vid) with
clock-level serialization (pjmedia_clock); the two layers give
complementary guarantees — the higher layer prevents the duplicate
destroy, the lower layer makes single-owner stop/destroy safe and
leak-free.

## How Has This Been Tested?
- Built project successfully after configure/dependency generation:
  - `./configure && make dep && make -j2`
  - `make -C pjmedia/build all`
- Ran targeted tests:
  - `make pjmedia-test` (pass)
- Stress validation (ASan/macOS with `Colorbar-active`) clean across
  repeated `pjsua-stress` runs: 10/10 at `-n 8 -v 4` 30 s, 8–10/10 at
  `-n 32 -v 8` 30 s (the rare miss is a test-side cleanup-window
  timeout, no ASan/assert).

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
