### PR TITLE
pjmedia: Handle zero-port bundle-only offers

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1273,10 +1273,87 @@ static void apply_answer_symmetric_pt(pj_pool_t *pool,
 }
 
 
+/* Return PJ_TRUE if a session-level group attribute contains the supplied MID
+ * in a BUNDLE group.
+ */
+static pj_bool_t bundle_group_contains_mid(const pjmedia_sdp_session *sdp,
+                                           const pj_str_t *mid)
+{
+    unsigned i;
+
+    for (i = 0; i < sdp->attr_count; ++i) {
+        const pjmedia_sdp_attr *attr = sdp->attr[i];
+        const char *pos, *end;
+        unsigned token_index = 0;
+        pj_bool_t is_bundle = PJ_FALSE;
+
+        if (pj_stricmp2(&attr->name, "group") != 0)
+            continue;
+
+        pos = attr->value.ptr;
+        end = attr->value.ptr + attr->value.slen;
+
+        while (pos < end) {
+            const char *token_start;
+            pj_str_t token;
+
+            while (pos < end && (*pos == ' ' || *pos == '\t'))
+                ++pos;
+            if (pos == end)
+                break;
+
+            token_start = pos;
+            while (pos < end && *pos != ' ' && *pos != '\t')
+                ++pos;
+
+            token.ptr = (char *)token_start;
+            token.slen = pos - token_start;
+
+            if (token_index++ == 0) {
+                is_bundle = (pj_stricmp2(&token, "BUNDLE") == 0);
+                if (!is_bundle)
+                    break;
+                continue;
+            }
+
+            if (is_bundle && pj_strcmp(&token, mid) == 0)
+                return PJ_TRUE;
+        }
+    }
+
+    return PJ_FALSE;
+}
+
+
+/* RFC 9143 allows a bundled m= section in an offer to use port zero when
+ * a=bundle-only is present.  The exception only applies when the section has
+ * a MID and that MID is actually listed in a session-level group:BUNDLE
+ * attribute.
+ */
+static pj_bool_t is_bundle_only_offer(const pjmedia_sdp_session *sdp,
+                                      const pjmedia_sdp_media *media)
+{
+    const pjmedia_sdp_attr *mid;
+
+    if (media->desc.port != 0 ||
+        !pjmedia_sdp_media_find_attr2(media, "bundle-only", NULL))
+    {
+        return PJ_FALSE;
+    }
+
+    mid = pjmedia_sdp_media_find_attr2(media, "mid", NULL);
+    if (!mid)
+        return PJ_FALSE;
+
+    return bundle_group_contains_mid(sdp, &mid->value);
+}
+
+
 /* Try to match offer with answer. */
 static pj_status_t match_offer(pj_pool_t *pool,
                                pj_bool_t prefer_remote_codec_order,
                                pj_bool_t answer_with_multiple_codecs,
+                               pj_bool_t bundle_only,
                                const pjmedia_sdp_media *offer,
                                const pjmedia_sdp_media *preanswer,
                                const pjmedia_sdp_session *preanswer_sdp,
@@ -1298,8 +1375,11 @@ static pj_status_t match_offer(pj_pool_t *pool,
     unsigned nclockrate = 0, clockrate[PJMEDIA_MAX_SDP_FMT];
     unsigned ntel_clockrate = 0, tel_clockrate[PJMEDIA_MAX_SDP_FMT];
 
-    /* If offer has zero port, just clone the offer */
-    if (offer->desc.port == 0) {
+    /* A zero port normally disables an offered media section. RFC 9143
+     * defines an exception for a valid bundle-only section, which must be
+     * answered using the BUNDLE transport rather than being rejected.
+     */
+    if (offer->desc.port == 0 && !bundle_only) {
         answer = sdp_media_clone_deactivate(pool, offer, preanswer,
                                             preanswer_sdp);
         *p_answer = answer;
@@ -1745,10 +1825,12 @@ static pj_status_t create_answer( pj_pool_t *pool,
         const pjmedia_sdp_media *om;    /* offer */
         const pjmedia_sdp_media *im;    /* initial media */
         pjmedia_sdp_media *am = NULL;   /* answer/result */
+        pj_bool_t bundle_only;
         pj_uint32_t om_tp;
         unsigned j;
 
         om = offer->media[i];
+        bundle_only = is_bundle_only_offer(offer, om);
 
         om_tp = pjmedia_sdp_transport_get_proto(&om->desc.transport);
         PJMEDIA_TP_PROTO_TRIM_FLAG(om_tp, PJMEDIA_TP_PROFILE_RTCP_FB);
@@ -1773,7 +1855,7 @@ static pj_status_t create_answer( pj_pool_t *pool,
 
                 /* See if it has matching codec. */
                 status2 = match_offer(pool, prefer_remote_codec_order,
-                                      answer_with_multiple_codecs,
+                                      answer_with_multiple_codecs, bundle_only,
                                       om, im, initial, &am);
                 if (status2 == PJ_SUCCESS) {
                     /* Mark media as used. */

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1290,9 +1290,11 @@ static pj_bool_t bundle_group_contains_mid(const pjmedia_sdp_session *sdp,
         if (pj_stricmp2(&attr->name, "group") != 0)
             continue;
 
+        if (attr->value.ptr == NULL || attr->value.slen == 0)
+            continue;
+
         pos = attr->value.ptr;
         end = attr->value.ptr + attr->value.slen;
-
         while (pos < end) {
             const char *token_start;
             pj_str_t token;

--- a/pjmedia/src/test/sdp_neg_test.c
+++ b/pjmedia/src/test/sdp_neg_test.c
@@ -1745,6 +1745,83 @@ static int sdp_neg_strict_validate_test(pj_pool_t *pool)
     return 0;
 }
 
+
+/* RFC 9143: an offered media section using port zero is not rejected when
+ * it has a=bundle-only and its MID belongs to the BUNDLE group.
+ */
+static int sdp_neg_bundle_only_test(pj_pool_t *pool)
+{
+    static char offer_str[] =
+        "v=0\r\n"
+        "o=- 0 0 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0 1\r\n"
+        "m=audio 4000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 0 RTP/AVP 96\r\n"
+        "a=mid:1\r\n"
+        "a=bundle-only\r\n"
+        "a=rtpmap:96 VP8/90000\r\n";
+
+    static char local_str[] =
+        "v=0\r\n"
+        "o=- 1 1 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0 1\r\n"
+        "m=audio 5000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 5002 RTP/AVP 96\r\n"
+        "a=mid:1\r\n"
+        "a=rtpmap:96 VP8/90000\r\n";
+
+    pjmedia_sdp_session *offer, *local;
+    pjmedia_sdp_neg *neg;
+    const pjmedia_sdp_session *active_local;
+    pj_status_t status;
+    char b1[sizeof(offer_str)], b2[sizeof(local_str)];
+
+    pj_memcpy(b1, offer_str, sizeof(offer_str));
+    pj_memcpy(b2, local_str, sizeof(local_str));
+
+    if (pjmedia_sdp_parse(pool, b1, pj_ansi_strlen(b1), &offer) !=
+        PJ_SUCCESS)
+    {
+        return -3000;
+    }
+
+    if (pjmedia_sdp_parse(pool, b2, pj_ansi_strlen(b2), &local) !=
+        PJ_SUCCESS)
+    {
+        return -3010;
+    }
+
+    if (pjmedia_sdp_neg_create_w_remote_offer(pool, local, offer, &neg) !=
+        PJ_SUCCESS)
+    {
+        return -3020;
+    }
+
+    status = pjmedia_sdp_neg_negotiate(pool, neg, 0);
+    if (status != PJ_SUCCESS) {
+        app_perror(status, "   sdp_neg_bundle_only_test: negotiate failed");
+        return -3030;
+    }
+
+    pjmedia_sdp_neg_get_active_local(neg, &active_local);
+
+    if (active_local->media_count != 2)
+        return -3040;
+
+    if (active_local->media[1]->desc.port == 0)
+        return -3050;
+
+    return 0;
+}
+
 int sdp_neg_test()
 {
     unsigned i;
@@ -1776,6 +1853,21 @@ int sdp_neg_test()
 
         PJ_LOG(3,(THIS_FILE, "  sdp_neg_static_pt_repr_test"));
         status = sdp_neg_static_pt_repr_test(pool);
+        pj_pool_release(pool);
+
+        if (status != 0)
+            return status;
+    }
+
+    {
+        pj_pool_t *pool;
+
+        pool = pj_pool_create(mem, "sdp_neg_bundle", 4000, 4000, NULL);
+        if (!pool)
+            return PJ_ENOMEM;
+
+        PJ_LOG(3,(THIS_FILE, "  sdp_neg_bundle_only_test"));
+        status = sdp_neg_bundle_only_test(pool);
         pj_pool_release(pool);
 
         if (status != 0)


### PR DESCRIPTION
## Description

This fixes handling of zero-port `a=bundle-only` media sections in SDP offers.

The issue was found while working on Asterisk issue `asterisk/asterisk#2010`, where a WebRTC offer contained multiple media sections in a BUNDLE group.

RFC 9143 allows a bundled media section to use port zero when it contains `a=bundle-only`. Previously, pjmedia rejected every zero-port media section before codec negotiation.

The fix:

* detects `a=bundle-only`,
* reads the media section `a=mid`,
* verifies that the MID belongs to `a=group:BUNDLE`,
* and continues normal negotiation only for valid BUNDLE-only sections.

Other zero-port media sections keep the existing rejection behavior.

## Testing

* Built pjproject master successfully.
* Ran `make pjmedia-test`.
* All 5 PJMEDIA test groups passed.
* Added a regression test for `port=0 + bundle-only + MID in group:BUNDLE`.
* Verified the original Asterisk WebRTC scenario.
