### PR TITLE
Add the option to avoid clock-less time when switching from/to null sound device

### DIFF
--- a/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
+++ b/pjsip-apps/src/3rdparty_media_sample/alt_pjsua_aud.c
@@ -657,6 +657,16 @@ PJ_DEF(pj_status_t) pjsua_set_null_snd_dev(void)
     return PJ_SUCCESS;
 }
 
+/* Use null sound device with configurable parameter. Alt media backend has no
+ * real sound device, so this is also a no-op that always succeeds.
+ */
+PJ_DEF(pj_status_t) pjsua_set_null_snd_dev2(
+                            const pjsua_null_snd_dev_param *snd_param)
+{
+    PJ_UNUSED_ARG(snd_param);
+    return PJ_SUCCESS;
+}
+
 /* Use no device! */
 PJ_DEF(pjmedia_port*) pjsua_set_no_snd_dev(void)
 {

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -2196,7 +2196,8 @@ typedef struct pjsua_callback
      * Callback when the sound device is about to be opened or closed.
      * This callback will be called even when null sound device or no
      * sound device is configured by the application (i.e. the
-     * #pjsua_set_null_snd_dev() and #pjsua_set_no_snd_dev() APIs).
+     * #pjsua_set_null_snd_dev(), #pjsua_set_null_snd_dev2(), and
+     * #pjsua_set_no_snd_dev() APIs).
      * Application can use the API #pjsua_get_snd_dev() to get the info
      * about which sound device is going to be opened/closed.
      *
@@ -8546,6 +8547,34 @@ PJ_DECL(void) pjsua_snd_dev_param_default(pjsua_snd_dev_param *prm);
 
 
 /**
+ * This structure specifies the parameters to set null sound device.
+ * Use pjsua_null_snd_dev_param_default() to initialize this structure with
+ * default values. Application should only override relevant fields to keep
+ * forward compatibility when new fields are added in the future.
+ */
+typedef struct pjsua_null_snd_dev_param
+{
+    /**
+     * If PJ_TRUE, switch using a gapless handover (start null clock first,
+     * then stop old device). If PJ_FALSE, use legacy behavior (stop old
+     * device first, then start null clock).
+     *
+     * Default: PJ_FALSE
+     */
+    pj_bool_t           avoid_clock_gap;
+
+} pjsua_null_snd_dev_param;
+
+
+/**
+ * Initialize pjsua_null_snd_dev_param with default values.
+ *
+ * @param prm           The parameter.
+ */
+PJ_DECL(void) pjsua_null_snd_dev_param_default(pjsua_null_snd_dev_param *prm);
+
+
+/**
  * This structure specifies the parameters for conference ports connection.
  * Use pjsua_conf_connect_param_default() to initialize this structure with
  * default values.
@@ -9235,10 +9264,26 @@ PJ_DECL(pj_status_t) pjsua_set_snd_dev2(const pjsua_snd_dev_param *snd_param);
  * Set pjsua to use null sound device. The null sound device only provides
  * the timing needed by the conference bridge, and will not interract with
  * any hardware.
+ * For configurable behavior, use #pjsua_set_null_snd_dev2().
  *
  * @return              PJ_SUCCESS on success, or the appropriate error code.
  */
 PJ_DECL(pj_status_t) pjsua_set_null_snd_dev(void);
+
+
+/**
+ * Set pjsua to use null sound device according to the specified param.
+ * The null sound device only provides the timing needed by the conference
+ * bridge, and will not interract with any hardware.
+ * Use #pjsua_null_snd_dev_param_default() to initialize the param.
+ *
+ * @param snd_param          Null sound device parameter.
+ *
+ * @return                   PJ_SUCCESS on success, or the appropriate
+ *                           error code.
+ */
+PJ_DECL(pj_status_t) pjsua_set_null_snd_dev2(
+                                const pjsua_null_snd_dev_param *snd_param);
 
 
 /**
@@ -9380,8 +9425,8 @@ PJ_DECL(pj_status_t) pjsua_snd_get_setting(pjmedia_aud_dev_cap cap,
  * media clock is driven by sound device in master port, but unfortunately
  * some sound devices may produce jittery clock. To improve media clock,
  * application can install Null Sound Device (i.e: using
- * pjsua_set_null_snd_dev()), which will act as a master port, and instantiate
- * the sound device as extra sound device.
+ * pjsua_set_null_snd_dev() or pjsua_set_null_snd_dev2()), which will act
+ * as a master port, and instantiate the sound device as extra sound device.
  *
  * Note that extra sound device will not have auto-close upon idle feature.
  * Also note that currently extra sound device only supports mono channel.

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -9262,7 +9262,7 @@ PJ_DECL(pj_status_t) pjsua_set_snd_dev2(const pjsua_snd_dev_param *snd_param);
 
 /**
  * Set pjsua to use null sound device. The null sound device only provides
- * the timing needed by the conference bridge, and will not interract with
+ * the timing needed by the conference bridge, and will not interact with
  * any hardware.
  * For configurable behavior, use #pjsua_set_null_snd_dev2().
  *
@@ -9274,7 +9274,7 @@ PJ_DECL(pj_status_t) pjsua_set_null_snd_dev(void);
 /**
  * Set pjsua to use null sound device according to the specified param.
  * The null sound device only provides the timing needed by the conference
- * bridge, and will not interract with any hardware.
+ * bridge, and will not interact with any hardware.
  * Use #pjsua_null_snd_dev_param_default() to initialize the param.
  *
  * @param snd_param          Null sound device parameter.

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -657,6 +657,8 @@ struct pjsua_data
     pjmedia_master_port *null_snd;  /**< Master port for null sound.    */
     pjmedia_port        *null_port; /**< Null port.                     */
     pj_bool_t            snd_is_on; /**< Media flow is currently active */
+    pj_bool_t            snd_avoid_clock_gap; /**< Keep clock continuity
+                                                    across null<->real dev */
     unsigned             snd_mode;  /**< Sound device mode.             */
 
     /* Video device */

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -1208,10 +1208,19 @@ public:
     /**
      * Set pjsua to use null sound device. The null sound device only provides
      * the timing needed by the conference bridge, and will not interract with
-     * any hardware.
+     * any hardware. For configurable behavior, use setNullDev2().
      *
      */
     void setNullDev() PJSUA2_THROW(Error);
+
+    /**
+     * Set pjsua to use null sound device with transition behavior control.
+     *
+     * @param avoidClockGap      If true, transition will prioritize clock
+     *                           continuity (may overlap briefly). If false,
+     *                           use legacy close-then-open behavior.
+     */
+    void setNullDev2(bool avoidClockGap) PJSUA2_THROW(Error);
 
     /**
      * Disconnect the main conference bridge from any sound devices, and let

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -29,8 +29,14 @@
  */
 /* Open sound dev */
 static pj_status_t open_snd_dev(pjmedia_snd_port_param *param);
-/* Close existing sound device */
-static void close_snd_dev(void);
+/* Close current sound device state. If close_null_snd is PJ_TRUE,
+ * null sound device will also be closed.
+ */
+static void close_snd_dev(pj_bool_t close_null_snd);
+/* Close a sound port instance only. This does not touch null sound device
+ * ownership/state.
+ */
+static void close_snd_port(pjmedia_snd_port *old_snd);
 /* Create audio device param */
 static pj_status_t create_aud_param(pjmedia_aud_param *param,
                                     pjmedia_aud_dev_index capture_dev,
@@ -446,7 +452,7 @@ static void close_snd_timer_cb( pj_timer_heap_t *th,
         PJ_LOG(4,(THIS_FILE,"Closing sound device after idle for %d second(s)",
                   pjsua_var.media_cfg.snd_auto_close_time));
 
-        close_snd_dev();
+        close_snd_dev(PJ_TRUE);
     }
     entry->id = PJ_FALSE;
     PJSUA_UNLOCK();
@@ -467,7 +473,7 @@ pj_status_t pjsua_aud_subsys_destroy()
 {
     unsigned i;
 
-    close_snd_dev();
+    close_snd_dev(PJ_TRUE);
 
     /* Destroy file players */
     for (i=0; i<PJ_ARRAY_SIZE(pjsua_var.player); ++i) {
@@ -830,6 +836,11 @@ PJ_DEF(void) pjsua_snd_dev_param_default(pjsua_snd_dev_param *prm)
     pj_bzero(prm, sizeof(*prm));
     prm->capture_dev = PJMEDIA_AUD_DEFAULT_CAPTURE_DEV;
     prm->playback_dev = PJMEDIA_AUD_DEFAULT_PLAYBACK_DEV;
+}
+
+PJ_DEF(void) pjsua_null_snd_dev_param_default(pjsua_null_snd_dev_param *prm)
+{
+    pj_bzero(prm, sizeof(*prm));
 }
 
 PJ_DEF(void) pjsua_conf_connect_param_default(pjsua_conf_connect_param *prm)
@@ -1899,10 +1910,55 @@ static pj_status_t on_aud_prev_rec_frame(void *user_data, pjmedia_frame *frame)
     return PJ_SUCCESS;
 }
 
+/* Close an old sound port instance without touching the current
+ * pjsua_var.snd_port/null_snd ownership.
+ */
+static void close_snd_port(pjmedia_snd_port *old_snd)
+{
+    pjmedia_aud_stream *strm;
+    pjmedia_aud_param param;
+    pjmedia_aud_dev_info cap_info, play_info;
+    pj_status_t st;
+
+    if (!old_snd)
+        return;
+
+    strm = pjmedia_snd_port_get_snd_stream(old_snd);
+    st = pjmedia_aud_stream_get_param(strm, &param);
+
+    if (st != PJ_SUCCESS ||
+        param.rec_id == PJSUA_SND_NO_DEV ||
+        pjmedia_aud_dev_get_info(param.rec_id, &cap_info) != PJ_SUCCESS)
+    {
+        cap_info.name[0] = '\0';
+    }
+    if (st != PJ_SUCCESS ||
+        pjmedia_aud_dev_get_info(param.play_id, &play_info) != PJ_SUCCESS)
+    {
+        play_info.name[0] = '\0';
+    }
+
+    PJ_LOG(4,(THIS_FILE, "Closing %s sound playback device and "
+                         "%s sound capture device",
+                         play_info.name, cap_info.name));
+
+    if (strm) {
+        pjmedia_event_unsubscribe(NULL, &on_media_event, NULL, strm);
+    }
+
+    pjmedia_snd_port_disconnect(old_snd);
+    pjmedia_snd_port_destroy(old_snd);
+}
+
 /* Open sound device with the setting. */
 static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
 {
     pjmedia_port *conf_port;
+    pjmedia_snd_port *new_snd_port = NULL;
+    pj_pool_t *new_snd_pool = NULL;
+    pjmedia_master_port *old_null_snd = NULL;
+    pj_pool_t *old_snd_pool = NULL;
+    pj_bool_t gapless_from_null = PJ_FALSE;
     pj_status_t status;
     pj_bool_t speaker_only = (pjsua_var.snd_mode & PJSUA_SND_DEV_SPEAKER_ONLY);
 
@@ -1915,8 +1971,27 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
         return pjsua_set_null_snd_dev();
     }
 
-    /* Close existing sound port */
-    close_snd_dev();
+    /* Avoid timer race while reopening/changing sound device. */
+    if (pjsua_var.snd_idle_timer.id) {
+        pjsip_endpt_cancel_timer(pjsua_var.endpt, &pjsua_var.snd_idle_timer);
+        pjsua_var.snd_idle_timer.id = PJ_FALSE;
+    }
+
+    gapless_from_null = (pjsua_var.snd_avoid_clock_gap &&
+                         pjsua_var.null_snd != NULL &&
+                         pjsua_var.snd_port == NULL);
+
+    /* Transition policy is one-shot: apply only to this open attempt. */
+    pjsua_var.snd_avoid_clock_gap = PJ_FALSE;
+
+    if (!gapless_from_null) {
+        /* Close existing active sound path (legacy behavior). */
+        close_snd_dev(PJ_TRUE);
+    } else {
+        /* Keep null clock alive until new real device is connected. */
+        old_null_snd = pjsua_var.null_snd;
+        old_snd_pool = pjsua_var.snd_pool;
+    }
 
     /* Save the device IDs */
     pjsua_var.cap_dev = param->base.rec_id;
@@ -1927,9 +2002,9 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
         (*pjsua_var.ua_cfg.cb.on_snd_dev_operation)(1);
     }
 
-    /* Create memory pool for sound device. */
-    pjsua_var.snd_pool = pjsua_pool_create("pjsua_snd", 4000, 4000);
-    PJ_ASSERT_RETURN(pjsua_var.snd_pool, PJ_ENOMEM);
+    /* Create memory pool for new sound device. */
+    new_snd_pool = pjsua_pool_create("pjsua_snd", 4000, 4000);
+    PJ_ASSERT_RETURN(new_snd_pool, PJ_ENOMEM);
 
     /* Setup preview callbacks, if configured */
     if (pjsua_var.media_cfg.on_aud_prev_play_frame)
@@ -1958,12 +2033,12 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
         cp_param.base.dir = PJMEDIA_DIR_PLAYBACK;
         cp_param.base.play_id = dev_id;
 
-        status = pjmedia_snd_port_create2(pjsua_var.snd_pool, &cp_param,
-                                          &pjsua_var.snd_port);
+        status = pjmedia_snd_port_create2(new_snd_pool, &cp_param,
+                                          &new_snd_port);
 
     } else {
-        status = pjmedia_snd_port_create2(pjsua_var.snd_pool,
-                                          param, &pjsua_var.snd_port);
+        status = pjmedia_snd_port_create2(new_snd_pool,
+                                          param, &new_snd_port);
     }
 
     if (status != PJ_SUCCESS)
@@ -1992,7 +2067,7 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
             resample_opt |= PJMEDIA_RESAMPLE_USE_LINEAR;
         }
 
-        status = pjmedia_resample_port_create(pjsua_var.snd_pool,
+        status = pjmedia_resample_port_create(new_snd_pool,
                                               conf_port,
                                               param->base.clock_rate,
                                               resample_opt,
@@ -2003,7 +2078,6 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
             PJ_LOG(4, (THIS_FILE,
                        "Error creating resample port: %s",
                        errmsg));
-            close_snd_dev();
             goto on_error;
         }
 
@@ -2034,14 +2108,27 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
 
 
     /* Connect sound port to the bridge */
-    status = pjmedia_snd_port_connect(pjsua_var.snd_port,
+    status = pjmedia_snd_port_connect(new_snd_port,
                                       conf_port );
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Unable to connect conference port to "
                                 "sound device", status);
-        pjmedia_snd_port_destroy(pjsua_var.snd_port);
-        pjsua_var.snd_port = NULL;
         goto on_error;
+    }
+
+    /* New sound device is now ready, commit ownership. */
+    pjsua_var.snd_port = new_snd_port;
+    pjsua_var.snd_pool = new_snd_pool;
+    new_snd_port = NULL;
+    new_snd_pool = NULL;
+
+    if (gapless_from_null && old_null_snd) {
+        PJ_LOG(4,(THIS_FILE, "Closing null sound device.."));
+        pjmedia_master_port_destroy(old_null_snd, PJ_FALSE);
+        pjsua_var.null_snd = NULL;
+
+        if (old_snd_pool && old_snd_pool != pjsua_var.snd_pool)
+            pj_pool_release(old_snd_pool);
     }
 
     /* Update sound device name. */
@@ -2098,13 +2185,21 @@ static pj_status_t open_snd_dev(pjmedia_snd_port_param *param)
     return PJ_SUCCESS;
 
 on_error:
+    if (new_snd_port)
+        pjmedia_snd_port_destroy(new_snd_port);
+    if (new_snd_pool)
+        pj_pool_release(new_snd_pool);
+
     pj_log_pop_indent();
     return status;
 }
 
 
-/* Close existing sound device */
-static void close_snd_dev(void)
+/* Close existing sound device.
+ * If close_null_snd is PJ_TRUE, this also closes null_snd and releases
+ * its pool ownership.
+ */
+static void close_snd_dev(pj_bool_t close_null_snd)
 {
     pj_log_push_indent();
 
@@ -2121,50 +2216,25 @@ static void close_snd_dev(void)
 
     /* Close sound device */
     if (pjsua_var.snd_port) {
-        pjmedia_aud_dev_info cap_info, play_info;
-        pjmedia_aud_stream *strm;
-        pjmedia_aud_param param;
-        pj_status_t status;
-
-        strm = pjmedia_snd_port_get_snd_stream(pjsua_var.snd_port);
-        status = pjmedia_aud_stream_get_param(strm, &param);
-
-        if (status != PJ_SUCCESS ||
-            param.rec_id == PJSUA_SND_NO_DEV ||
-            pjmedia_aud_dev_get_info(param.rec_id, &cap_info) != PJ_SUCCESS)
-        {
-            cap_info.name[0] = '\0';
-        }
-        if (status != PJ_SUCCESS ||
-            pjmedia_aud_dev_get_info(param.play_id, &play_info) != PJ_SUCCESS)
-        {
-            play_info.name[0] = '\0';
-        }
-
-        PJ_LOG(4,(THIS_FILE, "Closing %s sound playback device and "
-                             "%s sound capture device",
-                             play_info.name, cap_info.name));
-
-        /* Unsubscribe from audio device events */
-        pjmedia_event_unsubscribe(NULL, &on_media_event, NULL, strm);
-
-        pjmedia_snd_port_disconnect(pjsua_var.snd_port);
-        pjmedia_snd_port_destroy(pjsua_var.snd_port);
+        close_snd_port(pjsua_var.snd_port);
         pjsua_var.snd_port = NULL;
     }
 
-    /* Close null sound device */
-    if (pjsua_var.null_snd) {
+    /* Optionally close null sound device. */
+    if (close_null_snd && pjsua_var.null_snd) {
         PJ_LOG(4,(THIS_FILE, "Closing null sound device.."));
         pjmedia_master_port_destroy(pjsua_var.null_snd, PJ_FALSE);
         pjsua_var.null_snd = NULL;
     }
 
-    if (pjsua_var.snd_pool)
+    if (pjsua_var.snd_pool && (close_null_snd || !pjsua_var.null_snd))
         pj_pool_release(pjsua_var.snd_pool);
 
-    pjsua_var.snd_pool = NULL;
-    pjsua_var.snd_is_on = PJ_FALSE;
+    if (close_null_snd || !pjsua_var.null_snd)
+        pjsua_var.snd_pool = NULL;
+
+    pjsua_var.snd_is_on = (pjsua_var.snd_port || pjsua_var.null_snd)?
+                          PJ_TRUE : PJ_FALSE;
 
     pj_log_pop_indent();
 }
@@ -2370,76 +2440,183 @@ PJ_DEF(pj_status_t) pjsua_get_snd_dev(int *capture_dev,
 
 /*
  * Use null sound device.
+ * Caller must hold PJSUA_LOCK.
  */
-PJ_DEF(pj_status_t) pjsua_set_null_snd_dev(void)
+static pj_status_t create_null_snd(pj_pool_t *pool,
+                                   pjmedia_master_port **p_null)
 {
     pjmedia_port *conf_port;
     pj_status_t status;
 
-    PJ_LOG(4,(THIS_FILE, "Setting null sound device.."));
-    pj_log_push_indent();
-
-    PJSUA_LOCK();
-
-    /* Close existing sound device */
-    close_snd_dev();
-
-    pjsua_var.cap_dev = PJSUA_SND_NULL_DEV;
-    pjsua_var.play_dev = PJSUA_SND_NULL_DEV;
-
-    /* Notify app */
-    if (pjsua_var.ua_cfg.cb.on_snd_dev_operation) {
-        (*pjsua_var.ua_cfg.cb.on_snd_dev_operation)(1);
-    }
-
-    /* Create memory pool for sound device. */
-    pjsua_var.snd_pool = pjsua_pool_create("pjsua_snd", 4000, 4000);
-    if (!pjsua_var.snd_pool) {
-        pjsua_perror(THIS_FILE, "Unable to create pool for null sound device",
-                     PJ_ENOMEM);
-        PJSUA_UNLOCK();
-        pj_log_pop_indent();
-        return PJ_ENOMEM;
-    }
-    
     PJ_LOG(4,(THIS_FILE, "Opening null sound device.."));
 
     /* Get the port0 of the conference bridge. */
     conf_port = pjmedia_conf_get_master_port(pjsua_var.mconf);
     pj_assert(conf_port != NULL);
 
-    /* Create master port, connecting port0 of the conference bridge to
-     * a null port.
-     */
-    status = pjmedia_master_port_create(pjsua_var.snd_pool, pjsua_var.null_port,
-                                        conf_port, 0, &pjsua_var.null_snd);
+    status = pjmedia_master_port_create(pool,
+                                        pjsua_var.null_port,
+                                        conf_port,
+                                        0,
+                                        p_null);
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Unable to create null sound device",
                      status);
-        PJSUA_UNLOCK();
-        pj_log_pop_indent();
         return status;
     }
 
-    /* Start the master port */
-    status = pjmedia_master_port_start(pjsua_var.null_snd);
+    status = pjmedia_master_port_start(*p_null);
     if (status != PJ_SUCCESS) {
         pjsua_perror(THIS_FILE, "Unable to start null sound device",
                      status);
+        pjmedia_master_port_destroy(*p_null, PJ_FALSE);
+        *p_null = NULL;
+        return status;
+    }
+
+    return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjsua_set_null_snd_dev2(
+                            const pjsua_null_snd_dev_param *snd_param)
+{
+    pj_pool_t *new_pool = NULL;
+    pj_pool_t *old_pool;
+    pjmedia_master_port *new_null = NULL;
+    pjmedia_master_port *old_null;
+    pjmedia_snd_port *old_snd;
+    pj_bool_t avoid_clock_gap;
+    pj_bool_t was_on;
+    pj_status_t status;
+
+    PJ_LOG(4,(THIS_FILE, "Setting null sound device.."));
+    pj_log_push_indent();
+
+    PJ_ASSERT_RETURN(snd_param != NULL, PJ_EINVAL);
+    avoid_clock_gap = snd_param->avoid_clock_gap;
+
+    PJSUA_LOCK();
+
+    /* Store transition policy for the next null->real reopen attempt. */
+    pjsua_var.snd_avoid_clock_gap = avoid_clock_gap;
+
+    if (!avoid_clock_gap) {
+        /* Legacy behavior: close old source first, then open null clock. */
+
+        /* Close existing sound device */
+        close_snd_dev(PJ_TRUE);
+
+        pjsua_var.cap_dev = PJSUA_SND_NULL_DEV;
+        pjsua_var.play_dev = PJSUA_SND_NULL_DEV;
+
+        /* Notify app */
+        if (pjsua_var.ua_cfg.cb.on_snd_dev_operation) {
+            (*pjsua_var.ua_cfg.cb.on_snd_dev_operation)(1);
+        }
+
+        /* Create memory pool for sound device. */
+        pjsua_var.snd_pool = pjsua_pool_create("pjsua_snd", 4000, 4000);
+        if (!pjsua_var.snd_pool) {
+            pjsua_perror(THIS_FILE,
+                         "Unable to create pool for null sound device",
+                         PJ_ENOMEM);
+            PJSUA_UNLOCK();
+            pj_log_pop_indent();
+            return PJ_ENOMEM;
+        }
+
+        status = create_null_snd(pjsua_var.snd_pool,
+                                 &pjsua_var.null_snd);
+        if (status != PJ_SUCCESS) {
+            PJSUA_UNLOCK();
+            pj_log_pop_indent();
+            return status;
+        }
+
+        pjsua_var.no_snd = PJ_FALSE;
+        pjsua_var.snd_is_on = PJ_TRUE;
+
+        PJSUA_UNLOCK();
+        pj_log_pop_indent();
+        return PJ_SUCCESS;
+    }
+
+    /* Cancel sound device idle timer. */
+    if (pjsua_var.snd_idle_timer.id) {
+        pjsip_endpt_cancel_timer(pjsua_var.endpt, &pjsua_var.snd_idle_timer);
+        pjsua_var.snd_idle_timer.id = PJ_FALSE;
+    }
+
+    /* Start null clock first to avoid any clock-less transition gap. */
+    new_pool = pjsua_pool_create("pjsua_snd", 4000, 4000);
+    if (!new_pool) {
+        pjsua_perror(THIS_FILE, "Unable to create pool for null sound device",
+                     PJ_ENOMEM);
+        PJSUA_UNLOCK();
+        pj_log_pop_indent();
+        return PJ_ENOMEM;
+    }
+
+    old_snd = pjsua_var.snd_port;
+    old_null = pjsua_var.null_snd;
+    old_pool = pjsua_var.snd_pool;
+
+    status = create_null_snd(new_pool, &new_null);
+    if (status != PJ_SUCCESS) {
+        pj_pool_release(new_pool);
         PJSUA_UNLOCK();
         pj_log_pop_indent();
         return status;
     }
 
+    was_on = pjsua_var.snd_is_on;
+
+    /* Minimize overlap window: stop old source from driving the bridge
+     * immediately after replacement clock starts.
+     */
+    close_snd_port(old_snd);
+    pjsua_var.snd_port = NULL;
+    pjsua_var.snd_is_on = PJ_FALSE;
+
+    pjsua_var.cap_dev = PJSUA_SND_NULL_DEV;
+    pjsua_var.play_dev = PJSUA_SND_NULL_DEV;
+
+    if (was_on && pjsua_var.ua_cfg.cb.on_snd_dev_operation) {
+        (*pjsua_var.ua_cfg.cb.on_snd_dev_operation)(0);
+    }
+
+    /* Swap in the new null clock before destroying old clock source. */
+    pjsua_var.null_snd = new_null;
+    pjsua_var.snd_pool = new_pool;
     pjsua_var.no_snd = PJ_FALSE;
     pjsua_var.snd_is_on = PJ_TRUE;
+
+    if (old_null && old_null != new_null) {
+        PJ_LOG(4,(THIS_FILE, "Closing previous null sound device.."));
+        pjmedia_master_port_destroy(old_null, PJ_FALSE);
+    }
+
+    if (old_pool && old_pool != new_pool) {
+        pj_pool_release(old_pool);
+    }
+
+    /* Notify app */
+    if (pjsua_var.ua_cfg.cb.on_snd_dev_operation) {
+        (*pjsua_var.ua_cfg.cb.on_snd_dev_operation)(1);
+    }
 
     PJSUA_UNLOCK();
     pj_log_pop_indent();
     return PJ_SUCCESS;
 }
 
+PJ_DEF(pj_status_t) pjsua_set_null_snd_dev(void)
+{
+    pjsua_null_snd_dev_param null_snd_param;
 
+    pjsua_null_snd_dev_param_default(&null_snd_param);
+    return pjsua_set_null_snd_dev2(&null_snd_param);
+}
 
 /*
  * Use no device!
@@ -2449,7 +2626,7 @@ PJ_DEF(pjmedia_port*) pjsua_set_no_snd_dev(void)
     PJSUA_LOCK();
 
     /* Close existing sound device */
-    close_snd_dev();
+    close_snd_dev(PJ_TRUE);
     pjsua_var.no_snd = PJ_TRUE;
     pjsua_var.cap_dev = PJSUA_SND_NO_DEV;
     pjsua_var.play_dev = PJSUA_SND_NO_DEV;
@@ -2571,7 +2748,7 @@ PJ_DEF(pj_status_t) pjsua_snd_get_setting( pjmedia_aud_dev_cap cap,
     if (pjsua_var.aud_open_cnt==0) {
         PJ_LOG(4,(THIS_FILE, "Opening sound device to get initial settings"));
         pjsua_set_snd_dev(pjsua_var.cap_dev, pjsua_var.play_dev);
-        close_snd_dev();
+        close_snd_dev(PJ_TRUE);
     }
 
     if (pjsua_snd_is_active()) {

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1924,8 +1924,11 @@ static void close_snd_port(pjmedia_snd_port *old_snd)
         return;
 
     strm = pjmedia_snd_port_get_snd_stream(old_snd);
-    st = pjmedia_aud_stream_get_param(strm, &param);
-
+    if (strm) {
+        st = pjmedia_aud_stream_get_param(strm, &param);
+    } else {
+        st = PJ_EINVAL;
+    }
     if (st != PJ_SUCCESS ||
         param.rec_id == PJSUA_SND_NO_DEV ||
         pjmedia_aud_dev_get_info(param.rec_id, &cap_info) != PJ_SUCCESS)
@@ -2528,6 +2531,8 @@ PJ_DEF(pj_status_t) pjsua_set_null_snd_dev2(
         status = create_null_snd(pjsua_var.snd_pool,
                                  &pjsua_var.null_snd);
         if (status != PJ_SUCCESS) {
+            pj_pool_release(pjsua_var.snd_pool);
+            pjsua_var.snd_pool = NULL;
             PJSUA_UNLOCK();
             pj_log_pop_indent();
             return status;

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1125,6 +1125,15 @@ void AudDevManager::setNullDev() PJSUA2_THROW(Error)
     PJSUA2_CHECK_EXPR( pjsua_set_null_snd_dev() );
 }
 
+void AudDevManager::setNullDev2(bool avoidClockGap) PJSUA2_THROW(Error)
+{
+    pjsua_null_snd_dev_param param;
+
+    pjsua_null_snd_dev_param_default(&param);
+    param.avoid_clock_gap = avoidClockGap;
+    PJSUA2_CHECK_EXPR( pjsua_set_null_snd_dev2(&param) );
+}
+
 MediaPort *AudDevManager::setNoDev()
 {
     return (MediaPort*)pjsua_set_no_snd_dev();


### PR DESCRIPTION
### **Summary**

This PR adds a configurable null sound device API to avoid a clock-less transition window when switching audio paths, while preserving backward compatibility.

### **Use** Case Scenario (iOS Call Hold/Resume)

On iOS, the audio device may be closed when a call is put on hold.
When that happens, RTP timestamp progression may pause because the clock source is no longer running.
When the call resumes, RTP timestamp generation can continue from the value before hold, which may cause discontinuity/jitter or dropped packet behavior.

A common workaround is to switch to null sound device during hold so the media clock keeps running and RTP timestamps continue to advance.
However, with the current switching path, there can still be a brief clock-less gap when transitioning between null sound device and actual sound device in either direction.
This PR addresses that by adding a configurable transition mode to preserve clock continuity during null <> real device handover.

### **Motivation**

Switching to null sound device can briefly leave the conference bridge without a clock source. This change introduces an opt-in transition mode that prioritizes clock continuity.

### **What** Changed
- Added pjsua_null_snd_dev_param with default initializer support.
- Added pjsua_set_null_snd_dev2(const pjsua_null_snd_dev_param *snd_param).
- Kept pjsua_set_null_snd_dev() as a backward-compatible wrapper.
- Implemented configurable transition handling in the audio subsystem.
- Split sound-device close logic into clearer helper paths for device-only close versus full close.
- Added internal runtime policy tracking for the transition behavior.
- Updated PJSUA2 wrapper to expose setNullDev2(bool avoidClockGap).
- Updated alternate backend signature/comments to stay API-compatible.
- Updated documentation/comments to reference both null-sound APIs.

### **Behavior**

- avoid_clock_gap = PJ_FALSE:
legacy behavior (close old path first, then start null clock).
- avoid_clock_gap = PJ_TRUE:
gap-avoid behavior (start null clock first, then stop old device).
- The transition policy is one-shot and reset on the next open path so it does not persist unexpectedly.

### **Compatibility**
Existing callers using pjsua_set_null_snd_dev() continue to work unchanged.
New behavior is opt-in via the new parameterized API.

### **Possible** Negative Impact
When the new gap-avoid mode is enabled, there is a short overlap window where null clock is started before the previous sound path is fully closed. This avoids clock loss, but increases transition complexity and may expose edge races during rapid hold/resume toggles.

### **Scope** Notes
Testing-only legacy app changes are intentionally excluded from this PR.

### Testing
Not run in this branch.