### PR TITLE
transport_srtp_dtls: fix DTLS session not reset after fatal SSL error

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -81,7 +81,6 @@ static void on_ice_complete2(pjmedia_transport *tp,
                              void *user_data);
 
 static void dtls_on_destroy(void *arg);
-static void dtls_media_stop_channel(dtls_srtp *ds, unsigned idx);
 
 
 static pjmedia_transport_op dtls_op =
@@ -192,6 +191,9 @@ static unsigned valid_profiles_cnt;
 static X509     *dtls_cert;
 static EVP_PKEY *dtls_priv_key;
 static pj_status_t ssl_generate_cert(X509 **p_cert, EVP_PKEY **p_priv_key);
+
+/* Forward declaration */
+static void dtls_media_stop_channel(dtls_srtp* ds, unsigned idx);
 
 static pj_status_t dtls_init()
 {

--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -81,6 +81,7 @@ static void on_ice_complete2(pjmedia_transport *tp,
                              void *user_data);
 
 static void dtls_on_destroy(void *arg);
+static void dtls_media_stop_channel(dtls_srtp *ds, unsigned idx);
 
 
 static pjmedia_transport_op dtls_op =
@@ -1191,6 +1192,8 @@ static pj_status_t ssl_on_recv_packet(dtls_srtp *ds, unsigned idx,
 {
     char tmp[128];
     pj_size_t nwritten;
+    int ssl_err = SSL_ERROR_NONE;
+    pj_status_t flush_status;
 
     DTLS_LOCK(ds);
 
@@ -1220,10 +1223,13 @@ static pj_status_t ssl_on_recv_packet(dtls_srtp *ds, unsigned idx,
     while (1) {
         int rc = SSL_read(ds->ossl_ssl[idx], tmp, sizeof(tmp));
         if (rc <= 0) {
+            ssl_err = SSL_get_error(ds->ossl_ssl[idx], rc);
 #if DTLS_DEBUG
-            pj_status_t status = GET_SSL_STATUS(ds);
-            if (status != PJ_SUCCESS)
-                pj_perror(2, ds->base.name, status, "SSL_read() error");
+            {
+                pj_status_t status = GET_SSL_STATUS(ds);
+                if (status != PJ_SUCCESS)
+                    pj_perror(2, ds->base.name, status, "SSL_read() error");
+            }
 #endif
             break;
         }
@@ -1231,8 +1237,25 @@ static pj_status_t ssl_on_recv_packet(dtls_srtp *ds, unsigned idx,
 
     DTLS_UNLOCK(ds);
 
-    /* Flush anything pending in the write BIO */
-    return ssl_flush_wbio(ds, idx);
+    /* Flush anything pending in the write BIO (may include a fatal alert) */
+    flush_status = ssl_flush_wbio(ds, idx);
+
+    /* SSL_ERROR_SSL / SSL_ERROR_SYSCALL are unrecoverable: the session
+     * must not continue.  Destroy it immediately so the
+     * retransmission clock stops and the next incoming packet can trigger
+     * a fresh handshake.
+     */
+    if (ssl_err == SSL_ERROR_SSL || ssl_err == SSL_ERROR_SYSCALL) {
+        PJ_LOG(3,(ds->base.name,
+                  "DTLS-SRTP %s fatal SSL error (ssl_err=%d), resetting "
+                  "session", CHANNEL_TO_STRING(idx), ssl_err));
+        DTLS_LOCK(ds);
+        dtls_media_stop_channel(ds, idx);
+        DTLS_UNLOCK(ds);
+        return PJ_SUCCESS;
+    }
+
+    return flush_status;
 }
 
 
@@ -1358,13 +1381,27 @@ static pj_status_t dtls_on_recv(pjmedia_transport *tp, unsigned idx,
         }
     }
 
-    /* If our setup is ACTPASS, incoming packet may be a client hello,
-     * so let's update setup to PASSIVE and initiate DTLS handshake.
+    /* If our setup is ACTPASS/PASSIVE/UNKNOWN, incoming packet may be a
+     * ClientHello, so initiate server-side DTLS handshake.
      */
     if (!ds->nego_started[idx] &&
-        (ds->setup == DTLS_SETUP_ACTPASS || ds->setup == DTLS_SETUP_PASSIVE))
+        (ds->setup == DTLS_SETUP_ACTPASS || ds->setup == DTLS_SETUP_PASSIVE ||
+         ds->setup == DTLS_SETUP_UNKNOWN))
     {
         pj_status_t status;
+
+        /* If the DTLS role is not yet known (SDP not yet processed), defer
+         * until we have the remote fingerprint so certificate verification
+         * is possible.  The remote will retransmit and we will handle it
+         * once dtls_encode_sdp() or dtls_media_start() has run.
+         */
+        if (ds->setup == DTLS_SETUP_UNKNOWN && !ds->rem_fingerprint.slen) {
+            PJ_LOG(4, (ds->base.name, "DTLS-SRTP %s ClientHello received "
+                      "before SDP is processed, deferring",
+                      CHANNEL_TO_STRING(idx)));
+            DTLS_UNLOCK(ds);
+            return PJ_SUCCESS;
+        }
 
 #if defined(PJMEDIA_SRTP_DTLS_CHECK_HELLO_ADDR) && \
             PJMEDIA_SRTP_DTLS_CHECK_HELLO_ADDR==1
@@ -1376,7 +1413,7 @@ static pj_status_t dtls_on_recv(pjmedia_transport *tp, unsigned idx,
 
             /* Check the source address with the specified remote address from
              * the SDP. At this point, if the remote address information
-             * is not available yet (e.g.: remote SDP has not been received), 
+             * is not available yet (e.g.: remote SDP has not been received),
              * delay the handshake.
              * Note: when ICE is used, the source address checking will be
              * done in ICE session.


### PR DESCRIPTION
### Problem
When an SBC sends a DTLS `ClientHello` immediately after a 183 response, there is a race where the `ClientHello` can arrive before `pjmedia_transport_media_start()` has finished processing the remote SDP. This leads to two issues:

1. Issue 1 — Fatal alert sent but session not terminated (RFC 5246 §7.2)
If the SSL context was already created in client/connect mode, receiving the remote's `ClientHello` causes OpenSSL to send a fatal alert into the write BIO. `ssl_flush_wbio()` transmits the alert to the peer, but the broken SSL context is never destroyed. The retransmission clock keeps firing on a dead context, and a subsequent `dtls_media_start()` may recreate the session as server and send a ServerHello — violating RFC 5246 §7.2.

2. Issue 2 — `ClientHello` silently dropped when role is `DTLS_SETUP_UNKNOWN`
If the `ClientHello` arrives before `dtls_encode_sdp()` has determined the DTLS role, `ds->setup == DTLS_SETUP_UNKNOWN`. The lazy-start condition in `dtls_on_recv()` did not cover this state, so the packet fell through to `ssl_on_recv_packet()` and returned `PJ_EGONE` silently.


### Fix

1. Reset session on fatal SSL error (RFC 5246 s7.2) In `ssl_on_recv_packet()`, capture `SSL_get_error()` after `SSL_read()` fails. After flushing the write BIO (which transmits any pending fatal alert to the peer), if the error is `SSL_ERROR_SSL` or `SSL_ERROR_SYSCALL ` the session is unrecoverable. Call `dtls_media_stop_channel()` immediately to destroy the SSL context, stop the retransmission clock and reset the handshake flags, so the next incoming `ClientHello` can trigger a clean re-handshake rather than spinning on a broken context.

2. Defer `ClientHello` when DTLS role is not yet known (`SETUP_UNKNOWN`) In `dtls_on_recv()`, add `DTLS_SETUP_UNKNOWN` to the lazy-start condition so that a `ClientHello` arriving before `dtls_encode_sdp()` has determined the role is handled explicitly. If the remote fingerprint is not yet available (SDP not processed) the packet is deferred with a log message instead of being silently dropped via `PJ_EGONE`; the remote will retransmit once the role is established.