### PR TITLE
fix unsigned pkt_size underflow in parse_g723

### DIFF
--- a/pjmedia/src/pjmedia-codec/ipp_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ipp_codecs.c
@@ -420,6 +420,13 @@ static pj_status_t parse_g723(ipp_private_t *codec_data, void *pkt,
             return PJMEDIA_CODEC_EINMODE;
         }
 
+        /* Stop if the frame doesn't fit in the remaining packet. pkt_size
+         * is unsigned, so an oversized frame would wrap it around and let
+         * the loop read frame headers past the end of the payload.
+         */
+        if ((pj_size_t)framesize > pkt_size)
+            break;
+
         frames[count].type = PJMEDIA_FRAME_TYPE_AUDIO;
         frames[count].buf = f;
         frames[count].size = framesize;


### PR DESCRIPTION
## Description

parse_g723() picks each G.723.1 frame size (1, 4, 20 or 24 bytes) from the frame header byte and then does `pkt_size -= framesize` without first checking the frame fits in what is left of the RTP payload. pkt_size is unsigned, so a short or truncated packet whose header selects a larger frame wraps pkt_size around to a huge value. The `while (pkt_size && ...)` loop then keeps going and reads frame header bytes well past the end of the payload.

The check goes right after the frame size is known, so the loop stops before the read cursor leaves the packet and before a frame descriptor with an out-of-range size is emitted. Putting it in the parse loop keeps every G.723.1 caller covered without each one having to validate the payload first.

## Motivation and Context

A 2 byte payload whose first byte is 0x00 selects a 24 byte frame. Before the fix the cursor advances 24 bytes, pkt_size underflows, and the next iteration reads `f[0]` 22 bytes past a 2 byte buffer. The frames the stream layer receives also point at `framesize` bytes that are not in the packet, so the corruption carries into the decoder.

Before: ASan reports `heap-buffer-overflow READ of size 1` at the `f[0]` read for the truncated payload.
After: the loop returns the frames that actually fit (0 here) and ASan is clean.

## How Has This Been Tested?

The IPP codecs need Intel IPP to build, so I exercised the parse loop on its own: extracted it verbatim into a standalone program, fed it the 2 byte payload above with `*frame_cnt` set to 16 (what the stream layer asks for), and built it with `-fsanitize=address`. The unpatched loop trips the heap-buffer-overflow shown above; with the bounds check it parses 0 frames and exits clean. Same run repeated with valid single and multi frame G.723.1 payloads to confirm normal parsing is unchanged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
