### PR TITLE
ipjsua/ios: apply and resync video orientation on startup/resume

### DIFF
--- a/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
+++ b/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
@@ -188,9 +188,39 @@ static void pjsip_funcs(void *user_data)
         UIDeviceOrientation dev_ori = [[UIDevice currentDevice] orientation];
         int i;
 
-        if (dev_ori == prev_ori) return;
+        /* At startup or resume, device orientation may be unknown even when
+         * UI orientation is valid. Try UI orientation as fallback.
+         */
+        if (dev_ori < UIDeviceOrientationPortrait ||
+            dev_ori > UIDeviceOrientationLandscapeRight)
+        {
+            if (@available(iOS 13.0, *)) {
+                UIInterfaceOrientation if_ori =
+                    app.window.windowScene.interfaceOrientation;
 
-        NSLog(@"Device orientation changed: %d", (int)(prev_ori = dev_ori));
+                switch (if_ori) {
+                    case UIInterfaceOrientationPortrait:
+                        dev_ori = UIDeviceOrientationPortrait;
+                        break;
+                    case UIInterfaceOrientationPortraitUpsideDown:
+                        dev_ori = UIDeviceOrientationPortraitUpsideDown;
+                        break;
+                    case UIInterfaceOrientationLandscapeLeft:
+                        dev_ori = UIDeviceOrientationLandscapeLeft;
+                        break;
+                    case UIInterfaceOrientationLandscapeRight:
+                        dev_ori = UIDeviceOrientationLandscapeRight;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        if (dev_ori != prev_ori) {
+            NSLog(@"Device orientation changed: %d", (int)dev_ori);
+            prev_ori = dev_ori;
+        }
 
         if (dev_ori >= UIDeviceOrientationPortrait &&
             dev_ori <= UIDeviceOrientationLandscapeRight)
@@ -354,6 +384,11 @@ static void pjsuaOnAppConfigCb(pjsua_app_config *cfg)
                 selector:@selector(orientationChanged:)
                 name:UIDeviceOrientationDidChangeNotification
                 object:[UIDevice currentDevice]];
+
+            /* Apply current orientation once at startup so capture device
+             * orientation is correct even when app starts in landscape.
+             */
+            SCHEDULE_TIMER(HANDLE_ORI_CHANGE);
         });
         
         static char contact_uri_buf[1024];
@@ -644,7 +679,9 @@ didDectivateAudioSession:(AVAudioSession *) audioSession
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    // Restart any tasks that were paused (or not yet started) while the
+    // application was inactive.
+    SCHEDULE_TIMER(HANDLE_ORI_CHANGE);
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application

--- a/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
+++ b/pjsip-apps/src/pjsua/ios/ipjsua/ipjsuaAppDelegate.m
@@ -88,6 +88,50 @@ enum {
     pjsua_schedule_timer2(pjsip_funcs, (void *)action, 0); \
 }
 
+static UIDeviceOrientation get_ui_fallback_orientation(void)
+{
+    __block UIDeviceOrientation dev_ori = UIDeviceOrientationUnknown;
+
+    void (^read_ui_orientation)(void) = ^{
+        if (@available(iOS 13.0, *)) {
+            UIInterfaceOrientation if_ori =
+                app.window.windowScene.interfaceOrientation;
+
+            switch (if_ori) {
+                case UIInterfaceOrientationPortrait:
+                    dev_ori = UIDeviceOrientationPortrait;
+                    break;
+                case UIInterfaceOrientationPortraitUpsideDown:
+                    dev_ori = UIDeviceOrientationPortraitUpsideDown;
+                    break;
+                case UIInterfaceOrientationLandscapeLeft:
+                    dev_ori = UIDeviceOrientationLandscapeLeft;
+                    break;
+                case UIInterfaceOrientationLandscapeRight:
+                    dev_ori = UIDeviceOrientationLandscapeRight;
+                    break;
+                default:
+                    break;
+            }
+        }
+    };
+
+    if ([NSThread isMainThread]) {
+        read_ui_orientation();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), read_ui_orientation);
+    }
+
+    return dev_ori;
+}
+
+static pj_bool_t is_pjsua_ready_for_timer(void)
+{
+    pjsua_state st = pjsua_get_state();
+
+    return (st >= PJSUA_STATE_INIT && st < PJSUA_STATE_CLOSING);
+}
+
 static void pjsip_funcs(void *user_data)
 {
     /* IMPORTANT:
@@ -194,27 +238,7 @@ static void pjsip_funcs(void *user_data)
         if (dev_ori < UIDeviceOrientationPortrait ||
             dev_ori > UIDeviceOrientationLandscapeRight)
         {
-            if (@available(iOS 13.0, *)) {
-                UIInterfaceOrientation if_ori =
-                    app.window.windowScene.interfaceOrientation;
-
-                switch (if_ori) {
-                    case UIInterfaceOrientationPortrait:
-                        dev_ori = UIDeviceOrientationPortrait;
-                        break;
-                    case UIInterfaceOrientationPortraitUpsideDown:
-                        dev_ori = UIDeviceOrientationPortraitUpsideDown;
-                        break;
-                    case UIInterfaceOrientationLandscapeLeft:
-                        dev_ori = UIDeviceOrientationLandscapeLeft;
-                        break;
-                    case UIInterfaceOrientationLandscapeRight:
-                        dev_ori = UIDeviceOrientationLandscapeRight;
-                        break;
-                    default:
-                        break;
-                }
-            }
+            dev_ori = get_ui_fallback_orientation();
         }
 
         if (dev_ori != prev_ori) {
@@ -681,7 +705,9 @@ didDectivateAudioSession:(AVAudioSession *) audioSession
 {
     // Restart any tasks that were paused (or not yet started) while the
     // application was inactive.
-    SCHEDULE_TIMER(HANDLE_ORI_CHANGE);
+    if (is_pjsua_ready_for_timer()) {
+        SCHEDULE_TIMER(HANDLE_ORI_CHANGE);
+    }
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application


### PR DESCRIPTION
**Summary**
This change improves orientation handling in the iOS ipjsua sample so camera capture orientation is correct when the app starts or returns to foreground while already in landscape.

### What changed
- Apply an initial orientation sync after pjsua startup:
schedule HANDLE_ORI_CHANGE right after orientation notifications are registered.
- Resync orientation on app resume:
schedule HANDLE_ORI_CHANGE in applicationDidBecomeActive.
- Improve startup/resume fallback:
when UIDeviceOrientation is not usable (Unknown/non-portrait-landscape), fallback to UIInterfaceOrientation (iOS 13+ windowScene.interfaceOrientation).
- Keep orientation application robust:
do not skip applying orientation just because the value appears unchanged; newly-created capture streams still need explicit orientation set.

### Why
On iOS, when the app starts in landscape, orientation-change callbacks may not fire immediately. That can leave capture orientation stale until the user rotates the device. This patch ensures the current orientation is applied proactively and again on foreground resume.

### Scope
File changed: ipjsuaAppDelegate.m
No API changes.
No behavior change outside iOS sample orientation handling.

### Validation
Launch app while device is already in landscape (including charging-port-right case).
Start call/video and verify camera image is upright (head-up).
Background and foreground the app, then verify orientation remains correct without requiring a manual rotate.