### PR TITLE
PJSUA2: Hold a reference to tx_data in SipTxData::fromPj to prevent use-after-free

### DIFF
--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -738,7 +738,17 @@ SipTxData::SipTxData()
 void SipTxData::fromPj(pjsip_tx_data &tdata)
 {
     char straddr[PJ_INET6_ADDRSTRLEN+10];
-    
+
+    /* Hold a reference to the tx_data for the duration of this function.
+     * This is invoked from event callbacks (e.g. on_tsx_state) that may run
+     * on a worker thread and, in transaction termination/transport error
+     * paths, after the transaction group lock has been released. Without a
+     * reference the tx_data (and its pool) can be freed concurrently, causing
+     * a crash inside pjsip_tx_data_encode()/pjsip_msg_print() while the
+     * message is being encoded below.
+     */
+    pjsip_tx_data_add_ref(&tdata);
+
     info        = pjsip_tx_data_get_info(&tdata);
     pjsip_tx_data_encode(&tdata);
     wholeMsg    = string(tdata.buf.start, tdata.buf.cur - tdata.buf.start);
@@ -749,6 +759,8 @@ void SipTxData::fromPj(pjsip_tx_data &tdata)
         dstAddress = "";
     }
     pjTxData    = (void *)&tdata;
+
+    pjsip_tx_data_dec_ref(&tdata);
 }
 
 SipTransaction::SipTransaction()


### PR DESCRIPTION
## Problem

`pj::SipTxData::fromPj()` (`pjsip/src/pjsua2/siptypes.cpp`) calls `pjsip_tx_data_encode()` and reads `tdata.buf` on a `pjsip_tx_data` it receives **by reference** from an event, without holding a reference to it.

It runs from event callbacks such as `on_tsx_state` (`Endpoint::on_call_tsx_state` → `SipEvent::fromPj` → `SipTxData::fromPj`). In transaction termination / transport-error paths, `tsx_set_state()` releases the transaction group lock around the TU callback (`RELEASE_LOCK` / timeout timer). On a multi-threaded endpoint the `pjsip_tx_data` and its pool can then be freed concurrently while `fromPj()` is encoding it, leading to a use-after-free inside `pjsip_tx_data_encode()` → `pjsip_msg_print()`.

This was observed as an intermittent crash on a multi-threaded UA, predominantly while the SIP transport was being re-created after a NAT address change (re-REGISTER). The faulting frame is always `pjsip_msg_print` reached via `SipTxData::fromPj`; it presented both as a NULL message-buffer dereference and as a dereference of a corrupted (reused-memory) header pointer.

## Fix

Hold a reference to the `pjsip_tx_data` for the duration of `fromPj()` (`pjsip_tx_data_add_ref` / `pjsip_tx_data_dec_ref`), following the existing PJSUA2 pattern for retaining a tx_data past a callback (see `AuthChallenge` in `endpoint.cpp`). Guarding inside `fromPj()` covers all event sources that expose a tx_data (tsx-state `TX_MSG`, top-level `TX_MSG`, transport error).

## Testing

- `./configure && make` clean build (zero warnings).

Closes #5003
