### PR TITLE
pjsua: guard conf connect/disconnect against out-of-range port IDs

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1159,8 +1159,8 @@ PJ_DEF(pj_status_t) pjsua_conf_disconnect( pjsua_conf_port_id source,
     PJ_ASSERT_RETURN(source >= 0 && sink >= 0, PJ_EINVAL);
 
     /* Reject out-of-range port IDs gracefully; see pjsua_conf_connect2(). */
-    if (source >= (int)pjsua_var.media_cfg.max_media_ports ||
-        sink >= (int)pjsua_var.media_cfg.max_media_ports)
+    if ((unsigned)source >= pjsua_var.media_cfg.max_media_ports ||
+        (unsigned)sink >= pjsua_var.media_cfg.max_media_ports)
     {
         PJ_LOG(3,(THIS_FILE, "pjsua_conf_disconnect(%d, %d) failed: port ID "
                              "out of range (max_media_ports=%d)",

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -986,6 +986,21 @@ PJ_DEF(pj_status_t) pjsua_conf_connect2( pjsua_conf_port_id source,
 
     PJ_ASSERT_RETURN(source >= 0 && sink >= 0, PJ_EINVAL);
 
+    /* Reject out-of-range port IDs gracefully. An upper-bound violation can
+     * occur at run-time (e.g. a port removed by another thread), so return
+     * PJ_EINVAL instead of letting pjmedia_conf_connect_port() abort on its
+     * PJ_ASSERT_RETURN in debug/ASan builds.
+     */
+    if (source >= (int)pjsua_var.media_cfg.max_media_ports ||
+        sink >= (int)pjsua_var.media_cfg.max_media_ports)
+    {
+        PJ_LOG(3,(THIS_FILE, "pjsua_conf_connect(%d, %d) failed: port ID out "
+                             "of range (max_media_ports=%d)",
+                             source, sink,
+                             pjsua_var.media_cfg.max_media_ports));
+        return PJ_EINVAL;
+    }
+
     pj_log_push_indent();
 
     PJSUA_LOCK();
@@ -1142,6 +1157,18 @@ PJ_DEF(pj_status_t) pjsua_conf_disconnect( pjsua_conf_port_id source,
               source, sink));
 
     PJ_ASSERT_RETURN(source >= 0 && sink >= 0, PJ_EINVAL);
+
+    /* Reject out-of-range port IDs gracefully; see pjsua_conf_connect2(). */
+    if (source >= (int)pjsua_var.media_cfg.max_media_ports ||
+        sink >= (int)pjsua_var.media_cfg.max_media_ports)
+    {
+        PJ_LOG(3,(THIS_FILE, "pjsua_conf_disconnect(%d, %d) failed: port ID "
+                             "out of range (max_media_ports=%d)",
+                             source, sink,
+                             pjsua_var.media_cfg.max_media_ports));
+        return PJ_EINVAL;
+    }
+
     pj_log_push_indent();
 
     status = pjmedia_conf_disconnect_port(pjsua_var.mconf, source, sink);

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -1163,7 +1163,7 @@ PJ_DEF(pj_status_t) pjsua_conf_disconnect( pjsua_conf_port_id source,
         (unsigned)sink >= pjsua_var.media_cfg.max_media_ports)
     {
         PJ_LOG(3,(THIS_FILE, "pjsua_conf_disconnect(%d, %d) failed: port ID "
-                             "out of range (max_media_ports=%d)",
+                             "out of range (max_media_ports=%u)",
                              source, sink,
                              pjsua_var.media_cfg.max_media_ports));
         return PJ_EINVAL;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -995,7 +995,7 @@ PJ_DEF(pj_status_t) pjsua_conf_connect2( pjsua_conf_port_id source,
         (unsigned)sink >= pjsua_var.media_cfg.max_media_ports)
     {
         PJ_LOG(3,(THIS_FILE, "pjsua_conf_connect(%d, %d) failed: port ID out "
-                             "of range (max_media_ports=%d)",
+                             "of range (max_media_ports=%u)",
                              source, sink,
                              pjsua_var.media_cfg.max_media_ports));
         return PJ_EINVAL;

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -991,8 +991,8 @@ PJ_DEF(pj_status_t) pjsua_conf_connect2( pjsua_conf_port_id source,
      * PJ_EINVAL instead of letting pjmedia_conf_connect_port() abort on its
      * PJ_ASSERT_RETURN in debug/ASan builds.
      */
-    if (source >= (int)pjsua_var.media_cfg.max_media_ports ||
-        sink >= (int)pjsua_var.media_cfg.max_media_ports)
+    if ((unsigned)source >= pjsua_var.media_cfg.max_media_ports ||
+        (unsigned)sink >= pjsua_var.media_cfg.max_media_ports)
     {
         PJ_LOG(3,(THIS_FILE, "pjsua_conf_connect(%d, %d) failed: port ID out "
                              "of range (max_media_ports=%d)",


### PR DESCRIPTION
## Summary

`pjsua_conf_connect2()` and `pjsua_conf_disconnect()` only validated that the source/sink conference port IDs were **non-negative** before passing them down to `pjmedia_conf_connect_port()` / `pjmedia_conf_disconnect_port()`. Those pjmedia functions guard the upper bound with `PJ_ASSERT_RETURN`, which calls `pj_assert()` and **aborts the process** in debug/ASan builds (where `NDEBUG` is not defined) rather than returning an error.

An out-of-range port ID can occur legitimately at run-time — e.g. when a media port is removed by another thread under heavy load, leaving the caller holding a stale slot ID.

## The crash

This was hit by the `stress / asan` CI job, which aborts with:

```
conference.c: pjmedia_conf_connect_port:
  Assertion `conf && src_slot<conf->max_ports && sink_slot<conf->max_ports' failed.
```

Backtrace: `pjsua_conf_connect` → `pjsua_conf_connect2` → `pjmedia_conf_connect_port` → `abort` (exit 134). The surrounding log shows the process saturated (repeated `PJ_ETOOMANY` on media/video channel setup), which leaves calls holding stale conference slots. Because the stress test is randomized (`--shuffle`), the failure is intermittent.

## Fix

Validate the upper bound in both `pjsua_conf_connect2()` and `pjsua_conf_disconnect()` against `pjsua_media_config.max_media_ports` — the value the conference bridge is created with — and return `PJ_EINVAL` gracefully.

Key point: this is a plain `if` check, **not** a widened `PJ_ASSERT_RETURN`. Widening the assertion would still `abort()` in debug/ASan builds; returning before reaching the pjmedia call keeps that assertion from ever firing and makes behaviour consistent across debug and release builds (release already returns `PJ_EINVAL` there since asserts are compiled out).

## Notes

- Robustness hardening at the pjsua layer; no functional change to valid calls.
- Makes the `stress / asan` job deterministic-safe against this abort.
