### PR TITLE
[pjmedia] Fix VP8 RTP payload descriptor size in FFmpeg codec wrapper

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -413,10 +413,11 @@ static FUNC_PACKETIZE(vpx_packetize)
 {
     vpx_data *data = (vpx_data *)ff->data;
     pj_status_t status;
-    unsigned payload_desc_size = 1;
+    /* For VP8, use 4 bytes payload desc, see #4659 for more info */
+    unsigned payload_desc_size = (ff->desc->info.fmt_id == PJMEDIA_FORMAT_VP8)?
+                                 4 : 1;
     pj_uint8_t *outbuf = payload;
     pj_size_t out_size = *payload_len;
-    out_size -= payload_desc_size;
 
     status = pjmedia_vpx_packetize(data->pktz, bits_len, bits_pos, is_keyframe,
                                    &outbuf, &out_size);


### PR DESCRIPTION
Fixes #5061.

## Problem

The FFmpeg video codec wrapper `vpx_packetize()` in `ffmpeg_vid_codecs.c` hardcodes the VP8/VP9 RTP payload descriptor size to **1 byte**:

```c
unsigned payload_desc_size = 1;
...
out_size -= payload_desc_size;
...
pj_memcpy(outbuf + payload_desc_size, bits + *bits_pos, out_size);
```

Since #4659/#4660, `pjmedia_vpx_packetize()` writes a **4-byte** descriptor for VP8 (`0x80`, extended control bits `ILTK`, dual-octet PictureID) into the output buffer. Because the wrapper only reserves 1 byte, it copies the encoded VP8 frame at `outbuf + 1`, **overwriting descriptor bytes 1..3**.

The emitted RTP payload therefore looks like:

```
90 b0 1f 00 9d 01 2a ...      <- 0x90 desc byte 0, then VP8 frame clobbering bytes 1..3
```

Receivers see the extended (`X`) bit set in `0x90` but find frame data where the extension octets should be, so every VP8 frame is dropped before decode. This matches the reporter's WebRTC symptoms exactly: packets received, codec recognized as VP8, `framesReceived` increments, but `framesDecoded` stays `0`.

The native libvpx codec (`vpx.c`) already handles this correctly with a 4-byte descriptor; only the FFmpeg wrapper was left out of sync when the descriptor grew to 4 bytes.

## Fix

Align the FFmpeg wrapper with `vpx.c`:

- Use `payload_desc_size = (VP8 ? 4 : 1)` so the frame is copied after the full descriptor and the descriptor bytes are preserved.
- Drop `out_size -= payload_desc_size`: `pjmedia_vpx_packetize()` already accounts for the descriptor size internally (it computes `PJ_MIN(remaining, mtu - desc)` and checks `frame + desc <= buffer`), so the wrapper must pass the full output buffer size, exactly as `vpx.c` does. The previous subtraction double-counted the descriptor.

VP9 is unaffected (1-byte descriptor in both paths).

## Verification

Built with `./configure --disable-vpx` (so `PJMEDIA_HAS_FFMPEG_CODEC_VP8 == 1`, i.e. VP8 goes through FFmpeg — the reporter's configuration) and `PJMEDIA_HAS_VIDEO=1`:

- `ffmpeg_vid_codecs.c` compiles cleanly (`-Wall`), no new warnings.
- A behavioral test driving the **real** `pjmedia_vpx_packetize()` through the old and new wrapper logic on a VP8 keyframe:

```
OLD payload:  90 b0 1f 00 9d 01 2a 40 01 f0     <- broken (reporter's observed output)
NEW payload:  90 80 80 01 b0 1f 00 9d 01 2a     <- fixed: 4-byte desc + intact VP8 frame
```

The fixed output matches the reporter's expected `90 80 xx yy b0 1f 00 ...` (descriptor `90 80 80 01`, PictureID=1, followed by the untouched VP8 frame `b0 1f 00 ...`).

Co-Authored-By Claude Code