### PR TITLE
iOS: Guard audio session activation with SETUP_AV_AUDIO_SESSION (completes #1941)

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
+++ b/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
@@ -2216,10 +2216,10 @@ static pj_status_t ca_stream_start(pjmedia_aud_stream *strm)
     }
 
 #if !COREAUDIO_MAC && SETUP_AV_AUDIO_SESSION
-    /* When SETUP_AV_AUDIO_SESSION is 0 (CallKit mode), CallKit owns
-     * audio session activation via provider(_:didActivate:).
-     * PJSIP must NOT call setActive:true — it overrides CallKit's
-     * route and causes cold-start audio routing failures. */
+    /* Activate AVAudioSession only when SETUP_AV_AUDIO_SESSION is enabled.
+     * When it's disabled (typical for CallKit apps), the app/CallKit owns
+     * audio session activation (e.g., provider:didActivateAudioSession:),
+     * so PJSIP must not call setActive:. */
     if ([stream->sess setActive:true error:nil] != YES) {
         PJ_LOG(4, (THIS_FILE, "Warning: cannot activate audio session"));
     }

--- a/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
+++ b/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
@@ -2215,7 +2215,11 @@ static pj_status_t ca_stream_start(pjmedia_aud_stream *strm)
             return PJMEDIA_AUDIODEV_ERRNO_FROM_COREAUDIO(ostatus);
     }
 
-#if !COREAUDIO_MAC
+#if !COREAUDIO_MAC && SETUP_AV_AUDIO_SESSION
+    /* When SETUP_AV_AUDIO_SESSION is 0 (CallKit mode), CallKit owns
+     * audio session activation via provider(_:didActivate:).
+     * PJSIP must NOT call setActive:true — it overrides CallKit's
+     * route and causes cold-start audio routing failures. */
     if ([stream->sess setActive:true error:nil] != YES) {
         PJ_LOG(4, (THIS_FILE, "Warning: cannot activate audio session"));
     }


### PR DESCRIPTION
## Problem

Changeset r5461 (ticket #1941) added `SETUP_AV_AUDIO_SESSION 0` to let CallKit-integrated apps own their audio session. It properly guarded the **deactivation** in `ca_stream_stop()` with `#if !COREAUDIO_MAC && SETUP_AV_AUDIO_SESSION`, but missed applying the same guard to the **activation** in `ca_stream_start()`.

The activation `[sess setActive:true]` is still only guarded by `#if !COREAUDIO_MAC`, so it runs unconditionally on iOS — even when `SETUP_AV_AUDIO_SESSION` is 0.

## Impact

This contradicts the [official documentation](https://docs.pjsip.org/en/latest/get-started/ios/issues.html):

> Since #1941, application needs to set its own audio session category, mode, and **activation/deactivation**.

When using CallKit, this spurious `setActive:true` conflicts with CallKit's audio session activation (`provider(_:didActivate:)`). On **cold-start incoming calls** (app launched by VoIP push), it overrides CallKit's route, causing the VoiceProcessingIO AudioUnit to bind to the wrong output route. The user cannot switch to earpiece — audio is stuck on speaker.

Warm-start calls work fine because the audio session is already active, making the spurious `setActive:true` a no-op.

## Fix

Add the same `SETUP_AV_AUDIO_SESSION` guard to the activation that was already applied to the deactivation, completing the original intent of #1941.

**Before:**
```objc
#if !COREAUDIO_MAC
    if ([stream->sess setActive:true error:nil] != YES) {
```

**After:**
```objc
#if !COREAUDIO_MAC && SETUP_AV_AUDIO_SESSION
    if ([stream->sess setActive:true error:nil] != YES) {
```

This is a 1-line change. When `SETUP_AV_AUDIO_SESSION` is 0 (the default for CallKit integration), PJSIP will no longer call `setActive:true`, leaving audio session activation entirely to the application — exactly as documented.