### PR TITLE
pjsua2: Fix SockOpt copy semantics so optVal isn't left aliased

### DIFF
--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -153,6 +153,12 @@ public:
     /** Construct a socket option with the specified parameters. */
     SockOpt(int level, int optName, int optVal);
 
+    /** Copy constructor. */
+    SockOpt(const SockOpt &that);
+
+    /** Copy assignment operator. */
+    SockOpt& operator=(const SockOpt &that);
+
     /**
      * Set option value of type integer.
      *

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -352,6 +352,26 @@ SockOpt::SockOpt(int level, int optName, int optVal)
     setOptValInt(optVal);
 }
 
+SockOpt::SockOpt(const SockOpt &that)
+{
+    *this = that;
+}
+
+SockOpt& SockOpt::operator=(const SockOpt &that)
+{
+    if (this == &that)
+        return *this;
+
+    level = that.level;
+    optName = that.optName;
+    optLen = that.optLen;
+    optValInt = that.optValInt;
+    /* Re-point to our own optValInt if 'that' used its internal buffer. */
+    optVal = (that.optVal == &that.optValInt) ? &optValInt : that.optVal;
+
+    return *this;
+}
+
 void SockOpt::setOptValInt(int opt_val)
 {
     optVal = &optValInt;


### PR DESCRIPTION
## Problem

`SockOpt::optVal` points at the object's own `optValInt` member (set via `setOptValInt()`). The compiler-generated copy constructor and copy assignment do a shallow copy, so a copied `SockOpt`'s `optVal` still points into the **source** object's `optValInt`.

`SockOpt` is stored by value in `SockOptVector` (`std::vector<SockOpt>`), so routine vector operations — growth/reallocation, element copies, temporaries — produce copies whose `optVal` aliases memory that is freed once the source object is destroyed. `SockOptParams::toPj()` then reads `optVal`, which can dereference freed/stale memory.

## Fix

Add a copy constructor and copy assignment operator that re-point `optVal` to the destination's own `optValInt` when the source used its internal buffer, while preserving a `NULL`/external `optVal` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)