### PR TITLE
[pjmedia] Fix conference bridge port removal race in parallel backend

### DIFF
--- a/pjmedia/src/pjmedia/conf_thread.c
+++ b/pjmedia/src/pjmedia/conf_thread.c
@@ -2378,12 +2378,29 @@ PJ_DEF(pj_status_t) pjmedia_conf_remove_port( pjmedia_conf *conf,
         if (found) {
             pjmedia_conf_op_param prm;
 
+            /* Mark the port as removing before releasing the mutex, so
+             * other threads can no longer queue any operation on it
+             * (e.g: connect/disconnect) nor remove it again while it is
+             * being destroyed below.
+             */
+            conf_port->removing = PJ_TRUE;
+
             /* Release mutex to avoid deadlock */
             pj_mutex_unlock(conf->mutex);
 
-            /* Remove it */
+            /* The port has never been active (its add-op has just been
+             * cancelled above), so it has no connection and the clock
+             * thread never touches it. Do not call op_remove_port() from
+             * this thread as it modifies states shared with the clock
+             * thread (e.g: disconnecting the port from other ports and
+             * updating the active listener array), so it can only be run
+             * by the clock thread. The port's own resources are freed by
+             * op_remove_port2() below.
+             */
+            PJ_LOG(4,(THIS_FILE,"Removing new port %d (%.*s) synchronously",
+                      port, (int)conf_port->name.slen, conf_port->name.ptr));
+
             prm.remove_port.port = port;
-            status = op_remove_port(conf, &prm);
 
             if (conf->cb) {
                 pjmedia_conf_op_info op_info = { 0 };


### PR DESCRIPTION
## Problem

This is the parallel-bridge counterpart of #5057. The parallel conference bridge backend (`pjmedia/src/pjmedia/conf_thread.c`, selected via `PJMEDIA_CONF_BACKEND == PJMEDIA_CONF_PARALLEL_BRIDGE_BACKEND`) is maintained as a near-copy of the serial bridge (`conference.c`) and carries the **identical race condition** in the synchronous port-removal path of `pjmedia_conf_remove_port()`.

When a newly added port (still `is_new`, i.e. its ADD op has not yet been executed by the clock thread) is removed, `pjmedia_conf_remove_port()` cancels the queued ADD op under the mutex and then tears the port down synchronously. The problem: it releases `conf->mutex` **without marking the port `removing`**, leaving a window in which the dying slot still looks fully valid to other threads.

During that window:

- A concurrent `pjmedia_conf_connect_port()` passes validation and queues a CONNECT op on the slot. The clock thread can execute it after the teardown has begun, leaving a listener-array entry pointing at a slot that is freed moments later → NULL deref in `get_frame()` on the next tick.
- A concurrent `pjmedia_conf_remove_port()` no longer finds the (already cancelled) ADD op, so it queues a REMOVE op. The clock thread then runs the teardown concurrently with the synchronous removal on the API thread → double free / use-after-free.

Independently of the window, running `op_remove_port()` on the API thread is itself a contract violation: its disconnect scans and `active_listener[]` updates modify state owned by the clock thread, racing with `get_frame()` and queued ops.

## Fix

Mirrors #5057, adapted to this backend's structure:

- **Mark the port `removing` before releasing the mutex** in the synchronous removal path, so other threads can no longer queue ops on the slot nor remove it again (they get `PJ_EINVAL`, same as during a queued removal). The connect/disconnect/remove entry points already gate on `removing`.
- **Do not call `op_remove_port()` from the API thread.** A port whose ADD op was found and cancelled has never executed any op (ops are FIFO; any op referencing the slot was queued after its ADD), so it has no connection and nothing to disconnect.

Note a structural difference from the serial bridge: in `conf_thread.c` the port's own resources (resample states, delay buffer, pjmedia port, plus the parallel-bridge-specific tx_lock / slist caches) are destroyed in `destroy_conf_port()`, which is reached via `op_remove_port2()` — **not** in `op_remove_port()`. Since the synchronous path already calls `op_remove_port2()` at the end, simply dropping the `op_remove_port()` call is sufficient: resources are still destroyed and the slot is still freed synchronously. This preserves the *no-clock-running* use case the synchronous path exists for (immediate slot reclamation so the bridge doesn't run out of slots when the clock thread isn't draining the op queue).

## Testing

- `conf_thread.c` compiles cleanly (`-Wall`) under `PJMEDIA_CONF_BACKEND=PJMEDIA_CONF_PARALLEL_BRIDGE_BACKEND`.
- The reproducer attached to #5057 targets the same API and code path; this change applies the same reasoning to the parallel backend.

Refs #5057

Co-Authored-By Claude Code