### PR TITLE
bound pjstun_parse_msg header and attribute reads to buffer size

### DIFF
--- a/pjlib-util/src/pjlib-util/stun_simple.c
+++ b/pjlib-util/src/pjlib-util/stun_simple.c
@@ -57,6 +57,16 @@ PJ_DEF(pj_status_t) pjstun_parse_msg( void *buf, pj_size_t buf_len,
 
     PJ_CHECK_STACK();
 
+    /* The buffer must hold a full message header before any header field
+     * is read, otherwise the type/length reads below (and the buf_len
+     * subtraction) run past the end of the buffer.
+     */
+    if (buf_len < sizeof(pjstun_msg_hdr)) {
+        PJ_LOG(4,(THIS_FILE, "Error: STUN message too short (%lu bytes)",
+                             (unsigned long)buf_len));
+        return PJLIB_UTIL_ESTUNINMSGLEN;
+    }
+
     msg->hdr = (pjstun_msg_hdr*)buf;
     msg_type = pj_ntohs(msg->hdr->type);
 
@@ -84,7 +94,9 @@ PJ_DEF(pj_status_t) pjstun_parse_msg( void *buf, pj_size_t buf_len,
     msg->attr_count = 0;
     p_attr = (char*)buf + sizeof(pjstun_msg_hdr);
 
-    while (msg_len > 0 && msg->attr_count < attr_max_cnt) {
+    while (msg_len >= sizeof(pjstun_attr_hdr) &&
+           msg->attr_count < attr_max_cnt)
+    {
         pjstun_attr_hdr **attr = &msg->attr[msg->attr_count];
         pj_uint32_t len;
         pj_uint16_t attr_type;


### PR DESCRIPTION
## Description

`pjstun_parse_msg()` reads the 16-bit length field of each attribute, and of the message header, before checking the buffer is large enough to hold it. The attribute loop runs while `msg_len > 0`, so a binding response whose declared length leaves one to three trailing bytes drives the loop into a four-byte attribute header and reads its length field (offset 2) past the end of the buffer. The header path has the same shape: `type` and `length` are read, and `buf_len - sizeof(pjstun_msg_hdr)` is computed, before `buf_len` is known to cover the 20-byte header.

Before: a STUN response shorter than a header, or one whose trailing bytes cannot form an attribute, reads out of bounds. After: a full message header is required up front, and the attribute loop stops once fewer than `sizeof(pjstun_attr_hdr)` bytes remain, so a well-formed response parses exactly as before and a truncated tail is skipped. The bound belongs in the parser because that is where the wire length is turned into reads, and the response arrives straight off the socket from a possibly spoofed server. It mirrors the guard the modern parser already uses (`while (pdu_len >= ATTR_HDR_LEN)` in `stun_msg.c`). Tradeoff: one to three trailing bytes that used to return `ESTUNINATTRLEN` now return success with those bytes ignored.

## Motivation and Context

A short or hostile STUN response read through this public API can read past the supplied buffer. The bytes come from the network, so the length fields are attacker controlled.

## How Has This Been Tested?

Built pjlib-util with `-fsanitize=address` and called `pjstun_parse_msg()` with exact-size heap buffers.

- Before: `AddressSanitizer: heap-buffer-overflow READ of size 2` at `stun_simple.c:93`, 0 bytes after a 22-byte buffer (attribute length read); the same shape on a 3-byte buffer (header length read).
- After: the short buffer returns `ESTUNINMSGLEN`, the truncated-attribute buffer returns success with no attributes, and ASan is clean.

Existing pjlib-util tests (`stun_test`, `xml_test`, `json_test`, `encryption_test`) pass under ASan.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
