### PR TITLE
pjsip: handle fragmented CRLF keep-alive ping on TCP/TLS

### DIFF
--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1409,22 +1409,42 @@ static pj_status_t tcp_shutdown(pjsip_transport *transport)
  * Callback from ioqueue that an incoming data is received from the socket.
  */
 #if PJSIP_TCP_KEEP_ALIVE_RESPONSE
-/* Count the leading bytes of a received buffer that form RFC 5626 (Section
- * 4.4.1) CRLF keep-alive "ping"(s), i.e. one or more consecutive "\r\n\r\n"
- * (double CRLF) sequences at the start of the buffer. Returns 0 if the buffer
- * does not begin with a ping.
+/* RFC 5626 Section 4.4.1 CRLF keep-alive patterns: the accepted "ping" and
+ * the "pong" reply. Defined together in one place, with lengths derived via
+ * sizeof, so both can be adjusted - or made configurable, e.g. a single CRLF
+ * or a longer packet - without touching the scan/response logic. The pong
+ * has static lifetime so it stays valid until the (async) send completes.
  */
-static pj_size_t tcp_get_crlf_ka_len(const char *data, pj_size_t size)
-{
-    pj_size_t i = 0;
+static const char tcp_crlf_ka_ping[] = { '\r', '\n', '\r', '\n' };
+static const char tcp_crlf_ka_pong[] = { '\r', '\n' };
 
-    while (size - i >= 4 &&
-           data[i+0] == '\r' && data[i+1] == '\n' &&
-           data[i+2] == '\r' && data[i+3] == '\n')
+/* Count the leading bytes of a received buffer that form CRLF keep-alive
+ * "ping"(s), i.e. one or more consecutive ping patterns at the start of the
+ * buffer. Returns 0 if the buffer does not begin with a ping.
+ */
+static pj_size_t tcp_get_crlf_ka_len(const char *data, pj_size_t size,
+                                     pj_size_t *partial_len)
+{
+    const char *ka = tcp_crlf_ka_ping;
+    const pj_size_t ka_sz = sizeof(tcp_crlf_ka_ping);
+    pj_size_t matched = 0, tail;
+
+    while (size - matched >= ka_sz &&
+           pj_memcmp(data + matched, ka, ka_sz) == 0)
     {
-        i += 4;
+        matched += ka_sz;
     }
-    return i;
+
+    /* A ping may be fragmented across reads, leaving a 1..(ka_sz-1) byte
+     * prefix of the pattern at the end. Report it so the caller can retain
+     * and reassemble it with the next read, rather than handing it to the
+     * parser (whose leading-newline skip would drop it, leaving the ping
+     * unanswered).
+     */
+    tail = size - matched;
+    *partial_len = (tail >= 1 && tail < ka_sz &&
+                    pj_memcmp(data + matched, ka, tail) == 0) ? tail : 0;
+    return matched;
 }
 #endif
 
@@ -1468,14 +1488,12 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
          * SIP parser (which would otherwise drop them as a malformed message).
          */
         {
-            pj_size_t ka_len = tcp_get_crlf_ka_len((char*)data, size);
+            pj_size_t partial_len;
+            pj_size_t ka_len = tcp_get_crlf_ka_len((char*)data, size,
+                                                   &partial_len);
 
             if (ka_len) {
-                /* Static storage: the buffer must stay valid until the
-                 * (possibly asynchronous) send completes.
-                 */
-                static const char pong[] = { '\r', '\n' };
-                pj_ssize_t pong_len = 2;
+                pj_ssize_t pong_len = sizeof(tcp_crlf_ka_pong);
                 char addr[PJ_INET6_ADDRSTRLEN+10];
                 pj_status_t send_st;
 
@@ -1486,13 +1504,28 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
                                             sizeof(addr), 1)));
 
                 send_st = pj_activesock_send(tcp->asock, &tcp->pong_op_key.key,
-                                             pong, &pong_len, 0);
+                                             tcp_crlf_ka_pong, &pong_len, 0);
                 if (send_st != PJ_SUCCESS && send_st != PJ_EPENDING) {
                     tcp_perror(tcp->base.obj_name,
                                "Error sending CRLF keep-alive response",
                                send_st);
                 }
+            }
 
+            /* A ping fragmented across reads leaves a trailing incomplete
+             * ping: keep those 1-3 bytes so they reassemble with the next
+             * read (otherwise the parser's leading-newline skip would drop
+             * them and the ping would go unanswered).
+             */
+            if (partial_len) {
+                if (ka_len)
+                    pj_memmove(data, (char*)data + ka_len, partial_len);
+                *remainder = partial_len;
+                pj_pool_reset(rdata->tp_info.pool);
+                return PJ_TRUE;
+            }
+
+            if (ka_len) {
                 if (ka_len == size) {
                     /* Nothing but keep-alive(s) in this buffer. */
                     *remainder = 0;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -1937,22 +1937,42 @@ static pj_status_t tls_shutdown(pjsip_transport *transport)
  * Callback from ioqueue that an incoming data is received from the socket.
  */
 #if PJSIP_TLS_KEEP_ALIVE_RESPONSE
-/* Count the leading bytes of a received buffer that form RFC 5626 (Section
- * 4.4.1) CRLF keep-alive "ping"(s), i.e. one or more consecutive "\r\n\r\n"
- * (double CRLF) sequences at the start of the buffer. Returns 0 if the buffer
- * does not begin with a ping.
+/* RFC 5626 Section 4.4.1 CRLF keep-alive patterns: the accepted "ping" and
+ * the "pong" reply. Defined together in one place, with lengths derived via
+ * sizeof, so both can be adjusted - or made configurable, e.g. a single CRLF
+ * or a longer packet - without touching the scan/response logic. The pong
+ * has static lifetime so it stays valid until the (async) send completes.
  */
-static pj_size_t tls_get_crlf_ka_len(const char *data, pj_size_t size)
-{
-    pj_size_t i = 0;
+static const char tls_crlf_ka_ping[] = { '\r', '\n', '\r', '\n' };
+static const char tls_crlf_ka_pong[] = { '\r', '\n' };
 
-    while (size - i >= 4 &&
-           data[i+0] == '\r' && data[i+1] == '\n' &&
-           data[i+2] == '\r' && data[i+3] == '\n')
+/* Count the leading bytes of a received buffer that form CRLF keep-alive
+ * "ping"(s), i.e. one or more consecutive ping patterns at the start of the
+ * buffer. Returns 0 if the buffer does not begin with a ping.
+ */
+static pj_size_t tls_get_crlf_ka_len(const char *data, pj_size_t size,
+                                     pj_size_t *partial_len)
+{
+    const char *ka = tls_crlf_ka_ping;
+    const pj_size_t ka_sz = sizeof(tls_crlf_ka_ping);
+    pj_size_t matched = 0, tail;
+
+    while (size - matched >= ka_sz &&
+           pj_memcmp(data + matched, ka, ka_sz) == 0)
     {
-        i += 4;
+        matched += ka_sz;
     }
-    return i;
+
+    /* A ping may be fragmented across reads, leaving a 1..(ka_sz-1) byte
+     * prefix of the pattern at the end. Report it so the caller can retain
+     * and reassemble it with the next read, rather than handing it to the
+     * parser (whose leading-newline skip would drop it, leaving the ping
+     * unanswered).
+     */
+    tail = size - matched;
+    *partial_len = (tail >= 1 && tail < ka_sz &&
+                    pj_memcmp(data + matched, ka, tail) == 0) ? tail : 0;
+    return matched;
 }
 #endif
 
@@ -1996,14 +2016,12 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
          * SIP parser (which would otherwise drop them as a malformed message).
          */
         {
-            pj_size_t ka_len = tls_get_crlf_ka_len((char*)data, size);
+            pj_size_t partial_len;
+            pj_size_t ka_len = tls_get_crlf_ka_len((char*)data, size,
+                                                   &partial_len);
 
             if (ka_len) {
-                /* Static storage: the buffer must stay valid until the
-                 * (possibly asynchronous) send completes.
-                 */
-                static const char pong[] = { '\r', '\n' };
-                pj_ssize_t pong_len = 2;
+                pj_ssize_t pong_len = sizeof(tls_crlf_ka_pong);
                 char addr[PJ_INET6_ADDRSTRLEN+10];
                 pj_status_t send_st;
 
@@ -2014,7 +2032,7 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
                                             sizeof(addr), 1)));
 
                 send_st = pj_ssl_sock_send(tls->ssock, &tls->pong_op_key.key,
-                                           pong, &pong_len, 0);
+                                           tls_crlf_ka_pong, &pong_len, 0);
                 /* PJ_EBUSY means the data was queued behind an ongoing TLS
                  * renegotiation, i.e. it will still be sent; not an error.
                  */
@@ -2025,7 +2043,22 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
                                "Error sending CRLF keep-alive response",
                                send_st, &tls->remote_name);
                 }
+            }
 
+            /* A ping fragmented across reads leaves a trailing incomplete
+             * ping: keep those bytes so they reassemble with the next read
+             * (otherwise the parser's leading-newline skip would drop them
+             * and the ping would go unanswered).
+             */
+            if (partial_len) {
+                if (ka_len)
+                    pj_memmove(data, (char*)data + ka_len, partial_len);
+                *remainder = partial_len;
+                pj_pool_reset(rdata->tp_info.pool);
+                return PJ_TRUE;
+            }
+
+            if (ka_len) {
                 if (ka_len == size) {
                     /* Nothing but keep-alive(s) in this buffer. */
                     *remainder = 0;

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -315,6 +315,9 @@ static pj_ssize_t ka_recv_timeout(pj_sock_t sock, void *buf,
  *     packet rather than a keep-alive ping - is NOT answered.
  *  3. After the non-ping data, a genuine ping is still answered, i.e. the
  *     stream was not left in a bad state.
+ *  4. A ping fragmented across TCP reads ("\r\n"+"\r\n", and "\r"+"\n\r\n")
+ *     is reassembled and answered exactly once, with no pong for the
+ *     incomplete leading fragment.
  */
 int transport_tcp_keep_alive_test(void)
 {
@@ -412,6 +415,65 @@ int transport_tcp_keep_alive_test(void)
         PJ_LOG(3,(THIS_FILE, "   Error: expected a CRLF pong, got %d byte(s)",
                   (int)len));
         ret = -241;
+        goto on_return;
+    }
+
+    /* Phase 4-5: a ping fragmented across two reads ("\r\n" then "\r\n")
+     * must be reassembled and answered once. The first fragment on its own
+     * must not draw a pong, and must not be dropped either.
+     */
+    status = ka_send_raw(sock, ping, 2);                /* "\r\n" */
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send ping fragment", status);
+        ret = -250;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), NO_PONG_WAIT_MSEC);
+    if (len != 0) {
+        PJ_LOG(3,(THIS_FILE, "   Error: got %d byte(s) for a partial ping "
+                             "fragment (expected none)", (int)len));
+        ret = -251;
+        goto on_return;
+    }
+    status = ka_send_raw(sock, ping + 2, 2);            /* completing "\r\n" */
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send ping fragment", status);
+        ret = -252;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), PONG_WAIT_MSEC);
+    if (len != 2 || buf[0] != '\r' || buf[1] != '\n') {
+        PJ_LOG(3,(THIS_FILE, "   Error: expected a CRLF pong for a reassembled "
+                             "fragmented ping, got %d byte(s)", (int)len));
+        ret = -253;
+        goto on_return;
+    }
+
+    /* Phase 6-7: fragmentation on an odd boundary ("\r" then "\n\r\n"). */
+    status = ka_send_raw(sock, ping, 1);                /* "\r" */
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send ping fragment", status);
+        ret = -260;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), NO_PONG_WAIT_MSEC);
+    if (len != 0) {
+        PJ_LOG(3,(THIS_FILE, "   Error: got %d byte(s) for a 1-byte ping "
+                             "fragment (expected none)", (int)len));
+        ret = -261;
+        goto on_return;
+    }
+    status = ka_send_raw(sock, ping + 1, 3);            /* "\n\r\n" */
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send ping fragment", status);
+        ret = -262;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), PONG_WAIT_MSEC);
+    if (len != 2 || buf[0] != '\r' || buf[1] != '\n') {
+        PJ_LOG(3,(THIS_FILE, "   Error: expected a CRLF pong for an odd-boundary "
+                             "fragmented ping, got %d byte(s)", (int)len));
+        ret = -263;
         goto on_return;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #5059 (RFC 5626 CRLF keep-alive "pong" on TCP/TLS): handle a keep-alive **ping fragmented across reads**.

## Problem

The responder only recognized a complete `\r\n\r\n` ping within a single read (`*_get_crlf_ka_len()` requires ≥4 bytes). When the ping is split across TCP/TLS reads, e.g.:

- Read 1 `\r\n`, Read 2 `\r\n`, or
- Read 1 `\r`, Read 2 `\n\r\n`

each fragment is < 4 bytes, so the scan returns 0 and the partial bytes fall through to `pjsip_tpmgr_receive_packet()`. Its leading-newline skip (`sip_transport.c`, "Skip leading newlines") **consumes and drops** a newline-only buffer (returns the full length, reported via `tp_drop_data_cb` as `PJ_EIGNORED`). The fragments are therefore never reassembled, so `\r\n\r\n` is never seen and the ping goes **unanswered** (no pong).

Note the bytes do not reach the SIP parser — they are dropped by the newline skip before it — so there is no risk of corrupting a valid SIP message. The only symptom is a missed pong on a fragmented ping (benign, low-frequency: a 4-byte ping rarely splits across reads).

## Fix

In `on_data_read()` (TCP and TLS), after counting complete leading pings, detect a **trailing incomplete ping prefix** (1..len-1 bytes matching a prefix of the ping pattern) and retain it as the read *remainder* so it merges with the next read instead of being dropped. At most `ping_len - 1` bytes are ever held.

Implementation notes:

- Folded into the existing scan helper via a `partial_len` out-param — no new standalone function.
- The accepted **ping** and the **pong** reply are now single named constants (`*_crlf_ka_ping` / `*_crlf_ka_pong`) with `sizeof`-derived lengths, so both can be adjusted — or made configurable (single CRLF, longer packet) — without touching the scan/response logic. The fragment-hold and pong send generalize to any pattern length.

## Test

`transport_tcp_keep_alive_test` extended with fragmented-ping phases (`\r\n`+`\r\n` and `\r`+`\n\r\n`): the incomplete leading fragment draws no pong, and the reassembled ping is answered exactly once. Verified the new phases fail without the fix and pass with it.
