### PR TITLE
pjsua-lib: Reconnect on registration timeout over reliable transport

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2907,6 +2907,27 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
         PJ_LOG(2, (THIS_FILE, "SIP registration failed, status=%d (%.*s)", 
                    param->code, 
                    (int)param->reason.slen, param->reason.ptr));
+
+        /* Transaction timeout (no response, rdata==NULL) over a reliable
+         * transport may mean the connection was silently dropped. Shut it
+         * down to force a reconnect on the next registration. A real 408
+         * response (rdata!=NULL) means the connection is alive, so skip it.
+         */
+        if (param->code == PJSIP_SC_REQUEST_TIMEOUT && param->rdata == NULL) {
+            pjsip_regc_info reginfo;
+
+            pjsip_regc_get_info(param->regc, &reginfo);
+            if (reginfo.transport &&
+                (reginfo.transport->flag & PJSIP_TRANSPORT_RELIABLE))
+            {
+                PJ_LOG(3, (THIS_FILE,
+                           "Registration timed out, shutting down transport "
+                           "%s to force a reconnect on next registration",
+                           reginfo.transport->obj_name));
+                pjsip_transport_shutdown(reginfo.transport);
+            }
+        }
+
         destroy_regc(acc, PJ_TRUE);
 
         /* Clear Service-Route header */


### PR DESCRIPTION
## Problem

When a `REGISTER` is sent over a connection-oriented transport (TCP/TLS) and the transaction times out with **no response** (transaction Timer B/F fires, surfaced as status `408`), the underlying connection may have been silently dropped by the peer or an intermediary (e.g. a NAT/firewall dropping an idle mapping without sending a RST/FIN).

PJSIP does not learn the connection is dead in this case, so the transport stays cached and is considered usable. pjsua then keeps reusing the same dead connection for subsequent (auto-)re-registration attempts, which keep timing out. The account stays unregistered for a long time even though simply reconnecting would succeed immediately.

## Fix

In the registration callback (`regc_cb`), when a registration fails with a timeout (`PJSIP_SC_REQUEST_TIMEOUT`) on a **reliable** transport, shut the transport down with `pjsip_transport_shutdown()`. The transport manager then evicts it and the next registration attempt establishes a fresh connection instead of reusing the dead one.

Notes:
- Restricted to `PJSIP_TRANSPORT_RELIABLE` (TCP/TLS); UDP is connectionless and has nothing to tear down.
- Restricted to the timeout case only. A real 4xx/5xx response means bytes came back over the connection, so it is alive and is left untouched.
- `pjsip_transport_shutdown()` only marks the transport for graceful eviction once its reference count drops; it does not free anything synchronously, so it is safe to call here before `destroy_regc()`.
