### PR TITLE
tests/pjsua: add SRTP SDES hold/unhold restart test

### DIFF
--- a/tests/pjsua/scripts-sipp/uac-srtp-sdes-reinv-hold.py
+++ b/tests/pjsua/scripts-sipp/uac-srtp-sdes-reinv-hold.py
@@ -1,0 +1,17 @@
+#
+import inc_const as const
+
+# SDES-keyed SRTP call is put on old-style (RFC 2543, c=0.0.0.0) hold and
+# then resumed with a freshly generated SDES key, on the same dialog. This
+# exercises pjsua's SRTP session restart path (as UAS) rather than just
+# the initial keying negotiation covered by uac-srtp-sdes.py.
+
+PJSUA = ["--null-audio --max-calls=1 --auto-answer=200 --no-tcp --srtp-secure 0 --use-srtp 2 --srtp-keying=0"]
+
+PJSUA_EXPECTS = [[0, "SRTP uses keying method SDES", ""],
+                 [0, const.MEDIA_ACTIVE, ""],
+                 [0, "SRTP uses keying method SDES", ""],
+                 [0, const.MEDIA_HOLD, ""],
+                 [0, "SRTP uses keying method SDES", ""],
+                 [0, const.MEDIA_ACTIVE, ""]
+                ]

--- a/tests/pjsua/scripts-sipp/uac-srtp-sdes-reinv-hold.xml
+++ b/tests/pjsua/scripts-sipp/uac-srtp-sdes-reinv-hold.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+<!--                                                                    -->
+<!-- You should have received a copy of the GNU General Public License  -->
+<!-- along with this program; if not, write to the                      -->
+<!-- Free Software Foundation, Inc.,                                    -->
+<!-- 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA             -->
+<!--                                                                    -->
+<!--                                                                    -->
+
+<!-- SRTP (SDES) call is put on old-style hold (c=0.0.0.0) and then     -->
+<!-- resumed with a brand new SDES key, forcing pjsua to tear down and  -->
+<!-- restart its SRTP session mid-dialog.                               -->
+
+<scenario name="UAC">
+
+  <send>
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bKPj-1
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=Tester 234 123 IN IP4 127.0.0.1
+      s=Tester
+      c=IN IP4 127.0.0.1
+      t=0 0
+      m=audio 17424 RTP/SAVP 0 101
+      a=rtpmap:101 telephone-event/8000
+      a=sendrecv
+      a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:URF7iv+U7XFsqiWMmPYMPOuIqz3qjQjmLW/qP5+x
+    ]]>
+  </send>
+
+  <recv response="100"
+        optional="true">
+  </recv>
+
+  <recv response="180" optional="true">
+  </recv>
+
+  <recv response="200" rtd="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bKPj-2
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <!-- Re-INVITE #1: old-style (RFC 2543) hold, c=0.0.0.0, same SDES  -->
+  <!-- key as the initial offer.                                      -->
+  <send>
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bKPj-3
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=Tester 234 123 IN IP4 127.0.0.1
+      s=Tester
+      c=IN IP4 0.0.0.0
+      t=0 0
+      m=audio 17424 RTP/SAVP 0 101
+      a=rtpmap:101 telephone-event/8000
+      a=sendrecv
+      a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:URF7iv+U7XFsqiWMmPYMPOuIqz3qjQjmLW/qP5+x
+    ]]>
+  </send>
+
+  <recv response="100" optional="true">
+  </recv>
+
+  <recv response="200" rtd="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bKPj-4
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <!-- Re-INVITE #2: release hold, restore the real address, and     -->
+  <!-- offer a brand new SDES key -- pjsua must restart SRTP rather   -->
+  <!-- than keep reusing the held session's crypto context.           -->
+  <send>
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bKPj-5
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=Tester 234 123 IN IP4 127.0.0.1
+      s=Tester
+      c=IN IP4 127.0.0.1
+      t=0 0
+      m=audio 17424 RTP/SAVP 0 101
+      a=rtpmap:101 telephone-event/8000
+      a=sendrecv
+      a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:08xQbX6lbROmI6H2wKmrLPi0oAURF0eRftsfzgEv
+    ]]>
+  </send>
+
+  <recv response="100" optional="true">
+  </recv>
+
+  <recv response="200" rtd="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=z9hG4bKPj-6
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>


### PR DESCRIPTION
## Summary
- Adds `tests/pjsua/scripts-sipp/uac-srtp-sdes-reinv-hold.{xml,py}`, a new sipp scenario covering a gap in existing SRTP app-test coverage: an SDES-keyed SRTP call is put on old-style (RFC 2543, `c=0.0.0.0`) hold, then resumed on the same dialog with a freshly generated SDES key.
- Verifies pjsua correctly tears down and restarts its SRTP session on unhold (fresh keying negotiation, media back to `Active`) rather than reusing stale crypto state from the held session.
- Existing coverage (`uac-srtp-sdes.py`, `uac-srtp-sdes-reinv-dtls.py`, etc.) only exercises initial SDES/DTLS-SRTP negotiation and keying-method switches on re-INVITE — none exercised the hold/unhold + rekey path.

## Test plan
- [x] Ran locally against a release build of `pjsua` with real `sipp`: `python3 run.py mod_sipp.py scripts-sipp/uac-srtp-sdes-reinv-hold.xml` completes successfully (exit 0).
- [x] Confirmed the expected log sequence occurs in order: `SRTP uses keying method SDES` → media `Active` → `SDES` (hold re-INVITE) → media `Remote hold` → `SDES` (unhold re-INVITE with new key) → media `Active`.
- [x] No crashes/asserts; only expected transient `Error sending RTCP: No route to host` while held (address is `0.0.0.0`), matching documented RFC 2543 hold behavior.
- [ ] CI: picked up automatically by `runall.py`, which globs all `.xml` files under `scripts-sipp/`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>