### PR TITLE
Respond to RFC 5626 CRLF keep-alive ping on TCP and TLS transports

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -819,6 +819,21 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
+ * Specify whether to respond to an incoming RFC 5626 (Section 4.4.1) CRLF
+ * keep-alive "ping" (a double CRLF, i.e. "\r\n\r\n") received on a TCP
+ * transport with a single CRLF ("\r\n") "pong". This is the receiving
+ * (server) side of the CRLF keep-alive mechanism; the sending side is
+ * controlled by \a PJSIP_TCP_KEEP_ALIVE_INTERVAL and is independent of
+ * this setting.
+ *
+ * Default: 1 (enabled)
+ */
+#ifndef PJSIP_TCP_KEEP_ALIVE_RESPONSE
+#   define PJSIP_TCP_KEEP_ALIVE_RESPONSE    1
+#endif
+
+
+/**
  * The initial timeout interval for incoming TCP transports
  * (i.e. server side) in the event that no valid SIP message is received
  * following a successful connection. The value is in seconds.
@@ -862,6 +877,21 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  */
 #ifndef PJSIP_TLS_KEEP_ALIVE_DATA
 #   define PJSIP_TLS_KEEP_ALIVE_DATA        { "\r\n\r\n", 4 }
+#endif
+
+
+/**
+ * Specify whether to respond to an incoming RFC 5626 (Section 4.4.1) CRLF
+ * keep-alive "ping" (a double CRLF, i.e. "\r\n\r\n") received on a TLS
+ * transport with a single CRLF ("\r\n") "pong". This is the receiving
+ * (server) side of the CRLF keep-alive mechanism; the sending side is
+ * controlled by \a PJSIP_TLS_KEEP_ALIVE_INTERVAL and is independent of
+ * this setting.
+ *
+ * Default: 1 (enabled)
+ */
+#ifndef PJSIP_TLS_KEEP_ALIVE_RESPONSE
+#   define PJSIP_TLS_KEEP_ALIVE_RESPONSE    1
 #endif
 
 

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -112,6 +112,11 @@ struct tcp_transport
     pjsip_tx_data_op_key     ka_op_key;
     pj_str_t                 ka_pkt;
 
+    /* Dedicated op key for sending the CRLF keep-alive response ("pong"),
+     * so that it never collides with an in-flight keep-alive ("ping") send.
+     */
+    pjsip_tx_data_op_key     pong_op_key;
+
     /* TCP transport can only have  one rdata!
      * Otherwise chunks of incoming PDU may be received on different
      * buffer.
@@ -735,6 +740,7 @@ static pj_status_t tcp_create( struct tcp_listener *listener,
     tcp->ka_timer.user_data = (void*)tcp;
     tcp->ka_timer.cb = &tcp_keep_alive_timer;
     pj_ioqueue_op_key_init(&tcp->ka_op_key.key, sizeof(pj_ioqueue_op_key_t));
+    pj_ioqueue_op_key_init(&tcp->pong_op_key.key, sizeof(pj_ioqueue_op_key_t));
     pj_strdup(tcp->base.pool, &tcp->ka_pkt, &ka_pkt);
 
     if (is_server && listener->initial_timeout) {
@@ -1402,6 +1408,27 @@ static pj_status_t tcp_shutdown(pjsip_transport *transport)
 /* 
  * Callback from ioqueue that an incoming data is received from the socket.
  */
+#if PJSIP_TCP_KEEP_ALIVE_RESPONSE
+/* Count the leading bytes of a received buffer that form RFC 5626 (Section
+ * 4.4.1) CRLF keep-alive "ping"(s), i.e. one or more consecutive "\r\n\r\n"
+ * (double CRLF) sequences at the start of the buffer. Returns 0 if the buffer
+ * does not begin with a ping.
+ */
+static pj_size_t tcp_get_crlf_ka_len(const char *data, pj_size_t size)
+{
+    pj_size_t i = 0;
+
+    while (size - i >= 4 &&
+           data[i+0] == '\r' && data[i+1] == '\n' &&
+           data[i+2] == '\r' && data[i+3] == '\n')
+    {
+        i += 4;
+    }
+    return i;
+}
+#endif
+
+
 static pj_bool_t on_data_read(pj_activesock_t *asock,
                               void *data,
                               pj_size_t size,
@@ -1433,6 +1460,54 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
         pj_gettimeofday(&tcp->last_activity);
 
         pj_assert((void*)rdata->pkt_info.packet == data);
+
+#if PJSIP_TCP_KEEP_ALIVE_RESPONSE
+        /* RFC 5626 Section 4.4.1: respond to a received CRLF keep-alive
+         * "ping" (double CRLF) with a single CRLF "pong". Handle this before
+         * parsing and consume the ping byte(s), so they are not passed to the
+         * SIP parser (which would otherwise drop them as a malformed message).
+         */
+        {
+            pj_size_t ka_len = tcp_get_crlf_ka_len((char*)data, size);
+
+            if (ka_len) {
+                /* Static storage: the buffer must stay valid until the
+                 * (possibly asynchronous) send completes.
+                 */
+                static const char pong[] = { '\r', '\n' };
+                pj_ssize_t pong_len = 2;
+                char addr[PJ_INET6_ADDRSTRLEN+10];
+                pj_status_t send_st;
+
+                PJ_LOG(5,(tcp->base.obj_name,
+                          "Responding to CRLF keep-alive from %s",
+                          pj_addr_str_print(&tcp->base.remote_name.host,
+                                            tcp->base.remote_name.port, addr,
+                                            sizeof(addr), 1)));
+
+                send_st = pj_activesock_send(tcp->asock, &tcp->pong_op_key.key,
+                                             pong, &pong_len, 0);
+                if (send_st != PJ_SUCCESS && send_st != PJ_EPENDING) {
+                    tcp_perror(tcp->base.obj_name,
+                               "Error sending CRLF keep-alive response",
+                               send_st);
+                }
+
+                if (ka_len == size) {
+                    /* Nothing but keep-alive(s) in this buffer. */
+                    *remainder = 0;
+                    pj_pool_reset(rdata->tp_info.pool);
+                    return PJ_TRUE;
+                }
+
+                /* Consume the ping(s); shift the rest to the front of the
+                 * buffer and carry on parsing it as usual.
+                 */
+                pj_memmove(data, (char*)data + ka_len, size - ka_len);
+                size -= ka_len;
+            }
+        }
+#endif
 
         /* Init pkt_info part. */
         rdata->pkt_info.len = size;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -102,6 +102,11 @@ struct tls_transport
     pjsip_tx_data_op_key     ka_op_key;
     pj_str_t                 ka_pkt;
 
+    /* Dedicated op key for sending the CRLF keep-alive response ("pong"),
+     * so that it never collides with an in-flight keep-alive ("ping") send.
+     */
+    pjsip_tx_data_op_key     pong_op_key;
+
     /* TLS transport can only have  one rdata!
      * Otherwise chunks of incoming PDU may be received on different
      * buffer.
@@ -1082,6 +1087,7 @@ static pj_status_t tls_create( struct tls_listener *listener,
     tls->ka_timer.user_data = (void*)tls;
     tls->ka_timer.cb = &tls_keep_alive_timer;
     pj_ioqueue_op_key_init(&tls->ka_op_key.key, sizeof(pj_ioqueue_op_key_t));
+    pj_ioqueue_op_key_init(&tls->pong_op_key.key, sizeof(pj_ioqueue_op_key_t));
     pj_strdup(tls->base.pool, &tls->ka_pkt, &ka_pkt);
     
     /* Done setting up basic transport. */
@@ -1930,6 +1936,27 @@ static pj_status_t tls_shutdown(pjsip_transport *transport)
 /* 
  * Callback from ioqueue that an incoming data is received from the socket.
  */
+#if PJSIP_TLS_KEEP_ALIVE_RESPONSE
+/* Count the leading bytes of a received buffer that form RFC 5626 (Section
+ * 4.4.1) CRLF keep-alive "ping"(s), i.e. one or more consecutive "\r\n\r\n"
+ * (double CRLF) sequences at the start of the buffer. Returns 0 if the buffer
+ * does not begin with a ping.
+ */
+static pj_size_t tls_get_crlf_ka_len(const char *data, pj_size_t size)
+{
+    pj_size_t i = 0;
+
+    while (size - i >= 4 &&
+           data[i+0] == '\r' && data[i+1] == '\n' &&
+           data[i+2] == '\r' && data[i+3] == '\n')
+    {
+        i += 4;
+    }
+    return i;
+}
+#endif
+
+
 static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
                               void *data,
                               pj_size_t size,
@@ -1961,6 +1988,54 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
         pj_gettimeofday(&tls->last_activity);
 
         pj_assert((void*)rdata->pkt_info.packet == data);
+
+#if PJSIP_TLS_KEEP_ALIVE_RESPONSE
+        /* RFC 5626 Section 4.4.1: respond to a received CRLF keep-alive
+         * "ping" (double CRLF) with a single CRLF "pong". Handle this before
+         * parsing and consume the ping byte(s), so they are not passed to the
+         * SIP parser (which would otherwise drop them as a malformed message).
+         */
+        {
+            pj_size_t ka_len = tls_get_crlf_ka_len((char*)data, size);
+
+            if (ka_len) {
+                /* Static storage: the buffer must stay valid until the
+                 * (possibly asynchronous) send completes.
+                 */
+                static const char pong[] = { '\r', '\n' };
+                pj_ssize_t pong_len = 2;
+                char addr[PJ_INET6_ADDRSTRLEN+10];
+                pj_status_t send_st;
+
+                PJ_LOG(5,(tls->base.obj_name,
+                          "Responding to CRLF keep-alive from %s",
+                          pj_addr_str_print(&tls->base.remote_name.host,
+                                            tls->base.remote_name.port, addr,
+                                            sizeof(addr), 1)));
+
+                send_st = pj_ssl_sock_send(tls->ssock, &tls->pong_op_key.key,
+                                           pong, &pong_len, 0);
+                if (send_st != PJ_SUCCESS && send_st != PJ_EPENDING) {
+                    tls_perror(tls->base.obj_name,
+                               "Error sending CRLF keep-alive response",
+                               send_st, &tls->remote_name);
+                }
+
+                if (ka_len == size) {
+                    /* Nothing but keep-alive(s) in this buffer. */
+                    *remainder = 0;
+                    pj_pool_reset(rdata->tp_info.pool);
+                    return PJ_TRUE;
+                }
+
+                /* Consume the ping(s); shift the rest to the front of the
+                 * buffer and carry on parsing it as usual.
+                 */
+                pj_memmove(data, (char*)data + ka_len, size - ka_len);
+                size -= ka_len;
+            }
+        }
+#endif
 
         /* Init pkt_info part. */
         rdata->pkt_info.len = size;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -2015,7 +2015,12 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
 
                 send_st = pj_ssl_sock_send(tls->ssock, &tls->pong_op_key.key,
                                            pong, &pong_len, 0);
-                if (send_st != PJ_SUCCESS && send_st != PJ_EPENDING) {
+                /* PJ_EBUSY means the data was queued behind an ongoing TLS
+                 * renegotiation, i.e. it will still be sent; not an error.
+                 */
+                if (send_st != PJ_SUCCESS && send_st != PJ_EPENDING &&
+                    send_st != PJ_EBUSY)
+                {
                     tls_perror(tls->base.obj_name,
                                "Error sending CRLF keep-alive response",
                                send_st, &tls->remote_name);

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -365,6 +365,7 @@ int test_main(int argc, char *argv[])
 
 #if INCLUDE_TCP_TEST
     UT_ADD_TEST(&test_app.ut_app, transport_tcp_test, 0);
+    UT_ADD_TEST(&test_app.ut_app, transport_tcp_keep_alive_test, 0);
 #endif
 
     /* Note: put exclusive tests last */

--- a/pjsip/src/test/test.h
+++ b/pjsip/src/test/test.h
@@ -107,6 +107,7 @@ int transport_loop_test(void);
 int transport_loop_multi_test(void);
 int transport_loop_resolve_error_test(void);
 int transport_tcp_test(void);
+int transport_tcp_keep_alive_test(void);
 int resolve_test(void);
 int regc_test(void);
 int auth_async_test(void);

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -254,8 +254,188 @@ int transport_tcp_test(void)
     /* Done */
     return 0;
 }
+
+
+#if PJSIP_TCP_KEEP_ALIVE_RESPONSE
+/* Send raw bytes and let the server process them. */
+static pj_status_t ka_send_raw(pj_sock_t sock, const void *data, pj_size_t len)
+{
+    pj_ssize_t sent = (pj_ssize_t)len;
+    pj_status_t status;
+
+    status = pj_sock_send(sock, data, &sent, 0);
+    if (status == PJ_SUCCESS && sent != (pj_ssize_t)len)
+        status = PJ_ETOOSMALL;
+
+    /* Let the server read the data and produce any response. */
+    flush_events(500);
+    return status;
+}
+
+/* Receive up to buf_size bytes within timeout_ms. Returns the number of bytes
+ * read, 0 on timeout (nothing received), or -1 on error.
+ */
+static pj_ssize_t ka_recv_timeout(pj_sock_t sock, void *buf,
+                                  pj_size_t buf_size, unsigned timeout_ms)
+{
+    pj_fd_set_t rset;
+    pj_time_val timeout;
+    pj_ssize_t len;
+    int n;
+    pj_status_t status;
+
+    PJ_FD_ZERO(&rset);
+    PJ_FD_SET(sock, &rset);
+    timeout.sec = timeout_ms / 1000;
+    timeout.msec = timeout_ms % 1000;
+
+    n = pj_sock_select((int)sock + 1, &rset, NULL, NULL, &timeout);
+    if (n < 1 || !PJ_FD_ISSET(sock, &rset))
+        return 0;
+
+    len = (pj_ssize_t)buf_size;
+    status = pj_sock_recv(sock, buf, &len, 0);
+    if (status != PJ_SUCCESS)
+        return -1;
+    return len;
+}
+#endif  /* PJSIP_TCP_KEEP_ALIVE_RESPONSE */
+
+
+/*
+ * TCP CRLF keep-alive response test (RFC 5626 Section 4.4.1).
+ *
+ * Open a raw TCP connection to a PJSIP TCP listener and verify that:
+ *  1. A double-CRLF keep-alive "ping" ("\r\n\r\n") is answered with a
+ *     single-CRLF "pong" ("\r\n").
+ *  2. A double CRLF that is NOT at the start of the stream - here it trails
+ *     other data, mimicking CRLFs that are a continuation of a previous
+ *     packet rather than a keep-alive ping - is NOT answered.
+ *  3. After the non-ping data, a genuine ping is still answered, i.e. the
+ *     stream was not left in a bad state.
+ */
+int transport_tcp_keep_alive_test(void)
+{
+#if PJSIP_TCP_KEEP_ALIVE_RESPONSE
+    enum { PONG_WAIT_MSEC = 2000, NO_PONG_WAIT_MSEC = 500 };
+    pjsip_tpfactory *tpfactory = NULL;
+    pj_sock_t sock = PJ_INVALID_SOCKET;
+    pj_sockaddr_in rem_addr;
+    const char ping[] = { '\r', '\n', '\r', '\n' };
+    /* Non-ping data whose leading byte is not CRLF, followed by a double CRLF.
+     * The double CRLF here is a continuation, not a ping, so it must be
+     * ignored by the keep-alive responder.
+     */
+    const char not_ping[] = { 'X', '\r', '\n', '\r', '\n' };
+    char buf[8];
+    pj_ssize_t len;
+    pj_status_t status;
+    int ret = 0;
+
+    PJ_LOG(3,(THIS_FILE, "  testing TCP CRLF keep-alive response"));
+
+    /* Start TCP listener on arbitrary port. */
+    status = pjsip_tcp_transport_start(endpt, NULL, 1, &tpfactory);
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to start TCP transport", status);
+        return -200;
+    }
+
+    /* Create a raw client socket and connect to the listener. */
+    status = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0, &sock);
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to create socket", status);
+        ret = -210;
+        goto on_return;
+    }
+
+    status = pj_sockaddr_in_init(&rem_addr, &tpfactory->addr_name.host,
+                                 (pj_uint16_t)tpfactory->addr_name.port);
+    if (status != PJ_SUCCESS) {
+        ret = -211;
+        goto on_return;
+    }
+
+    status = pj_sock_connect(sock, &rem_addr, sizeof(rem_addr));
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to connect to TCP listener", status);
+        ret = -212;
+        goto on_return;
+    }
+
+    /* Let the server accept the connection. */
+    flush_events(100);
+
+    /* Phase 1: a plain ping must be answered with exactly one CRLF pong. */
+    status = ka_send_raw(sock, ping, sizeof(ping));
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send keep-alive ping", status);
+        ret = -213;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), PONG_WAIT_MSEC);
+    if (len != 2 || buf[0] != '\r' || buf[1] != '\n') {
+        PJ_LOG(3,(THIS_FILE, "   Error: expected a CRLF pong, got %d byte(s)",
+                  (int)len));
+        ret = -220;
+        goto on_return;
+    }
+
+    /* Phase 2: a double CRLF that is not at the front of the stream must not
+     * be treated as a ping, hence no pong.
+     */
+    status = ka_send_raw(sock, not_ping, sizeof(not_ping));
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send non-ping data", status);
+        ret = -230;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), NO_PONG_WAIT_MSEC);
+    if (len != 0) {
+        PJ_LOG(3,(THIS_FILE, "   Error: got %d byte(s) response to a non-ping "
+                             "double CRLF (expected none)", (int)len));
+        ret = -231;
+        goto on_return;
+    }
+
+    /* Phase 3: a genuine ping after the non-ping data is still answered. */
+    status = ka_send_raw(sock, ping, sizeof(ping));
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send keep-alive ping", status);
+        ret = -240;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), PONG_WAIT_MSEC);
+    if (len != 2 || buf[0] != '\r' || buf[1] != '\n') {
+        PJ_LOG(3,(THIS_FILE, "   Error: expected a CRLF pong, got %d byte(s)",
+                  (int)len));
+        ret = -241;
+        goto on_return;
+    }
+
+    PJ_LOG(3,(THIS_FILE, "   TCP keep-alive response test OK"));
+
+on_return:
+    if (sock != PJ_INVALID_SOCKET)
+        pj_sock_close(sock);
+    if (tpfactory) {
+        pjsip_tpmgr_unregister_tpfactory(pjsip_endpt_get_tpmgr(endpt),
+                                         tpfactory);
+    }
+    flush_events(500);
+    return ret;
+#else
+    PJ_LOG(3,(THIS_FILE, "  skipping TCP CRLF keep-alive response test "
+                         "(PJSIP_TCP_KEEP_ALIVE_RESPONSE=0)"));
+    return 0;
+#endif  /* PJSIP_TCP_KEEP_ALIVE_RESPONSE */
+}
 #else   /* PJ_HAS_TCP */
 int transport_tcp_test(void)
+{
+    return 0;
+}
+int transport_tcp_keep_alive_test(void)
 {
     return 0;
 }

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -290,7 +290,9 @@ static pj_ssize_t ka_recv_timeout(pj_sock_t sock, void *buf,
     timeout.msec = timeout_ms % 1000;
 
     n = pj_sock_select((int)sock + 1, &rset, NULL, NULL, &timeout);
-    if (n < 1 || !PJ_FD_ISSET(sock, &rset))
+    if (n < 0)
+        return -1;
+    if (n == 0 || !PJ_FD_ISSET(sock, &rset))
         return 0;
 
     len = (pj_ssize_t)buf_size;


### PR DESCRIPTION
pjsip implements only the **sending** side of the RFC 5626 (Section 4.4.1) CRLF keep-alive: an idle TCP/TLS connection periodically sends a double-CRLF *ping* (`\r\n\r\n`, see `tcp_keep_alive_timer` / `PJSIP_TCP_KEEP_ALIVE_DATA`). It never answered an incoming ping, so a peer that uses CRLF keep-alives to probe liveness gets no *pong* and may tear down or needlessly reconnect the flow.

This adds the **receiving** side as a standalone transport-layer behavior (independent of the pjsua/RFC 5626 outbound client code).

Thanks to **Rajesh Batagurki** for proposing this feature/patch.

### What it does
When a stream transport (TCP or TLS) receives a double CRLF at the **start** of the read buffer, it replies with a single-CRLF pong (`\r\n`) before parsing, and consumes the ping byte(s).

Detection is deliberately limited to the front of the buffer. `pjsip_tpmgr_receive_packet()` only ever consumes whole messages, and an incomplete message keeps its start-line at the front of the buffer, so the buffer always begins at a SIP message boundary. A double CRLF appearing as message **body** content or as a **header/body separator** is therefore never at the front and is never mistaken for a ping.

### Notes
- A dedicated op key (`pong_op_key`) is used for the pong send so it can never collide with an in-flight keep-alive ping send that reuses `ka_op_key`.
- The response is **independent** of the keep-alive send interval — a pure server that does not send its own pings still answers them.
- Gated by `PJSIP_TCP_KEEP_ALIVE_RESPONSE` / `PJSIP_TLS_KEEP_ALIVE_RESPONSE` (default enabled).

### Testing
Adds `transport_tcp_keep_alive_test` to pjsip-test, verifying:
1. a plain ping is answered with exactly one CRLF pong;
2. a double CRLF that is **not** at the front of the stream (trailing other data, i.e. a continuation rather than a ping) is **not** answered;
3. a genuine ping after that non-ping data is still answered (stream not left in a bad state).

`make pjsip-test` builds clean (`-Wall`, no warnings); the new test and the existing `transport_tcp_test` both pass. The TLS path mirrors the TCP path exactly.

Co-Authored-By Claude Code