### PR TITLE
make opensl_to_pj_error forward declared and static

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/opensl_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/opensl_dev.c
@@ -113,6 +113,8 @@ struct opensl_aud_stream
     W_SLBufferQueueItf  recordBufQ;
 };
 
+static pj_status_t opensl_to_pj_error(SLresult code);
+
 /* Factory prototypes */
 static pj_status_t opensl_init(pjmedia_aud_dev_factory *f);
 static pj_status_t opensl_destroy(pjmedia_aud_dev_factory *f);
@@ -333,7 +335,7 @@ void bqRecorderCallback(W_SLBufferQueueItf bq, void *context)
     }
 }
 
-pj_status_t opensl_to_pj_error(SLresult code)
+static pj_status_t opensl_to_pj_error(SLresult code)
 {
     switch(code) {
         case SL_RESULT_SUCCESS:


### PR DESCRIPTION
opensl_to_pj_error is used at lines 229 and 311, defined at line 336, but has no forward declaration in the prototype block (lines 117–145). With newer Android NDK (Clang in C99 mode), implicit function declarations are a hard error:

```
../src/pjmedia-audiodev/opensl_dev.c:229:37: error: call to undeclared function 'opensl_to_pj_error'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```