### PR TITLE
pjsua2: fix AudioMediaPlayer use-after-free on async EOF callback

### DIFF
--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -80,9 +80,10 @@ struct file_reader_port
 };
 
 
-static pj_status_t file_get_frame(pjmedia_port *this_port, 
+static pj_status_t file_get_frame(pjmedia_port *this_port,
                                   pjmedia_frame *frame);
 static pj_status_t file_on_destroy(pjmedia_port *this_port);
+static pj_status_t file_on_event(pjmedia_event *event, void *user_data);
 
 static struct file_reader_port *create_file_port(pj_pool_t *pool)
 {
@@ -740,6 +741,19 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_set_eof_cb2(pjmedia_port *port,
     PJ_ASSERT_RETURN(port->info.signature == SIGNATURE, -PJ_EINVALIDOP);
 
     fport = (struct file_reader_port*) port;
+
+    /* On clear, synchronously unsubscribe so a pending EOF event can't dispatch
+     * cb2 against a freed owner; unsubscribe drains any in-flight callback via
+     * the event mgr cb_mutex. Unconditional (unsubscribe is idempotent and
+     * always drains): the subscribed flag is set on the media thread without a
+     * lock, so a stale read here could otherwise skip the drain. Clear cb2
+     * first so a concurrent file_get_frame() EOF can't re-arm the subscription.
+     */
+    if (!cb) {
+        fport->cb2 = NULL;
+        pjmedia_event_unsubscribe(NULL, &file_on_event, fport, fport);
+        fport->subscribed = PJ_FALSE;
+    }
 
     fport->base.port_data.pdata = user_data;
     fport->cb2 = cb;

--- a/pjmedia/src/pjmedia/wav_playlist.c
+++ b/pjmedia/src/pjmedia/wav_playlist.c
@@ -759,6 +759,14 @@ PJ_DEF(pj_status_t) pjmedia_wav_playlist_set_eof_cb2(pjmedia_port *port,
 
     fport = (struct playlist_port*) port;
 
+    /* See pjmedia_wav_player_set_eof_cb2(): unconditionally drain EOF
+     * subscription on clear (unsubscribe is idempotent and always drains). */
+    if (!cb) {
+        fport->cb2 = NULL;
+        pjmedia_event_unsubscribe(NULL, &file_on_event, fport, fport);
+        fport->subscribed = PJ_FALSE;
+    }
+
     fport->base.port_data.pdata = user_data;
     fport->cb2 = cb;
 

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -795,6 +795,12 @@ public:
     /**
      * Destructor. This will unregister the player port from the conference
      * bridge.
+     *
+     * To prevent a use-after-free, the destructor synchronously cancels the
+     * EOF callback, blocking until any in-flight onEof2() on the media event
+     * worker thread returns. Destroying from inside onEof2() is safe (the event
+     * lock is recursive), but destroying from another thread while holding a
+     * lock that onEof2() also takes can deadlock; avoid that.
      */
     virtual ~AudioMediaPlayer();
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -601,6 +601,17 @@ AudioMediaPlayer::AudioMediaPlayer()
 AudioMediaPlayer::~AudioMediaPlayer()
 {
     if (playerId != PJSUA_INVALID_ID) {
+        /* Cancel the EOF callback synchronously while still alive: port destroy
+         * is async, so the subscription would otherwise fire eof_cb() on freed
+         * memory.
+         */
+        pjmedia_port *port;
+        if (pjsua_player_get_port(playerId, &port) == PJ_SUCCESS) {
+            if (port->info.signature == PJMEDIA_SIG_PORT_WAV_PLAYER)
+                pjmedia_wav_player_set_eof_cb2(port, NULL, NULL);
+            else if (port->info.signature == PJMEDIA_SIG_PORT_WAV_PLAYLIST)
+                pjmedia_wav_playlist_set_eof_cb2(port, NULL, NULL);
+        }
         PJSUA2_CATCH_IGNORE( unregisterMediaPort() );
         pjsua_player_destroy(playerId);
     }


### PR DESCRIPTION
## Problem

Destroying an `AudioMediaPlayer` (e.g. mid-playback, or shortly after it reaches EOF) can crash with a SIGSEGV in `eof_cb()` running on a freed object. The faulting address differs on every crash — it's a jump through a freed vtable — but the stack is always:

```
#0  <freed>
#1  libpjsua2   AudioMediaPlayer::eof_cb()         media.cpp
#2  libpjmedia  file_on_event()                    wav_player.c
#3  libpjmedia  event_mgr_distribute_events()      event.c
#4  libpjmedia  event_worker_thread()              event.c
```

## Root cause

At EOF, `file_get_frame()` publishes an async `PJMEDIA_EVENT_CALLBACK`. It is dispatched later, on the pjmedia **event-worker thread**, via `file_on_event()` → `cb2` (= `AudioMediaPlayer::eof_cb`, with `usr_data = this`).

`~AudioMediaPlayer()` → `pjsua_player_destroy()` → `pjmedia_port_destroy()` only does `pjmedia_port_dec_ref()` on the port's group lock. The conference bridge still holds a reference and removes the port **asynchronously**, so `file_on_destroy()` — and the `pjmedia_event_unsubscribe()` inside it — run long after the C++ object has been freed. A queued/in-flight EOF event then dereferences freed memory.

## Fix

Cancel the subscription synchronously, while the object is still alive. Clearing the EOF callback via `pjmedia_wav_player_set_eof_cb2(port, NULL, NULL)` now unsubscribes from the media event; `pjmedia_event_unsubscribe()` blocks on the event manager's `cb_mutex` until any in-flight callback has drained, and prevents future dispatch. `~AudioMediaPlayer()` calls it before teardown (the port is still alive at that point — only its destroy is async).

Details:
- `cb2` is cleared **before** the unsubscribe, so a concurrent `file_get_frame()` at EOF (the port is still on the bridge) can't take the re-subscribe path and re-arm in the gap.
- `cb_mutex` is recursive, so destroying from inside `onEof2()` is safe. Destroying from another thread while holding a lock that `onEof2()` also acquires can deadlock (lock-order inversion) — documented on the destructor.
- Applies to both `wav_player.c` and `wav_playlist.c`.

