### PR TITLE
Fix video stripes after camera switch on iOS with portrait angle fix

### DIFF
--- a/pjmedia/src/pjmedia-videodev/android_dev.c
+++ b/pjmedia/src/pjmedia-videodev/android_dev.c
@@ -969,7 +969,6 @@ static pj_status_t and_stream_set_cap(pjmedia_vid_dev_stream *s,
 
             /* Ok, let's do the switch */
             adi = &strm->factory->dev_info[p->target_id];
-            PJ_LOG(4, (THIS_FILE, "Switching camera to %s..", adi->info.name));
 
             /* Call PjCamera::Start() method */
             with_attach = jni_get_env(&jni_env);

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -1187,11 +1187,27 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
                      deviceInputWithDevice:di[p->target_id].dev
                      error:&error];
 
+            if (!new_dev_input) {
+                PJ_LOG(3, (THIS_FILE,
+                           "Failed to create capture device input: %s",
+                           error? [error.localizedDescription
+                                   UTF8String] : "unknown"));
+                return PJ_EUNKNOWN;
+            }
+
             [strm->cap_session beginConfiguration];
             [strm->cap_session removeInput:cur_dev_input];
+            if (![strm->cap_session canAddInput:new_dev_input]) {
+                /* Restore previous input on failure */
+                [strm->cap_session addInput:cur_dev_input];
+                [strm->cap_session commitConfiguration];
+                PJ_LOG(3, (THIS_FILE, "Session cannot accept "
+                           "new capture device input"));
+                return PJ_EUNKNOWN;
+            }
             [strm->cap_session addInput:new_dev_input];
             [strm->cap_session commitConfiguration];
-            
+
             strm->dev_input = new_dev_input;
             strm->param.cap_id = p->target_id;
             strm->cam_portrait_angle = -1;
@@ -1199,7 +1215,7 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
             /* Set the orientation as well */
             darwin_stream_set_cap(s, PJMEDIA_VID_DEV_CAP_ORIENTATION,
                                &strm->param.orient);
-            
+
             return PJ_SUCCESS;
         }
         

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -1194,7 +1194,8 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
             
             strm->dev_input = new_dev_input;
             strm->param.cap_id = p->target_id;
-            
+            strm->cam_portrait_angle = -1;
+
             /* Set the orientation as well */
             darwin_stream_set_cap(s, PJMEDIA_VID_DEV_CAP_ORIENTATION,
                                &strm->param.orient);

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -1340,6 +1340,7 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
                 const CGFloat cap_ori[4] = { 0, 90, 180, 270};
                 int idx;
                 int rotation;
+                int effective_portrait_angle;
 
                 if (strm->param.orient < PJMEDIA_ORIENT_NATURAL ||
                     strm->param.orient > PJMEDIA_ORIENT_ROTATE_270DEG)
@@ -1362,6 +1363,7 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
                  *                   180=upsidedown, 270=LandscapeLeft
                  * rotation = (cam_portrait_angle - 90 + cap_ori[idx]) % 360
                  */
+                effective_portrait_angle = -1;
                 if (strm->cam_portrait_angle < 0) {
                     AVCaptureDeviceRotationCoordinator *coord =
                         [[AVCaptureDeviceRotationCoordinator alloc]
@@ -1386,18 +1388,34 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
                             device_tilt = -1; break;
                         }
 
+                        PJ_LOG(3, (THIS_FILE,
+                                   "Detected orientation, "
+                                   "UIDeviceOrientation=%d, coord_angle=%d, "
+                                   "device_tilt=%d",
+                                   (int)[UIDevice currentDevice].orientation,
+                                   coord_angle, device_tilt));
+
                         if (device_tilt >= 0) {
                             strm->cam_portrait_angle =
                                 (coord_angle + device_tilt) % 360;
+                        } else {
+                            /* Orientation unknown (face-up/down); use
+                             * coordinator's angle as best-effort — it
+                             * reflects the last known non-face orientation.
+                             * Do not cache: cam_portrait_angle stays -1 so
+                             * it is recomputed when orientation is known. */
+                            effective_portrait_angle = coord_angle;
                         }
                     }
                 }
+                if (strm->cam_portrait_angle >= 0)
+                    effective_portrait_angle = strm->cam_portrait_angle;
 
-                if (strm->cam_portrait_angle >= 0) {
-                    rotation = (strm->cam_portrait_angle - 90 +
+                if (effective_portrait_angle >= 0) {
+                    rotation = (effective_portrait_angle - 90 +
                                 (int)cap_ori[idx] + 360) % 360;
                 } else {
-                    /* Device orientation unknown; fall back to conventional. */
+                    /* Coordinator unavailable; fall back to conventional. */
                     rotation = (int)cap_ori[idx];
                 }
 #else

--- a/pjmedia/src/pjmedia/videodev.c
+++ b/pjmedia/src/pjmedia/videodev.c
@@ -627,6 +627,7 @@ PJ_DEF(pj_status_t) pjmedia_vid_dev_stream_set_cap(
      */
     if (cap == PJMEDIA_VID_DEV_CAP_SWITCH) {
         pjmedia_vid_dev_factory *f;
+        pjmedia_vid_dev_info dev_info;
         unsigned local_idx;
         pj_status_t status;
         pjmedia_vid_dev_switch_param p = *(pjmedia_vid_dev_switch_param*)value;
@@ -638,6 +639,9 @@ PJ_DEF(pj_status_t) pjmedia_vid_dev_stream_set_cap(
         /* Make sure that current & target devices share the same factory */
         if (f->sys.drv_idx != strm->sys.drv_idx)
             return PJMEDIA_EVID_INVDEV;
+
+        if (f->op->get_dev_info(f, local_idx, &dev_info) == PJ_SUCCESS)
+            PJ_LOG(4, (THIS_FILE, "Switching camera to %s..", dev_info.name));
 
         p.target_id = local_idx;
         return strm->op->set_cap(strm, cap, &p);


### PR DESCRIPTION
Continuing #5017.

When switching cameras via `PJMEDIA_VID_DEV_CAP_SWITCH`, `cam_portrait_angle` was not reset, causing the new camera's rotation to be computed using the stale angle calibrated for the previous camera. Reset it to -1 so it is recalibrated against the new device on the next orientation set.