### PR TITLE
Fix spurious media restart on repeated early-media SDP answer

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -128,6 +128,10 @@ struct pjmedia_stream
                                                  is used to put RTP marker
                                                  bit.                       */
     pj_uint32_t              ts_vad_disabled;/**< TS when VAD was disabled. */
+    pj_bool_t                vad_suspended; /**< VAD temporarily suspended at
+                                                 startup (suspended in the
+                                                 codec only; codec_param keeps
+                                                 the configured VAD value).  */
     pj_uint32_t              tx_duration;   /**< TX duration in timestamp.  */
 
     unsigned                 soft_start_cnt;/**< Stream soft start counter */
@@ -1357,16 +1361,16 @@ static pj_status_t put_frame( pjmedia_port *port,
     }
 #endif
 
-    /* If VAD is temporarily disabled during creation, enable it
-     * after transmitting for VAD_SUSPEND_SEC seconds.
+    /* If VAD was suspended at creation, re-enable it after VAD_SUSPEND_MSEC.
+     * codec_param already holds the configured value, so just re-apply it.
      */
-    if (stream->vad_enabled != stream->codec_param.setting.vad &&
+    if (stream->vad_suspended &&
         (stream->tx_duration - stream->ts_vad_disabled) >
            PJMEDIA_PIA_SRATE(&c_strm->port.info) *
           PJMEDIA_STREAM_VAD_SUSPEND_MSEC / 1000)
     {
-        stream->codec_param.setting.vad = stream->vad_enabled;
         pjmedia_codec_modify(stream->codec, &stream->codec_param);
+        stream->vad_suspended = PJ_FALSE;
         PJ_LOG(4,(c_strm->port.info.name.ptr,"VAD re-enabled"));
     }
 
@@ -2087,12 +2091,19 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
     }
 
 
-    /* Initially disable the VAD in the stream, to help traverse NAT better */
+    /* Initially disable VAD in the stream to help traverse NAT better. We
+     * suspend it in the codec only; codec_param (hence pjmedia_stream_get_info())
+     * keeps the configured VAD value, so the transient isn't mistaken for a
+     * media change that would needlessly restart the stream (dropping audio).
+     */
     stream->vad_enabled = stream->codec_param.setting.vad;
     if (PJMEDIA_STREAM_VAD_SUSPEND_MSEC > 0 && stream->vad_enabled) {
-        stream->codec_param.setting.vad = 0;
+        pjmedia_codec_param vad_param = stream->codec_param;
+
+        vad_param.setting.vad = 0;
+        stream->vad_suspended = PJ_TRUE;
         stream->ts_vad_disabled = 0;
-        pjmedia_codec_modify(stream->codec, &stream->codec_param);
+        pjmedia_codec_modify(stream->codec, &vad_param);
         PJ_LOG(4,(c_strm->port.info.name.ptr,"VAD temporarily disabled"));
     }
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2471,12 +2471,32 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
         {
             pjsip_sdp_info *tdata_sdp_info;
             const pjmedia_sdp_session *reoffer_sdp = NULL;
+            const pjmedia_sdp_session *active_remote = NULL;
 
             if (pjmedia_sdp_neg_get_state(inv->neg) !=
                 PJMEDIA_SDP_NEG_STATE_DONE)
             {
                 PJ_LOG(4,(inv->obj_name, "SDP negotiation in progress, "
                           "message body in %s response is ignored",
+                          (st_code/10==18? "early" : "final" )));
+                return PJ_SUCCESS;
+            }
+
+            /* Non-forking (same To tag): if the new SDP answer is identical to
+             * the negotiated one, skip renegotiation to avoid a needless media
+             * restart (jitter buffer reset, dropped early media) when a remote
+             * repeats the same answer across 18x responses.
+             */
+            if (pj_stricmp(&tsx_inv_data->done_tag, &res_tag) == 0 &&
+                sdp_info->sdp &&
+                pjmedia_sdp_neg_get_active_remote(inv->neg, &active_remote)
+                    == PJ_SUCCESS &&
+                active_remote &&
+                pjmedia_sdp_session_cmp(active_remote, sdp_info->sdp, 0)
+                    == PJ_SUCCESS)
+            {
+                PJ_LOG(4,(inv->obj_name, "Ignored %s response with unchanged "
+                          "SDP answer in early media (no renegotiation)",
                           (st_code/10==18? "early" : "final" )));
                 return PJ_SUCCESS;
             }

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2496,7 +2496,7 @@ static pj_status_t inv_check_sdp_in_incoming_msg( pjsip_inv_session *inv,
                     == PJ_SUCCESS)
             {
                 PJ_LOG(4,(inv->obj_name, "Ignored %s response with unchanged "
-                          "SDP answer in early media (no renegotiation)",
+                          "SDP answer (no renegotiation)",
                           (st_code/10==18? "early" : "final" )));
                 return PJ_SUCCESS;
             }


### PR DESCRIPTION
## Problem

When a remote repeats an **identical SDP answer** across multiple unreliable `18x` responses during early media (e.g. `183` / `183` / `180`), the audio stream is torn down and rebuilt on every response. Each rebuild resets the jitter buffer and drops audio — typically the start of the early-media tone/announcement. RTP reception itself is fine (no packet loss); the problem is purely the receiver-side media restarts.

## Root cause and fix (two layers)

**`pjmedia/stream.c` — media-layer correctness (root cause)**
At stream creation, the VAD startup-suspend (`PJMEDIA_STREAM_VAD_SUSPEND_MSEC`, default 600 ms) temporarily set `codec_param.setting.vad = 0`. Because `stream->si.param` aliases `codec_param`, `pjmedia_stream_get_info()` reported that transient value. pjsua's `is_media_changed()` then compared it against the freshly parsed SDP (`vad = 1`) and treated it as a media change, forcing a needless stream rebuild whenever a renegotiation happened inside the suspend window.

VAD is now suspended **in the codec only**, via a temporary param plus a `vad_suspended` flag. `codec_param` keeps the configured value, so `pjmedia_stream_get_info()` stays stable and `is_media_changed()` no longer sees a phantom change.

**`pjsip/sip_inv.c` — signaling-layer gate (efficiency)**
In the non-forking early-media case (same To-tag), renegotiation is now skipped when the newly received SDP answer is identical to the one already negotiated, avoiding the unnecessary media update entirely. Forked responses (different To-tag) and genuinely changed SDP are still renegotiated.

The two layers are complementary: the `sip_inv.c` gate avoids the wasteful renegotiation for repeated answers, while the `stream.c` fix guarantees no spurious restart even when a renegotiation does occur (forking with identical media, app re-INVITE within the suspend window, etc.).

## Testing

Built cleanly (`make`). No automated test added; verified against the reported early-media scenario.

Reported by Johannes Westhuis.

Co-Authored-By Claude Code