### PR TITLE
reject UDP length below header size in pcap reader

### DIFF
--- a/pjlib-util/src/pjlib-util/pcap.c
+++ b/pjlib-util/src/pjlib-util/pcap.c
@@ -364,7 +364,17 @@ PJ_DEF(pj_status_t) pj_pcap_read_udp_with_timestamp(
                 pj_memcpy(udp_hdr, &tmp.udp, sizeof(*udp_hdr));
             }
 
-            /* Calculate payload size */
+            /* Calculate payload size. The UDP length field covers the
+             * header plus payload, so anything below the header size is
+             * malformed; subtracting it would underflow sz and defeat the
+             * buffer check below.
+             */
+            if (pj_ntohs(tmp.udp.len) < sizeof(tmp.udp)) {
+                TRACE_((file->obj_name, "Invalid UDP length %d, skipping",
+                        pj_ntohs(tmp.udp.len)));
+                SKIP_PKT();
+                continue;
+            }
             sz = pj_ntohs(tmp.udp.len) - sizeof(tmp.udp);
             break;
         default:


### PR DESCRIPTION
## Description

In `pj_pcap_read_udp_with_timestamp()` the UDP payload size is taken straight from the packet: `sz = pj_ntohs(tmp.udp.len) - sizeof(tmp.udp)`. The 16-bit UDP length field comes from the pcap file and is never checked against the 8-byte header. When `udp.len` is below 8, the subtraction underflows `sz` (a signed `pj_ssize_t`) to a negative value, which then slips past the `if (sz > *udp_payload_size)` guard and reaches `read_file()`, where `fread(data, 1, (size_t)sz, fd)` reinterprets it as a huge count and writes every remaining file byte into the caller's payload buffer.

Before: a record with `udp.len < 8` produces a negative size that defeats the buffer check and overflows `udp_payload`. After: the length is validated against the header size first, and a malformed record is skipped like the other rejected packets in this switch, so well-formed records read exactly as before. The check sits in the reader because that is where the wire length is turned into a buffer size; callers only see the clamped payload.

## Motivation and Context

A malformed/hostile capture file can corrupt memory past the supplied buffer when read through this API.

## How Has This Been Tested?

Built pjlib-util with `-fsanitize=address` and parsed a crafted pcap whose single UDP record has `udp.len = 4` followed by 200 payload bytes, read into an 8-byte buffer.

- Before: `AddressSanitizer: heap-buffer-overflow WRITE of size 200` in `fread` via `pcap.c:385`.
- After: the record is skipped and a valid record in the same file still reads its full payload correctly; ASan is clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.