### PR TITLE
pjsua: guard on_call_state against stale inv on recycled call slot (#4992)

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -5262,6 +5262,20 @@ static void pjsua_call_on_state_changed(pjsip_inv_session *inv,
         return;
     }
 
+    /* Stale callback guard (see pjsua_call_on_media_update): a leftover inv
+     * whose call slot has been recycled into a new dialog. Running the
+     * teardown below (media deinit, on_call_state, reset_call) would wipe
+     * the live call's slot and drop its own DISCONNECTED (issue #4992).
+     */
+    if (call->inv != inv) {
+        PJ_LOG(4, (THIS_FILE,
+                   "Ignoring stale state change on call %d "
+                   "(inv %p != current %p, state=%d)",
+                   call->index, inv, (void*)call->inv, inv->state));
+        pj_log_pop_indent();
+        return;
+    }
+
 
     /* Get call times */
     switch (inv->state) {


### PR DESCRIPTION
## Issue

Fixes #4992. Under a high-concurrency outbound call burst (single event-loop thread, `threadCnt=0`, UDP), an outgoing INVITE is occasionally terminated at the native layer **without** `on_call_state(PJSIP_INV_STATE_DISCONNECTED)` ever firing. The app sees `CALLING`/`EARLY`, then nothing; a later `getInfo()` throws `PJSIP_ESESSIONTERMINATED`. On the wire the INVITE goes out with **no retransmissions and no response** — i.e. the transaction was destroyed locally, not by a network response or Timer B.

## Root cause

This is the same **call-slot-reuse / stale-`inv` race** documented and partially fixed in #4995. A leftover invite session — kept alive by a still-pending transaction after its dialog was torn down — fires a state change after pjsua has recycled its call slot into a new, live dialog. `pjsua_call_on_state_changed()` resolves the slot through `inv->dlg->mod_data[mod.id]`, so the stale `inv` lands on the recycled slot whose `call->inv` now points at the live call. It then runs the full `DISCONNECTED` teardown against the live call:

- `pjsua_media_channel_deinit(call->index)` — deinits the live call's media
- `on_call_state(call->index, e)` — misreports under the live call's id
- `--call_cnt; reset_call(call->index)` — wipes the live call's slot and nulls its `inv`

After that the live call's own real `DISCONNECTED` can never be delivered, matching every symptom in the report. In a release/`NDEBUG` build the related `med_prov_cnt` assertion is compiled out, so the corruption surfaces as a silently dropped callback rather than a crash.

#4995 added a stale-callback guard (`call->inv != inv`) to `pjsua_call_on_media_update()` and `pjsua_call_on_tsx_state_changed()`, but not to the `DISCONNECTED` dispatcher `pjsua_call_on_state_changed()` — the most destructive one to leave unguarded because it calls `reset_call()`.

## Fix

Extend the identical guard to `pjsua_call_on_state_changed()`, before any slot-mutating work: drop the event when `call->inv != inv`. For a normal call `call->inv == inv` holds throughout the callback (`call->inv` is set at creation and nulled only at the end of this same function), so only genuinely stale events are dropped — no behavior change for normal calls.

## Testing

- `cd pjsip/build && make` — builds clean, no new warnings.