### PR TITLE
Fix race between transport_udp send and destroy

### DIFF
--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -1137,6 +1137,7 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
                                        pj_size_t size)
 {
     struct transport_udp *udp = (struct transport_udp*)tp;
+    pj_ioqueue_key_t *key;
     pj_ssize_t sent;
     unsigned id;
     struct pending_write *pw;
@@ -1149,6 +1150,14 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
     PJ_ASSERT_RETURN(size <= PJMEDIA_MAX_MTU, PJ_ETOOBIG);
 
     if (!udp->started) {
+        return PJ_SUCCESS;
+    }
+
+    /* Snapshot the key — a concurrent transport_destroy() can clear
+     * udp->rtp_key. pj_ioqueue_sendto() handles a closing key
+     * gracefully via PJ_ECANCELLED, but asserts on NULL. */
+    key = udp->rtp_key;
+    if (!key) {
         return PJ_SUCCESS;
     }
 
@@ -1179,10 +1188,10 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
     pj_memcpy(pw->buffer, pkt, size);
 
     sent = size;
-    status = pj_ioqueue_sendto( udp->rtp_key, 
+    status = pj_ioqueue_sendto( key,
                                 &udp->rtp_pending_write[id].op_key,
                                 pw->buffer, &sent, 0,
-                                &udp->rem_rtp_addr, 
+                                &udp->rem_rtp_addr,
                                 udp->addr_len);
 
     if (status != PJ_EPENDING) {
@@ -1216,6 +1225,7 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
                                         pj_size_t size)
 {
     struct transport_udp *udp = (struct transport_udp*)tp;
+    pj_ioqueue_key_t *key;
     pj_ssize_t sent;
     pj_status_t status;
 
@@ -1225,14 +1235,19 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
         return PJ_SUCCESS;
     }
 
+    /* Snapshot the key (see transport_send_rtp for rationale). */
+    key = udp->use_rtcp_mux ? udp->rtp_key : udp->rtcp_key;
+    if (!key) {
+        return PJ_SUCCESS;
+    }
+
     if (addr == NULL) {
         addr = &udp->rem_rtcp_addr;
         addr_len = udp->addr_len;
     }
 
     sent = size;
-    status = pj_ioqueue_sendto( (udp->use_rtcp_mux? udp->rtp_key:
-                                 udp->rtcp_key), &udp->rtcp_write_op,
+    status = pj_ioqueue_sendto( key, &udp->rtcp_write_op,
                                 pkt, &sent, 0, addr, addr_len);
 
     if (status==PJ_SUCCESS || status==PJ_EPENDING)


### PR DESCRIPTION
# Race between transport_udp send and destroy— analysis and fix

Under high call churn, `transport_send_rtp` (and `transport_send_rtcp2`)
in `pjmedia/src/pjmedia/transport_udp.c` dereferenced `udp->rtp_key`
after the `!udp->started` gate. A concurrent `transport_destroy()`
could clear `udp->rtp_key = NULL` in that window, causing
`pj_ioqueue_sendto`'s `PJ_ASSERT_RETURN(key && …)` to fire `abort()`
from the pjmedia clock-pump thread.

Fix: snapshot `udp->rtp_key` into a local after the `!udp->started`
check and early-return on NULL, matching the existing best-effort
defensive style. Same shape for the RTCP send path. Pushed in commit
`69c14ca21` on the `stress-test` branch.

## How it was caught

`pjsua-stress` running under TSan in CI on PR #4993 (run
27337257988). The SIGSEGV/SIGABRT handler in `pjsua_stress.c` dumped
a backtrace, and the workflow's `addr2line` post-processing produced
the named stack:

```
crash_signal_handler          pjsua_stress.c:942
transport_send_rtp            transport_udp.c:1182   <- pj_ioqueue_sendto(NULL, ...)
pjmedia_transport_send_rtp    transport.h:872
transport_send_rtp            transport_srtp.c:1378   <- SRTP wrapper
pjmedia_transport_send_rtp    transport.h:872
put_frame_imp                 stream.c:1280
put_frame                     stream.c:1415
write_port                    conference.c:2609
get_frame                     conference.c:2981
clock_callback                master_port.c:193
clock_thread                  clock_thread.c:448      <- pjmedia clock-pump thread
thread_main                   os_core_unix.c:768
```

The abort message in the log was:

```
pjsua-stress-x86_64-pc-linux-gnu: ../src/pj/ioqueue_common_abs.c:1282:
pj_ioqueue_sendto: Assertion `key && op_key && data && length' failed.
```

Of the four operands in the assertion, only `key` can plausibly be
NULL: `op_key` and `data` are addresses of struct members of a
non-null `udp` (would have segfaulted earlier if `udp` itself were
NULL), and `length` is a stack-local pointer. So **`udp->rtp_key`
was NULL** when the clock-pump thread reached `pj_ioqueue_sendto`.

## The objects involved

```
struct transport_udp        per-call UDP RTP/RTCP transport
  rtp_key       pj_ioqueue_key_t *   socket handle, NULLed at destroy
  rtcp_key      pj_ioqueue_key_t *   ditto
  rtp_sock      socket fd
  rtcp_sock     socket fd
  started       pj_bool_t            "transport is started" flag
  use_rtcp_mux  pj_bool_t            send RTCP via rtp_key if true
```

The transport is shared between the call's audio/video stream
(producer of frames) and the pjmedia clock thread (which pumps frames
through the conf bridge → stream → SRTP → UDP).

## The race

`transport_send_rtp()` (paraphrased, before fix):

```c
if (!udp->started) {
    return PJ_SUCCESS;             /* (A) gate, then... */
}

/* tx-drop-pct check, pending-write bookkeeping, memcpy ... */

sent = size;
status = pj_ioqueue_sendto(udp->rtp_key,    /* (B) deref */
                           &udp->rtp_pending_write[id].op_key,
                           pw->buffer, &sent, 0,
                           &udp->rem_rtp_addr,
                           udp->addr_len);
```

`transport_destroy()` (paraphrased):

```c
PJ_LOG(4, ("UDP media transport destroying"));

if (udp->rtp_key) {
    pj_ioqueue_unregister(udp->rtp_key);   /* blocks if cb in flight */
    udp->rtp_key = NULL;
    udp->rtp_sock = PJ_INVALID_SOCKET;
}
if (udp->rtcp_key) {
    pj_ioqueue_unregister(udp->rtcp_key);
    udp->rtcp_key = NULL;
    udp->rtcp_sock = PJ_INVALID_SOCKET;
}
```

The interleaving that aborts:

1. Clock-pump thread enters `transport_send_rtp` and passes the
   `!udp->started` check at (A) — `started` is still `PJ_TRUE`.
2. Another thread runs `transport_destroy()` for this transport:
   unregisters and NULLs `udp->rtp_key`.
3. Clock-pump thread reaches (B) and reads `udp->rtp_key` — now NULL.
4. `pj_ioqueue_sendto(NULL, …)`'s `PJ_ASSERT_RETURN(key && …)` fires
   `abort()` (PJ asserts are active in sanitizer builds).

The existing `!udp->started` gate is necessary but not sufficient:
nothing else atomically links the gate to the actual send. The
RTCP send path (`transport_send_rtcp2` around line 1234) had the
same shape.

### Why the assert (not a "graceful" failure)

`pj_ioqueue_sendto` does handle a *closing or closed* key gracefully
via `IS_CLOSING(key)` → `PJ_ECANCELLED`. The hard abort fires only
when `key` is `NULL`. The existing PJ pattern is that callers must
never pass a NULL key — the assert is intended to catch caller bugs,
not handle teardown races.

## Fix

Snapshot `udp->rtp_key` into a local after the `!udp->started` gate
and early-return on NULL. Same shape for the RTCP path.

```c
static pj_status_t transport_send_rtp(pjmedia_transport *tp,
                                      const void *pkt,
                                      pj_size_t size)
{
    struct transport_udp *udp = (struct transport_udp*)tp;
    pj_ioqueue_key_t *key;
    pj_ssize_t sent;
    unsigned id;
    struct pending_write *pw;
    pj_status_t status;

    /* ...existing size check... */

    if (!udp->started) {
        return PJ_SUCCESS;
    }

    /* Snapshot the key — a concurrent transport_destroy() can clear
     * udp->rtp_key. pj_ioqueue_sendto() handles a closing key
     * gracefully via PJ_ECANCELLED, but asserts on NULL. */
    key = udp->rtp_key;
    if (!key) {
        return PJ_SUCCESS;
    }

    /* ...existing tx-drop, pending-write bookkeeping, memcpy... */

    sent = size;
    status = pj_ioqueue_sendto(key,                  /* <-- local */
                               &udp->rtp_pending_write[id].op_key,
                               pw->buffer, &sent, 0,
                               &udp->rem_rtp_addr,
                               udp->addr_len);

    /* ...existing pending-flag handling... */
}
```

The matching RTCP defense (`transport_send_rtcp2`):

```c
pj_ioqueue_key_t *key;
...
if (!udp->started) {
    return PJ_SUCCESS;
}

/* Snapshot the key (see transport_send_rtp for rationale). */
key = udp->use_rtcp_mux ? udp->rtp_key : udp->rtcp_key;
if (!key) {
    return PJ_SUCCESS;
}
...
status = pj_ioqueue_sendto(key, &udp->rtcp_write_op,
                           pkt, &sent, 0, addr, addr_len);
```

## Why this is sufficient (but not a full structural fix)

- **Eliminates the abort.** The only `pj_ioqueue_sendto` failure
  mode the assert protected against is a NULL key. The snapshot
  ensures that if `udp->rtp_key` is NULL at the moment we read it,
  we return `PJ_SUCCESS` instead of asserting.

- **Closing key still handled.** If the snapshotted key is non-NULL
  but `pj_ioqueue_unregister` has begun closing it, `pj_ioqueue_sendto`
  returns `PJ_ECANCELLED` through `IS_CLOSING(key)`. That path was
  always safe; we did not need to change it.

- **Window not fully closed.** The patch shortens the unsafe window
  but does not eliminate it: between reading `udp->rtp_key` into
  `key` and entering `pj_ioqueue_sendto`, the key can still be
  unregistered. That case lands in the `PJ_ECANCELLED` path, which
  is fine. The remaining "real" race would be a use-after-free if
  the ioqueue key memory were freed (not just unregistered) in that
  window — but pjlib's grp-lock-based ioqueue key lifecycle defers
  free until in-flight references drain.

- **Matches existing style.** The function already had a
  best-effort `!udp->started` defense (in lieu of locking). Adding
  the NULL-key snapshot is the same pattern, one layer deeper.

The structural cleaner fix would have `transport_destroy` quiesce
in-flight sends (e.g. via the transport's grp_lock or a refcount
on each send), so that "transport is being destroyed" and "send
is in flight" can never overlap. That is a larger pjmedia change
spanning RTP/RTCP/SRTP layers; this patch keeps the change local
and removes the observed crash signature.

## How to reproduce / verify

- Run the stress test under TSan with high call churn so the
  transport-attach / destroy cycle overlaps with the pjmedia clock
  thread pumping frames.
- Before the fix: `pj_ioqueue_sendto: Assertion 'key && …' failed`
  from a stack rooted at `clock_thread → ... → transport_send_rtp`
  (or the RTCP variant).
- After the fix: same workload no longer aborts on the NULL-key
  path; teardown returns `PJ_SUCCESS` from the send and lets the
  destroy proceed.

The CI `stress / tsan` and `stress / asan` jobs exercise this load
with `-n 1024 -v 32 -t 4 --duration 480` (8 minutes) in
`.github/workflows/ci-linux.yml`.