### PR TITLE
rtcp_fb: Fix to 'reading 8 bytes from a region of size 4' errors on GCC 15.2.0.

### DIFF
--- a/pjmedia/include/pjmedia/rtcp_fb.h
+++ b/pjmedia/include/pjmedia/rtcp_fb.h
@@ -336,7 +336,7 @@ PJ_DECL(pj_status_t) pjmedia_rtcp_fb_build_nack(
                                         void *buf,
                                         pj_size_t *length,
                                         unsigned nack_cnt,
-                                        const pjmedia_rtcp_fb_nack nack[]);
+                                        const pjmedia_rtcp_fb_nack *nack);
 
 
 /**
@@ -378,7 +378,7 @@ PJ_DECL(pj_status_t) pjmedia_rtcp_fb_build_sli(
                                         void *buf,
                                         pj_size_t *length,
                                         unsigned sli_cnt,
-                                        const pjmedia_rtcp_fb_sli sli[]);
+                                        const pjmedia_rtcp_fb_sli *sli);
 
 
 /**
@@ -422,7 +422,7 @@ PJ_DECL(pj_status_t) pjmedia_rtcp_fb_parse_nack(
                                         const void *buf,
                                         pj_size_t length,
                                         unsigned *nack_cnt,
-                                        pjmedia_rtcp_fb_nack nack[]);
+                                        pjmedia_rtcp_fb_nack *nack);
 
 
 /**
@@ -456,7 +456,7 @@ PJ_DECL(pj_status_t) pjmedia_rtcp_fb_parse_sli(
                                         const void *buf,
                                         pj_size_t length,
                                         unsigned *sli_cnt,
-                                        pjmedia_rtcp_fb_sli sli[]);
+                                        pjmedia_rtcp_fb_sli *sli);
 
 
 /**

--- a/pjmedia/src/pjmedia/rtcp_fb.c
+++ b/pjmedia/src/pjmedia/rtcp_fb.c
@@ -40,7 +40,7 @@ PJ_DEF(pj_status_t) pjmedia_rtcp_fb_build_nack(
                                         void *buf,
                                         pj_size_t *length,
                                         unsigned nack_cnt,
-                                        const pjmedia_rtcp_fb_nack nack[])
+                                        const pjmedia_rtcp_fb_nack *nack)
 {
     pjmedia_rtcp_fb_common *hdr;
     pj_uint8_t *p;
@@ -118,7 +118,7 @@ PJ_DEF(pj_status_t) pjmedia_rtcp_fb_build_sli(
                                         void *buf,
                                         pj_size_t *length,
                                         unsigned sli_cnt,
-                                        const pjmedia_rtcp_fb_sli sli[])
+                                        const pjmedia_rtcp_fb_sli *sli)
 {
     pjmedia_rtcp_fb_common *hdr;
     pj_uint8_t *p;
@@ -332,7 +332,7 @@ typedef struct sdp_codec_info_t
 static pj_status_t get_codec_info_from_sdp(pjmedia_endpt *endpt,
                                            const pjmedia_sdp_media *m,
                                            unsigned *sci_cnt,
-                                           sdp_codec_info_t sci[])
+                                           sdp_codec_info_t *sci)
 {
     pjmedia_codec_mgr *codec_mgr;
     unsigned j, cnt = 0;
@@ -624,7 +624,7 @@ PJ_DEF(pj_status_t) pjmedia_rtcp_fb_parse_nack(
                                         const void *buf,
                                         pj_size_t length,
                                         unsigned *nack_cnt,
-                                        pjmedia_rtcp_fb_nack nack[])
+                                        pjmedia_rtcp_fb_nack *nack)
 {
     pjmedia_rtcp_fb_common *hdr = (pjmedia_rtcp_fb_common*) buf;
     pj_uint8_t *p;
@@ -688,7 +688,7 @@ PJ_DEF(pj_status_t) pjmedia_rtcp_fb_parse_sli(
                                         const void *buf,
                                         pj_size_t length,
                                         unsigned *sli_cnt,
-                                        pjmedia_rtcp_fb_sli sli[])
+                                        pjmedia_rtcp_fb_sli *sli)
 {
     pjmedia_rtcp_fb_common *hdr = (pjmedia_rtcp_fb_common*) buf;
     pj_uint8_t *p;


### PR DESCRIPTION
Fixes the following warnings as error under GCC 15.2.0 when using the TSAN thread analyzer with options:
`-g -O1 -fno-omit-frame-pointer -fsanitize=thread`

```C
In function ‘build_rtcp_fb’,
    inlined from ‘pjmedia_stream_send_rtcp’ at pjproject/pjmedia/src/pjmedia/stream_common.c:692:18:
pjproject/pjmedia/src/pjmedia/stream_common.c:619:18: error: ‘pjmedia_rtcp_fb_build_nack’ reading 8 bytes from a region of size 4 [-Werror=stringop-overread]
  619 |         status = pjmedia_rtcp_fb_build_nack(&c_strm->rtcp, buf, length, 1,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  620 |                                             &c_strm->rtcp_fb_nack);
      |                                             ~~~~~~~~~~~~~~~~~~~~~~
pjproject/pjmedia/src/pjmedia/stream_common.c:619:18: note: referencing argument 5 of type ‘const pjmedia_rtcp_fb_nack[0]’
In file included from pjproject/pjmedia/include/pjmedia/event.h:27,
                 from pjproject/pjmedia/include/pjmedia/port.h:27,
                 from pjproject/pjmedia/include/pjmedia/codec.h:28,
                 from pjproject/pjmedia/include/pjmedia/stream_common.h:28,
                 from pjproject/pjmedia/src/pjmedia/stream_common.c:18:
pjproject/pjmedia/include/pjmedia/rtcp_fb.h: In function ‘pjmedia_stream_send_rtcp’:
pjproject/pjmedia/include/pjmedia/rtcp_fb.h:334:22: note: in a call to function ‘pjmedia_rtcp_fb_build_nack’
  334 | PJ_DECL(pj_status_t) pjmedia_rtcp_fb_build_nack(
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
pjproject/pjmedia/src/pjmedia/stream_common.c:762:18: error: ‘pjmedia_rtcp_fb_build_nack’ reading 8 bytes from a region of size 4 [-Werror=stringop-overread]
  762 |         status = pjmedia_rtcp_fb_build_nack(&c_strm->rtcp, pkt+len, &fb_len,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  763 |                                             1, &c_strm->rtcp_fb_nack);
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~
pjproject/pjmedia/src/pjmedia/stream_common.c:762:18: note: referencing argument 5 of type ‘const pjmedia_rtcp_fb_nack[0]’
pjproject/pjmedia/include/pjmedia/rtcp_fb.h:334:22: note: in a call to function ‘pjmedia_rtcp_fb_build_nack’
  334 | PJ_DECL(pj_status_t) pjmedia_rtcp_fb_build_nack(
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
```