### PR TITLE
bound pjmedia_codec_amr_parse reads to pkt_size

### DIFF
--- a/pjmedia/include/pjmedia-codec/amr_helper.h
+++ b/pjmedia/include/pjmedia-codec/amr_helper.h
@@ -1093,6 +1093,9 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
     pj_uint8_t r_bitptr = 0;
     pj_uint8_t *r = (pj_uint8_t*)pkt;
 
+    /* End of the packet, used to bound all reads below */
+    pj_uint8_t *pkt_end = (pj_uint8_t*)pkt + pkt_size;
+
     /* env vars for AMR or AMRWB */
     pj_uint8_t               SID_FT;
     const pj_uint8_t        *framelen_tbl;
@@ -1114,8 +1117,13 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
         order_maps      = pjmedia_codec_amrwb_ordermaps;
     }
 
-    PJ_UNUSED_ARG(pkt_size);
     PJ_UNUSED_ARG(order_maps);
+
+    /* Empty packet, nothing to parse */
+    if (r >= pkt_end) {
+        *nframes = 0;
+        return PJ_SUCCESS;
+    }
 
     /* Code Mode Request, 4 bits */
     *cmr = (pj_uint8_t)((*r >> 4) & 0x0F);
@@ -1129,6 +1137,15 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
     for (;;) {
         pj_uint8_t TOC = 0;
         pj_uint8_t F, FT, Q;
+
+        /* Make sure the TOC byte(s) are within the packet. The 4 and 6
+         * bit-offset cases straddle two octets, so they need one more byte.
+         */
+        if (r >= pkt_end ||
+            ((r_bitptr == 4 || r_bitptr == 6) && r + 1 >= pkt_end))
+        {
+            break;
+        }
 
         if (r_bitptr == 0) {
             TOC = (pj_uint8_t)(*r >> 2);
@@ -1187,9 +1204,23 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
     /* Speech frames */
     while (cnt < *nframes) {
         pj_uint8_t FT;
+        unsigned flen;
 
         info = (pjmedia_codec_amr_bit_info*) &frames[cnt].bit_info;
         FT = info->frame_type;
+
+        /* Number of packet bytes this frame spans */
+        if (setting->octet_aligned) {
+            flen = framelen_tbl[FT];
+        } else if (FT == 14 || FT == 15) {
+            flen = 0;
+        } else {
+            flen = (framelenbit_tbl[FT] + r_bitptr + 7) >> 3;
+        }
+
+        /* Stop if the frame data is not fully contained in the packet */
+        if (r + flen > pkt_end)
+            break;
 
         frames[cnt].buf = r;
         info->start_bit = r_bitptr;
@@ -1222,6 +1253,7 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
         }
         ++cnt;
     }
+    *nframes = cnt;
 
     return PJ_SUCCESS;
 }

--- a/pjmedia/include/pjmedia-codec/amr_helper.h
+++ b/pjmedia/include/pjmedia-codec/amr_helper.h
@@ -1094,7 +1094,7 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
     pj_uint8_t *r = (pj_uint8_t*)pkt;
 
     /* End of the packet, used to bound all reads below */
-    pj_uint8_t *pkt_end = (pj_uint8_t*)pkt + pkt_size;
+    pj_uint8_t *pkt_end = pkt_size ? ((pj_uint8_t*)pkt + pkt_size) : (pj_uint8_t*)pkt;
 
     /* env vars for AMR or AMRWB */
     pj_uint8_t               SID_FT;
@@ -1120,7 +1120,7 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
     PJ_UNUSED_ARG(order_maps);
 
     /* Empty packet, nothing to parse */
-    if (r >= pkt_end) {
+    if (pkt_size == 0) {
         *nframes = 0;
         return PJ_SUCCESS;
     }
@@ -1219,7 +1219,7 @@ PJ_INLINE(pj_status_t) pjmedia_codec_amr_parse(
         }
 
         /* Stop if the frame data is not fully contained in the packet */
-        if (r + flen > pkt_end)
+        if ((pj_size_t)(pkt_end - r) < flen)
             break;
 
         frames[cnt].buf = r;


### PR DESCRIPTION
pjmedia_codec_amr_parse() marks pkt_size as PJ_UNUSED_ARG and moves its read cursor using only the TOC "more frames" (F) bit and the per-frame lengths. The stream layer always asks for up to 16 frames, so a short AMR RTP payload that keeps F set runs the cursor well past the end of the payload buffer. ASan reports a heap read at the TOC fetch on a 2-byte octet-aligned packet.

Before, the only stop conditions were the requested frame count and the F bit, both attacker controlled. After, every TOC fetch and every speech frame is checked against pkt + pkt_size, and nframes is trimmed to what the packet actually holds. The bound lives in the helper because all three AMR codecs (opencore, ipp, passthrough) hand it the raw payload, so one check covers each caller. Tradeoff: a truncated frame at the tail is now dropped instead of being returned with an out-of-range buffer pointer.