### PR TITLE
Fix assertion in on_rx_rtcp with uninitialized remote RTCP address

### DIFF
--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -789,9 +789,15 @@ static void on_rx_rtcp(pj_ioqueue_key_t *key,
         /* Check if RTCP source address is the same as the configured
          * remote address, and switch the address when they are
          * different.
+         *
+         * Skip when rem_rtcp_addr is not initialized yet (sa_family==0),
+         * e.g. an RTCP packet arriving before transport_attach2() or on a
+         * recycled transport: pj_sockaddr_cmp() would call
+         * pj_sockaddr_get_addr_len(), which asserts on an invalid family.
          */
         if (bytes_read>0 &&
-            (udp->options & PJMEDIA_UDP_NO_SRC_ADDR_CHECKING)==0)
+            (udp->options & PJMEDIA_UDP_NO_SRC_ADDR_CHECKING)==0 &&
+            udp->rem_rtcp_addr.addr.sa_family != 0)
         {
             if (pj_sockaddr_cmp(&udp->rem_rtcp_addr, &udp->rtcp_src_addr) == 0) {
                 /* Still receiving from rem_rtcp_addr, don't switch */


### PR DESCRIPTION
## Problem

With `PJMEDIA_TRANSPORT_SWITCH_REMOTE_ADDR` enabled (the default), an RTCP packet arriving on a UDP transport whose `rem_rtcp_addr` is still uninitialized (`sa_family == 0`) aborts the process:

```
#0 abort()
#1 __assert_fail()
#2 pj_sockaddr_get_addr_len()   ← asserts family is AF_INET/AF_INET6
#3 pj_sockaddr_cmp()
#4 on_rx_rtcp()                 ← transport_udp.c
#5 pj_ioqueue_poll()
```

`on_rx_rtcp()` compares the RTCP source against the configured remote with `pj_sockaddr_cmp(&udp->rem_rtcp_addr, &udp->rtcp_src_addr)`. But `rem_rtcp_addr` is only set in `transport_attach2()`, while the RTCP socket's `recvfrom` is posted at transport **creation**. So an RTCP packet that arrives **before the transport is attached** — or on a transport struct recycled/zeroed under high call load (batch teardown then immediate re-allocation) — reaches the compare with `rem_rtcp_addr.sa_family == 0`, and `pj_sockaddr_get_addr_len()` asserts.

## Fix

Skip the source-address switch check when `rem_rtcp_addr` is not yet initialized (`sa_family == 0`), consistent with the `pj_sockaddr` convention that `sa_family == 0` means "not set":

```c
if (bytes_read>0 &&
    (udp->options & PJMEDIA_UDP_NO_SRC_ADDR_CHECKING)==0 &&
    udp->rem_rtcp_addr.addr.sa_family != 0)
{
    if (pj_sockaddr_cmp(&udp->rem_rtcp_addr, &udp->rtcp_src_addr) == 0) {
```

A configured remote always has a valid family (including a `0.0.0.0` hold address, which is still `AF_INET`), so normal behavior is unchanged; only the genuinely-uninitialized case is skipped.

## Notes

- **RTP path is not affected**: its remote-address switch decision is made in the stream callback (`stream_imp_common.c`) which only runs after attach with an initialized `rem_rtp_addr`; the transport's `on_rx_rtp` itself only does `pj_sockaddr_cp` (no compare).
- **ICE transport is not affected**: its `pj_sockaddr_cmp` calls are in ICE candidate/SDP processing, not an on-receive switch path against a pre-attach address.
- Related but distinct from the recently-merged send-side teardown fix (#5016) and the RTP receive-side fix (#5001).

## Testing

Built cleanly (pjmedia + full). The guard is behavior-preserving for attached transports; it only suppresses the compare in the pre-attach / uninitialized window that previously asserted.

Reported by Rajesh Batagurki.

Co-Authored-By Claude Code