### PR TITLE
fix: crash in subscribe_buddy

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_pres.c
+++ b/pjsip/src/pjsua-lib/pjsua_pres.c
@@ -2231,7 +2231,7 @@ static void subscribe_buddy(pjsua_buddy_id buddy_id,
         return;
     }
 
-    pjsip_dlg_dec_lock(buddy->dlg);
+    pjsip_dlg_dec_lock(dlg);
     if (tmp_pool) pj_pool_release(tmp_pool);
     pj_log_pop_indent();
 }


### PR DESCRIPTION
Fix an inconsistence when decreasing the `dlg` lock. `dlg` keeps a safe spare copy of `buddy->dlg` just in case the buddy resets it's state in between.

While

```c
if (status != PJ_SUCCESS) {
    pjsip_dlg_dec_lock(dlg); // 2223 
    ...
    return;
}
```

uses the cache, it is not used in

```c
pjsip_dlg_dec_lock(buddy->dlg); // 2234
```

which leads to a crash here.