### PR TITLE
Properly close FFmpeg codec context

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1271,12 +1271,17 @@ static void print_ffmpeg_err(int err)
 
 static void free_codec_context(AVCodecContext **ctx, pj_bool_t opened)
 {
+#if LIBAVCODEC_VER_AT_LEAST(60,39)
+    PJ_UNUSED_ARG(opened);
+    avcodec_free_context(ctx);
+#else
     if (!*ctx)
         return;
     if (opened)
         avcodec_close(*ctx);
     av_free(*ctx);
     *ctx = NULL;
+#endif
 }
 
 static pj_status_t open_ffmpeg_codec(ffmpeg_private *ff,

--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -1269,6 +1269,16 @@ static void print_ffmpeg_err(int err)
 
 }
 
+static void free_codec_context(AVCodecContext **ctx, pj_bool_t opened)
+{
+    if (!*ctx)
+        return;
+    if (opened)
+        avcodec_close(*ctx);
+    av_free(*ctx);
+    *ctx = NULL;
+}
+
 static pj_status_t open_ffmpeg_codec(ffmpeg_private *ff,
                                      pj_mutex_t *ff_mutex)
 {
@@ -1395,18 +1405,8 @@ static pj_status_t open_ffmpeg_codec(ffmpeg_private *ff,
     return PJ_SUCCESS;
 
 on_error:
-    if (ff->enc_ctx) {
-        if (enc_opened)
-            avcodec_close(ff->enc_ctx);
-        av_free(ff->enc_ctx);
-        ff->enc_ctx = NULL;
-    }
-    if (ff->dec_ctx) {
-        if (dec_opened)
-            avcodec_close(ff->dec_ctx);
-        av_free(ff->dec_ctx);
-        ff->dec_ctx = NULL;
-    }
+    free_codec_context(&ff->enc_ctx, enc_opened);
+    free_codec_context(&ff->dec_ctx, dec_opened);
     return status;
 }
 
@@ -1498,16 +1498,8 @@ static pj_status_t ffmpeg_codec_close( pjmedia_vid_codec *codec )
     ff_mutex = ((struct ffmpeg_factory*)codec->factory)->mutex;
 
     pj_mutex_lock(ff_mutex);
-    if (ff->enc_ctx) {
-        avcodec_close(ff->enc_ctx);
-        av_free(ff->enc_ctx);
-    }
-    if (ff->dec_ctx && ff->dec_ctx!=ff->enc_ctx) {
-        avcodec_close(ff->dec_ctx);
-        av_free(ff->dec_ctx);
-    }
-    ff->enc_ctx = NULL;
-    ff->dec_ctx = NULL;
+    free_codec_context(&ff->enc_ctx, PJ_TRUE);
+    free_codec_context(&ff->dec_ctx, PJ_TRUE);
     pj_mutex_unlock(ff_mutex);
 
     return PJ_SUCCESS;

--- a/pjmedia/src/pjmedia/ffmpeg_util.h
+++ b/pjmedia/src/pjmedia/ffmpeg_util.h
@@ -57,10 +57,6 @@
                                               (LIBAVUTIL_VERSION_MAJOR == major && \
                                                LIBAVUTIL_VERSION_MINOR >= minor))
 
-#if LIBAVCODEC_VER_AT_LEAST(60,39)
-#   define avcodec_close(x)     ((void)0)
-#endif
-
 void pjmedia_ffmpeg_add_ref();
 void pjmedia_ffmpeg_dec_ref();
 


### PR DESCRIPTION
This PR prevents leaking memory, threads and other resources when closing a video stream with libavcodec 60.39 or newer, thus fixing a regression in commit 0369f2c2fcb38be64252a56e81d5308e436112c2.