### PR TITLE
Add best effort to obtain stack trace in stress test deadlock

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -730,7 +730,7 @@ jobs:
         # at 5 min by the binary, stress phase is 6 min), so 15 is generous.
         ./pjsua-stress-$ARCH -n 512 -v 16 -t 4 --duration 360 --log-level 4 > stress.log 2>&1 &
         app_pid=$!
-        tail --pid=$app_pid -f stress.log &
+        tail --pid=$app_pid -n +1 -f stress.log &
         (
           sleep 900
           if kill -0 $app_pid 2>/dev/null; then
@@ -821,7 +821,7 @@ jobs:
         # at 5 min by the binary, stress phase is 6 min), so 15 is generous.
         ./pjsua-stress-$ARCH -n 512 -v 16 -t 4 --duration 360 --log-level 4 > stress.log 2>&1 &
         app_pid=$!
-        tail --pid=$app_pid -f stress.log &
+        tail --pid=$app_pid -n +1 -f stress.log &
         (
           sleep 900
           if kill -0 $app_pid 2>/dev/null; then

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -701,7 +701,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies
-      run: sudo apt-get update && sudo apt-get install -y nasm
+      run: sudo apt-get update && sudo apt-get install -y nasm gdb
     - name: get openh264
       run: git clone --depth 1 --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
     - name: build openh264
@@ -723,14 +723,38 @@ jobs:
         export ASAN_OPTIONS="halt_on_error=1"
         ARCH=$(make --no-print-directory -s infotarget)
         cd pjsip/bin
+        # Run in the background (log streamed to the console by tail) so a
+        # watchdog can dump thread stacks and kill the binary if it hangs.
+        # Without this a deadlock is a silent 45-minute job timeout with no
+        # diagnostics. A healthy run finishes in ~8 minutes (ramp is capped
+        # at 5 min by the binary, stress phase is 6 min), so 15 is generous.
+        ./pjsua-stress-$ARCH -n 512 -v 16 -t 4 --duration 360 --log-level 4 > stress.log 2>&1 &
+        app_pid=$!
+        tail --pid=$app_pid -f stress.log &
+        (
+          sleep 900
+          if kill -0 $app_pid 2>/dev/null; then
+            {
+              echo ""
+              echo "=== pjsua_stress watchdog: still running after 900 s, dumping thread stacks ==="
+              sudo gdb -p $app_pid -batch -ex "thread apply all bt" 2>&1
+            } >> stress.log
+            touch watchdog.fired
+            kill -9 $app_pid 2>/dev/null
+          fi
+        ) > /dev/null 2>&1 &
+        watchdog_pid=$!
         # Temporarily disable errexit so a crashed binary doesn't kill the
-        # step before we capture PIPESTATUS and decode the backtrace.
-        # DON'T use `|| :` here — `:` runs as a single-command pipeline
-        # that resets PIPESTATUS to (0), masking the real exit code.
+        # step before we capture the exit code and decode the backtrace.
         set +e
-        ./pjsua-stress-$ARCH -n 512 -v 16 -t 4 --duration 360 --log-level 4 2>&1 | tee stress.log
-        rc=${PIPESTATUS[0]}
+        wait $app_pid
+        rc=$?
         set -e
+        kill $watchdog_pid 2>/dev/null || true
+        if [ -f watchdog.fired ]; then
+          echo "::error::pjsua-stress hung; watchdog killed it after 900 s, thread stacks are in the uploaded stress.log"
+          exit 124
+        fi
         # If our crash handler dumped a backtrace, resolve the static-frame
         # offsets via addr2line so the names land in the uploaded log.
         if grep -q "=== pjsua_stress backtrace ===" stress.log; then
@@ -769,7 +793,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies
-      run: sudo apt-get update && sudo apt-get install -y nasm
+      run: sudo apt-get update && sudo apt-get install -y nasm gdb
     - name: get openh264
       run: git clone --depth 1 --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
     - name: build openh264
@@ -790,14 +814,38 @@ jobs:
         export TSAN_OPTIONS="suppressions=$GITHUB_WORKSPACE/tests/sanitizers/tsan.supp halt_on_error=1"
         ARCH=$(make --no-print-directory -s infotarget)
         cd pjsip/bin
+        # Run in the background (log streamed to the console by tail) so a
+        # watchdog can dump thread stacks and kill the binary if it hangs.
+        # Without this a deadlock is a silent 45-minute job timeout with no
+        # diagnostics. A healthy run finishes in ~8 minutes (ramp is capped
+        # at 5 min by the binary, stress phase is 6 min), so 15 is generous.
+        ./pjsua-stress-$ARCH -n 512 -v 16 -t 4 --duration 360 --log-level 4 > stress.log 2>&1 &
+        app_pid=$!
+        tail --pid=$app_pid -f stress.log &
+        (
+          sleep 900
+          if kill -0 $app_pid 2>/dev/null; then
+            {
+              echo ""
+              echo "=== pjsua_stress watchdog: still running after 900 s, dumping thread stacks ==="
+              sudo gdb -p $app_pid -batch -ex "thread apply all bt" 2>&1
+            } >> stress.log
+            touch watchdog.fired
+            kill -9 $app_pid 2>/dev/null
+          fi
+        ) > /dev/null 2>&1 &
+        watchdog_pid=$!
         # Temporarily disable errexit so a crashed binary doesn't kill the
-        # step before we capture PIPESTATUS and decode the backtrace.
-        # DON'T use `|| :` here — `:` runs as a single-command pipeline
-        # that resets PIPESTATUS to (0), masking the real exit code.
+        # step before we capture the exit code and decode the backtrace.
         set +e
-        ./pjsua-stress-$ARCH -n 512 -v 16 -t 4 --duration 360 --log-level 4 2>&1 | tee stress.log
-        rc=${PIPESTATUS[0]}
+        wait $app_pid
+        rc=$?
         set -e
+        kill $watchdog_pid 2>/dev/null || true
+        if [ -f watchdog.fired ]; then
+          echo "::error::pjsua-stress hung; watchdog killed it after 900 s, thread stacks are in the uploaded stress.log"
+          exit 124
+        fi
         # If our crash handler dumped a backtrace, resolve the static-frame
         # offsets via addr2line so the names land in the uploaded log.
         if grep -q "=== pjsua_stress backtrace ===" stress.log; then

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y nasm
+        run: sudo apt-get update && sudo apt-get install -y nasm gdb
 
       - name: Get openh264
         run: git clone --depth 1 --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
@@ -60,14 +60,39 @@ jobs:
           export ASAN_OPTIONS="halt_on_error=1"
           ARCH=$(make --no-print-directory -s infotarget)
           cd pjsip/bin
+          # Run in the background (log streamed to the console by tail) so a
+          # watchdog can dump thread stacks and kill the binary if it hangs.
+          # Without this a deadlock is a silent 60-minute job timeout with no
+          # diagnostics. A healthy run finishes in ~20 minutes (ramp is
+          # capped at 5 min by the binary, stress phase is 10 min), so 25 is
+          # generous.
+          ./pjsua-stress-$ARCH -n 1024 -v 32 -t 8 --duration 600 --log-level 4 > stress.log 2>&1 &
+          app_pid=$!
+          tail --pid=$app_pid -f stress.log &
+          (
+            sleep 1500
+            if kill -0 $app_pid 2>/dev/null; then
+              {
+                echo ""
+                echo "=== pjsua_stress watchdog: still running after 1500 s, dumping thread stacks ==="
+                sudo gdb -p $app_pid -batch -ex "thread apply all bt" 2>&1
+              } >> stress.log
+              touch watchdog.fired
+              kill -9 $app_pid 2>/dev/null
+            fi
+          ) > /dev/null 2>&1 &
+          watchdog_pid=$!
           # Temporarily disable errexit so a crashed binary doesn't kill the
-          # step before we capture PIPESTATUS and decode the backtrace.
-          # DON'T use `|| :` here — `:` runs as a single-command pipeline
-          # that resets PIPESTATUS to (0), masking the real exit code.
+          # step before we capture the exit code and decode the backtrace.
           set +e
-          ./pjsua-stress-$ARCH -n 1024 -v 32 -t 8 --duration 600 --log-level 4 2>&1 | tee stress.log
-          rc=${PIPESTATUS[0]}
+          wait $app_pid
+          rc=$?
           set -e
+          kill $watchdog_pid 2>/dev/null || true
+          if [ -f watchdog.fired ]; then
+            echo "::error::pjsua-stress hung; watchdog killed it after 1500 s, thread stacks are in the uploaded stress.log"
+            exit 124
+          fi
           # If our crash handler dumped a backtrace, resolve the static-frame
           # offsets via addr2line so the names land in the uploaded log.
           if grep -q "=== pjsua_stress backtrace ===" stress.log; then

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -68,7 +68,7 @@ jobs:
           # generous.
           ./pjsua-stress-$ARCH -n 1024 -v 32 -t 8 --duration 600 --log-level 4 > stress.log 2>&1 &
           app_pid=$!
-          tail --pid=$app_pid -f stress.log &
+          tail --pid=$app_pid -n +1 -f stress.log &
           (
             sleep 1500
             if kill -0 $app_pid 2>/dev/null; then

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3486,9 +3486,14 @@ static void log_call_dump(int call_id)
         }
         p_orig = p[part_len];
         p[part_len] = '\0';
-        /* Trim the trailing newline, the logger appends one */
-        if (part_len > 0 && p[part_len-1] == '\n')
+        /* Trim the trailing newline (and optional CR), the logger
+         * appends one
+         */
+        if (part_len > 0 && p[part_len-1] == '\n') {
             p[part_len-1] = '\0';
+            if (part_len > 1 && p[part_len-2] == '\r')
+                p[part_len-2] = '\0';
+        }
         PJ_LOG(3,(THIS_FILE, "%s", p));
         p[part_len] = p_orig;
         part_idx += part_len;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -3447,15 +3447,14 @@ static void stop_media_session(pjsua_call_id call_id)
  * printing it is a bit tricky, it should be printed part by part as long 
  * as the logger can accept.
  */
-static void log_call_dump(int call_id) 
+static void log_call_dump(int call_id)
 {
     pj_pool_t *pool;
     unsigned call_dump_len;
     unsigned part_len;
     unsigned part_idx;
-    unsigned log_decor;
     char *buf;
-    enum { BUF_LEN = 10*1024 };
+    enum { BUF_LEN = 10*1024, MAX_PART_LEN = PJ_LOG_MAX_SIZE-80 };
     pj_status_t status;
 
     pool = pjsua_pool_create("tmp", 1024, 1024);
@@ -3468,26 +3467,32 @@ static void log_call_dump(int call_id)
 
     call_dump_len = (unsigned)pj_ansi_strlen(buf);
 
-    log_decor = pj_log_get_decor();
-    pj_log_set_decor(log_decor & ~(PJ_LOG_HAS_NEWLINE | PJ_LOG_HAS_CR));
-    PJ_LOG(3,(THIS_FILE, "\n"));
-    pj_log_set_decor(0);
-
+    /* Print in parts split at line boundaries. Don't touch the log decor:
+     * it is process-global, so the save/clear/restore done here previously
+     * raced with other threads and could leave the decor cleared for good.
+     */
     part_idx = 0;
-    part_len = PJ_LOG_MAX_SIZE-80;
     while (part_idx < call_dump_len) {
         char p_orig, *p;
 
         p = buf + part_idx;
-        if (part_idx + part_len > call_dump_len)
-            part_len = call_dump_len - part_idx;
+        part_len = call_dump_len - part_idx;
+        if (part_len > MAX_PART_LEN) {
+            part_len = MAX_PART_LEN;
+            while (part_len > 0 && p[part_len-1] != '\n')
+                --part_len;
+            if (part_len == 0)
+                part_len = MAX_PART_LEN;
+        }
         p_orig = p[part_len];
         p[part_len] = '\0';
+        /* Trim the trailing newline, the logger appends one */
+        if (part_len > 0 && p[part_len-1] == '\n')
+            p[part_len-1] = '\0';
         PJ_LOG(3,(THIS_FILE, "%s", p));
         p[part_len] = p_orig;
         part_idx += part_len;
     }
-    pj_log_set_decor(log_decor);
 
 on_return:
     pj_pool_release(pool);


### PR DESCRIPTION
Follow-up to the `stress / asan` hang on PR #5074 (run 29330620040): the job hit the 45-minute timeout with no ASan report, no assertion, and no crash — the stress binary deadlocked ~160 s into the 360 s stress phase and wrote nothing for its final 40 minutes (three `Timed-out trying to acquire PJSUA mutex` warnings from `pjsua_call_hangup()`/`pjsua_call_set_hold()`, then silence). The same hang hit `stress / tsan` on an unrelated PR (#5070) the day before, so it is a pre-existing intermittent deadlock. Two changes to make the next occurrence diagnosable:

## 1. Fix global log decor race in `log_call_dump()` (pjsua_media.c)

`log_call_dump()` saved, cleared, and restored the **process-global** log decor around the chunked call-stats dump. With concurrent call teardowns, one thread can save the decor already cleared by another and restore that — permanently stripping timestamps and newlines from all subsequent output. In the failing run this hit ~85 s in: the rest of the 142 MB log has no timestamps and ends in a single 661 KB line, which made the hang forensics much harder.

The dump is now printed in chunks split at line boundaries (same ~3 log calls per dump as before), so each chunk is a normal decorated log message and no global state is touched.

## 2. Add a hang watchdog to the stress CI jobs (ci-linux.yml, stress-test.yml)

The stress binary now runs in the background (log streamed to the console via `tail --pid`) with a watchdog alongside: if the binary is still alive after 900 s (PR jobs; healthy runs take ~8 min) / 1500 s (weekly; ~20 min), the watchdog appends `gdb -p <pid> -batch -ex "thread apply all bt"` output to `stress.log`, kills the process, and fails the step with exit 124 and an error annotation. `gdb` added to the apt installs. The app's real exit code is still propagated (via `wait` instead of `PIPESTATUS`); crash-backtrace decoding and the sanitizer log checks are unchanged.

A deadlock now costs 15 minutes instead of 45 and uploads thread stacks instead of nothing.

## Validation

- `make` clean (zero warnings) with the pjsua_media.c change; chunking loop additionally exercised by a standalone ASan-built test (content preserved across chunk boundaries, oversize-single-line hard-split fallback, no-trailing-newline and lone-newline edge cases).
- Both workflows YAML-parse; all three embedded scripts pass `bash -n`; the watchdog control flow was exercised with a scaled-down harness for all three paths (normal exit → pass, crash → exit code propagated, hang → stacks in `stress.log`, exit 124).

Co-Authored-By Claude Code
