### PR TITLE
Log transport-acquire fallback and document TCP-switch prerequisite

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -500,6 +500,14 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  * larger than this value the request will be sent with TCP. This setting
  * is useful only when PJSIP_DONT_SWITCH_TO_TCP is set to 0.
  *
+ * Note that the switch only takes effect when a TCP (or, for a sips: target,
+ * TLS) transport is available to carry the request: the library upgrades the
+ * resolved destination to the stream transport, but if no such transport has
+ * been created/registered, transport acquisition for it fails; if the sender
+ * allows fallback to the next resolved address, the request may then be sent
+ * oversized over UDP. Applications that rely on this automatic switch should
+ * therefore create a TCP/TLS transport in addition to the UDP one.
+ *
  * Default is 1300 bytes.
  */
 #ifndef PJSIP_UDP_SIZE_THRESHOLD

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -500,13 +500,13 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  * larger than this value the request will be sent with TCP. This setting
  * is useful only when PJSIP_DONT_SWITCH_TO_TCP is set to 0.
  *
- * Note that the switch only takes effect when a TCP (or, for a sips: target,
- * TLS) transport is available to carry the request: the library upgrades the
- * resolved destination to the stream transport, but if no such transport has
- * been created/registered, transport acquisition for it fails; if the sender
- * allows fallback to the next resolved address, the request may then be sent
- * oversized over UDP. Applications that rely on this automatic switch should
- * therefore create a TCP/TLS transport in addition to the UDP one.
+ * Note that the switch only takes effect when a TCP transport is available to
+ * carry the request: the library upgrades the resolved destination to TCP, but
+ * if no TCP transport has been created/registered, transport acquisition for it
+ * fails; if the sender allows fallback to the next resolved address, the
+ * request may then be sent oversized over UDP. Applications that rely on this
+ * automatic switch should therefore create a TCP transport in addition to the
+ * UDP one.
  *
  * Default is 1300 bytes.
  */

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1213,6 +1213,12 @@ static void stateless_send_transport_cb( void *token,
                                                 tdata,
                                                 &stateless_data->cur_transport);
         if (status != PJ_SUCCESS) {
+            /* Couldn't acquire this transport; fall through to the next resolved
+             * address (e.g. an 18.1.1 TCP upgrade reverts to UDP with no TCP tp). */
+            PJ_LOG(5,(THIS_FILE, "Unable to acquire %s transport for %s "
+                                 "(err=%d), trying next address",
+                                 pjsip_transport_get_type_name(cur_addr_type),
+                                 pjsip_tx_data_get_info(tdata), status));
             sent = -status;
             continue;
         }

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1213,12 +1213,14 @@ static void stateless_send_transport_cb( void *token,
                                                 tdata,
                                                 &stateless_data->cur_transport);
         if (status != PJ_SUCCESS) {
-            /* Couldn't acquire this transport; fall through to the next resolved
-             * address (e.g. an 18.1.1 TCP upgrade reverts to UDP with no TCP tp). */
-            PJ_LOG(5,(THIS_FILE, "Unable to acquire %s transport for %s "
-                                 "(err=%d), trying next address",
-                                 pjsip_transport_get_type_name(cur_addr_type),
-                                 pjsip_tx_data_get_info(tdata), status));
+            /* Couldn't acquire this transport; fall through to the next
+             * resolved address (e.g. RFC 3261 18.1.1 TCP upgrade reverts to
+             * UDP when no TCP transport is available). */
+            PJ_PERROR(5,(THIS_FILE, status,
+                         "Unable to acquire %s transport for %s, "
+                         "trying next address",
+                         pjsip_transport_get_type_name(cur_addr_type),
+                         pjsip_tx_data_get_info(tdata)));
             sent = -status;
             continue;
         }


### PR DESCRIPTION
Fixes #5075
 **Docs + logging only — no behaviour change.**

## Motivation
`pjsip_endpt_send_request_stateless()` silently advances to the next resolved address when `pjsip_endpt_acquire_transport2()` fails for the current one. That hides a genuinely confusing case:

- The RFC 3261 §18.1.1 size switch upgrades an over-MTU request to TCP by inserting TCP address entries ahead of the UDP ones.
- If the application only ever created a **UDP** transport, acquiring the TCP transport fails, the code falls through to the original UDP entry, and the oversized request is sent over **UDP** — where it fragments and is frequently dropped by NATs/proxies.
- Nothing is logged at the fallback point, so from the app’s side the request simply never gets through (call/registration times out with no explanation).

This cost real debugging time for a softphone that opened only a UDP transport. The switch itself is working as designed — it just needs a stream transport to switch *to* — but that prerequisite is neither logged nor documented.

## Change
1. `sip_util.c`: a `PJ_LOG(5,…)` at the transport-acquire fallback naming the transport type, the message, and the error — so the "wanted TCP, fell back" path is visible at trace level. Level 5 matches this file’s existing diagnostics and avoids log-spam in healthy multi-homed pools.
2. `sip_config.h`: a note on `PJSIP_UDP_SIZE_THRESHOLD` that the automatic switch requires a TCP (or, for `sips:`, TLS) transport to be registered, and that without one an over-MTU request may be sent oversized over UDP.

## Validation
- Full CI matrix on my fork before submitting.
- Reviewed against maintainer conventions (log level/idiom, C89, comment length, doc-note accuracy) via a DeepWiki deep pass.
- Manually compiled the `sip_util.c` change against 2.17 (`aarch64-apple-darwin`); no new warnings.

RFC reference: RFC 3261 §18.1.1 (congestion-controlled transport for requests within 200 bytes of the path MTU / over 1300 bytes). Default SIP ports for context: 5060 UDP/TCP, 5061 TLS.