### PR TITLE
[pjmedia] fix crash in conference bridge

### DIFF
--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -301,6 +301,8 @@ static pj_status_t op_disconnect_ports(pjmedia_conf *conf,
 static pj_status_t op_adjust_conn_level(pjmedia_conf *conf,
                                         const pjmedia_conf_op_param *prm);
 
+static void destroy_conf_port_resources(struct conf_port *conf_port);
+
 static op_entry* get_free_op_entry(pjmedia_conf *conf)
 {
     op_entry *ope = NULL;
@@ -1875,17 +1877,37 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
         if (found) {
             pjmedia_conf_op_param prm;
 
+            /* Mark the port as removing before releasing the mutex, so
+             * other threads can no longer queue any operation on it
+             * (e.g: connect/disconnect) nor remove it again while it is
+             * being destroyed below.
+             */
+            conf_port->removing = PJ_TRUE;
+
             /* Release mutex to avoid deadlock */
             pj_mutex_unlock(conf->mutex);
 
-            /* Remove it */
+            /* The port has never been active (its add-op has just been
+             * cancelled above), so it has no connection and the clock
+             * thread never touches it. It is safe to destroy the port
+             * resources from this thread. Note that op_remove_port()
+             * must not be called from here as it modifies states shared
+             * with the clock thread (e.g: while disconnecting the port
+             * from other ports), so it can only be run by the clock
+             * thread.
+             */
+            destroy_conf_port_resources(conf_port);
+
+            PJ_LOG(4,(THIS_FILE,"Removing new port %d (%.*s) synchronously",
+                      port, (int)conf_port->name.slen, conf_port->name.ptr));
+
             prm.remove_port.port = port;
-            status = op_remove_port(conf, &prm);
 
             if (conf->cb) {
                 pjmedia_conf_op_info op_info = { 0 };
 
                 pj_log_push_indent();
+                op_info.conf = conf;
                 op_info.op_type = PJMEDIA_CONF_OP_REMOVE_PORT;
                 op_info.status = status;
                 op_info.op_param = prm;
@@ -1929,6 +1951,42 @@ on_return:
 }
 
 
+/*
+ * Destroy resources owned by a conference port: resample states, delay
+ * buffer, and the pjmedia port for passive ports.
+ *
+ * For a port that has been activated in the bridge, this must only be
+ * called from the clock thread, via op_remove_port(). For a newly added
+ * port whose add-op has been cancelled, this may be called from the
+ * thread invoking pjmedia_conf_remove_port(), as such port is never
+ * accessed by the clock thread.
+ */
+static void destroy_conf_port_resources(struct conf_port *conf_port)
+{
+    /* Destroy resample if this conf port has it. */
+    if (conf_port->rx_resample) {
+        pjmedia_resample_destroy(conf_port->rx_resample);
+        conf_port->rx_resample = NULL;
+    }
+    if (conf_port->tx_resample) {
+        pjmedia_resample_destroy(conf_port->tx_resample);
+        conf_port->tx_resample = NULL;
+    }
+
+    /* Destroy pjmedia port if this conf port is passive port,
+     * i.e: has delay buf.
+     */
+    if (conf_port->delay_buf) {
+        pjmedia_delay_buf_destroy(conf_port->delay_buf);
+        conf_port->delay_buf = NULL;
+
+        if (conf_port->port)
+            pjmedia_port_destroy(conf_port->port);
+        conf_port->port = NULL;
+    }
+}
+
+
 static pj_status_t op_remove_port(pjmedia_conf *conf,
                                   const pjmedia_conf_op_param *prm)
 {
@@ -1967,27 +2025,8 @@ static pj_status_t op_remove_port(pjmedia_conf *conf,
                       "Fail to stop transmission from %d->any", port));
     }
     
-    /* Destroy resample if this conf port has it. */
-    if (conf_port->rx_resample) {
-        pjmedia_resample_destroy(conf_port->rx_resample);
-        conf_port->rx_resample = NULL;
-    }
-    if (conf_port->tx_resample) {
-        pjmedia_resample_destroy(conf_port->tx_resample);
-        conf_port->tx_resample = NULL;
-    }
-
-    /* Destroy pjmedia port if this conf port is passive port,
-     * i.e: has delay buf.
-     */
-    if (conf_port->delay_buf) {
-        pjmedia_delay_buf_destroy(conf_port->delay_buf);
-        conf_port->delay_buf = NULL;
-
-        if (conf_port->port)
-            pjmedia_port_destroy(conf_port->port);
-        conf_port->port = NULL;
-    }
+    /* Destroy the port's own resources. */
+    destroy_conf_port_resources(conf_port);
 
     PJ_LOG(4,(THIS_FILE,"Removing port %d (%.*s)",
               port, (int)conf_port->name.slen, conf_port->name.ptr));


### PR DESCRIPTION
I experienced a crash of one of my apps today.
The app is based on pjproject 2.16 + backports but I confirmed the problem still exists in master.
There is a race condition in the conference bridge code (conference.c; I didn't check the other implementations).

In my case there were 3 threads involved:
- SIP-worker ("PJSUA")
- Application thread
- clock thread ("confbridge")

Whenever a callback is received from PJSUA (e.g. on_call_state(), on_call_media_state(), ...)
my wrapper library will post it onto the application thread.

### What happened was:
- A call was made and immediately accepted
- PJSUA emitted callbacks as usual, including on_call_media_state()
- While this was happening, the remote peer initiated a re-INVITE to direct the RTP stream to a different target.
  This caused PJSUA to destroy and recreate the media stream.
- While the media stream destruction/recreation was happening the application thread was handling the call media callback posted earlier where it would *conf_connect* which then led to a crash in the confbridge.

The problem is that `pjmedia_conf_remove_port()` leaves a small gap because it temporarily gives up the 
`conf->mutex` without marking the port as being *removed*. When during that time another thread calls `pjmedia_conf_connect_port()` on the same port, it doesn't bail out early but queues the connection op.

### How I used AI (Claude Code):
With the application log and the sources side by side I told Claude Code to analyse the issue and propose a fix.
It managed to find the issue and even produced a small test program which reproduces the issue; for completeness sake; I'll attach it here.
Please note: I didn't run the reproducer it ran myself, Claude did it all by itself.

### Everything below this point was created by Claude Code:
- - -
## Problem

I have been seeing two kinds of sporadic crashes in the audio conference
bridge (`pjmedia/src/pjmedia/conference.c`, serial bridge backend) in a
multi-threaded application:

1. When `pjmedia_conf_remove_port()` is called for the same port from two
   threads at (nearly) the same time, the heap gets corrupted
   (double-frees, e.g. of resample states).
2. When one thread calls `pjmedia_conf_remove_port()` while another thread
   calls `pjmedia_conf_connect_port()` involving the same slot, the bridge
   crashes later on the clock thread, inside `get_frame()`, when the timer
   tick runs.

Both crashes trace back to the synchronous removal path for newly added
ports introduced in #4253.

## Root cause

The bridge's threading contract is: the mutex protects the `ports[]`
slots, the op queue and the `removing`/`is_new` flags, while all
structural state (listener arrays, `transmitter_cnt`, resource
destruction) is only ever touched by the clock thread, which executes
queued ops in `handle_op_queue()` and runs `get_frame()` without holding
the mutex.

The synchronous removal path in `pjmedia_conf_remove_port()` (taken when
the port's ADD op is still queued) breaks this contract. After cancelling
the pending ops under the mutex, it releases the mutex **without setting
`conf_port->removing`** and then runs `op_remove_port()` +
`op_remove_port2()` on the calling thread. Until `op_remove_port2()`
frees the slot, the port still looks fully valid to every other thread,
so during the teardown window:

- `pjmedia_conf_connect_port()` passes validation and queues a CONNECT op
  on the dying slot. The clock thread can execute it while the teardown
  is in progress (after the disconnect scan already ran), leaving a
  listener array entry that points to a slot which is freed moments
  later. On the next tick, `get_frame()` does
  `listener = conf->ports[conf_port->listener_slots[cj]]` and
  dereferences the resulting NULL pointer (around line 2884; there is no
  NULL check there by design, because listener arrays are supposed to be
  consistent with `ports[]` at all times).

- a concurrent `pjmedia_conf_remove_port()` on the same port no longer
  finds the (already cancelled) ADD op, so it queues a REMOVE op. The
  clock thread then runs `op_remove_port()` concurrently with the
  synchronous removal on the API thread. The destroy sequence in
  `op_remove_port()` is not safe against concurrent execution, so the
  port's resample states / delay buffer / port get destroyed twice
  (a literal double-free with heap-backed resample backends such as
  speex), or the `conf_port` is accessed after the other thread freed it.

Independently of the window, running `op_remove_port()` on the API thread
is itself a contract violation: its wildcard disconnect scans read and
modify other ports' listener arrays lock-free, racing with `get_frame()`
and with ops executing on the clock thread.

## Fix

- Mark the port as `removing` before releasing the mutex in the
  synchronous removal path, so other threads can no longer queue ops on
  the slot nor remove it again (they get `PJ_EINVAL`, same as during a
  queued removal).
- Do not call `op_remove_port()` from the API thread. A port whose ADD op
  was found and cancelled has never executed any op (ops are FIFO and
  any op referencing the slot must have been queued after its ADD), so it
  has no connections; only its own resources need to be destroyed. The
  resource teardown is moved into a new helper,
  `destroy_conf_port_resources()`, shared with `op_remove_port()`.
- Also set `pjmedia_conf_op_info::conf` in the synchronous removal
  callback; it was the only callback invocation leaving it NULL (missed
  by #4699).

The port-ID uniqueness guarantee from #4722 is preserved (the slot is
still freed only after the removal callback, via `op_remove_port2()`),
and the op cancellation logic is unchanged.

## Reproduction

The stress program below reproduces the `get_frame()` crash reliably:

- The bridge is created with `PJMEDIA_CONF_NO_DEVICE` and a "clock"
  thread pumps `pjmedia_port_get_frame()` on the master port, emulating
  the sound device clock.
- A churn thread adds a fresh 8 kHz null port (so resample states are
  created), publishes its slot, immediately removes it (hitting the
  synchronous removal path) and destroys the port.
- An attacker thread hammers `pjmedia_conf_connect_port()` and
  occasionally `pjmedia_conf_remove_port()` on the published slot.
- The conf op callback sleeps 1 ms on REMOVE ops. The callback is invoked
  inside the unprotected window of the synchronous removal path, so this
  only *widens* a window that exists anyway (logging, scheduling); it
  does not create the race.

Without this fix the program crashes within about a second:

```
Thread 2 "clock" received signal SIGSEGV, Segmentation fault.
#0  get_frame () at ../src/pjmedia/conference.c
#1  clock_thread (arg=<optimised out>) at confrace.c:79
```

With the fix it runs to completion; a typical 20 s run:

```
SURVIVED: cycles=21392 clock_ticks=365971312 t2_connect ok/fail=33/97858561 t2_remove ok/fail=11/12232313
```

The `fail` counts are the hostile connect/remove attempts correctly
rejected with `PJ_EINVAL` while the removal is in progress; the few `ok`
counts are attempts that landed outside the removal and went through the
normal queued path.

Note: with the default libresample backend, `pjmedia_resample_destroy()`
is a no-op, so the double-free flavor of the bug shows up as memory
corruption/UAF rather than an immediate abort; with the speex resample
backend it is a literal double `free()`.

<details>
<summary><b>confrace.c</b> (build with the usual PJ_CFLAGS/PJ_LDFLAGS/PJ_LDLIBS from build.mak)</summary>

```c
/*
 * Stress repro for race conditions in pjmedia conference bridge port
 * removal (pjmedia/src/pjmedia/conference.c).
 *
 * Setup:
 *  - Bridge created with PJMEDIA_CONF_NO_DEVICE; a "clock" thread pumps
 *    pjmedia_port_get_frame() on the master port, emulating the sound
 *    device clock (this is the thread that executes queued ops and mixes).
 *  - A long-lived "stable" null port occupies one slot.
 *  - Churn thread (T1): add_port() a fresh 8kHz null port, publish its
 *    slot, then immediately remove_port() it -> takes the synchronous
 *    "is_new" removal path. Then destroys the pjmedia port (standard app
 *    behavior) and starts over.
 *  - Attacker thread (T2): hammers pjmedia_conf_connect_port(stable->victim),
 *    connect(victim->stable) and occasionally pjmedia_conf_remove_port(victim)
 *    using the published slot.
 *
 * The conf op callback sleeps ~1ms on REMOVE_PORT ops. In the synchronous
 * removal path the callback runs between op_remove_port() (teardown) and
 * op_remove_port2() (slot free), i.e. inside the unprotected window where
 * conf->ports[slot] is still non-NULL and (unfixed) 'removing' is not set.
 * This widens a window that exists anyway (logging, scheduling); it does
 * not create it.
 *
 * Expected on UNFIXED code: crash within seconds, typically SIGSEGV in
 * get_frame() dereferencing conf->ports[stale_listener_slot] == NULL
 * (conference.c ~line 2884), or corruption from concurrent op_remove_port().
 * Expected on FIXED code: runs to completion, prints SURVIVED, and T2's
 * connect/remove attempts during removal fail with EINVAL.
 */
#include <pjmedia.h>
#include <pjlib.h>

#define THIS_FILE       "confrace.c"
#define CONF_CLOCK      16000
#define CONF_SPF        320     /* 20 ms */
#define VICTIM_CLOCK    8000    /* != CONF_CLOCK => resample ports */
#define VICTIM_SPF      160
#define MAX_PORTS       16

static pjmedia_conf     *g_conf;
static pjmedia_port     *g_master;
static volatile int      g_victim_slot = -1;
static volatile int      g_stable_slot = -1;
static volatile pj_bool_t g_stop = PJ_FALSE;

/* Counters (approximate, non-atomic is fine for reporting) */
static volatile unsigned g_cycles = 0;
static volatile unsigned g_t2_connect_ok = 0;
static volatile unsigned g_t2_connect_fail = 0;
static volatile unsigned g_t2_remove_ok = 0;
static volatile unsigned g_t2_remove_fail = 0;
static volatile unsigned g_clock_ticks = 0;

/* Widen the sync-removal window: the callback is invoked between
 * op_remove_port() and op_remove_port2() on the remover's thread.
 */
static void on_conf_op(const pjmedia_conf_op_info *info)
{
    if (info->op_type == PJMEDIA_CONF_OP_REMOVE_PORT &&
        info->status == PJ_SUCCESS)
    {
        pj_thread_sleep(1);
    }
}

/* Emulates the sound device / master clock. */
static int clock_thread(void *arg)
{
    pj_int16_t buf[CONF_SPF];
    pjmedia_frame frame;

    PJ_UNUSED_ARG(arg);

    while (!g_stop) {
        frame.buf = buf;
        frame.size = sizeof(buf);
        frame.type = PJMEDIA_FRAME_TYPE_AUDIO;
        pjmedia_port_get_frame(g_master, &frame);
        ++g_clock_ticks;
    }
    return 0;
}

/* Add + immediately remove a new port (synchronous removal path). */
static int churn_thread(void *arg)
{
    pj_pool_t *pool = (pj_pool_t*)arg;

    while (!g_stop) {
        pjmedia_port *vport = NULL;
        unsigned slot = 0;
        pj_status_t status;

        status = pjmedia_null_port_create(pool, VICTIM_CLOCK, 1, VICTIM_SPF,
                                          16, &vport);
        if (status != PJ_SUCCESS)
            break;

        status = pjmedia_conf_add_port(g_conf, pool, vport, NULL, &slot);
        if (status != PJ_SUCCESS) {
            pjmedia_port_destroy(vport);
            continue;
        }

        /* Publish the slot so T2 can attack it */
        g_victim_slot = (int)slot;

        /* Immediately remove: the ADD op is usually still queued, so this
         * takes the synchronous removal path.
         */
        pjmedia_conf_remove_port(g_conf, slot);

        g_victim_slot = -1;

        /* Standard app behavior: release our reference to the port */
        pjmedia_port_destroy(vport);

        ++g_cycles;
    }
    return 0;
}

/* Attack the victim slot with connect/remove from another thread. */
static int attacker_thread(void *arg)
{
    unsigned iter = 0;

    PJ_UNUSED_ARG(arg);

    while (!g_stop) {
        int s = g_victim_slot;

        if (s >= 0) {
            pj_status_t status;

            status = pjmedia_conf_connect_port(g_conf, g_stable_slot,
                                               (unsigned)s, 0);
            if (status == PJ_SUCCESS) ++g_t2_connect_ok;
            else ++g_t2_connect_fail;

            status = pjmedia_conf_connect_port(g_conf, (unsigned)s,
                                               g_stable_slot, 0);
            if (status == PJ_SUCCESS) ++g_t2_connect_ok;
            else ++g_t2_connect_fail;

            if ((++iter & 0x03) == 0) {
                status = pjmedia_conf_remove_port(g_conf, (unsigned)s);
                if (status == PJ_SUCCESS) ++g_t2_remove_ok;
                else ++g_t2_remove_fail;
            }
        } else {
            pj_thread_sleep(0);
        }
    }
    return 0;
}

int main(int argc, char *argv[])
{
    pj_caching_pool cp;
    pj_pool_t *pool;
    pjmedia_port *stable_port;
    pj_thread_t *thr_clock, *thr_churn, *thr_attack;
    pjmedia_frame frame;
    pj_int16_t buf[CONF_SPF];
    unsigned run_secs = (argc > 1) ? (unsigned)atoi(argv[1]) : 15;
    unsigned slot;
    pj_status_t status;

    pj_log_set_level(1);

    status = pj_init();
    if (status != PJ_SUCCESS) return 1;

    pj_caching_pool_init(&cp, NULL, 0);
    pool = pj_pool_create(&cp.factory, "confrace", 4000, 4000, NULL);

    status = pjmedia_conf_create(pool, MAX_PORTS, CONF_CLOCK, 1, CONF_SPF,
                                 16, PJMEDIA_CONF_NO_DEVICE, &g_conf);
    if (status != PJ_SUCCESS) {
        printf("conf create failed\n");
        return 1;
    }

    pjmedia_conf_set_op_cb(g_conf, &on_conf_op);

    g_master = pjmedia_conf_get_master_port(g_conf);
    if (!g_master) {
        printf("no master port\n");
        return 1;
    }

    /* Long-lived stable port (same rate as bridge) */
    status = pjmedia_null_port_create(pool, CONF_CLOCK, 1, CONF_SPF, 16,
                                      &stable_port);
    if (status != PJ_SUCCESS) return 1;
    status = pjmedia_conf_add_port(g_conf, pool, stable_port, NULL, &slot);
    if (status != PJ_SUCCESS) return 1;
    g_stable_slot = (int)slot;

    /* Pump once so the stable port's ADD op executes (port becomes active) */
    frame.buf = buf;
    frame.size = sizeof(buf);
    pjmedia_port_get_frame(g_master, &frame);

    printf("running for %u secs; stable slot=%d\n", run_secs, g_stable_slot);
    fflush(stdout);

    pj_thread_create(pool, "clock", &clock_thread, NULL, 0, 0, &thr_clock);
    pj_thread_create(pool, "churn", &churn_thread, pool, 0, 0, &thr_churn);
    pj_thread_create(pool, "attack", &attacker_thread, NULL, 0, 0,
                     &thr_attack);

    pj_thread_sleep(run_secs * 1000);

    g_stop = PJ_TRUE;
    pj_thread_join(thr_churn);
    pj_thread_join(thr_attack);
    pj_thread_join(thr_clock);

    pjmedia_conf_destroy(g_conf);
    pjmedia_port_destroy(stable_port);

    printf("SURVIVED: cycles=%u clock_ticks=%u "
           "t2_connect ok/fail=%u/%u t2_remove ok/fail=%u/%u\n",
           g_cycles, g_clock_ticks,
           g_t2_connect_ok, g_t2_connect_fail,
           g_t2_remove_ok, g_t2_remove_fail);

    pj_pool_release(pool);
    pj_caching_pool_destroy(&cp);
    pj_shutdown();
    return 0;
}
```

</details>
