### PR TITLE
Fix Opus decode failure when remote raises ptime mid-stream

### DIFF
--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -505,6 +505,7 @@ static pj_status_t get_frame( pjmedia_port *port, pjmedia_frame *frame)
             /* Got "NORMAL" frame from jitter buffer */
             pjmedia_frame frame_in, frame_out;
             pj_bool_t use_dec_buf = PJ_FALSE;
+            unsigned exp_decoded_samples;
 
             stream->plc_cnt = 0;
 
@@ -518,13 +519,21 @@ static pj_status_t get_frame( pjmedia_port *port, pjmedia_frame *frame)
             frame_out.size = frame->size - samples_count*BYTES_PER_SAMPLE;
 
             /* Check if we need to use the decode buffer, i.e: codec is opus
-             * and the decoded frame is larger than the stream frame.
+             * and the decoded frame is larger than the stream frame. The
+             * per-frame decoded size is signalled by the codec via bit_info,
+             * but when the remote raises the ptime mid-stream (e.g. 20->40 ms)
+             * only the first frame carries it; subsequent frames rely on
+             * samples_per_frame, which tracks the updated dec_ptime. Use
+             * whichever is larger so every oversized frame (any ptime up to
+             * the dec_buf capacity) gets the bigger buffer instead of failing
+             * to decode into a too-small stream frame.
              */
+            exp_decoded_samples = PJ_MAX(bit_info, samples_per_frame);
             if (stream->dec_buf &&
-                bit_info * sizeof(pj_int16_t) > frame_out.size)
+                exp_decoded_samples * sizeof(pj_int16_t) > frame_out.size)
             {
                 stream->dec_buf_pos = 0;
-                stream->dec_buf_count = bit_info;
+                stream->dec_buf_count = exp_decoded_samples;
 
                 use_dec_buf = PJ_TRUE;
                 frame_out.buf = stream->dec_buf;


### PR DESCRIPTION
## Problem

Opus allows the packet duration (ptime) to change on the fly, and a peer may send frames larger than the negotiated value mid-call — e.g. raising ptime from 20 ms to 40 ms. When that happens, decoding fails and the audio becomes continuously distorted ("wow and flutter") for the whole period the larger ptime is in effect. Decreasing ptime (e.g. 40→20) is unaffected, and fixed-ptime codecs (PCMU, etc.) are unaffected.

The decode log shows repeated:
```
opus.c  Decode failed!
strm... codec decode() error: ...EFAILED
strm... Jitter buffer empty (prefetch=N), plc invoked
```

## Root cause

When the decoded Opus frame is larger than the stream's output frame, pjmedia must decode into the dedicated oversized decode buffer (`stream->dec_buf`, sized for 120 ms). In `get_frame()` (`pjmedia/src/pjmedia/stream.c`), the decision to use that buffer was driven solely by the per-frame `bit_info` signal set by the Opus codec.

However, `codec_parse()` (`pjmedia/src/pjmedia-codec/opus.c`) sets `bit_info` only on the **single frame where the ptime change is first detected**. Every subsequent larger frame carries `bit_info = 0`, so it was decoded into the smaller (20 ms-sized) stream frame, and `opus_decode()` returned `OPUS_BUFFER_TOO_SMALL` → "Decode failed!" → jitter-buffer underrun → PLC → continuous distortion. (The transition frame and the PLC frames still produce audio, which is why the result is distortion rather than silence.)

This is a generic Opus issue — any sustained incoming ptime larger than the stream's output ptime triggers it; it is not specific to any particular peer behaviour.

## Fix

Base the decode-buffer decision on the expected decoded size, `max(bit_info, samples_per_frame)`. `samples_per_frame` already tracks the updated `dec_ptime` (the jitter buffer is reset and `dec_ptime` updated when the change is detected), so every oversized frame — at any ptime up to the `dec_buf` capacity (120 ms) — now uses the larger buffer and decodes successfully. The normal output-sized path is unchanged, and the `dec_buf` is doled out across output frames as before.

## Testing

Built cleanly (pjmedia + full). The fix is confined to the decode-buffer sizing in `get_frame()`; the normal 20 ms path is unchanged (decoded size equals the output slot, so the existing inline-decode path is taken).

Reported by Marcus Froeschl.

Co-Authored-By Claude Code