### PR TITLE
pjsua: fix spurious TCP/TLS connection on incoming/outgoing call and incoming SUBSCRIBE

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2086,24 +2086,40 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
     {
         /* Choose local interface to use in Via if acc is not using
          * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1804
+         * Skip if the caller's Contact resolves to a reliable (TCP/TLS)
+         * transport: pjsua_acc_get_uac_addr() would open a spurious outbound
+         * connection to the Contact when contact_use_src_port is enabled.
          */
-        char target_buf[PJSIP_MAX_URL_SIZE];
-        pj_str_t target;
-        pjsip_host_port via_addr;
-        const void *via_tp;
-
-        target.ptr = target_buf;
-        target.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
-                                      dlg->target,
-                                      target_buf, sizeof(target_buf));
-        if (target.slen < 0) target.slen = 0;
-
-        if (pjsua_acc_get_uac_addr(acc_id, dlg->pool, &target,
-                                   &via_addr, NULL, NULL,
-                                   &via_tp) == PJ_SUCCESS)
         {
-            pjsip_dlg_set_via_sent_by(dlg, &via_addr,
-                                      (pjsip_transport*)via_tp);
+            char target_buf[PJSIP_MAX_URL_SIZE];
+            pj_str_t target;
+            pjsip_host_port via_addr;
+            const void *via_tp;
+            pjsip_host_info dest_info;
+            pj_bool_t reliable_dest = PJ_FALSE;
+
+            if (pjsip_get_dest_info((const pjsip_uri*)dlg->target, NULL,
+                                    dlg->pool, &dest_info) == PJ_SUCCESS)
+            {
+                reliable_dest = (dest_info.flag & PJSIP_TRANSPORT_RELIABLE)
+                                != 0;
+            }
+
+            if (!reliable_dest) {
+                target.ptr = target_buf;
+                target.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
+                                              dlg->target,
+                                              target_buf, sizeof(target_buf));
+                if (target.slen < 0) target.slen = 0;
+
+                if (pjsua_acc_get_uac_addr(acc_id, dlg->pool, &target,
+                                           &via_addr, NULL, NULL,
+                                           &via_tp) == PJ_SUCCESS)
+                {
+                    pjsip_dlg_set_via_sent_by(dlg, &via_addr,
+                                              (pjsip_transport*)via_tp);
+                }
+            }
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -2086,9 +2086,9 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
     {
         /* Choose local interface to use in Via if acc is not using
          * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1804
-         * Skip if the caller's Contact resolves to a reliable (TCP/TLS)
-         * transport: pjsua_acc_get_uac_addr() would open a spurious outbound
-         * connection to the Contact when contact_use_src_port is enabled.
+         * Skip if the caller's Contact resolves to a reliable transport
+         * (e.g., TCP/TLS): pjsua_acc_get_uac_addr() would open a spurious
+         * outbound connection to the Contact when contact_use_src_port is enabled.
          */
         {
             char target_buf[PJSIP_MAX_URL_SIZE];

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -765,11 +765,25 @@ static void dlg_set_via(pjsip_dialog *dlg, pjsua_acc *acc)
     {
         /* Choose local interface to use in Via if acc is not using
          * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1804
+         * Skip if the outgoing target resolves to a reliable transport
+         * (e.g., TCP/TLS): pjsua_acc_get_uac_addr() would open a spurious
+         * outbound connection when contact_use_src_port is enabled, while
+         * the Via is correctly resolved when the request is actually sent
+         * over the real outbound connection.
          */
         pjsip_host_port via_addr;
         const void *via_tp;
+        pjsip_host_info dest_info;
+        pj_bool_t reliable_dest = PJ_FALSE;
 
-        if (pjsua_acc_get_uac_addr(acc->index, dlg->pool, &acc->cfg.id,
+        if (pjsip_get_dest_info((const pjsip_uri*)dlg->target, NULL,
+                                dlg->pool, &dest_info) == PJ_SUCCESS)
+        {
+            reliable_dest = (dest_info.flag & PJSIP_TRANSPORT_RELIABLE) != 0;
+        }
+
+        if (!reliable_dest &&
+            pjsua_acc_get_uac_addr(acc->index, dlg->pool, &acc->cfg.id,
                                    &via_addr, NULL, NULL,
                                    &via_tp) == PJ_SUCCESS)
         {

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -1068,24 +1068,38 @@ static pj_bool_t pres_on_rx_request(pjsip_rx_data *rdata)
     {
         /* Choose local interface to use in Via if acc is not using
          * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1412
+         * Skip if the subscriber's Contact resolves to a reliable transport
+         * (e.g., TCP/TLS): pjsua_acc_get_uac_addr() would open a spurious
+         * outbound connection to the Contact when contact_use_src_port is
+         * enabled.
          */
         char target_buf[PJSIP_MAX_URL_SIZE];
         pj_str_t target;
         pjsip_host_port via_addr;
         const void *via_tp;
+        pjsip_host_info dest_info;
+        pj_bool_t reliable_dest = PJ_FALSE;
 
-        target.ptr = target_buf;
-        target.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
-                                      dlg->target,
-                                      target_buf, sizeof(target_buf));
-        if (target.slen < 0) target.slen = 0;
-
-        if (pjsua_acc_get_uac_addr(acc_id, dlg->pool, &target,
-                                   &via_addr, NULL, NULL,
-                                   &via_tp) == PJ_SUCCESS)
+        if (pjsip_get_dest_info((const pjsip_uri*)dlg->target, NULL,
+                                dlg->pool, &dest_info) == PJ_SUCCESS)
         {
-            pjsip_dlg_set_via_sent_by(dlg, &via_addr,
-                                      (pjsip_transport*)via_tp);
+            reliable_dest = (dest_info.flag & PJSIP_TRANSPORT_RELIABLE) != 0;
+        }
+
+        if (!reliable_dest) {
+            target.ptr = target_buf;
+            target.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
+                                          dlg->target,
+                                          target_buf, sizeof(target_buf));
+            if (target.slen < 0) target.slen = 0;
+
+            if (pjsua_acc_get_uac_addr(acc_id, dlg->pool, &target,
+                                       &via_addr, NULL, NULL,
+                                       &via_tp) == PJ_SUCCESS)
+            {
+                pjsip_dlg_set_via_sent_by(dlg, &via_addr,
+                                          (pjsip_transport*)via_tp);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

When an account has `contact_use_src_port` enabled, `pjsua_acc_get_uac_addr()` calls `pjsip_endpt_acquire_transport2()` to discover the kernel-assigned source port for the local Via address. For a reliable (TCP/TLS) target this opens a **real outbound connection** purely to read that port — a connection that is never used for any SIP message and lingers until the idle timer reaps it.

This spurious connection is opened from three places that determine the local Via `sent-by` when the account is **not** using STUN/UPnP:

1. **`pjsua_call_on_incoming()`** — incoming call (UAS). Probes the caller's Contact; responses and in-dialog requests reuse the inbound connection, so the probe is never needed.
2. **`dlg_set_via()`** — outgoing call (UAC). Probes the account id URI (`acc->cfg.id`), which points at the local listener / registrar rather than the callee, producing a spurious (often loopback) connection on every outbound call.
3. **`pres_on_rx_request()`** — incoming SUBSCRIBE (UAS). Same pattern as the incoming call: NOTIFYs and responses reuse the inbound connection.

## Fix

Skip the `pjsua_acc_get_uac_addr()` call when the dialog target resolves to a reliable (TCP/TLS) transport, using `pjsip_get_dest_info(dlg->target)`. For UDP the behavior is unchanged, so the STUN-opt-out Via selection of #1804 / #1412 is preserved.

## Sample scenario (incoming call)

1. UAC calls UAS over TCP with `contact_use_src_port` enabled.
2. INVITE arrives at UAS on the existing inbound TCP connection.
3. `pjsua_call_on_incoming()` tries to determine the local Via address by calling `pjsua_acc_get_uac_addr()` with `dlg->target` (the caller's Contact, e.g. `sip:caller@192.168.1.100:5080;transport=tcp`).
4. Because `contact_use_src_port` is set, `pjsua_acc_get_uac_addr()` calls `pjsip_endpt_acquire_transport2()` toward `192.168.1.100:5080` — opening a **new outbound TCP connection** to the caller.
5. This spurious connection is registered in the transport hash but never used for any SIP message.

The outgoing-call case is analogous, except the probe is aimed at `acc->cfg.id` (the local listener / registrar), so the wasted connection is typically a **loopback** connection created on every `pjsua_call_make_call()` over TCP/TLS.

## Why the fix does not affect the Via header or outgoing requests

`pjsip_dlg_set_via_sent_by()` stores an address in `dlg->via_addr`, which is later copied to `tdata->via_addr` in `pjsip_dlg_send_request()`. When the message is serialized, `via->sent_by` is set from `tdata->via_addr` **only if** `tdata->via_tp` matches the transport actually used to send (`cur_transport`). Otherwise it falls back to `cur_transport->local_name`.

For TCP/TLS, `pjsua_acc_get_uac_addr()` acquires transport T toward the target and returns `T->local_name` as `via_addr`. At send time:

- If T == `cur_transport`: override applies, but `tdata->via_addr == T->local_name == cur_transport->local_name` — identical result.
- If T != `cur_transport` (e.g. request goes through a proxy): override is ignored, `via->sent_by = cur_transport->local_name`.

In both cases the Via `sent-by` value is the same as without the override. Skipping the call produces no change in the outgoing Via header — a reliable transport never carries a STUN-mapped address, so `cur_transport->local_name` is always the correct local address.

For responses (180, 200 OK, etc.), `dlg->via_addr` has no effect at all — `pjsip_endpt_create_response()` copies Via headers verbatim from the incoming request.

## Notes

- The skip decision keys off the actual message transport (`dlg->target`). Making it fully route-set-aware (using the incoming Record-Route / dialog route set for the UAS sites, or the account route-set first entry for the UAC site) is a separate, UDP-only refinement and is intentionally out of scope here.
