### PR TITLE
Fix abort/invalid port in WAV/AVI player on malformed header

### DIFF
--- a/pjmedia/include/pjmedia/errno.h
+++ b/pjmedia/include/pjmedia/errno.h
@@ -544,6 +544,11 @@ PJ_BEGIN_DECL
  * Unsupported AVI file.
  */
 #define PJMEDIA_EAVIUNSUPP          (PJMEDIA_ERRNO_START+191)    /* 220191 */
+/**
+ * @hideinitializer
+ * Not a valid AVI file.
+ */
+#define PJMEDIA_ENOTVALIDAVI        (PJMEDIA_ERRNO_START+192)    /* 220192 */
 
 
 /************************************************************

--- a/pjmedia/src/pjmedia/avi_player.c
+++ b/pjmedia/src/pjmedia/avi_player.c
@@ -253,7 +253,7 @@ pjmedia_avi_player_create_streams(pj_pool_t *pool_,
     if (fport[0]->fsize <= (pj_off_t)(sizeof(riff_hdr_t) + sizeof(avih_hdr_t) +
                                       sizeof(strl_hdr_t)))
     {
-        status = PJMEDIA_EINVALIMEDIATYPE;
+        status = PJMEDIA_ENOTVALIDAVI;
         goto on_error;
     }
 
@@ -276,7 +276,7 @@ pjmedia_avi_player_create_streams(pj_pool_t *pool_,
         !COMPARE_TAG(avi_hdr.avih_hdr.hdrl_tag, PJMEDIA_AVI_HDRL_TAG) ||
         !COMPARE_TAG(avi_hdr.avih_hdr.avih, PJMEDIA_AVI_AVIH_TAG))
     {
-        status = PJMEDIA_EINVALIMEDIATYPE;
+        status = PJMEDIA_ENOTVALIDAVI;
         goto on_error;
     }
 
@@ -533,6 +533,15 @@ pjmedia_avi_player_create_streams(pj_pool_t *pool_,
         } else {
             strf_audio_hdr_t *strf_hdr =
                 &avi_hdr.strf_hdr[fport[i]->stream_id].strf_audio_hdr;
+
+            /* Reject zero sample rate / channel count (malformed header) to
+             * avoid a zero clock rate propagating into the audio port, which
+             * would later cause a division by zero / invalid port.
+             */
+            if (strf_hdr->sample_rate == 0 || strf_hdr->nchannels == 0) {
+                status = PJMEDIA_ENOTVALIDAVI;
+                goto on_error;
+            }
 
             fport[i]->bits_per_sample = strf_hdr->bits_per_sample;
             //fport[i]->usec_per_frame = avi_hdr.avih_hdr.usec_per_frame;
@@ -854,7 +863,7 @@ static pj_status_t skip_forward(pjmedia_port *this_port, pj_size_t frames)
                            (unsigned long)pos));
             }
 
-            return PJMEDIA_ENOTVALIDWAVE;
+            return PJMEDIA_ENOTVALIDAVI;
         }
 
         PJ_CHECK_OVERFLOW_UINT32_TO_LONG(ch.len, return PJ_EINVAL);
@@ -1147,7 +1156,7 @@ static pj_status_t avi_get_frame(pjmedia_port *this_port,
                                ch.id, ch.len,
                                (unsigned long)pos));
                 }
-                status = PJMEDIA_ENOTVALIDWAVE;
+                status = PJMEDIA_ENOTVALIDAVI;
                 goto on_error2;
             }
 

--- a/pjmedia/src/pjmedia/errno.c
+++ b/pjmedia/src/pjmedia/errno.c
@@ -146,6 +146,7 @@ static const struct
     PJ_BUILD_ERR( PJMEDIA_EWAVETOOSHORT,    "WAVE file too short" ),
     PJ_BUILD_ERR( PJMEDIA_EFRMFILETOOBIG,   "Sound frame too large for file buffer"),
     PJ_BUILD_ERR( PJMEDIA_EAVIUNSUPP,       "Unsupported AVI file"),
+    PJ_BUILD_ERR( PJMEDIA_ENOTVALIDAVI,     "Not a valid AVI file"),
 
     /* Sound device errors: */
     PJ_BUILD_ERR( PJMEDIA_ENOSNDREC,        "No suitable sound capture device" ),

--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -399,8 +399,18 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool_,
         goto on_error;
     }
 
+    /* Validate sample rate and channel count. A malformed header with a zero
+     * sample rate or channel count would otherwise abort in
+     * pjmedia_port_info_init() (or yield a zero samples-per-frame).
+     */
+    if (wave_hdr.fmt_hdr.sample_rate == 0 || wave_hdr.fmt_hdr.nchan == 0) {
+        pj_file_close(fport->fd);
+        status = PJMEDIA_ENOTVALIDWAVE;
+        goto on_error;
+    }
+
     fport->fmt_tag = (pjmedia_wave_fmt_tag)wave_hdr.fmt_hdr.fmt_tag;
-    fport->bytes_per_sample = (pj_uint16_t) 
+    fport->bytes_per_sample = (pj_uint16_t)
                               (wave_hdr.fmt_hdr.bits_per_sample / 8);
 
     /* If length of fmt_header is greater than 16, skip the remaining


### PR DESCRIPTION
## Problem

The WAV fuzzing harness added in #5008 surfaced a pre-existing **assertion abort** (not a memory-safety bug) in the WAV player. A crafted WAV whose `fmt` chunk has **sample rate == 0** or **channel count == 0** passes the existing format checks (bit depth / block align) and is handed straight to `pjmedia_port_info_init()`, whose `PJ_ASSERT(clock_rate && channel_count)` aborts (ASan reports it as `ABRT ... in pthread_kill`):

```
fuzz-wav: ../src/pjmedia/port.c:43: pjmedia_port_info_init: Assertion `clock_rate && channel_count' failed.
  pjmedia_port_info_init        port.c:43
  pjmedia_wav_player_port_create wav_player.c:480
  LLVMFuzzerTestOneInput        fuzz-wav.c
```

In a build with asserts disabled it's still wrong: `samples_per_frame` computes to `0`.

The AVI player has the same class of issue: a zero sample rate / channel count in the audio stream header produces an audio port with a zero clock rate, which later divides by zero.

## Fix

- **`wav_player.c`**: reject `sample_rate == 0 || nchan == 0` and return `PJMEDIA_ENOTVALIDWAVE`.
- **`avi_player.c`**: reject `sample_rate == 0 || nchannels == 0` in the audio stream header.
- Add a dedicated **`PJMEDIA_ENOTVALIDAVI`** error code (*"Not a valid AVI file"*) and use it for the AVI structural-validity checks that previously returned `PJMEDIA_EINVALIMEDIATYPE` (file too short, RIFF/AVI magic mismatch) or the misnamed `PJMEDIA_ENOTVALIDWAVE` (invalid chunk). The new code slots into a free range and is purely additive.

## Motivation / how it was found

The new WAV/AVI fuzz harness in #5008 (https://github.com/pjsip/pjproject/pull/5008) hit this assertion on CI. This change validates the header so the players reject malformed input gracefully. It addresses this specific assertion; the harness may still surface other malformed-input paths.

## Testing

Built cleanly (pjmedia + full). The guards only reject malformed headers that previously aborted (WAV) or produced an invalid zero-clock-rate port (AVI); valid files are unaffected.

Co-Authored-By Claude Code