### PR TITLE
Reject zero rate/scale in AVI video stream header (#5008)

### DIFF
--- a/pjmedia/src/pjmedia/avi_player.c
+++ b/pjmedia/src/pjmedia/avi_player.c
@@ -502,6 +502,16 @@ pjmedia_avi_player_create_streams(pj_pool_t *pool_,
                 &avi_hdr.strf_hdr[fport[i]->stream_id].strf_video_hdr;
             const pjmedia_video_format_info *vfi;
 
+            /* Reject zero rate (fps numerator) or scale (fps denominator)
+             * from a malformed header. A zero scale would otherwise be passed
+             * as a zero frame-rate denominator to pjmedia_format_init_video(),
+             * which aborts (or later causes a division by zero).
+             */
+            if (strl_hdr->rate == 0 || strl_hdr->scale == 0) {
+                status = PJMEDIA_ENOTVALIDAVI;
+                goto on_error;
+            }
+
             vfi = pjmedia_get_video_format_info(
                 pjmedia_video_format_mgr_instance(),
                 strl_hdr->codec);


### PR DESCRIPTION
Hardens the AVI player against a malformed video stream header, found via the WAV/AVI fuzzing harness in #5008.

### Problem

`pjmedia_avi_player_create_streams()` passes the video stream's `rate` (fps numerator) and `scale` (fps denominator) straight from the file into `pjmedia_format_init_video()`:

```c
pjmedia_format_init_video(&fport[i]->base.info.fmt, fport[i]->fmt_id,
                          strf_hdr->biWidth, strf_hdr->biHeight,
                          strl_hdr->rate, strl_hdr->scale);
```

`pjmedia_format_init_video()` asserts the fps denominator is non-zero (`format.c:103`). A crafted AVI whose video `strl` header has `scale == 0` (or `rate == 0`) aborts the process; with asserts disabled it yields a zero frame-rate denominator and a later division by zero.

### Fix

Validate `rate` and `scale` before building the video format, returning `PJMEDIA_ENOTVALIDAVI` for a zero value — mirroring the audio-stream guard added in #5030.

### Relation to #5030

#5030 guarded the AVI **audio** stream and the WAV header, but was found via the WAV fuzzing harness, which does not initialize the video format manager and therefore never reaches the AVI **video** path. Once the harness initializes the video subsystem (see #5008), the video path is fuzzed and this zero `scale`/`rate` crash surfaces. This PR closes that gap.

### Testing

Reproduced and verified the fix locally with the #5008 harness built under clang + ASan + libFuzzer (video enabled). The crashing AVI input now returns cleanly, and ~10M fuzz executions across WAV/AVI inputs (many codec FourCCs: MJPG/DIVX/FMP4/I420/RGB3) complete with no crashes.

Co-Authored-By Claude Code