### PR TITLE
Fix crash in vid_stream send_rtp during concurrent send-manager detach

### DIFF
--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -419,6 +419,7 @@ static send_entry* get_send_entry(send_stream *ss)
 static void send_rtp(send_stream *ss, send_entry *entry)
 {
     pj_timestamp send_ts;
+    send_manager *mgr;
 
     pj_grp_lock_acquire(ss->grp_lock);
 
@@ -427,6 +428,9 @@ static void send_rtp(send_stream *ss, send_entry *entry)
         pj_grp_lock_release(ss->grp_lock);
         return;
     }
+    /* Snapshot under ss->grp_lock — detach_send_manager() will NULL
+     * ss->mgr later, but we need a stable pointer to lock against. */
+    mgr = ss->mgr;
 
     /* Calculate earliest sending time allowed by rate control */
     ss->rc_total += entry->buf_size;
@@ -445,12 +449,28 @@ static void send_rtp(send_stream *ss, send_entry *entry)
     /* Add ref stream to avoid premature destroy of stream */
     pj_grp_lock_add_ref(ss->grp_lock);
 
+    /* Keep mgr alive across the ss->grp_lock release, even if a
+     * concurrent detach drops the per-stream mgr ref. */
+    pj_grp_lock_add_ref(mgr->grp_lock);
+
     pj_grp_lock_release(ss->grp_lock);
 
-    /* Queue the packet */
-    pj_grp_lock_acquire(ss->mgr->grp_lock);
-    pj_list_push_back(&ss->mgr->send_list, entry);
-    pj_grp_lock_release(ss->mgr->grp_lock);
+    /* Queue the packet. detach_send_manager() mutates ss->mgr under
+     * mgr->grp_lock, so the recheck below is sufficient to know whether
+     * the queue is still being drained by the worker thread. */
+    pj_grp_lock_acquire(mgr->grp_lock);
+    if (ss->mgr == mgr) {
+        pj_list_push_back(&mgr->send_list, entry);
+        pj_grp_lock_release(mgr->grp_lock);
+    } else {
+        /* Detach drained the queue and stopped the worker between our
+         * release of ss->grp_lock and now; the entry would never be
+         * processed, so drop the stream ref we just added. */
+        pj_grp_lock_release(mgr->grp_lock);
+        pj_grp_lock_dec_ref(ss->grp_lock);
+    }
+
+    pj_grp_lock_dec_ref(mgr->grp_lock);
 }
 
 

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -351,7 +351,13 @@ static pj_status_t detach_send_manager(send_stream *ss)
         }
         e = next;
     }
+    /* Also hold ss->grp_lock for the write so send_rtp()'s read of
+     * ss->mgr (taken under ss->grp_lock) doesn't race with this store.
+     * Lock order is mgr->grp_lock -> ss->grp_lock; no other path holds
+     * the two nested in the opposite order. */
+    pj_grp_lock_acquire(ss->grp_lock);
     ss->mgr = NULL;
+    pj_grp_lock_release(ss->grp_lock);
     pj_grp_lock_release(mgr->grp_lock);
 
     /* Stop send manager thread */
@@ -465,8 +471,12 @@ static void send_rtp(send_stream *ss, send_entry *entry)
     } else {
         /* Detach drained the queue and stopped the worker between our
          * release of ss->grp_lock and now; the entry would never be
-         * processed, so drop the stream ref we just added. */
+         * processed. Recycle it to ss->free_list (matching the worker
+         * thread pattern) and drop the stream ref we just added. */
         pj_grp_lock_release(mgr->grp_lock);
+        pj_grp_lock_acquire(ss->grp_lock);
+        pj_list_push_back(&ss->free_list, entry);
+        pj_grp_lock_release(ss->grp_lock);
         pj_grp_lock_dec_ref(ss->grp_lock);
     }
 


### PR DESCRIPTION
# Fix crash in vid_stream send_rtp during concurrent send-manager detach

Under high call churn, `send_rtp()` in `pjmedia/src/pjmedia/vid_stream.c`
released `ss->grp_lock`, then dereferenced `ss->mgr` again to acquire
`mgr->grp_lock` and push onto `mgr->send_list`. A concurrent
`detach_send_manager()` could null `ss->mgr` in that window, causing
`pj_list_push_back(&NULL->send_list, …)` and a SIGSEGV from the video
conference's clock thread.

Fix: snapshot `ss->mgr` into a local while still holding `ss->grp_lock`,
add a temporary ref on `mgr->grp_lock` (so the manager can't be freed
across the lock release), and recheck `ss->mgr == mgr` under
`mgr->grp_lock` before pushing. Pushed in commit `85ae3478d` on the
`stress-test` branch.

## How it was caught

`pjsua-stress` running under TSan in CI (`stress / tsan` on
PR #4993, run 27388981634). The new SIGSEGV/SIGABRT handler in
`pjsua_stress.c` dumped a backtrace, and the workflow's `addr2line`
post-processing produced the named stack:

```
crash_signal_handler          pjsua_stress.c:944
pj_list_push_back             list.h:126            <- SIGSEGV
send_rtp                      vid_stream.c:452
put_frame                     vid_stream.c:899
on_clock_tick                 vid_conf.c:1334       <- video conf clock thread
clock_thread                  clock_thread.c:448
thread_main                   os_core_unix.c:768
```

The crash itself was at `list.h:126`:

```c
PJ_IDEF(void) pj_list_push_back(pj_list_type *list, pj_list_type *node)
{
    pj_list_insert_after(((pj_list*)list)->prev, node);
}
```

reading `((pj_list*)list)->prev` where `list` was a small `offsetof`
address derived from a NULL `ss->mgr`.

## The objects involved

```
send_stream  *ss          per-stream
  grp_lock                    refs the stream
  free_list                   pool of reusable send_entry
  mgr                         -> send_manager (or NULL after detach)

send_manager *mgr         shared (one per process today)
  grp_lock                    refs the manager
  send_list                   queue of send_entry awaiting worker
  thread                      worker thread that drains send_list
  is_quitting                 worker stop flag

send_entry                preallocated RTP packet buffer
  stream  -> ss
  send_ts                     earliest send time (rate-control)
```

The `send_manager`'s worker thread exists to throttle outbound RTP
when `PJMEDIA_VID_STREAM_RC_SEND_THREAD` rate-control is selected
(this is the default — see `vid_stream.h:117`).

## The race

`send_rtp()` (paraphrased, before fix):

```c
pj_grp_lock_acquire(ss->grp_lock);
if (ss->mgr == NULL) { release; return; }
/* ...rate-control timestamp math... */
pj_grp_lock_add_ref(ss->grp_lock);          /* refs the STREAM   */
pj_grp_lock_release(ss->grp_lock);          /* (A) release       */

pj_grp_lock_acquire(ss->mgr->grp_lock);     /* (B) deref ss->mgr */
pj_list_push_back(&ss->mgr->send_list, entry);   /* line 452 ← SEGV */
pj_grp_lock_release(ss->mgr->grp_lock);
```

`detach_send_manager()` (paraphrased):

```c
pj_grp_lock_acquire(mgr->grp_lock);
/* walk send_list; for each entry belonging to ss:
       pj_list_erase(e); pj_grp_lock_dec_ref(ss->grp_lock); */
ss->mgr = NULL;
pj_grp_lock_release(mgr->grp_lock);

/* stop the worker */
mgr->is_quitting = PJ_TRUE;
pj_thread_join(mgr->thread);
pj_thread_destroy(mgr->thread);

pj_grp_lock_dec_ref(mgr->grp_lock);          /* may destroy mgr */
```

The interleaving that crashes:

1. send_rtp checks `ss->mgr != NULL` under `ss->grp_lock` — passes.
2. send_rtp releases `ss->grp_lock` (point (A) above).
3. detach_send_manager acquires `mgr->grp_lock`, sets `ss->mgr = NULL`,
   releases `mgr->grp_lock`.
4. send_rtp dereferences `ss->mgr` (point (B)). It's now NULL.
   `&NULL->send_list` evaluates to a small `offsetof` address;
   `pj_list_push_back` reads through it → SIGSEGV.

The existing `pj_grp_lock_add_ref(ss->grp_lock)` at the old line 446
only refs the **stream**, not the **manager**, so it doesn't protect
this dereference.

### Secondary hazard

Even if `ss->mgr` happened to still be readable, the manager object
itself could be freed in this window. The per-stream ref on
`mgr->grp_lock` added by `attach_send_manager` is dropped at the end
of `detach_send_manager`. If this stream was the last attached stream,
the dec_ref destroys the manager via `send_mgr_on_destroy`. The next
read of `ss->mgr->grp_lock` would then be use-after-free, not just a
NULL deref.

## Fix

Snapshot the manager into a local while still holding `ss->grp_lock`,
take a temporary extra ref on `mgr->grp_lock` (so the manager can't be
destroyed across the `ss->grp_lock` release), then **recheck**
`ss->mgr == mgr` under `mgr->grp_lock` before pushing.

```c
static void send_rtp(send_stream *ss, send_entry *entry)
{
    pj_timestamp send_ts;
    send_manager *mgr;

    pj_grp_lock_acquire(ss->grp_lock);

    if (ss->mgr == NULL) {
        pj_grp_lock_release(ss->grp_lock);
        return;
    }
    /* Snapshot under ss->grp_lock — detach_send_manager() will NULL
     * ss->mgr later, but we need a stable pointer to lock against. */
    mgr = ss->mgr;

    /* ...existing rate-control timestamp math... */

    /* Existing: ref the STREAM for the entry that will sit in the queue.
     * Dropped by the worker thread when the entry is processed, or by
     * detach when it erases this stream's entries. */
    pj_grp_lock_add_ref(ss->grp_lock);

    /* Keep mgr alive across the ss->grp_lock release, even if a
     * concurrent detach drops the per-stream mgr ref. */
    pj_grp_lock_add_ref(mgr->grp_lock);

    pj_grp_lock_release(ss->grp_lock);

    /* Queue the packet. detach_send_manager() mutates ss->mgr under
     * mgr->grp_lock, so the recheck below is sufficient to know whether
     * the queue is still being drained by the worker thread. */
    pj_grp_lock_acquire(mgr->grp_lock);
    if (ss->mgr == mgr) {
        pj_list_push_back(&mgr->send_list, entry);
        pj_grp_lock_release(mgr->grp_lock);
    } else {
        /* Detach drained the queue and stopped the worker between our
         * release of ss->grp_lock and now; the entry would never be
         * processed, so drop the stream ref we just added. */
        pj_grp_lock_release(mgr->grp_lock);
        pj_grp_lock_dec_ref(ss->grp_lock);
    }

    pj_grp_lock_dec_ref(mgr->grp_lock);
}
```

### Why this is sound

- **Manager stays alive across the lock release.** The temporary
  `pj_grp_lock_add_ref(mgr->grp_lock)` is performed while still
  holding `ss->grp_lock`. At that point `ss->mgr == mgr` and the
  per-stream ref from `attach_send_manager` is still held, so `mgr`
  is alive. The extra ref guarantees it stays alive until our matching
  `dec_ref` at the end of `send_rtp`.

- **Recheck is correct.** `detach_send_manager` mutates `ss->mgr` only
  while holding `mgr->grp_lock`. So when we hold `mgr->grp_lock` and
  read `ss->mgr`, the value is stable; it is either our snapshot
  (queue is still being drained, push is safe) or a different value
  (detach already drained the queue and stopped the worker, so
  pushing would leak the entry forever).

- **No ref leak.** The stream ref added at
  `pj_grp_lock_add_ref(ss->grp_lock)` is balanced on either path:
    - **Push path:** worker thread `dec_ref`s the stream after sending
      (`vid_stream.c:260`), or `detach_send_manager` `dec_ref`s the
      stream when it erases the queued entry (line 346).
    - **Race-lost path:** the new `else` branch `dec_ref`s the stream
      inline.

- **Entry pool slot:** in the race-lost path the entry is not returned
  to `ss->free_list`. The entry is a `pj_pool_alloc` from
  `ss->pool`, which is freed when the stream is destroyed, so this is
  not a real leak — and it matches the existing behaviour of
  `detach_send_manager`, which erases entries from `mgr->send_list`
  without returning them to `ss->free_list` (lines 348-350 are
  commented out).

## Related code paths (not changed, but worth noting)

`get_send_entry` (vid_stream.c:369) follows the same check-then-use
pattern on `ss->mgr`, but only uses `ss->mgr` for the NULL check —
the rest of the function only touches `ss->pool` / `ss->free_list`,
both of which are protected by `ss->grp_lock`. So no SEGV there, but
the check is also no longer load-bearing now that `send_rtp` is safe
against detach.

The structural cleaner fix would be to have the worker thread drain
on detach (instead of nulling `ss->mgr`) and use a real completion
handshake. That's a larger refactor, but the patch above is
sufficient to eliminate the observed crash without changing the
module's lock topology.

## How to reproduce / verify

- Run the stress test under TSan with high call churn and
  `PJMEDIA_VID_STREAM_RC_SEND_THREAD` (the default).
- Before the fix: SIGSEGV at `pj_list_push_back` reachable from
  `clock_thread → vid_conf::on_clock_tick → vid_stream::put_frame →
   vid_stream::send_rtp`.
- After the fix: same workload runs to the end of the stress phase
  without hitting that signature.

The CI `stress / tsan` job exercises this load with
`-n 1024 -v 32 -t 4 --duration 480` (8 minutes).