### PR TITLE
ssl_sock_ossl: fix OpenSSL 4.0 compatibility

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -1645,10 +1645,7 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
                     if (PEM_read_bio_X509(new_bio, &x, NULL, NULL) == NULL)
                         break;
 
-                    if ((xn = X509_get_subject_name(x)) == NULL)
-                        break;
-
-                    if ((xn = X509_NAME_dup(xn)) == NULL )
+                    if ((xn = X509_NAME_dup(X509_get_subject_name(x))) == NULL )
                         break;
 
 #if !USING_BORINGSSL
@@ -2105,9 +2102,9 @@ static pj_bool_t parse_ossl_asn1_time(pj_time_val *tv, pj_bool_t *gmt,
     pj_parsed_time pt;
     int i;
 
-    utc = tm->type == V_ASN1_UTCTIME;
-    p = (char*)tm->data;
-    len = tm->length;
+    utc = ASN1_STRING_type(tm) == V_ASN1_UTCTIME;
+    p = (char*)ASN1_STRING_get0_data(tm);
+    len = ASN1_STRING_length(tm);
     end = p + len - 1;
 
     /* GMT */

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2103,8 +2103,8 @@ static pj_bool_t parse_ossl_asn1_time(pj_time_val *tv, pj_bool_t *gmt,
     int i;
 
     utc = ASN1_STRING_type(tm) == V_ASN1_UTCTIME;
-    p = (char*)ASN1_STRING_get0_data(tm);
-    len = ASN1_STRING_length(tm);
+    p = (char*)M_ASN1_STRING_data((ASN1_STRING*)tm);
+    len = M_ASN1_STRING_length((ASN1_STRING*)tm);
     end = p + len - 1;
 
     /* GMT */

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2103,8 +2103,8 @@ static pj_bool_t parse_ossl_asn1_time(pj_time_val *tv, pj_bool_t *gmt,
     int i;
 
     utc = ASN1_STRING_type(tm) == V_ASN1_UTCTIME;
-    p = (char*)M_ASN1_STRING_data((ASN1_STRING*)tm);
-    len = M_ASN1_STRING_length((ASN1_STRING*)tm);
+    p = (char*)M_ASN1_STRING_data(tm);
+    len = M_ASN1_STRING_length(tm);
     end = p + len - 1;
 
     /* GMT */


### PR DESCRIPTION
X509_get_subject_name() now returns `const X509_NAME *` in OpenSSL 4.0; inline into X509_NAME_dup() to avoid discarding the const qualifier. Replace direct ASN1_TIME field access (`->type`, `->data`, `->length`) with ASN1_STRING accessor functions.

Fixes build failure reported in Debian bug #1137476 and Ubuntu LP #2154830.