### PR TITLE
pjsua: propagate --rtcp-mux to local transport accounts

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1965,6 +1965,7 @@ static pj_status_t app_init(void)
             app_config_init_video(&acc_cfg);
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
+            acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
             pjsua_acc_modify(aid, &acc_cfg);
         }
 
@@ -2010,6 +2011,7 @@ static pj_status_t app_init(void)
             app_config_init_video(&acc_cfg);
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
+            acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
             // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
             pjsua_acc_modify(aid, &acc_cfg);
         }
@@ -2046,6 +2048,7 @@ static pj_status_t app_init(void)
             app_config_init_video(&acc_cfg);
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
+            acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
             pjsua_acc_modify(aid, &acc_cfg);
         }
 
@@ -2077,6 +2080,7 @@ static pj_status_t app_init(void)
             app_config_init_video(&acc_cfg);
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
+            acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
             // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
             pjsua_acc_modify(aid, &acc_cfg);
         }
@@ -2117,6 +2121,7 @@ static pj_status_t app_init(void)
             app_config_init_video(&acc_cfg);
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
+            acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
             pjsua_acc_modify(acc_id, &acc_cfg);
         }
 
@@ -2147,6 +2152,7 @@ static pj_status_t app_init(void)
             app_config_init_video(&acc_cfg);
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
+            acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
             // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
             pjsua_acc_modify(aid, &acc_cfg);
         }

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -85,6 +85,7 @@ typedef struct pjsua_app_config
     pj_bool_t               keep_call_on_tsx_fail;
     pjsua_transport_config  udp_cfg;
     pjsua_transport_config  rtp_cfg;
+    pj_bool_t               enable_rtcp_mux;
     pjsip_redirect_op       redir_op;
     int                     srtp_keying;
 

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1250,6 +1250,7 @@ static pj_status_t parse_args(int argc, char *argv[],
 
         case OPT_RTCP_MUX:
             cur_acc->enable_rtcp_mux = PJ_TRUE;
+            cfg->enable_rtcp_mux = PJ_TRUE;
             break;
 
 #if defined(PJMEDIA_HAS_SRTP) && (PJMEDIA_HAS_SRTP != 0)
@@ -1823,6 +1824,7 @@ static void default_config()
     cfg->udp_cfg.port = 5060;
     pjsua_transport_config_default(&cfg->rtp_cfg);
     cfg->rtp_cfg.port = 4000;
+    cfg->enable_rtcp_mux = PJ_FALSE;
     cfg->redir_op = PJSIP_REDIRECT_ACCEPT_REPLACE;
     cfg->duration = PJSUA_APP_NO_LIMIT_DURATION;
     cfg->wav_id = PJSUA_INVALID_ID;
@@ -2231,6 +2233,11 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
     }
     if (config->enable_qos) {
         pj_strcat2(&cfg, "--set-qos\n");
+    }
+    /* When there are no registered accounts, --rtcp-mux is not written by
+     * write_account_settings(), so emit it here from the global flag. */
+    if (config->acc_cnt == 0 && config->enable_rtcp_mux) {
+        pj_strcat2(&cfg, "--rtcp-mux\n");
     }
 
     /* Message Composition Indication */


### PR DESCRIPTION
When `--rtcp-mux` is specified, it was only written to `cur_acc->enable_rtcp_mux`, which covers registered SIP accounts. Local transport accounts (UDP, UDP6, TCP, TCP6, TLS, TLS6) are created via `pjsua_acc_add_local()` and then updated with selective field overrides; enable_rtcp_mux was never included in those overrides, so RTCP multiplexing was silently ignored for those accounts.

Fix by adding `enable_rtcp_mux` as a global field on `pjsua_app_config` (alongside `rtp_cfg`), setting it in `OPT_RTCP_MUX` parsing, and propagating it to each local transport account in `app_init()`.