### PR TITLE
Add TLS 1.3 session resumption to OpenSSL backend

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -1275,6 +1275,18 @@
 
 
 /**
+ * Maximum number of TLS client sessions cached for resumption by the OpenSSL
+ * backend when pj_ssl_sock_param.enable_session_reuse is set. Sessions are
+ * cached per server name; the oldest entry is evicted when the cache is full.
+ *
+ * Default: 64
+ */
+#ifndef PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE
+#   define PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE   64
+#endif
+
+
+/**
  * Disable WSAECONNRESET error for UDP sockets on Win32 platforms. See
  * https://github.com/pjsip/pjproject/issues/1197.
  *

--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -1018,6 +1018,14 @@ typedef struct pj_ssl_sock_info
      */
     void *native_ssl;
 
+    /**
+     * Describes whether the established connection resumed a previous TLS
+     * session (abbreviated handshake) instead of performing a full handshake.
+     * Only meaningful when \a established is PJ_TRUE. Currently only set by
+     * the OpenSSL backend.
+     */
+    pj_bool_t session_reused;
+
 } pj_ssl_sock_info;
 
 
@@ -1301,10 +1309,23 @@ typedef struct pj_ssl_sock_param
 
     /**
      * Specify if renegotiation is enabled for TLSv1.2 or earlier.
-     * 
+     *
      * Default: PJ_TRUE
      */
     pj_bool_t enable_renegotiation;
+
+    /**
+     * Specify if TLS session reuse (resumption) is enabled. When acting as
+     * client, the backend will cache sessions per server name (see
+     * \a server_name) and resume them on subsequent connections, avoiding a
+     * full handshake. When acting as server, the backend will issue session
+     * tickets (including TLS 1.3 tickets) so clients can resume.
+     *
+     * Currently only implemented by the OpenSSL backend.
+     *
+     * Default: PJ_FALSE
+     */
+    pj_bool_t enable_session_reuse;
 
 } pj_ssl_sock_param;
 

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -1807,6 +1807,8 @@ PJ_DEF(pj_status_t) pj_ssl_sock_get_info (pj_ssl_sock_t *ssock,
     {
         ossl_sock_t *ossock = (ossl_sock_t *)ssock;
         info->native_ssl = ossock->ossl_ssl;
+        if (info->established && ossock->ossl_ssl)
+            info->session_reused = SSL_session_reused(ossock->ossl_ssl);
     }
 #endif
 

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -595,7 +595,7 @@ static int sess_cache_find(const char *name)
  * held on sess (as handed to new_session_cb). Any previous session for the
  * same name is replaced. The new entry becomes MRU (front of the array).
  */
-static void sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
+static pj_bool_t sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
 {
     int idx;
     unsigned n;
@@ -603,8 +603,7 @@ static void sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
     if (!ossl_sess_cache_lock || name->slen == 0 ||
         name->slen >= PJ_MAX_HOSTNAME)
     {
-        SSL_SESSION_free(sess);
-        return;
+        return PJ_FALSE;
     }
 
     pj_lock_acquire(ossl_sess_cache_lock);
@@ -638,6 +637,7 @@ static void sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
     }
 
     pj_lock_release(ossl_sess_cache_lock);
+    return PJ_TRUE;
 }
 
 /* Look up a cached session for the given server name. On success, returns the
@@ -715,8 +715,7 @@ static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
     pj_ssl_sock_t *ssock = SSL_get_ex_data(ssl, sslsock_idx);
 
     if (ssock && ssock->param.server_name.slen) {
-        sess_cache_store(&ssock->param.server_name, sess);
-        return 1;
+        return sess_cache_store(&ssock->param.server_name, sess) ? 1 : 0;
     }
     return 0;
 }
@@ -2919,4 +2918,3 @@ static pj_status_t ssl_renegotiate(pj_ssl_sock_t *ssock)
 
 
 #endif  /* PJ_HAS_SSL_SOCK */
-

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -553,6 +553,175 @@ static int openssl_init_count;
 /* OpenSSL application data index */
 static int sslsock_idx;
 
+/* Client TLS session cache for session resumption. TLS 1.3 delivers the
+ * resumption ticket via a NewSessionTicket message after the handshake, so it
+ * is captured asynchronously in new_session_cb() and stored here keyed by the
+ * target server name, then re-injected on the next connection to the same
+ * server. Entries are kept MRU-first; the least recently used is evicted when
+ * the cache is full.
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#  define OSSL_SESS_CACHE_ENABLED   1
+#else
+#  define OSSL_SESS_CACHE_ENABLED   0
+#endif
+
+#if OSSL_SESS_CACHE_ENABLED
+typedef struct ossl_sess_cache_entry {
+    char          server_name[PJ_MAX_HOSTNAME];
+    SSL_SESSION  *sess;
+} ossl_sess_cache_entry;
+
+static ossl_sess_cache_entry ossl_sess_cache[PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE];
+static unsigned              ossl_sess_cache_cnt;
+static pj_caching_pool       ossl_sess_cp;
+static pj_pool_t            *ossl_sess_pool;
+static pj_lock_t            *ossl_sess_cache_lock;
+
+/* Find the cache slot for the given server name. Returns -1 if not found.
+ * Caller must hold ossl_sess_cache_lock.
+ */
+static int sess_cache_find(const char *name)
+{
+    unsigned i;
+    for (i = 0; i < ossl_sess_cache_cnt; ++i) {
+        if (pj_ansi_strcmp(ossl_sess_cache[i].server_name, name) == 0)
+            return (int)i;
+    }
+    return -1;
+}
+
+/* Store a session for the given server name, taking ownership of the reference
+ * held on sess (as handed to new_session_cb). Any previous session for the
+ * same name is replaced. The new entry becomes MRU (front of the array).
+ */
+static void sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
+{
+    int idx;
+    unsigned n;
+
+    if (!ossl_sess_cache_lock || name->slen == 0 ||
+        name->slen >= PJ_MAX_HOSTNAME)
+    {
+        SSL_SESSION_free(sess);
+        return;
+    }
+
+    pj_lock_acquire(ossl_sess_cache_lock);
+
+    /* Drop any existing entry for this name so we can re-insert at front. */
+    {
+        char nbuf[PJ_MAX_HOSTNAME];
+        pj_memcpy(nbuf, name->ptr, name->slen);
+        nbuf[name->slen] = '\0';
+
+        idx = sess_cache_find(nbuf);
+        if (idx >= 0) {
+            SSL_SESSION_free(ossl_sess_cache[idx].sess);
+            for (n = (unsigned)idx; n + 1 < ossl_sess_cache_cnt; ++n)
+                ossl_sess_cache[n] = ossl_sess_cache[n + 1];
+            ossl_sess_cache_cnt--;
+        } else if (ossl_sess_cache_cnt == PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE) {
+            /* Evict least recently used (last). */
+            SSL_SESSION_free(ossl_sess_cache[ossl_sess_cache_cnt - 1].sess);
+            ossl_sess_cache_cnt--;
+        }
+
+        /* Shift existing entries down and insert at front. */
+        for (n = ossl_sess_cache_cnt; n > 0; --n)
+            ossl_sess_cache[n] = ossl_sess_cache[n - 1];
+
+        pj_memcpy(ossl_sess_cache[0].server_name, name->ptr, name->slen);
+        ossl_sess_cache[0].server_name[name->slen] = '\0';
+        ossl_sess_cache[0].sess = sess;
+        ossl_sess_cache_cnt++;
+    }
+
+    pj_lock_release(ossl_sess_cache_lock);
+}
+
+/* Look up a cached session for the given server name. On success, returns the
+ * session with its reference count incremented (caller must SSL_SESSION_free()
+ * it) and promotes the entry to MRU. Returns NULL if not found.
+ */
+static SSL_SESSION *sess_cache_get(const pj_str_t *name)
+{
+    char nbuf[PJ_MAX_HOSTNAME];
+    SSL_SESSION *sess = NULL;
+    int idx;
+
+    if (!ossl_sess_cache_lock || name->slen == 0 ||
+        name->slen >= PJ_MAX_HOSTNAME)
+    {
+        return NULL;
+    }
+
+    pj_memcpy(nbuf, name->ptr, name->slen);
+    nbuf[name->slen] = '\0';
+
+    pj_lock_acquire(ossl_sess_cache_lock);
+    idx = sess_cache_find(nbuf);
+    if (idx >= 0) {
+        unsigned n;
+        ossl_sess_cache_entry e = ossl_sess_cache[idx];
+
+        sess = e.sess;
+        SSL_SESSION_up_ref(sess);
+
+        /* Promote to MRU. */
+        for (n = (unsigned)idx; n > 0; --n)
+            ossl_sess_cache[n] = ossl_sess_cache[n - 1];
+        ossl_sess_cache[0] = e;
+    }
+    pj_lock_release(ossl_sess_cache_lock);
+
+    return sess;
+}
+
+/* Free all cached sessions and destroy the cache lock. Registered as an
+ * atexit handler.
+ */
+static void sess_cache_clear(void)
+{
+    unsigned i;
+
+    if (ossl_sess_cache_lock)
+        pj_lock_acquire(ossl_sess_cache_lock);
+
+    for (i = 0; i < ossl_sess_cache_cnt; ++i)
+        SSL_SESSION_free(ossl_sess_cache[i].sess);
+    ossl_sess_cache_cnt = 0;
+
+    if (ossl_sess_cache_lock) {
+        pj_lock_t *lck = ossl_sess_cache_lock;
+        ossl_sess_cache_lock = NULL;
+        pj_lock_release(lck);
+        pj_lock_destroy(lck);
+    }
+    if (ossl_sess_pool) {
+        pj_pool_release(ossl_sess_pool);
+        ossl_sess_pool = NULL;
+        pj_caching_pool_destroy(&ossl_sess_cp);
+    }
+}
+
+/* OpenSSL "new session" callback (client side). Fires when a session becomes
+ * available for caching, which for TLS 1.3 happens after the handshake when a
+ * NewSessionTicket is received. Returning 1 tells OpenSSL we retain the
+ * reference on sess.
+ */
+static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
+{
+    pj_ssl_sock_t *ssock = SSL_get_ex_data(ssl, sslsock_idx);
+
+    if (ssock && ssock->param.server_name.slen) {
+        sess_cache_store(&ssock->param.server_name, sess);
+        return 1;
+    }
+    return 0;
+}
+#endif  /* OSSL_SESS_CACHE_ENABLED */
+
 #if defined(PJ_SSL_SOCK_OSSL_USE_THREAD_CB) && \
     PJ_SSL_SOCK_OSSL_USE_THREAD_CB != 0 && OPENSSL_VERSION_NUMBER < 0x10100000L
 
@@ -926,6 +1095,32 @@ static pj_status_t init_openssl(void)
     }
 #endif
 
+#if OSSL_SESS_CACHE_ENABLED
+    /* Create the client session cache lock. */
+    pj_caching_pool_init(&ossl_sess_cp, NULL, 0);
+    ossl_sess_pool = pj_pool_create(&ossl_sess_cp.factory, "ssl_sess", 512,
+                                    512, NULL);
+    if (ossl_sess_pool) {
+        status = pj_lock_create_recursive_mutex(ossl_sess_pool, "ssl_sess",
+                                                &ossl_sess_cache_lock);
+    } else {
+        status = PJ_ENOMEM;
+    }
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(2, (THIS_FILE, status, "Warning! Unable to create TLS "
+                      "session cache lock, session reuse will not work"));
+        ossl_sess_cache_lock = NULL;
+        if (ossl_sess_pool) {
+            pj_pool_release(ossl_sess_pool);
+            ossl_sess_pool = NULL;
+            pj_caching_pool_destroy(&ossl_sess_cp);
+        }
+    } else {
+        pj_atexit(&sess_cache_clear);
+    }
+    status = PJ_SUCCESS;
+#endif
+
     openssl_init_count = 1;
     return status;
 }
@@ -1239,13 +1434,16 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
         unsigned int sid_ctx = SERVER_SESSION_ID_CONTEXT;
 
 #if SERVER_DISABLE_SESSION_TICKETS
-        /* Disable session tickets for TLSv1.2 and below. */
-        ssl_opt |= SSL_OP_NO_TICKET;
+        /* Disable session tickets (incl. TLSv1.3) unless the application
+         * opts in to session reuse.
+         */
+        if (!ssock->param.enable_session_reuse) {
+            ssl_opt |= SSL_OP_NO_TICKET;
 #ifdef SSL_CTX_set_num_tickets
-        /* Set the number of TLSv1.3 session tickets issued to 0. */
-        SSL_CTX_set_num_tickets(ctx, 0);
+            /* Set the number of TLSv1.3 session tickets issued to 0. */
+            SSL_CTX_set_num_tickets(ctx, 0);
 #endif
-
+        }
 #endif
 
         SSL_CTX_set_timeout(ctx, SERVER_SESSION_TIMEOUT);
@@ -1256,6 +1454,16 @@ static pj_status_t init_ossl_ctx(pj_ssl_sock_t *ssock)
                                   "context. Session reuse will not work."));
         }
     }
+#if OSSL_SESS_CACHE_ENABLED
+    else if (ssock->param.enable_session_reuse) {
+        /* Client: enable session caching and capture new sessions (incl.
+         * TLSv1.3 tickets which arrive after the handshake) via callback.
+         */
+        SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_CLIENT |
+                                            SSL_SESS_CACHE_NO_INTERNAL_STORE);
+        SSL_CTX_sess_set_new_cb(ctx, &new_session_cb);
+    }
+#endif
 
 #ifdef SSL_OP_NO_RENEGOTIATION
     if (!ssock->param.enable_renegotiation) {
@@ -1763,6 +1971,19 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
     (void)BIO_set_close(ossock->ossl_rbio, BIO_CLOSE);
     (void)BIO_set_close(ossock->ossl_wbio, BIO_CLOSE);
     SSL_set_bio(ossock->ossl_ssl, ossock->ossl_rbio, ossock->ossl_wbio);
+
+#if OSSL_SESS_CACHE_ENABLED
+    /* Client: resume a cached session for this server, if any. */
+    if (!ssock->is_server && ssock->param.enable_session_reuse &&
+        ssock->param.server_name.slen)
+    {
+        SSL_SESSION *sess = sess_cache_get(&ssock->param.server_name);
+        if (sess) {
+            SSL_set_session(ossock->ossl_ssl, sess);
+            SSL_SESSION_free(sess);
+        }
+    }
+#endif
 
     return PJ_SUCCESS;
 }

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -2101,8 +2101,10 @@ static pj_bool_t reuse_on_accept(pj_ssl_sock_t *ssock,
     read_buf[0] = st->read_buf;
     status = pj_ssl_sock_start_read2(newsock, st->pool, sizeof(st->read_buf),
                                      read_buf, 0);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+        pj_ssl_sock_close(newsock);
         return PJ_TRUE;
+    }
 
     /* Send a greeting. For TLS 1.3 the NewSessionTicket precedes this on the
      * wire, so the client caches the session while reading.
@@ -2110,8 +2112,10 @@ static pj_bool_t reuse_on_accept(pj_ssl_sock_t *ssock,
     len = (pj_ssize_t)pj_ansi_strlen(reuse_greeting);
     status = pj_ssl_sock_send(newsock, &st->send_key.op_key, reuse_greeting,
                               &len, 0);
-    if (status != PJ_SUCCESS && status != PJ_EPENDING)
+    if (status != PJ_SUCCESS && status != PJ_EPENDING) {
+        pj_ssl_sock_close(newsock);
         return PJ_TRUE;
+    }
 
     return PJ_TRUE;
 }
@@ -2126,6 +2130,7 @@ static pj_bool_t reuse_on_connect(pj_ssl_sock_t *ssock, pj_status_t status)
     if (status != PJ_SUCCESS) {
         st->err = status;
         st->done = PJ_TRUE;
+        pj_ssl_sock_close(ssock);
         return PJ_FALSE;
     }
 
@@ -2138,6 +2143,7 @@ static pj_bool_t reuse_on_connect(pj_ssl_sock_t *ssock, pj_status_t status)
     if (status != PJ_SUCCESS) {
         st->err = status;
         st->done = PJ_TRUE;
+        pj_ssl_sock_close(ssock);
         return PJ_FALSE;
     }
     return PJ_TRUE;
@@ -2260,6 +2266,7 @@ static int session_reuse_test(void)
         } else if (status == PJ_EPENDING) {
             status = PJ_SUCCESS;
         } else {
+            pj_ssl_sock_close(ssock_cli);
             goto on_return;
         }
 
@@ -2480,4 +2487,3 @@ int ssl_sock_test(void)
  */
 int dummy_ssl_sock_test;
 #endif  /* INCLUDE_SSLSOCK_TEST */
-

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -2052,6 +2052,280 @@ on_return:
 
 
 
+/*
+ * TLS session resumption test (OpenSSL backend). Opens a server that issues
+ * TLS 1.3 session tickets, then makes two client connections to it with
+ * session reuse enabled. The first connection must perform a full handshake;
+ * the second must resume the cached session.
+ */
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+
+static const char reuse_greeting[] = "hello";
+
+struct reuse_state
+{
+    pj_pool_t      *pool;
+    pj_bool_t       is_server;
+    pj_bool_t       done;           /* client round completed              */
+    pj_status_t     err;
+    pj_bool_t       reused;         /* client: was the session resumed     */
+    pj_uint8_t      read_buf[128];
+    struct send_key send_key;
+};
+
+static pj_bool_t reuse_on_accept(pj_ssl_sock_t *ssock,
+                                 pj_ssl_sock_t *newsock,
+                                 const pj_sockaddr_t *src_addr,
+                                 int src_addr_len,
+                                 pj_status_t accept_status)
+{
+    struct reuse_state *parent_st = (struct reuse_state*)
+                                    pj_ssl_sock_get_user_data(ssock);
+    struct reuse_state *st;
+    void *read_buf[1];
+    pj_ssize_t len;
+    pj_status_t status;
+
+    PJ_UNUSED_ARG(src_addr);
+    PJ_UNUSED_ARG(src_addr_len);
+
+    if (accept_status != PJ_SUCCESS)
+        return PJ_TRUE;             /* keep listening */
+
+    st = (struct reuse_state*) pj_pool_zalloc(parent_st->pool, sizeof(*st));
+    st->pool = parent_st->pool;
+    st->is_server = PJ_TRUE;
+    pj_ssl_sock_set_user_data(newsock, st);
+
+    /* Read so we notice the client closing (EOF). */
+    read_buf[0] = st->read_buf;
+    status = pj_ssl_sock_start_read2(newsock, st->pool, sizeof(st->read_buf),
+                                     read_buf, 0);
+    if (status != PJ_SUCCESS)
+        return PJ_TRUE;
+
+    /* Send a greeting. For TLS 1.3 the NewSessionTicket precedes this on the
+     * wire, so the client caches the session while reading.
+     */
+    len = (pj_ssize_t)pj_ansi_strlen(reuse_greeting);
+    status = pj_ssl_sock_send(newsock, &st->send_key.op_key, reuse_greeting,
+                              &len, 0);
+    if (status != PJ_SUCCESS && status != PJ_EPENDING)
+        return PJ_TRUE;
+
+    return PJ_TRUE;
+}
+
+static pj_bool_t reuse_on_connect(pj_ssl_sock_t *ssock, pj_status_t status)
+{
+    struct reuse_state *st = (struct reuse_state*)
+                             pj_ssl_sock_get_user_data(ssock);
+    pj_ssl_sock_info info;
+    void *read_buf[1];
+
+    if (status != PJ_SUCCESS) {
+        st->err = status;
+        st->done = PJ_TRUE;
+        return PJ_FALSE;
+    }
+
+    if (pj_ssl_sock_get_info(ssock, &info) == PJ_SUCCESS)
+        st->reused = info.session_reused;
+
+    read_buf[0] = st->read_buf;
+    status = pj_ssl_sock_start_read2(ssock, st->pool, sizeof(st->read_buf),
+                                     read_buf, 0);
+    if (status != PJ_SUCCESS) {
+        st->err = status;
+        st->done = PJ_TRUE;
+        return PJ_FALSE;
+    }
+    return PJ_TRUE;
+}
+
+static pj_bool_t reuse_on_read(pj_ssl_sock_t *ssock,
+                               void *data, pj_size_t size,
+                               pj_status_t status, pj_size_t *remainder)
+{
+    struct reuse_state *st = (struct reuse_state*)
+                             pj_ssl_sock_get_user_data(ssock);
+    PJ_UNUSED_ARG(data);
+    PJ_UNUSED_ARG(remainder);
+
+    if (st->is_server) {
+        /* Client closed or error -> tear down the accepted socket. */
+        if (status != PJ_SUCCESS) {
+            pj_ssl_sock_close(ssock);
+            return PJ_FALSE;
+        }
+        return PJ_TRUE;
+    }
+
+    /* Client: receiving the greeting means the NewSessionTicket (if any) has
+     * already been processed and cached.
+     */
+    if (size > 0)
+        st->done = PJ_TRUE;
+    if (status != PJ_SUCCESS) {
+        if (status != PJ_EEOF)
+            st->err = status;
+        st->done = PJ_TRUE;
+    }
+    if (st->done) {
+        pj_ssl_sock_close(ssock);
+        return PJ_FALSE;
+    }
+    return PJ_TRUE;
+}
+
+static int session_reuse_test(void)
+{
+    pj_pool_t *pool = NULL;
+    pj_ioqueue_t *ioqueue = NULL;
+    pj_timer_heap_t *timer = NULL;
+    pj_ssl_sock_t *ssock_serv = NULL;
+    pj_ssl_sock_param param;
+    struct reuse_state state_serv;
+    pj_sockaddr bind_addr, listen_addr;
+    pj_str_t tmp_st;
+    pj_bool_t reused[2];
+    int i;
+    pj_status_t status;
+
+    pj_bzero(&state_serv, sizeof(state_serv));
+    reused[0] = PJ_TRUE;    /* expect full handshake -> should become FALSE */
+    reused[1] = PJ_FALSE;   /* expect resumption     -> should become TRUE  */
+
+    pool = pj_pool_create(mem, "ssl_reuse", 512, 512, NULL);
+    status = pj_ioqueue_create(pool, 8, &ioqueue);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+    status = pj_timer_heap_create(pool, 8, &timer);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+
+    /* Server: issue TLS 1.3 tickets. */
+    pj_ssl_sock_param_default(&param);
+    param.cb.on_accept_complete2 = &reuse_on_accept;
+    param.cb.on_data_read = &reuse_on_read;
+    param.cb.on_data_sent = &ssl_on_data_sent;
+    param.ioqueue = ioqueue;
+    param.timer_heap = timer;
+    param.proto = PJ_SSL_SOCK_PROTO_TLS1_3;
+    param.enable_session_reuse = PJ_TRUE;
+    param.user_data = &state_serv;
+    state_serv.pool = pool;
+    state_serv.is_server = PJ_TRUE;
+
+    pj_sockaddr_init(PJ_AF_INET, &listen_addr,
+                     pj_strset2(&tmp_st, "127.0.0.1"), 0);
+
+    status = ssl_test_create_server(pool, &param, "session_reuse_test",
+                                    &ssock_serv, &listen_addr);
+    if (status != PJ_SUCCESS)
+        goto on_return;
+
+    /* Two client rounds against the same server. */
+    for (i = 0; i < 2; ++i) {
+        pj_ssl_sock_t *ssock_cli = NULL;
+        pj_ssl_sock_param cparam;
+        struct reuse_state state_cli;
+        unsigned loop;
+
+        pj_bzero(&state_cli, sizeof(state_cli));
+        state_cli.pool = pool;
+
+        pj_ssl_sock_param_default(&cparam);
+        cparam.cb.on_connect_complete = &reuse_on_connect;
+        cparam.cb.on_data_read = &reuse_on_read;
+        cparam.cb.on_data_sent = &ssl_on_data_sent;
+        cparam.ioqueue = ioqueue;
+        cparam.timer_heap = timer;
+        cparam.proto = PJ_SSL_SOCK_PROTO_TLS1_3;
+        cparam.enable_session_reuse = PJ_TRUE;
+        cparam.server_name = pj_str("127.0.0.1");
+        cparam.user_data = &state_cli;
+
+        status = pj_ssl_sock_create(pool, &cparam, &ssock_cli);
+        if (status != PJ_SUCCESS)
+            goto on_return;
+
+        pj_sockaddr_init(PJ_AF_INET, &bind_addr,
+                         pj_strset2(&tmp_st, "127.0.0.1"), 0);
+        status = pj_ssl_sock_start_connect(ssock_cli, pool, &bind_addr,
+                                           &listen_addr,
+                                           pj_sockaddr_get_len(&listen_addr));
+        if (status == PJ_SUCCESS) {
+            reuse_on_connect(ssock_cli, PJ_SUCCESS);
+        } else if (status == PJ_EPENDING) {
+            status = PJ_SUCCESS;
+        } else {
+            goto on_return;
+        }
+
+        /* Wait for this round to complete. */
+        loop = 0;
+        while (!state_cli.done && !state_cli.err && loop++ < 1000) {
+            pj_time_val delay = {0, 100};
+            pj_ioqueue_poll(ioqueue, &delay);
+            pj_timer_heap_poll(timer, NULL);
+        }
+
+        /* Drain so the ticket is fully processed and the server-side socket
+         * observes the client close.
+         */
+        {
+            pj_time_val delay = {0, 500};
+            loop = 0;
+            while (pj_ioqueue_poll(ioqueue, &delay) > 0 && loop++ < 100)
+                ;
+            pj_timer_heap_poll(timer, NULL);
+        }
+
+        if (state_cli.err) {
+            status = state_cli.err;
+            goto on_return;
+        }
+
+        PJ_LOG(3, ("", "...connection %d: session_reused=%d",
+                   i + 1, state_cli.reused));
+        reused[i] = state_cli.reused;
+    }
+
+    if (reused[0]) {
+        PJ_LOG(1, ("", "...ERROR: first connection unexpectedly resumed"));
+        status = PJ_EBUG;
+        goto on_return;
+    }
+    if (!reused[1]) {
+        PJ_LOG(1, ("", "...ERROR: second connection did not resume session"));
+        status = PJ_EBUG;
+        goto on_return;
+    }
+    PJ_LOG(3, ("", "...session resumption OK"));
+    status = PJ_SUCCESS;
+
+on_return:
+    if (ssock_serv)
+        pj_ssl_sock_close(ssock_serv);
+    if (ioqueue) {
+        pj_time_val delay = {0, 500};
+        while (pj_ioqueue_poll(ioqueue, &delay) > 0)
+            ;
+    }
+    if (timer)
+        pj_timer_heap_destroy(timer);
+    if (ioqueue)
+        pj_ioqueue_destroy(ioqueue);
+    if (pool)
+        pj_pool_release(pool);
+
+    return (status == PJ_SUCCESS) ? 0 : -1;
+}
+
+#endif  /* PJ_SSL_SOCK_IMP_OPENSSL */
+
+
 int ssl_sock_test(void)
 {
     int ret;
@@ -2096,6 +2370,13 @@ int ssl_sock_test(void)
                     PJ_FALSE, PJ_FALSE);
     if (ret != 0)
         return ret;
+
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+    PJ_LOG(3,("", "..TLSv1.3 session resumption test"));
+    ret = session_reuse_test();
+    if (ret != 0)
+        return ret;
+#endif
 #endif
 
     PJ_LOG(3,("", "..echo test w/ compatible proto: server TLSv1.2 vs client TLSv1.2"));


### PR DESCRIPTION
## Summary

Adds TLS session resumption to the OpenSSL secure-socket backend, controlled by a new opt-in param `pj_ssl_sock_param.enable_session_reuse` (default off).

Previously every outgoing TLS connection performed a full handshake and the server side actively disabled session tickets. TLS 1.3 delivers the resumption ticket via a `NewSessionTicket` message **after** the handshake, and each outgoing connection uses its own `SSL_CTX`, so captured sessions are held in a **process-global, mutex-protected cache keyed by server name** and re-injected on the next connection to the same host.

When `enable_session_reuse` is set:
- **Client** caches sessions per `server_name` (via `SSL_CTX_sess_set_new_cb`) and resumes them (`SSL_set_session`), avoiding a full handshake.
- **Server** issues session tickets (including TLS 1.3 tickets), which were previously always disabled.

## Changes

- **`ssl_sock.h` / `config.h`**: new `enable_session_reuse` param, `session_reused` info field, and `PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE` (default 64).
- **`ssl_sock_ossl.c`**: session cache + helpers (correct `SSL_SESSION` ref-counting, LRU eviction, `pj_atexit` cleanup for ASan), new-session callback, session injection in `ssl_create`, and gating of server ticket disabling on the flag. Guarded to OpenSSL ≥ 1.1.0.
- **`ssl_sock_imp_common.c`**: populate `info.session_reused` via `SSL_session_reused()`.
- **`pjlib-test/ssl_sock.c`**: `session_reuse_test()` opens a ticket-issuing server and makes two client connections, asserting the first is a full handshake and the second resumes.

## Testing

- OpenSSL backend and test compile warning-free (`-Wall`) against OpenSSL 3.4.1.
- `pjlib` + `pjlib-test` build and link cleanly.
- The new `session_reuse_test` runs as part of `pjlib-test ssl_sock` in OpenSSL-enabled builds (e.g. CI).

## Notes

- Opt-in; default behavior is unchanged.
- Empty `server_name` (e.g. connecting by IP) → resumption is skipped.
- Not wired into `pjsip_tls_setting` in this change; lives at the pjlib `pj_ssl_sock` level.
