### PR TITLE
Use sdp_pool instead of srtp memory pool to avoid memory leak in TLS call with periodic REINVITE.

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -991,7 +991,7 @@ static pj_status_t create_srtp_ctx(transport_srtp *srtp,
                    setting->tx_roc.roc,
                    (err == srtp_err_status_ok)? "succeeded": "failed"));
     }
-    ctx->tx_policy = *tx;
+    ctx->tx_policy = *tx; /* pointer to dynamic memory erased below: */
     pj_strset(&ctx->tx_policy.key,  ctx->tx_key, tx->key.slen);
     ctx->tx_policy.name=pj_str(crypto_suites[get_crypto_idx(&tx->name)].name);
 
@@ -1043,7 +1043,7 @@ static pj_status_t create_srtp_ctx(transport_srtp *srtp,
                    setting->rx_roc.ssrc, setting->rx_roc.roc,
                    (err == srtp_err_status_ok)? "succeeded": "failed"));
     }
-    ctx->rx_policy = *rx;
+    ctx->rx_policy = *rx; /* pointer to dynamic memory erased below: */
     pj_strset(&ctx->rx_policy.key,  ctx->rx_key, rx->key.slen);
     ctx->rx_policy.name=pj_str(crypto_suites[get_crypto_idx(&rx->name)].name);
 

--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -486,8 +486,8 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
                  */
                 if (cr_attr_count >= PJ_ARRAY_SIZE(tags))
                     return PJMEDIA_SRTP_ESDPINCRYPTO;
-
-                status = parse_attr_crypto(srtp->pool, m_rem->attr[i],
+                /* use sdp_pool because srtp->pool lives as long as the call */
+                status = parse_attr_crypto(sdp_pool, m_rem->attr[i],
                                            &tmp_rx_crypto,
                                            &tags[cr_attr_count]);
                 if (status != PJ_SUCCESS)
@@ -691,8 +691,10 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
         if (srtp->srtp_ctx.tx_policy_neg.name.slen == 0)
             return PJ_SUCCESS;
 
-        /* Get the local crypto. */
-        fill_local_crypto(srtp->pool, m_loc, PJ_FALSE,
+        /* Get the local crypto. 
+         * do not use srtp->pool because it may live as long as the call, thus memleak     
+         */
+        fill_local_crypto(pool, m_loc, PJ_FALSE,
                           loc_crypto, &loc_cryto_cnt);
 
         if (loc_cryto_cnt == 0)
@@ -737,14 +739,14 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
             //DEACTIVATE_MEDIA(pool, m_loc);
             //return PJMEDIA_SDP_EINPROTO;
         //}
-        fill_local_crypto(srtp->pool, m_loc, PJ_TRUE,
+        fill_local_crypto(pool, m_loc, PJ_TRUE,
                           loc_crypto, &loc_cryto_cnt);
     } else if (srtp->setting.use == PJMEDIA_SRTP_MANDATORY) {
         if (srtp->peer_use != PJMEDIA_SRTP_MANDATORY) {
             DEACTIVATE_MEDIA(pool, m_loc);
             return PJMEDIA_SDP_EINPROTO;
         }
-        fill_local_crypto(srtp->pool, m_loc, PJ_TRUE,
+        fill_local_crypto(pool, m_loc, PJ_TRUE,
                           loc_crypto, &loc_cryto_cnt);
     }
 
@@ -761,7 +763,7 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
 
         has_crypto_attr = PJ_TRUE;
 
-        status = parse_attr_crypto(srtp->pool, m_rem->attr[i],
+        status = parse_attr_crypto(pool, m_rem->attr[i],
                                    &tmp_tx_crypto, &rem_tag);
         if (status != PJ_SUCCESS)
             return status;


### PR DESCRIPTION
Use sdp_pool instead of srtp memory pool to avoid memory leak in a persistent TLS call with reinvite containing SDP.

I am connecting pjsua (answering call) with freeswitch (initiating call) using TLS. Freeswitch is sending about every 50 s a REINVITE.
After each such REINVITE additional 1886 bytes are used in srtp pool which leads to monotonous memory leak 

srtp0x79c874054760:   **722000** of   766024 (94%) used, nblocks: 762
after REINVITE:
srtp0x79c874054760:   **723886** of   768024 (94%) used, nblocks: 764

here after call duration 4h47m already 723886 bytes are leaked.

This patch fixes that memory leak. Resulting pjsua passes our stress test routine.

I have not checked whether similar problem exists in DTLS.

Please review and merge or suggest other bugfix for that memory leak.