### PR TITLE
bound Sec-WebSocket-Accept read to received handshake data

### DIFF
--- a/pjlib-util/src/pjlib-util/websock.c
+++ b/pjlib-util/src/pjlib-util/websock.c
@@ -486,8 +486,10 @@ static pj_status_t process_handshake_response(pj_websock *ws,
     /* find_substr_i() only guarantees the 22-byte header name fits within
      * the parsed headers, but the compare below reads a fixed accept_len
      * bytes. Make sure the whole value is present before reading it.
+     * accept_hdr never points past data + *parsed_len, so subtract to keep
+     * the check well-defined instead of forming accept_hdr + accept_len.
      */
-    if (accept_hdr + accept_len > (const char*)data + *parsed_len) {
+    if (accept_len > (const char*)data + *parsed_len - accept_hdr) {
         PJ_LOG(2, (THIS_FILE, "WebSocket handshake: "
                    "truncated Sec-WebSocket-Accept"));
         return PJ_EUNKNOWN;

--- a/pjlib-util/src/pjlib-util/websock.c
+++ b/pjlib-util/src/pjlib-util/websock.c
@@ -483,6 +483,16 @@ static pj_status_t process_handshake_response(pj_websock *ws,
     }
     accept_hdr += 22; /* skip header name + ": " */
 
+    /* find_substr_i() only guarantees the 22-byte header name fits within
+     * the parsed headers, but the compare below reads a fixed accept_len
+     * bytes. Make sure the whole value is present before reading it.
+     */
+    if (accept_hdr + accept_len > (const char*)data + *parsed_len) {
+        PJ_LOG(2, (THIS_FILE, "WebSocket handshake: "
+                   "truncated Sec-WebSocket-Accept"));
+        return PJ_EUNKNOWN;
+    }
+
     /* Compare */
     if (pj_memcmp(accept_hdr, expected_accept, accept_len) != 0) {
         PJ_LOG(2, (THIS_FILE, "WebSocket handshake: "


### PR DESCRIPTION
## Description

`process_handshake_response()` locates the `Sec-WebSocket-Accept` header in a server's 101 response with `find_substr_i()`, which only proves the 22-byte header name fits inside the parsed header length. It then advances past the name and runs `pj_memcmp(accept_hdr, expected_accept, accept_len)` with a fixed `accept_len` of 28 (base64 of a 20-byte SHA-1). When the accept header sits at the end of the parsed data with a short or empty value, the compare reads up to 28 bytes past the parsed region. The response is read straight into the 64 KB `rx_buf` off the socket, so a server that fills the buffer and puts the accept header last drives the read past the allocation.

Before: a 101 response whose `Sec-WebSocket-Accept` value is shorter than 28 bytes and ends the headers reads past the received data (and past `rx_buf` when it is full). After: the value must lie within the parsed headers before the compare, so a truncated accept fails the handshake instead of reading out of bounds. The check belongs next to the compare because that is where the fixed 28-byte read happens and the bytes arrive from a remote server. Tradeoff: a malformed response that used to reach the byte compare and mismatch now returns `PJ_EUNKNOWN` one step earlier.

## Motivation and Context

The handshake response comes from the remote WebSocket server, so its length and header layout are attacker controlled. A short accept value lets the fixed-length compare read past the receive buffer.

## How Has This Been Tested?

Built pjlib-util and ran the existing `websock_test` (local echo server handshake); it passes, so valid handshakes are unaffected. Reproduced the read on its own: extracted `find_substr_i()` and the accept compare verbatim into a standalone program built with `-fsanitize=address`, and fed it a 60-byte 101 response ending in `Sec-WebSocket-Accept: \r\n\r\n` placed at the end of an exact-size heap buffer.

- Before: `AddressSanitizer: heap-buffer-overflow READ of size 28` at the `pj_memcmp`.
- After: the guard returns `PJ_EUNKNOWN` and ASan is clean.

Full pjlib-util suite (xml, json, encryption, stun, resolver, websock, http_client) passes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
