### PR TITLE
Add buffer bounds check in print_media_type()

### DIFF
--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -1402,7 +1402,11 @@ static int print_media_type(char *buf, unsigned len,
     const pjsip_parser_const_t *pc;
 
     /* Check buffer for "type/subtype"; params are checked below. */
-    if ((pj_ssize_t)len < media->type.slen + 1 + media->subtype.slen)
+    if (media->type.slen < 0 || media->subtype.slen < 0)
+        return -1;
+    if ((pj_size_t)len <= (pj_size_t)media->type.slen)
+        return -1;
+    if ((pj_size_t)len - (pj_size_t)media->type.slen - 1 < (pj_size_t)media->subtype.slen)
         return -1;
 
     pj_memcpy(p, media->type.ptr, media->type.slen);

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -1401,6 +1401,10 @@ static int print_media_type(char *buf, unsigned len,
     pj_ssize_t printed;
     const pjsip_parser_const_t *pc;
 
+    /* Check buffer for "type/subtype"; params are checked below. */
+    if ((pj_ssize_t)len < media->type.slen + 1 + media->subtype.slen)
+        return -1;
+
     pj_memcpy(p, media->type.ptr, media->type.slen);
     p += media->type.slen;
     *p++ = '/';

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -544,7 +544,11 @@ PJ_DEF(pj_ssize_t) pjsip_msg_print( const pjsip_msg *msg,
             }
             pj_memcpy(p, ctype_hdr.ptr, ctype_hdr.slen);
             p += ctype_hdr.slen;
-            p += print_media_type(p, (unsigned)(end-p), media);
+            len = print_media_type(p, (unsigned)(end-p), media);
+            /* Defensive; buffer is already validated above. */
+            if (len < 0)
+                return -1;
+            p += len;
             *p++ = '\r';
             *p++ = '\n';
 
@@ -1454,6 +1458,9 @@ static int pjsip_ctype_hdr_print( pjsip_ctype_hdr *hdr,
     *p++ = ' ';
 
     len = print_media_type(p, (unsigned)(buf+size-p), &hdr->media);
+    /* Defensive; buffer is already validated above. */
+    if (len < 0)
+        return -1;
     p += len;
 
     *p = '\0';


### PR DESCRIPTION
print_media_type() in pjsip/src/pjsip/sip_msg.c writes "type/subtype" into the output buffer without checking that it fits, relying entirely on callers to provide a large enough buffer.

The internal callers — pjsip_ctype_hdr_print() and pjsip_msg_print() — validate the buffer beforehand, so SIP message serialization is unaffected. However, the public pjsip_media_type_print() API forwards the caller's buffer straight through with no check, so an undersized buffer there would overflow.

This adds an explicit length check before the writes, consistent with the other header printers in this file. The trailing media parameters are already bounds-checked by pjsip_param_print_on().

Not a remotely-triggerable issue (no attacker-controlled path through the library); this is defensive hardening of the public API.

Co-Authored-By Claude Code