### PR TITLE
pjsua: select dialog Via address toward the actual next hop

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -845,6 +845,35 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
                                    int *p_secure,
                                    const void **p_tp);
 
+/* Get local transport address suitable to be used for the Via address of
+ * requests sent by a UAS dialog. Unlike pjsua_acc_get_uac_addr(), the next
+ * hop is taken from the dialog route set (from the incoming Record-Route),
+ * falling back to the remote target. Returns PJ_ENOTFOUND when the next hop
+ * is a reliable transport (the Via is then resolved at send time), so the
+ * caller should leave the Via untouched.
+ */
+pj_status_t pjsua_acc_get_uas_addr(pjsua_acc_id acc_id,
+                                   pj_pool_t *pool,
+                                   pjsip_dialog *dlg,
+                                   pjsip_host_port *addr,
+                                   pjsip_transport_type_e *p_tp_type,
+                                   int *p_secure,
+                                   const void **p_tp);
+
+/* Get local transport address for the Via of requests sent by a UAC dialog.
+ * Like pjsua_acc_get_uac_addr(), the next hop is the account outbound proxy
+ * when configured, but otherwise the dialog's remote target (not the account
+ * id URI). Returns PJ_ENOTFOUND when the next hop is a reliable transport (the
+ * Via is resolved at send time), so the caller should leave the Via untouched.
+ */
+pj_status_t pjsua_acc_get_uac_dlg_addr(pjsua_acc_id acc_id,
+                                       pj_pool_t *pool,
+                                       pjsip_dialog *dlg,
+                                       pjsip_host_port *addr,
+                                       pjsip_transport_type_e *p_tp_type,
+                                       int *p_secure,
+                                       const void **p_tp);
+
 /**
  * Handle incoming invite request.
  */

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -4073,16 +4073,20 @@ static int get_ip_addr_ver(const pj_str_t *host)
 /* Get local transport address suitable to be used for Via or Contact address
  * to send request to the specified destination URI.
  */
-pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
-                                   pj_pool_t *pool,
-                                   const pj_str_t *dst_uri,
-                                   pjsip_host_port *addr,
-                                   pjsip_transport_type_e *p_tp_type,
-                                   int *secure,
-                                   const void **p_tp)
+/* Determine the local address to use in the Via/Contact for requests sent
+ * toward sip_uri (the effective next hop). Factored out of
+ * pjsua_acc_get_uac_addr() so it can be shared with the dialog (UAS) variant
+ * pjsua_acc_get_uas_addr().
+ */
+static pj_status_t get_uac_addr_for_sip_uri(pjsua_acc_id acc_id,
+                                            pj_pool_t *pool,
+                                            pjsip_sip_uri *sip_uri,
+                                            pjsip_host_port *addr,
+                                            pjsip_transport_type_e *p_tp_type,
+                                            int *secure,
+                                            const void **p_tp)
 {
     pjsua_acc *acc;
-    pjsip_sip_uri *sip_uri;
     pj_status_t status;
     pjsip_transport_type_e tp_type = PJSIP_TRANSPORT_UNSPECIFIED;
     unsigned flag;
@@ -4092,31 +4096,7 @@ pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
     pjsip_tpmgr_fla2_param tfla2_prm;
     pj_bool_t update_addr = PJ_TRUE;
 
-    PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id), PJ_EINVAL);
     acc = &pjsua_var.acc[acc_id];
-
-    /* If route-set is configured for the account, then URI is the
-     * first entry of the route-set.
-     */
-    if (!pj_list_empty(&acc->route_set)) {
-        sip_uri = (pjsip_sip_uri*)
-                  pjsip_uri_get_uri(acc->route_set.next->name_addr.uri);
-    } else {
-        pj_str_t tmp;
-        pjsip_uri *uri;
-
-        pj_strdup_with_null(pool, &tmp, dst_uri);
-
-        uri = pjsip_parse_uri(pool, tmp.ptr, tmp.slen, 0);
-        if (uri == NULL)
-            return PJSIP_EINVALIDURI;
-
-        /* For non-SIP scheme, route set should be configured */
-        if (!PJSIP_URI_SCHEME_IS_SIP(uri) && !PJSIP_URI_SCHEME_IS_SIPS(uri))
-            return PJSIP_ENOROUTESET;
-
-        sip_uri = (pjsip_sip_uri*)pjsip_uri_get_uri(uri);
-    }
 
     /* Get transport type of the URI */
     if (sip_uri->transport_param.slen == 0) {
@@ -4393,6 +4373,142 @@ on_return:
         *p_tp = tfla2_prm.ret_tp;
 
     return PJ_SUCCESS;
+}
+
+
+pj_status_t pjsua_acc_get_uac_addr(pjsua_acc_id acc_id,
+                                   pj_pool_t *pool,
+                                   const pj_str_t *dst_uri,
+                                   pjsip_host_port *addr,
+                                   pjsip_transport_type_e *p_tp_type,
+                                   int *secure,
+                                   const void **p_tp)
+{
+    pjsua_acc *acc;
+    pjsip_sip_uri *sip_uri;
+
+    PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id), PJ_EINVAL);
+    acc = &pjsua_var.acc[acc_id];
+
+    /* If route-set is configured for the account, then URI is the
+     * first entry of the route-set.
+     */
+    if (!pj_list_empty(&acc->route_set)) {
+        sip_uri = (pjsip_sip_uri*)
+                  pjsip_uri_get_uri(acc->route_set.next->name_addr.uri);
+    } else {
+        pj_str_t tmp;
+        pjsip_uri *uri;
+
+        pj_strdup_with_null(pool, &tmp, dst_uri);
+
+        uri = pjsip_parse_uri(pool, tmp.ptr, tmp.slen, 0);
+        if (uri == NULL)
+            return PJSIP_EINVALIDURI;
+
+        /* For non-SIP scheme, route set should be configured */
+        if (!PJSIP_URI_SCHEME_IS_SIP(uri) && !PJSIP_URI_SCHEME_IS_SIPS(uri))
+            return PJSIP_ENOROUTESET;
+
+        sip_uri = (pjsip_sip_uri*)pjsip_uri_get_uri(uri);
+    }
+
+    return get_uac_addr_for_sip_uri(acc_id, pool, sip_uri, addr,
+                                    p_tp_type, secure, p_tp);
+}
+
+
+/* Compute the local Via address toward next_hop, skipping reliable transports
+ * (their Via is resolved from the real connection at send time, and probing
+ * here would open a spurious outbound connection when contact_use_src_port is
+ * enabled). Shared by the dialog variants below. Returns PJ_ENOTFOUND when the
+ * next hop is reliable, so the caller leaves the Via untouched.
+ */
+static pj_status_t get_dlg_via_addr(pjsua_acc_id acc_id,
+                                    pj_pool_t *pool,
+                                    pjsip_uri *next_hop,
+                                    pjsip_host_port *addr,
+                                    pjsip_transport_type_e *p_tp_type,
+                                    int *secure,
+                                    const void **p_tp)
+{
+    pjsip_host_info dest_info;
+
+    if (!PJSIP_URI_SCHEME_IS_SIP(next_hop) &&
+        !PJSIP_URI_SCHEME_IS_SIPS(next_hop))
+    {
+        return PJSIP_ENOROUTESET;
+    }
+
+    if (pjsip_get_dest_info(next_hop, NULL, pool, &dest_info) == PJ_SUCCESS &&
+        (dest_info.flag & PJSIP_TRANSPORT_RELIABLE) != 0)
+    {
+        return PJ_ENOTFOUND;
+    }
+
+    return get_uac_addr_for_sip_uri(acc_id, pool,
+                                    (pjsip_sip_uri*)pjsip_uri_get_uri(next_hop),
+                                    addr, p_tp_type, secure, p_tp);
+}
+
+
+/* UAS (incoming dialog) variant of pjsua_acc_get_uac_addr().
+ *
+ * In-dialog requests sent by a UAS dialog are routed via the dialog route set
+ * (built from the incoming Record-Route), falling back to the remote target -
+ * NOT via the account's outbound proxy. Select the local Via address toward
+ * that actual next hop.
+ */
+pj_status_t pjsua_acc_get_uas_addr(pjsua_acc_id acc_id,
+                                   pj_pool_t *pool,
+                                   pjsip_dialog *dlg,
+                                   pjsip_host_port *addr,
+                                   pjsip_transport_type_e *p_tp_type,
+                                   int *secure,
+                                   const void **p_tp)
+{
+    pjsip_uri *next_hop;
+
+    PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id) && dlg, PJ_EINVAL);
+
+    if (!pj_list_empty(&dlg->route_set))
+        next_hop = dlg->route_set.next->name_addr.uri;
+    else
+        next_hop = dlg->target;
+
+    return get_dlg_via_addr(acc_id, pool, next_hop, addr,
+                            p_tp_type, secure, p_tp);
+}
+
+
+/* UAC dialog variant of pjsua_acc_get_uac_addr().
+ *
+ * As with the account-based resolution, the next hop is the account's outbound
+ * proxy (acc->route_set) when configured; otherwise it is the dialog's remote
+ * target (the actual request destination) rather than the account id URI, so
+ * that on a multihomed host the Via reflects the interface toward the peer.
+ */
+pj_status_t pjsua_acc_get_uac_dlg_addr(pjsua_acc_id acc_id,
+                                       pj_pool_t *pool,
+                                       pjsip_dialog *dlg,
+                                       pjsip_host_port *addr,
+                                       pjsip_transport_type_e *p_tp_type,
+                                       int *secure,
+                                       const void **p_tp)
+{
+    pjsua_acc *acc;
+    pjsip_uri *next_hop;
+
+    PJ_ASSERT_RETURN(pjsua_acc_is_valid(acc_id) && dlg, PJ_EINVAL);
+    acc = &pjsua_var.acc[acc_id];
+
+    if (!pj_list_empty(&acc->route_set))
+        next_hop = acc->route_set.next->name_addr.uri;
+    else
+        next_hop = dlg->target;
+
+    return get_dlg_via_addr(acc_id, pool, next_hop, addr,
+                            p_tp_type, secure, p_tp);
 }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -763,29 +763,17 @@ static void dlg_set_via(pjsip_dialog *dlg, pjsua_acc *acc)
     } else if (!pjsua_sip_acc_is_using_stun(acc->index) &&
                !pjsua_sip_acc_is_using_upnp(acc->index))
     {
-        /* Choose local interface to use in Via if acc is not using
-         * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1804
-         * Skip if the outgoing target resolves to a reliable transport
-         * (e.g., TCP/TLS): pjsua_acc_get_uac_addr() would open a spurious
-         * outbound connection when contact_use_src_port is enabled, while
-         * the Via is correctly resolved when the request is actually sent
-         * over the real outbound connection.
+        /* Choose local interface to use in Via if acc is not using STUN nor
+         * UPnP. See https://github.com/pjsip/pjproject/issues/1804
+         * The address is selected toward the actual next hop (account outbound
+         * proxy if set, else the dialog's remote target); reliable transports
+         * are skipped and resolved at send time.
          */
         pjsip_host_port via_addr;
         const void *via_tp;
-        pjsip_host_info dest_info;
-        pj_bool_t reliable_dest = PJ_FALSE;
 
-        if (pjsip_get_dest_info((const pjsip_uri*)dlg->target, NULL,
-                                dlg->pool, &dest_info) == PJ_SUCCESS)
-        {
-            reliable_dest = (dest_info.flag & PJSIP_TRANSPORT_RELIABLE) != 0;
-        }
-
-        if (!reliable_dest &&
-            pjsua_acc_get_uac_addr(acc->index, dlg->pool, &acc->cfg.id,
-                                   &via_addr, NULL, NULL,
-                                   &via_tp) == PJ_SUCCESS)
+        if (pjsua_acc_get_uac_dlg_addr(acc->index, dlg->pool, dlg, &via_addr,
+                                       NULL, NULL, &via_tp) == PJ_SUCCESS)
         {
             pjsip_dlg_set_via_sent_by(dlg, &via_addr,
                                       (pjsip_transport*)via_tp);
@@ -2100,42 +2088,20 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
     } else if (!pjsua_sip_acc_is_using_stun(acc_id) &&
                !pjsua_sip_acc_is_using_upnp(acc_id))
     {
-        /* Choose local interface to use in Via if acc is not using
-         * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1804
-         * Skip if the caller's Contact resolves to a reliable transport
-         * (e.g., TCP/TLS): pjsua_acc_get_uac_addr() would open a spurious
-         * outbound connection to the Contact when contact_use_src_port is enabled.
+        /* Choose local interface to use in Via if acc is not using STUN nor
+         * UPnP. See https://github.com/pjsip/pjproject/issues/1804
+         * The address is selected toward the dialog's actual next hop (route
+         * set from Record-Route, else the remote target); reliable transports
+         * are skipped and resolved at send time.
          */
+        pjsip_host_port via_addr;
+        const void *via_tp;
+
+        if (pjsua_acc_get_uas_addr(acc_id, dlg->pool, dlg, &via_addr,
+                                   NULL, NULL, &via_tp) == PJ_SUCCESS)
         {
-            char target_buf[PJSIP_MAX_URL_SIZE];
-            pj_str_t target;
-            pjsip_host_port via_addr;
-            const void *via_tp;
-            pjsip_host_info dest_info;
-            pj_bool_t reliable_dest = PJ_FALSE;
-
-            if (pjsip_get_dest_info((const pjsip_uri*)dlg->target, NULL,
-                                    dlg->pool, &dest_info) == PJ_SUCCESS)
-            {
-                reliable_dest = (dest_info.flag & PJSIP_TRANSPORT_RELIABLE)
-                                != 0;
-            }
-
-            if (!reliable_dest) {
-                target.ptr = target_buf;
-                target.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
-                                              dlg->target,
-                                              target_buf, sizeof(target_buf));
-                if (target.slen < 0) target.slen = 0;
-
-                if (pjsua_acc_get_uac_addr(acc_id, dlg->pool, &target,
-                                           &via_addr, NULL, NULL,
-                                           &via_tp) == PJ_SUCCESS)
-                {
-                    pjsip_dlg_set_via_sent_by(dlg, &via_addr,
-                                              (pjsip_transport*)via_tp);
-                }
-            }
+            pjsip_dlg_set_via_sent_by(dlg, &via_addr,
+                                      (pjsip_transport*)via_tp);
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -1066,40 +1066,20 @@ static pj_bool_t pres_on_rx_request(pjsip_rx_data *rdata)
     } else if (!pjsua_sip_acc_is_using_stun(acc_id) &&
                !pjsua_sip_acc_is_using_upnp(acc_id))
     {
-        /* Choose local interface to use in Via if acc is not using
-         * STUN nor UPnP. See https://github.com/pjsip/pjproject/issues/1412
-         * Skip if the subscriber's Contact resolves to a reliable transport
-         * (e.g., TCP/TLS): pjsua_acc_get_uac_addr() would open a spurious
-         * outbound connection to the Contact when contact_use_src_port is
-         * enabled.
+        /* Choose local interface to use in Via if acc is not using STUN nor
+         * UPnP. See https://github.com/pjsip/pjproject/issues/1412
+         * The address is selected toward the dialog's actual next hop (route
+         * set from Record-Route, else the remote target); reliable transports
+         * are skipped and resolved at send time.
          */
-        char target_buf[PJSIP_MAX_URL_SIZE];
-        pj_str_t target;
         pjsip_host_port via_addr;
         const void *via_tp;
-        pjsip_host_info dest_info;
-        pj_bool_t reliable_dest = PJ_FALSE;
 
-        if (pjsip_get_dest_info((const pjsip_uri*)dlg->target, NULL,
-                                dlg->pool, &dest_info) == PJ_SUCCESS)
+        if (pjsua_acc_get_uas_addr(acc_id, dlg->pool, dlg, &via_addr,
+                                   NULL, NULL, &via_tp) == PJ_SUCCESS)
         {
-            reliable_dest = (dest_info.flag & PJSIP_TRANSPORT_RELIABLE) != 0;
-        }
-
-        if (!reliable_dest) {
-            target.ptr = target_buf;
-            target.slen = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
-                                          dlg->target,
-                                          target_buf, sizeof(target_buf));
-            if (target.slen < 0) target.slen = 0;
-
-            if (pjsua_acc_get_uac_addr(acc_id, dlg->pool, &target,
-                                       &via_addr, NULL, NULL,
-                                       &via_tp) == PJ_SUCCESS)
-            {
-                pjsip_dlg_set_via_sent_by(dlg, &via_addr,
-                                          (pjsip_transport*)via_tp);
-            }
+            pjsip_dlg_set_via_sent_by(dlg, &via_addr,
+                                      (pjsip_transport*)via_tp);
         }
     }
 


### PR DESCRIPTION
Follow-up to #5051 (now merged); this PR targets master and contains only its own change.

## Problem

When an account is not using STUN/UPnP, pjsua selects the local Via `sent-by` for a dialog via `pjsua_acc_get_uac_addr()`. That function resolves the destination from the **account's** outbound proxy (`acc->route_set`) or the passed target URI. That reference is wrong for the request's actual next hop in two cases:

- **UAS dialogs** (incoming call, incoming SUBSCRIBE): in-dialog requests (BYE, NOTIFY, re-INVITE) are routed via the **dialog** route set built from the incoming Record-Route, falling back to the remote target — never the account's outbound proxy.
- **Outgoing call** (`dlg_set_via`): the target passed was `acc->cfg.id` (the account id URI), not the dialog's remote target. With no account proxy, the Via is computed toward the account domain instead of the actual callee.

On a multihomed host these can put the wrong local interface in the Via.

## Change

Factor the address-resolution body of `pjsua_acc_get_uac_addr()` into a shared static core `get_uac_addr_for_sip_uri()` — **behavior for all existing UAC callers is unchanged** — and add two dialog variants that compute the address toward the actual next hop and skip reliable transports (their Via is resolved from the real connection at send time; they return `PJ_ENOTFOUND` so the caller leaves the Via untouched):

- `pjsua_acc_get_uas_addr()` — next hop = `dlg->route_set` top (from the incoming Record-Route), else `dlg->target`. Used by `pjsua_call_on_incoming()` and `pres_on_rx_request()`.
- `pjsua_acc_get_uac_dlg_addr()` — next hop = account outbound proxy when set, else the dialog's remote target (`dlg->target`) rather than `acc->cfg.id`. Used by `dlg_set_via()`.

Keying the reliable-transport skip off the true next hop also fixes a corner case where a UDP next hop reached via a reliable target/proxy could get a STUN-mapped address in the Via (#1804 / #1412).

## Notes

- UDP behavior in the common case (no Record-Route, no account proxy) is unchanged — the address is still computed toward `dlg->target`.
- No public API change; the two new functions are internal (`pjsua_internal.h`).

## Testing

Non-sanitizer build:
- `100_simple.py` (UDP call) — pass
- `200_tcp.py` (TCP call) — pass

(The `100_peertopeer.py` presence test fails identically on master and is a pre-existing environment issue, not related to this change.)
