### PR TITLE
pjsua: fix server affinity bugs for UDP/TLS/TCP accounts

### DIFF
--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1459,6 +1459,7 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request_stateless(pjsip_endpoint *endpt,
 {
     pjsip_host_info dest_info;
     pjsip_send_state *stateless_data;
+    pj_bool_t tp_pinned = PJ_FALSE;
     pj_status_t status;
 
     PJ_ASSERT_RETURN(endpt && tdata, PJ_EINVAL);
@@ -1474,6 +1475,47 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request_stateless(pjsip_endpoint *endpt,
     stateless_data->endpt = endpt;
     stateless_data->tdata = tdata;
     stateless_data->app_cb = cb;
+
+    /* If the caller selected a specific, connected reliable transport
+     * (e.g. server affinity, #4964), the message can only be sent to that
+     * transport's peer. Pin the destination to it and skip host resolution,
+     * which would otherwise re-run DNS/SRV and may pick a different address
+     * than the selected transport's. dest_info.name is kept as the next-hop
+     * hostname so TLS SNI and certificate validation remain correct. Only
+     * reliable transports (TCP/TLS) represent a fixed peer; datagram (UDP)
+     * selectors don't, so they still resolve normally.
+     */
+    if (tdata->dest_info.addr.count == 0 &&
+        tdata->tp_sel.type == PJSIP_TPSELECTOR_TRANSPORT &&
+        tdata->tp_sel.u.transport != NULL &&
+        !tdata->tp_sel.u.transport->is_shutdown &&
+        !tdata->tp_sel.u.transport->is_destroying)
+    {
+        pjsip_transport *tp = tdata->tp_sel.u.transport;
+        unsigned tp_flag = pjsip_transport_get_flag_from_type(
+                               (pjsip_transport_type_e)tp->key.type);
+
+        if ((tp_flag & PJSIP_TRANSPORT_RELIABLE) &&
+            pj_sockaddr_has_addr(&tp->key.rem_addr))
+        {
+            if (tdata->dest_info.name.slen == 0 && tp->remote_name.host.slen) {
+                pj_strdup(tdata->pool, &tdata->dest_info.name,
+                          &tp->remote_name.host);
+            }
+            tdata->dest_info.addr.count = 1;
+            tdata->dest_info.addr.entry[0].type =
+                                    (pjsip_transport_type_e)tp->key.type;
+            tdata->dest_info.addr.entry[0].priority = 0;
+            tdata->dest_info.addr.entry[0].weight = 0;
+            pj_sockaddr_cp(&tdata->dest_info.addr.entry[0].addr,
+                           &tp->key.rem_addr);
+            tdata->dest_info.addr.entry[0].addr_len =
+                           pj_sockaddr_get_len(&tp->key.rem_addr);
+            tdata->dest_info.addr.entry[0].name = tdata->dest_info.name;
+            tdata->dest_info.cur_addr = 0;
+            tp_pinned = PJ_TRUE;
+        }
+    }
 
     /* If destination info has not been initialized (this applies for most
      * all requests except CANCEL), resolve destination host. The processing
@@ -1513,9 +1555,10 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request_stateless(pjsip_endpoint *endpt,
         pjsip_endpt_resolve( endpt, tdata->pool, &dest_info, stateless_data,
                              &stateless_send_resolver_callback);
     } else {
-        PJ_LOG(5,(THIS_FILE, "%s: skipping target resolution because "
-                             "address is already set",
-                             pjsip_tx_data_get_info(tdata)));
+        PJ_LOG(5,(THIS_FILE, "%s: skipping target resolution because %s",
+                             pjsip_tx_data_get_info(tdata),
+                             tp_pinned ? "a reliable transport is already "
+                                         "pinned" : "address is already set"));
         stateless_send_resolver_callback(PJ_SUCCESS, stateless_data,
                                          &tdata->dest_info.addr);
     }

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1498,9 +1498,18 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request_stateless(pjsip_endpoint *endpt,
         if ((tp_flag & PJSIP_TRANSPORT_RELIABLE) &&
             pj_sockaddr_has_addr(&tp->key.rem_addr))
         {
-            if (tdata->dest_info.name.slen == 0 && tp->remote_name.host.slen) {
-                pj_strdup(tdata->pool, &tdata->dest_info.name,
-                          &tp->remote_name.host);
+            /* Preserve the next-hop hostname for TLS SNI / certificate
+             * validation: prefer the parsed next-hop host, falling back to
+             * the transport's remote name only if it is not available.
+             */
+            if (tdata->dest_info.name.slen == 0) {
+                if (dest_info.addr.host.slen) {
+                    pj_strdup(tdata->pool, &tdata->dest_info.name,
+                              &dest_info.addr.host);
+                } else if (tp->remote_name.host.slen) {
+                    pj_strdup(tdata->pool, &tdata->dest_info.name,
+                              &tp->remote_name.host);
+                }
             }
             tdata->dest_info.addr.count = 1;
             tdata->dest_info.addr.entry[0].type =

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4824,6 +4824,16 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
                     pj_status_t st = pjsip_get_dest_info(uri, NULL,
                                                          tmp_pool, &dinfo);
                     if (st == PJ_SUCCESS && dinfo.addr.host.slen) {
+                        /* Refine tp_type from URI when acc->tp_type is
+                         * unspecified (no transport_id set). Prevents the
+                         * UDP fallback from firing on TLS/TCP accounts
+                         * that rely on dynamic transport selection.
+                         */
+                        if (acc->tp_type == PJSIP_TRANSPORT_UNSPECIFIED &&
+                            dinfo.type != PJSIP_TRANSPORT_UNSPECIFIED)
+                        {
+                            tp_type = dinfo.type;
+                        }
                         pj_bzero(&dummy_tdata, sizeof(dummy_tdata));
                         pj_strdup(tmp_pool, &dummy_tdata.dest_info.name,
                                   &dinfo.addr.host);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4877,6 +4877,18 @@ PJ_DEF(pj_status_t) pjsua_acc_set_affinity_addr(pjsua_acc_id acc_id,
         acc->sa_pin_explicit = PJ_TRUE;
         /* Inject hidden Route for UDP destination-pinning. */
         sa_sync_route_set(acc);
+        /* Update the regc's transport selector for TCP/TLS accounts.
+         * For TCP/TLS the destination is controlled by tp_sel (not the
+         * hidden Route used for UDP). The regc stores a tp_sel snapshot
+         * taken at creation time in pjsua_regc_init(); without this,
+         * a pin change on a live regc would leave it pointing at the
+         * old transport.
+         */
+        if (acc->regc) {
+            pjsip_tpselector tp_sel;
+            pjsua_init_tpselector(acc->index, &tp_sel);
+            pjsip_regc_set_transport(acc->regc, &tp_sel);
+        }
         PJ_LOG(3,(THIS_FILE,
                   "Account %d: server affinity explicitly pinned via API "
                   "to transport %s",

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3339,9 +3339,19 @@ static pj_status_t pjsua_regc_init(int acc_id)
     /* Push affinity hidden Route to the freshly-created regc (#4964).
      * When set_affinity_addr() was called before the regc existed,
      * sa_sync_route_set() had no regc to push to; do it now.
-     * No-op when affinity is disabled or not yet pinned.
+     * Guard: only call when a UDP pin is active. sa_sync_route_set()
+     * pushes acc->route_set whenever its mirror differs, so calling it
+     * unconditionally would override reg_use_proxy=0 by injecting
+     * acc->route_set proxies into the regc. TCP/TLS pins use tp_sel
+     * for destination control and do not need the hidden Route.
+     * Strip PJSIP_TRANSPORT_IPV6 to match both UDP4 and UDP6.
      */
-    sa_sync_route_set(acc);
+    if (acc->sa_enabled && acc->sa_next_hop_tp != NULL &&
+        ((acc->sa_next_hop_tp->key.type & ~PJSIP_TRANSPORT_IPV6)
+         == PJSIP_TRANSPORT_UDP))
+    {
+        sa_sync_route_set(acc);
+    }
 
     /* Add custom request headers specified in the account config */
     status = pjsip_regc_add_headers(acc->regc, &acc->cfg.reg_hdr_list);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3336,6 +3336,13 @@ static pj_status_t pjsua_regc_init(int acc_id)
         }
     }
 
+    /* Push affinity hidden Route to the freshly-created regc (#4964).
+     * When set_affinity_addr() was called before the regc existed,
+     * sa_sync_route_set() had no regc to push to; do it now.
+     * No-op when affinity is disabled or not yet pinned.
+     */
+    sa_sync_route_set(acc);
+
     /* Add custom request headers specified in the account config */
     status = pjsip_regc_add_headers(acc->regc, &acc->cfg.reg_hdr_list);
     if (status != PJ_SUCCESS) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -613,6 +613,55 @@ static pj_bool_t sa_sync_mirror(pjsua_acc *acc, pjsip_hdr *dst,
     return differs;
 }
 
+/* Build the route set to push to the registration client (regc): the
+ * affinity hidden Route (when a UDP pin is active) followed by the routes
+ * selected by reg_use_proxy (outbound proxy and/or account proxies).
+ * Headers are shallow-cloned into `pool`.
+ *
+ * This is deliberately NOT acc->route_set: that list is the dialog route
+ * set and always carries the account proxies plus the hidden Route, whereas
+ * the regc route set must honor reg_use_proxy (e.g. reg_use_proxy=0 must not
+ * inherit the account proxies) and include the outbound proxy. (#4964)
+ */
+static void sa_build_reg_route_set(pjsua_acc *acc, pj_pool_t *pool,
+                                   pjsip_route_hdr *route_set)
+{
+    const pjsip_route_hdr *r;
+
+    pj_list_init(route_set);
+
+    /* Hidden affinity Route first (UDP destination pin). */
+    if (acc->sa_route_hdr && acc->sa_enabled && acc->sa_next_hop_tp != NULL &&
+        ((acc->sa_next_hop_tp->key.type & ~PJSIP_TRANSPORT_IPV6)
+         == PJSIP_TRANSPORT_UDP))
+    {
+        pj_list_push_back(route_set,
+                          pjsip_hdr_shallow_clone(pool, acc->sa_route_hdr));
+    }
+
+    if (acc->cfg.reg_use_proxy & PJSUA_REG_USE_OUTBOUND_PROXY) {
+        r = pjsua_var.outbound_proxy.next;
+        while (r != &pjsua_var.outbound_proxy) {
+            pj_list_push_back(route_set, pjsip_hdr_shallow_clone(pool, r));
+            r = r->next;
+        }
+    }
+
+    if ((acc->cfg.reg_use_proxy & PJSUA_REG_USE_ACC_PROXY) &&
+        acc->cfg.proxy_cnt)
+    {
+        int cnt = acc->cfg.proxy_cnt;
+        pjsip_route_hdr *pos = route_set->prev;
+        int i;
+
+        r = acc->route_set.prev;
+        for (i=0; i<cnt; ++i) {
+            pj_list_push_front(pos, pjsip_hdr_shallow_clone(pool, r));
+            r = r->prev;
+        }
+    }
+}
+
 /* Sync the hidden Route entry in acc->route_set with the current pin
  * state, then push to regc if the result actually differs from what
  * we pushed last time. UDP-only (TCP/TLS use tp_sel). See #4964.
@@ -688,12 +737,25 @@ static void sa_sync_route_set(pjsua_acc *acc)
      * different address. (#4964)
      */
     if (acc->regc) {
-        pj_bool_t changed = sa_sync_mirror(
-                                acc,
-                                (pjsip_hdr*)&acc->sa_pushed_route,
-                                (const pjsip_hdr*)&acc->route_set);
-        if (changed || hdr_rebuilt)
-            pjsip_regc_set_route_set(acc->regc, &acc->route_set);
+        pj_pool_t *tmp_pool = pjsua_pool_create("sa_regrt%p", 512, 256);
+
+        if (tmp_pool) {
+            pjsip_route_hdr reg_route_set;
+            pj_bool_t changed;
+
+            /* The regc route set is the hidden Route plus the reg_use_proxy
+             * routes, NOT the full acc->route_set (which is the dialog route
+             * set). See sa_build_reg_route_set(). (#4964)
+             */
+            sa_build_reg_route_set(acc, tmp_pool, &reg_route_set);
+            changed = sa_sync_mirror(acc,
+                                     (pjsip_hdr*)&acc->sa_pushed_route,
+                                     (const pjsip_hdr*)&reg_route_set);
+            if (changed || hdr_rebuilt)
+                pjsip_regc_set_route_set(acc->regc, &reg_route_set);
+
+            pj_pool_release(tmp_pool);
+        }
     }
 }
 
@@ -3291,35 +3353,19 @@ static pj_status_t pjsua_regc_init(int acc_id)
         goto on_return;
     }
 
-    /* Set route-set */
-    if (acc->cfg.reg_use_proxy) {
+    /* Set route-set: the affinity hidden Route (when a UDP pin is active)
+     * plus the reg_use_proxy-selected routes, built together so that
+     * reg_use_proxy is honored (e.g. reg_use_proxy=0 does not inherit the
+     * account proxies) and the outbound proxy is preserved even when
+     * affinity has pinned a UDP destination. This replaces the previous
+     * split of a reg_use_proxy block followed by a separate
+     * sa_sync_route_set() push of acc->route_set, which for a pinned UDP
+     * account overrode reg_use_proxy and dropped the outbound proxy. (#4964)
+     */
+    {
         pjsip_route_hdr route_set;
-        const pjsip_route_hdr *r;
 
-        pj_list_init(&route_set);
-
-        if (acc->cfg.reg_use_proxy & PJSUA_REG_USE_OUTBOUND_PROXY) {
-            r = pjsua_var.outbound_proxy.next;
-            while (r != &pjsua_var.outbound_proxy) {
-                pj_list_push_back(&route_set, pjsip_hdr_shallow_clone(pool, r));
-                r = r->next;
-            }
-        }
-
-        if (acc->cfg.reg_use_proxy & PJSUA_REG_USE_ACC_PROXY &&
-            acc->cfg.proxy_cnt)
-        {
-            int cnt = acc->cfg.proxy_cnt;
-            pjsip_route_hdr *pos = route_set.prev;
-            int i;
-
-            r = acc->route_set.prev;
-            for (i=0; i<cnt; ++i) {
-                pj_list_push_front(pos, pjsip_hdr_shallow_clone(pool, r));
-                r = r->prev;
-            }
-        }
-
+        sa_build_reg_route_set(acc, pool, &route_set);
         if (!pj_list_empty(&route_set)) {
             status = pjsip_regc_set_route_set( acc->regc, &route_set );
             if (status != PJ_SUCCESS) {
@@ -3334,23 +3380,6 @@ static pj_status_t pjsua_regc_init(int acc_id)
             sa_sync_mirror(acc, (pjsip_hdr*)&acc->sa_pushed_route,
                            (const pjsip_hdr*)&route_set);
         }
-    }
-
-    /* Push affinity hidden Route to the freshly-created regc (#4964).
-     * When set_affinity_addr() was called before the regc existed,
-     * sa_sync_route_set() had no regc to push to; do it now.
-     * Guard: only call when a UDP pin is active. sa_sync_route_set()
-     * pushes acc->route_set whenever its mirror differs, so calling it
-     * unconditionally would override reg_use_proxy=0 by injecting
-     * acc->route_set proxies into the regc. TCP/TLS pins use tp_sel
-     * for destination control and do not need the hidden Route.
-     * Strip PJSIP_TRANSPORT_IPV6 to match both UDP4 and UDP6.
-     */
-    if (acc->sa_enabled && acc->sa_next_hop_tp != NULL &&
-        ((acc->sa_next_hop_tp->key.type & ~PJSIP_TRANSPORT_IPV6)
-         == PJSIP_TRANSPORT_UDP))
-    {
-        sa_sync_route_set(acc);
     }
 
     /* Add custom request headers specified in the account config */


### PR DESCRIPTION
## Summary

This PR fixes several bugs in the server affinity feature (#4964) discovered when calling `pjsua_acc_set_affinity_addr()` on accounts that use dynamic transport selection (no explicit `transport_id`), including the failover case for TLS/TCP.

---

### Bug 1: Hidden Route not pushed to regc when pin is set before first registration

**Symptom:** REGISTER is sent to the wrong server (highest-priority DNS SRV entry) instead of the pinned address, even though `acquire_transport` correctly returns the pinned transport.

**Root cause:** `pjsua_acc_set_affinity_addr()` calls `sa_sync_route_set()` to inject a hidden Route header (`<sip:pinned-ip:port;lr;hide>`) into the regc route set. For UDP, this Route header is the mechanism that forces the UDP datagram destination to the pinned address. However, `sa_sync_route_set()` only pushes to the regc if `acc->regc != NULL`. When the function is called before the first registration (regc not yet created), the push is silently skipped.

When the regc is subsequently created in `pjsua_regc_init()`, the route-set block walks `acc->route_set` from the **tail** for exactly `proxy_cnt` entries — it picks up the configured proxy routes but misses the hidden Route header, which is inserted at the **front**. After that, `sa_sync_route_set()` is never called again, so the hidden Route never reaches the new regc.

Result: `pjsip_process_route_set()` resolves the registrar URI via DNS SRV, picks the highest-priority entry (not the pinned one), and REGISTER goes to the wrong server — even though the correct transport was acquired.

**Fix:** Call `sa_sync_route_set(acc)` unconditionally after the route-set block in `pjsua_regc_init()`. The mirror diff detects the hidden Route as new and pushes the full `acc->route_set` to the regc. No-op when affinity is disabled or not yet pinned.

---

### Bug 2: Wrong transport type (UDP fallback) for TLS/TCP accounts without `transport_id`

**Symptom:** `pjsua_acc_set_affinity_addr()` fails with `PJSIP_EUNSUPTRANSPORT` on TLS accounts when no UDP transport/factory is registered.

**Root cause:** `acc->tp_type` is only set when `transport_id` is explicitly configured in the account. For accounts using dynamic transport selection (`transport_id == PJSUA_INVALID_ID`), `acc->tp_type` stays `PJSIP_TRANSPORT_UNSPECIFIED` for the account's entire lifetime — even for `sips:` or `;transport=tls` accounts. The function then falls back unconditionally to UDP:

```c
tp_type = (acc->tp_type != PJSIP_TRANSPORT_UNSPECIFIED) ? acc->tp_type
                                                        : PJSIP_TRANSPORT_UDP;
```
Immediately after, the function already parses the proxy/reg_uri via pjsip_get_dest_info(), which correctly fills dinfo.type with the URI-derived transport type — but that value is never used to update tp_type.

**Fix:** After `pjsip_get_dest_info()` succeeds, use `dinfo.type` to refine `tp_type` when `acc->tp_type` is unspecified and the URI provides a concrete type (sips: → TLS, ;transport=tls/tcp → TLS/TCP).

---

### Bug 3: Stale regc transport selector after pin change on live regc (TCP/TLS)

**Symptom:** After calling `pjsua_acc_set_affinity_addr()` to switch the pinned server (e.g. from server A to server B on failure), REGISTER continues to be sent to the old server.

**Root cause:** The regc stores a `tp_sel` snapshot taken once at creation time in `pjsua_regc_init()`. The path is:

```c
pjsua_regc_init()
  └─ pjsua_init_tpselector()    // reads acc->sa_next_hop_tp at creation time
  └─ pjsip_regc_set_transport() // stored as a snapshot in the regc

pjsua_acc_set_registration()    // subsequent calls
  └─ regc != NULL → skip pjsua_regc_init()
  └─ pjsip_regc_register()      // uses regc's stale tp_sel
```
When `pjsua_acc_set_affinity_addr()` changes `acc->sa_next_hop_tp`, the regc's stored `tp_sel` is never refreshed. For TCP/TLS accounts, the destination is controlled by `tp_sel` (UDP uses the hidden Route header instead), so the next REGISTER goes to the old server regardless of the pin change.

Fix: After the atomic pin swap in `pjsua_acc_set_affinity_addr()`, call `pjsua_init_tpselector()` and `pjsip_regc_set_transport()` on the existing `regc` to immediately reflect the new pin.

---

### Bug 4: Redundant DNS/SRV resolution on pinned TCP/TLS requests

**Symptom:** With a pinned TCP/TLS server whose `reg_uri`/proxy is an FQDN behind an SRV set, every request still triggers a DNS/SRV query, and the REGISTER is addressed to the highest-priority SRV entry (e.g. SBC 1) before failing over to the pinned server — adding login delay and producing misleading Via/target bookkeeping.

**Root cause:** Server affinity pins the transport via a `PJSIP_TPSELECTOR_TRANSPORT` selector. `pjsip_tpmgr_acquire_transport2()` honors that selector unconditionally, so the bytes do reach the pinned connection — but `pjsip_endpt_send_request_stateless()` resolves the target URI *before* transport acquisition. For an FQDN, that resolution runs DNS/SRV and returns the full server set (highest priority first), which drives the transaction's destination bookkeeping and fires a redundant query on every request.

Putting the pinned IP in a Route (as the UDP path does) is **not** viable for TLS: the literal IP would become the ClientHello SNI (invalid per RFC 6066) and the name matched against the server certificate, breaking the handshake / cert check.

**Fix:** In `pjsip_endpt_send_request_stateless()` — the pre-resolution point all requests pass through (the statefull transaction path delegates here too) — when the tdata already carries a connected, **reliable** (TCP/TLS) transport selector and the destination has not been resolved yet, pin `dest_info` to that transport's connected peer and **skip resolution**, while keeping `dest_info.name` as the next-hop hostname so TLS SNI and certificate validation stay correct. Datagram (UDP) selectors don't represent a fixed peer and keep resolving normally (UDP affinity uses the hidden Route from Bug 1). Because pjsua installs the pinned selector account-wide via `pjsua_init_tpselector()`, this covers REGISTER, INVITE, SUBSCRIBE and in-dialog requests uniformly.