### PR TITLE
pjsua: Return PJ_ETOOMANY instead of asserting when account table full

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -785,8 +785,15 @@ PJ_DEF(pj_status_t) pjsua_acc_add( const pjsua_acc_config *cfg,
     pj_status_t status = PJ_SUCCESS;
 
     PJ_ASSERT_RETURN(cfg, PJ_EINVAL);
-    PJ_ASSERT_RETURN(pjsua_var.acc_cnt < PJ_ARRAY_SIZE(pjsua_var.acc),
-                     PJ_ETOOMANY);
+
+    /* The account table being full is a runtime condition driven by how many
+     * accounts the application adds, not a programmer invariant, so return an
+     * error in all build configurations instead of asserting (which aborts in
+     * debug builds). This mirrors how pjsua_call_make_call() handles the
+     * analogous PJSUA_MAX_CALLS limit.
+     */
+    if (pjsua_var.acc_cnt >= PJ_ARRAY_SIZE(pjsua_var.acc))
+        return PJ_ETOOMANY;
 
 #if !PJ_HAS_IPV6
     PJ_ASSERT_RETURN(cfg->ipv6_sip_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -786,12 +786,6 @@ PJ_DEF(pj_status_t) pjsua_acc_add( const pjsua_acc_config *cfg,
 
     PJ_ASSERT_RETURN(cfg, PJ_EINVAL);
 
-    /* The account table being full is a runtime condition driven by how many
-     * accounts the application adds, not a programmer invariant, so return an
-     * error in all build configurations instead of asserting (which aborts in
-     * debug builds). This mirrors how pjsua_call_make_call() handles the
-     * analogous PJSUA_MAX_CALLS limit.
-     */
     if (pjsua_var.acc_cnt >= PJ_ARRAY_SIZE(pjsua_var.acc))
         return PJ_ETOOMANY;
 


### PR DESCRIPTION
Fixes #5069

### Problem

`pjsua_acc_add()` guards the account-table-full condition with
`PJ_ASSERT_RETURN(pjsua_var.acc_cnt < PJ_ARRAY_SIZE(pjsua_var.acc), PJ_ETOOMANY)`.
In debug builds `pj_assert()` aborts the process; in release it returns `PJ_ETOOMANY`.
The table being full is a runtime condition driven by application input (easy to hit under
`PJ_CONFIG_IPHONE`, where `PJSUA_MAX_ACC` is 4), not a programmer invariant — see the linked
issue for the full rationale.

### Fix

Replace the capacity assert with a plain `if (...) return PJ_ETOOMANY;`, mirroring how
`pjsua_call_make_call()` already handles the analogous `PJSUA_MAX_CALLS` limit (plain `if` →
`PJ_ETOOMANY`; incoming INVITE at the limit → stateless `486 Busy Here` — neither asserts).
The neighbouring `PJ_ASSERT_RETURN(cfg, PJ_EINVAL)` (genuine null-pointer invariant) and the
later free-slot-scan `PJ_ASSERT_ON_FAIL` are deliberately left as asserts.

Release behaviour is unchanged (`PJ_ASSERT_RETURN` already returned `PJ_ETOOMANY` there);
only the debug-build abort is removed. No networking/RFC-visible behaviour is affected.

### Validation

- Manual repro: debug build, add `PJSUA_MAX_ACC + 1` accounts — previously aborted, now
  returns `PJ_ETOOMANY`; release behaviour identical before/after.
