### PR TITLE
pjmedia/wav_player: fix uninitialized fmt header and signed-shift UB

### DIFF
--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -326,6 +326,12 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool_,
         goto on_error;
 
 
+    /* Zero the header first: it is read and byte-swapped in stages, and
+     * pjmedia_wave_hdr_file_to_host() swaps the whole struct (including
+     * data_hdr) before all fields have been read from the file.
+     */
+    pj_bzero(&wave_hdr, sizeof(wave_hdr));
+
     /* Read the RIFF file header only. */
     size_to_read = size_read = sizeof(wave_hdr.riff_hdr);
     status = pj_file_read( fport->fd, &wave_hdr, &size_read);

--- a/pjmedia/src/pjmedia/wav_player.c
+++ b/pjmedia/src/pjmedia/wav_player.c
@@ -212,7 +212,8 @@ static pj_status_t read_wav_until(struct file_reader_port *fport,
             pj_uint32_t sig = subchunk.id;
             pj_off_t fpos;
             pj_file_getpos(fport->fd, &fpos);
-            if ((sig & (0xFF << 24)) && (sig & (0xFF << 16)) && (sig & (0xFF << 8)) && (sig & (0xFF << 0)))
+            if ((sig & 0xFF000000) && (sig & 0x00FF0000) &&
+                (sig & 0x0000FF00) && (sig & 0x000000FF))
             {
                 PJ_LOG(2, (THIS_FILE,
                            "%.*s. Zero length chunk of type %s found at offset=%lu (read_wav_until)",
@@ -366,10 +367,18 @@ PJ_DEF(pj_status_t) pjmedia_wav_player_port_create( pj_pool_t *pool_,
     pj_memcpy(&wave_hdr.fmt_hdr, &chunk, sizeof(chunk));
 
     /* Read the rest of `fmt ` chunk. */
-    size_read = sizeof(wave_hdr.fmt_hdr) - sizeof(chunk);
+    size_to_read = size_read = sizeof(wave_hdr.fmt_hdr) - sizeof(chunk);
     status = pj_file_read(fport->fd, &wave_hdr.fmt_hdr.fmt_tag, &size_read);
     if (status != PJ_SUCCESS) {
         pj_file_close(fport->fd);
+        goto on_error;
+    }
+    if (size_read != size_to_read) {
+        /* File truncated within the `fmt ` chunk; the remaining fmt header
+         * fields would be left uninitialized.
+         */
+        pj_file_close(fport->fd);
+        status = PJMEDIA_EWAVETOOSHORT;
         goto on_error;
     }
 


### PR DESCRIPTION
## Problem

The WAV/AVI container fuzz harness added in #5008 (CIFuzz) surfaces two latent bugs in `pjmedia_wav_player_port_create()` (`pjmedia/src/pjmedia/wav_player.c`). Both are reachable from a fully attacker-controlled file header and were reported by the MemorySanitizer and UndefinedBehaviorSanitizer CIFuzz jobs.

### 1. MSan — use-of-uninitialized-value (`wav_player.c:379`)

When the file ends right after the 8-byte `fmt ` subchunk header, the read of the rest of the `fmt ` chunk returns `PJ_SUCCESS` with a short count. The remaining fmt header fields (`fmt_tag`, `bits_per_sample`, `block_align`, ...) are left uninitialized on the stack and then read in the format-validation `switch`.

```
SUMMARY: MemorySanitizer: use-of-uninitialized-value wav_player.c:379:5 in pjmedia_wav_player_port_create
  Uninitialized value was created by an allocation of 'wave_hdr' in the stack frame (wav_player.c:257)
```

### 2. UBSan — signed left-shift overflow (`wav_player.c:214`)

In `read_wav_until()`, the FOURCC printable-check used `0xFF << 24`. `0xFF` is a signed `int` (255) and `255 << 24` overflows the sign bit of a 32-bit `int`.

```
wav_player.c: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior in pjmedia_wav_player_port_create
```

Both bugs pre-date the harness (introduced in #3928 and #4545 respectively); the new fuzz target is simply the first thing to exercise these paths.

## Fix

- Add a short-read length check after reading the rest of the `fmt ` chunk (`size_read != size_to_read` → `PJMEDIA_EWAVETOOSHORT`), mirroring the existing RIFF-header check.
- Replace the signed `0xFF << N` masks with unsigned hex literals (`0xFF000000` ... `0x000000FF`).

## Validation

Reproduced the CIFuzz build locally (OSS-Fuzz `pjsip` recipe: `PJMEDIA_HAS_VIDEO=1`, same `--disable-*` flags) and ran the `fuzz-wav` target (WAV + AVI) under clang sanitizers:

| Sanitizer | Runs | Result |
| --- | --- | --- |
| ASan | ~2.0M | clean — no memory-corruption bug |
| UBSan | ~1.0M | clean — no UB |

The UBSan fix was additionally confirmed by A/B reproduction: reverting just the shift change reproduces the exact `left shift of 255 by 24 places` error; restoring it makes the same input pass.