### PR TITLE
pjsip-simple: fix Coverity null pointer dereference in on_new_transaction() (CID 1663842)

### DIFF
--- a/pjsip/src/pjsip-simple/evsub.c
+++ b/pjsip/src/pjsip-simple/evsub.c
@@ -1665,13 +1665,13 @@ static pjsip_evsub *on_new_transaction( pjsip_transaction *tsx,
      * Take note that it could be us that is trying to send a final message,
      * such as final NOTIFY upon unsubscription.
      */
-    if (dlgsub == dlgsub_head ||
-        (dlgsub->sub &&
-            tsx->role == PJSIP_ROLE_UAS &&
+    if (dlgsub == dlgsub_head || dlgsub->sub == NULL ||
+        (tsx->role == PJSIP_ROLE_UAS &&
             pjsip_evsub_get_state(dlgsub->sub)==PJSIP_EVSUB_STATE_TERMINATED))
     {
-        const char *reason_msg = 
-            (dlgsub == dlgsub_head ? "Subscription Does Not Exist" :
+        const char *reason_msg =
+            (dlgsub == dlgsub_head || dlgsub->sub == NULL ?
+             "Subscription Does Not Exist" :
              "Subscription already terminated");
 
         /* This could be incoming request to create new subscription */


### PR DESCRIPTION
## Summary

Fixes Coverity issue **CID 1663842 (FORWARD_NULL)** in `pjsip/src/pjsip-simple/evsub.c`.

The freed-subscription guard in the dialog-subscription search loop of `on_new_transaction()` can `break` out of the loop pointing at a node where `dlgsub->sub == NULL` while `dlgsub != dlgsub_head`. The post-loop "not found" check only tested `dlgsub == dlgsub_head` (plus a NULL-guarded terminated case), so this scenario fell through to the "Found!" path where `sub = dlgsub->sub` (NULL) was dereferenced at `sub->pending_tsx++`.

## Fix

Add `dlgsub->sub == NULL` to the "not found" condition so such a node is treated as "Subscription Does Not Exist" and returns NULL. This also guarantees `dlgsub->sub` is non-NULL at the subsequent assignment, allowing the now-redundant inner NULL guard on the terminated check to be dropped.

## Testing

- `evsub.c` compiles cleanly with no errors or warnings (`-Wall`).
