### PR TITLE
pjmedia: fix out-of-bounds writes in pjmedia_endpt_create_audio_sdp()

### DIFF
--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -494,7 +494,6 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
                                                      codec_info, &codec_param);
         if (status != PJ_SUCCESS)
             return status;
-        fmt = &m->desc.fmt[m->desc.fmt_count++];
         pt = codec_info->pt;
 
         /* Rearrange dynamic payload type to make sure it is inside 96-127
@@ -520,10 +519,18 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
             pt = pt_check;
         }
 
+        /* Bail out if format array is full (PT chosen before fmt_count++) */
+        if (m->desc.fmt_count >= PJMEDIA_MAX_SDP_FMT) {
+            PJ_LOG(4,(THIS_FILE, "Warning: SDP format array is full, "
+                      "some audio codecs are omitted"));
+            break;
+        }
+
         /* Take a note of used dynamic PT */
         if (pt >= 96)
             used_pt[used_pt_num++] = pt;
 
+        fmt = &m->desc.fmt[m->desc.fmt_count++];
         fmt->ptr = (char*) pj_pool_alloc(pool, 8);
         fmt->slen = pj_utoa(pt, fmt->ptr);
 
@@ -651,6 +658,15 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
             char buf[160];
             unsigned j = 0;
             unsigned pt;
+
+            /* Bail out if format or used-PT array is full */
+            if (m->desc.fmt_count >= PJMEDIA_MAX_SDP_FMT ||
+                used_pt_num >= PJMEDIA_MAX_SDP_FMT)
+            {
+                PJ_LOG(4,(THIS_FILE, "Warning: no space left in SDP format "
+                          "array, some telephone-events are omitted"));
+                break;
+            }
 
             /* Find PT for this tel-event */
             if (i == 0) {

--- a/pjmedia/src/pjmedia/endpoint.c
+++ b/pjmedia/src/pjmedia/endpoint.c
@@ -527,8 +527,14 @@ pjmedia_endpt_create_audio_sdp(pjmedia_endpt *endpt,
         }
 
         /* Take a note of used dynamic PT */
-        if (pt >= 96)
+        if (pt >= 96) {
+            if (used_pt_num >= PJMEDIA_MAX_SDP_FMT) {
+                PJ_LOG(4,(THIS_FILE, "Warning: used-PT array is full, "
+                          "some audio codecs are omitted"));
+                break;
+            }
             used_pt[used_pt_num++] = pt;
+        }
 
         fmt = &m->desc.fmt[m->desc.fmt_count++];
         fmt->ptr = (char*) pj_pool_alloc(pool, 8);


### PR DESCRIPTION
## Summary

Fixes two out-of-bounds write paths in `pjmedia_endpt_create_audio_sdp()` (`pjmedia/src/pjmedia/endpoint.c`).

When the codec manager is fully populated (`codec_cnt == PJMEDIA_MAX_SDP_FMT`, default 32) and telephone-event support is enabled (the default), the function could write one element past the fixed-size arrays `m->desc.fmt[PJMEDIA_MAX_SDP_FMT]` and `used_pt[PJMEDIA_MAX_SDP_FMT]`.

## Details

- **Telephone-event append (primary):** after the codec loop fills all 32 `desc.fmt` slots, the telephone-event loop appended to `desc.fmt[]` and `used_pt[]` without any capacity check, writing to index `PJMEDIA_MAX_SDP_FMT`.
- **Full dynamic-payload case:** with 32 enabled dynamic codecs, the last codec incremented `fmt_count` *before* its dynamic payload-type search failed and `break`'d, leaving the counter advanced with a stale entry and compounding the overflow into both arrays.

This is CWE-787 (out-of-bounds write). Note it is **not remotely reachable** — the trigger is governed entirely by local codec registration (`codec_mgr.codec_cnt`), which a SIP/SDP peer cannot influence; the function only *builds* the local offer. It is a hardening fix rather than a remotely-exploitable vulnerability.

## Fix

- Choose the dynamic payload type **before** advancing `fmt_count`, so a failed PT search no longer leaves the counter advanced.
- Bounds-check both `fmt_count` and `used_pt_num` before every append in the codec loop and the telephone-event loop.
- Excess formats are omitted with a `PJ_LOG` warning instead of overflowing. Normal configurations (well under 32 codecs) are unaffected and produce identical output.

## Testing

- `cd pjmedia/build && make` — compiles cleanly (`-Wall`, ASan build), no new warnings.

Thank you to Nan Yang for the report.

Co-Authored-By Claude Code