### PR TITLE
Fixed insufficient buffer in Opus repacketizer

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -833,6 +833,12 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
         opus_data->parse_buf_size = MAX_ENCODED_PACKET_SIZE * 2;
         opus_data->parse_buf = pj_pool_alloc(opus_data->pool,
                                              opus_data->parse_buf_size);
+        if (!opus_data->parse_buf) {
+            opus_data->parse_buf_size = 0;
+            PJ_LOG(2, (THIS_FILE, "Unable to allocate parse buffer"));
+            pj_mutex_unlock(opus_data->mutex);
+            return PJ_ENOMEM;
+        }
     }
 
     /* Initialize the repacketizers */

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -146,6 +146,8 @@ struct opus_data
     pjmedia_frame                dec_frame[2];
     int                          dec_frame_index;
     pj_size_t                    dec_frame_buf_size;
+    unsigned char               *parse_buf;
+    pj_size_t                    parse_buf_size;
 };
 
 /* Codec factory instance */
@@ -821,6 +823,18 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
                 opus_data->dec_frame_buf_size);
     opus_data->dec_frame_index = -1;
 
+    /* Output buffer for codec_parse(). The repacketizer may expand a
+     * multi-frame packet (one shared TOC byte) into N separate single-frame
+     * packets (each with its own TOC), so the total can exceed the input
+     * size. Use a dedicated, persistent buffer sized generously enough to
+     * accommodate any expansion of a MAX_ENCODED_PACKET_SIZE input.
+     */
+    if (!opus_data->parse_buf) {
+        opus_data->parse_buf_size = MAX_ENCODED_PACKET_SIZE * 2;
+        opus_data->parse_buf = pj_pool_alloc(opus_data->pool,
+                                             opus_data->parse_buf_size);
+    }
+
     /* Initialize the repacketizers */
     opus_repacketizer_init(opus_data->enc_packer);
     opus_repacketizer_init(opus_data->dec_packer);
@@ -953,9 +967,22 @@ static pj_status_t  codec_parse( pjmedia_codec *codec,
 
     out_pos = 0;
     for (i = 0; i < num_frames; ++i) {
+        /* Write extracted single-frame packets into parse_buf rather than
+         * back into pkt, which would overflow when the per-frame outputs
+         * (each with their own TOC byte) total more than pkt_size.
+         */
+        if ((pj_size_t)out_pos >= opus_data->parse_buf_size) {
+            PJ_LOG(5, (THIS_FILE, "Parse output buffer exhausted "
+                       "(pkt_size=%lu, frame=%d)",
+                       (unsigned long)pkt_size, i));
+            pj_mutex_unlock (opus_data->mutex);
+            return PJMEDIA_CODEC_EFAILED;
+        }
         size = opus_repacketizer_out_range(opus_data->dec_packer, i, i+1,
-                                           ((unsigned char*)pkt) + out_pos,
-                                           sizeof(tmp_buf));
+                                           opus_data->parse_buf + out_pos,
+                                           (opus_int32)
+                                           (opus_data->parse_buf_size -
+                                            out_pos));
         if (size < 0) {
             PJ_LOG(5, (THIS_FILE, "Parse failed! (pkt_size=%lu, err=%d)",
                        (unsigned long)pkt_size, size));
@@ -963,7 +990,7 @@ static pj_status_t  codec_parse( pjmedia_codec *codec,
             return PJMEDIA_CODEC_EFAILED;
         }
         frames[i].type = PJMEDIA_FRAME_TYPE_AUDIO;
-        frames[i].buf = ((char*)pkt) + out_pos;
+        frames[i].buf = opus_data->parse_buf + out_pos;
         frames[i].size = size;
         frames[i].bit_info = 0;
 


### PR DESCRIPTION
# Insufficient buffer in `opus_repacketizer_out_range_impl` via `codec_parse`

## Issue

ASan report from OSS-Fuzz (fuzz-audio):

```
==247==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7aef568e08d2
WRITE of size 136 at 0x7aef568e08d2 thread T0
    #0 __interceptor_memmove
    #1 opus_repacketizer_out_range_impl
    #2 opus_repacketizer_out_range
    #3 codec_parse pjsip/pjmedia/src/pjmedia-codec/opus.c:956:16
    #4 pjmedia_codec_parse pjsip/pjmedia/include/pjmedia/codec.h:1070:12
    #5 test_codec_cycle pjsip/tests/fuzz/fuzz-audio.c:327:18
    #6 LLVMFuzzerTestOneInput pjsip/tests/fuzz/fuzz-audio.c:385:9
```

Test case: `clusterfuzz-testcase-minimized-fuzz-audio-4561975815503872`.

## Root Cause

`codec_parse` was using the caller-supplied `pkt` buffer as the output
destination for `opus_repacketizer_out_range`, while passing
`sizeof(tmp_buf)` (= `MAX_ENCODED_PACKET_SIZE` = 1280) as the maxlen:

```c
unsigned char tmp_buf[MAX_ENCODED_PACKET_SIZE];
...
pj_memcpy(tmp_buf, pkt, pkt_size);
opus_repacketizer_init(opus_data->dec_packer);
opus_repacketizer_cat(opus_data->dec_packer, tmp_buf, (opus_int32)pkt_size);
...
out_pos = 0;
for (i = 0; i < num_frames; ++i) {
    size = opus_repacketizer_out_range(opus_data->dec_packer, i, i+1,
                                       ((unsigned char*)pkt) + out_pos,
                                       sizeof(tmp_buf));   /* <-- bug */
    ...
    frames[i].buf = ((char*)pkt) + out_pos;
    out_pos += size;
}
```

Two assumptions are broken:

1. **`sizeof(tmp_buf)` is not the capacity of `pkt`.** The API contract
   (`pjmedia/include/pjmedia/codec.h:421`) defines `pkt_size` as the size of
   the input packet, not the buffer's capacity. When `pkt_size` is small
   (e.g. fuzz input where `pkt` is a heap allocation of exactly `Size`
   bytes), the in-place write can run past the end of the allocation.

2. **The per-frame outputs sum to more than the input.** An Opus packet
   containing N frames shares a single TOC byte plus framing. Splitting it
   into N self-delimited single-frame packets adds a TOC byte to each
   output. Worst case (code 3 CBR with up to 48 frames), the total output
   can exceed the input by ~46 bytes — so even bounding maxlen by
   `pkt_size - out_pos` would reject otherwise-valid packets.

The in-place rewrite happened to work in normal RTP usage only because the
RTP payload buffer typically had headroom past `payloadlen`. The fuzzer
exposed the latent bug.

## Fix

Write the per-frame outputs into a dedicated, persistent buffer owned by
the codec instance, instead of overwriting the caller's `pkt`. The buffer
lives in the codec pool and is sized to handle the worst-case expansion.

This is safe because the downstream caller (`stream.c`) copies the data via
`pjmedia_jbuf_put_frame3` before the next `parse()` call, so a per-codec
shared output buffer has the same lifetime semantics as the existing
`dec_frame` buffers.

### Changes to `pjmedia/src/pjmedia-codec/opus.c`

1. Add fields to `struct opus_data`:

   ```c
   unsigned char               *parse_buf;
   pj_size_t                    parse_buf_size;
   ```

2. Allocate the buffer in `codec_open`:

   ```c
   if (!opus_data->parse_buf) {
       opus_data->parse_buf_size = MAX_ENCODED_PACKET_SIZE * 2;
       opus_data->parse_buf = pj_pool_alloc(opus_data->pool,
                                            opus_data->parse_buf_size);
   }
   ```

   Worst-case expansion of a `MAX_ENCODED_PACKET_SIZE` input is bounded by
   the number of frames (≤ 48) added as TOC bytes, so `2 *
   MAX_ENCODED_PACKET_SIZE` is comfortably large.

3. Route `codec_parse` output into `parse_buf` and bound `maxlen` by the
   remaining space, with an explicit pre-check:

   ```c
   out_pos = 0;
   for (i = 0; i < num_frames; ++i) {
       if ((pj_size_t)out_pos >= opus_data->parse_buf_size) {
           PJ_LOG(5, (THIS_FILE, "Parse output buffer exhausted "
                      "(pkt_size=%lu, frame=%d)",
                      (unsigned long)pkt_size, i));
           pj_mutex_unlock(opus_data->mutex);
           return PJMEDIA_CODEC_EFAILED;
       }
       size = opus_repacketizer_out_range(opus_data->dec_packer, i, i+1,
                                          opus_data->parse_buf + out_pos,
                                          (opus_int32)
                                          (opus_data->parse_buf_size -
                                           out_pos));
       ...
       frames[i].buf = opus_data->parse_buf + out_pos;
       ...
   }
   ```

The caller's `pkt` buffer is no longer mutated, and the output cannot
overflow the dedicated buffer because `maxlen` is always strictly bounded
by the remaining capacity.

## Verification

- `cd pjmedia/build && make` — builds cleanly, no warnings.
- The fuzz reproducer no longer triggers the heap-buffer-overflow.
