### PR TITLE
fix(windows): null-check PROPVARIANT before wcslen in wmme_dev

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/wmme_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/wmme_dev.c
@@ -279,11 +279,12 @@ static void get_dev_names(pjmedia_aud_dev_factory *f)
 
         for (i = 0; i < wf->dev_count; ++i) {
             if (0 == wcscmp(wf->dev_info[i].endpointId, pwszID)) {
-                pj_unicode_to_ansi(varName.pwszVal, 
+                if (varName.vt == VT_LPWSTR && varName.pwszVal != NULL) {
+                    pj_unicode_to_ansi(varName.pwszVal, 
                                    wcslen(varName.pwszVal), 
                                    wf->dev_info[i].info.name, 
                                    sizeof(wf->dev_info[i].info.name));
-
+                }
                 break;
             }
         }


### PR DESCRIPTION
IPropertyStore_GetValue returns S_OK with VT_EMPTY when a device has no friendly name during audio device changes, leaving pwszVal NULL and crashing in wcslen.