### PR TITLE
pjsua: fix unused function warning for attr_matches_fmt

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1272,6 +1272,7 @@ on_return:
     return status;
 }
 
+#if !PJSUA_MEDIA_HAS_PJMEDIA
 /* Check whether an rtpmap/fmtp attribute value refers to the given payload
  * type (SDP format). The attribute value must begin with the payload type
  * token followed by whitespace or end-of-string. An empty fmt never matches.
@@ -1287,6 +1288,7 @@ static pj_bool_t attr_matches_fmt(const pj_str_t *attr_val,
             (attr_val->slen == fmt->slen ||
              pj_isspace((unsigned char)attr_val->ptr[fmt->slen])));
 }
+#endif
 
 pj_status_t create_temp_sdp(pj_pool_t *pool,
                             const pjmedia_sdp_session *rem_sdp,


### PR DESCRIPTION
## Problem

`attr_matches_fmt` introduced in #4938 is only called inside the
`#else` branch of `#if PJSUA_MEDIA_HAS_PJMEDIA`, but its definition
was not guarded by the same condition. When building with PJMEDIA
(the default), the function is compiled but never referenced, causing
a build error on compilers with `-Werror`:

    ../src/pjsua-lib/pjsua_call.c:1279:18: error: unused function
        'attr_matches_fmt' [-Werror,-Wunused-function]

## Fix

Wrap the function definition in `#if !PJSUA_MEDIA_HAS_PJMEDIA` to
match the only call site, so it is only compiled when it is actually
used.