### PR TITLE
tests: add AMR-WB fmtp, Speex/32000, and G.722.1 32kHz codec coverage

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -108,7 +108,7 @@ jobs:
         git clone --depth 1 https://github.com/pjsip/cirunner.git
         cirunner/installlinux.sh
     - name: install dependencies
-      run: sudo apt-get update && sudo apt-get install -y swig sip-tester libopencore-amrnb-dev
+      run: sudo apt-get update && sudo apt-get install -y swig sip-tester libopencore-amrnb-dev libopencore-amrwb-dev libvo-amrwbenc-dev
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h
     - name: configure
@@ -143,6 +143,8 @@ jobs:
         cat pjsua-caps
     - name: ensure AMR codec is installed
       run: cat pjsua-caps | grep -E 'AMR/8000'
+    - name: ensure AMR-WB codec is installed
+      run: cat pjsua-caps | grep -E 'AMR-WB/16000'
     - name: pjsua-test
       run: make pjsua-test
     - name: upload artifacts on failure
@@ -301,7 +303,7 @@ jobs:
         git clone --depth 1 https://github.com/pjsip/cirunner.git
         cirunner/installlinux.sh
     - name: install dependencies
-      run: sudo apt-get update && sudo apt-get install -y swig nasm sip-tester libvpx-dev libopencore-amrnb-dev libsdl2-dev
+      run: sudo apt-get update && sudo apt-get install -y swig nasm sip-tester libvpx-dev libopencore-amrnb-dev libopencore-amrwb-dev libvo-amrwbenc-dev libsdl2-dev
     - name: get openh264
       run: git clone --depth 1 --single-branch --branch openh264v2.1.0 https://github.com/cisco/openh264.git
     - name: build openh264
@@ -341,6 +343,8 @@ jobs:
         cat pjsua-caps
     - name: ensure AMR codec is installed
       run: cat pjsua-caps | grep -E 'AMR/8000'
+    - name: ensure AMR-WB codec is installed
+      run: cat pjsua-caps | grep -E 'AMR-WB/16000'
     - name: ensure H264 codec is installed
       run: cat pjsua-caps | grep -E 'H264/'
     - name: ensure VP8 codec is installed
@@ -525,7 +529,7 @@ jobs:
         git clone --depth 1 https://github.com/pjsip/cirunner.git
         cirunner/installlinux.sh
     - name: install dependencies
-      run: sudo apt-get update && sudo apt-get install -y swig sip-tester libopencore-amrnb-dev
+      run: sudo apt-get update && sudo apt-get install -y swig sip-tester libopencore-amrnb-dev libopencore-amrwb-dev libvo-amrwbenc-dev
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo -e "#define PJ_IOQUEUE_CALLBACK_NO_LOCK 0\n#define PJMEDIA_CONF_BACKEND PJMEDIA_CONF_PARALLEL_BRIDGE_BACKEND\n#define PJMEDIA_CONF_THREADS 4" >> config_site.h
     - name: configure

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -128,7 +128,7 @@ jobs:
         git clone --depth 1 https://github.com/pjsip/cirunner.git
         cirunner/installmac.sh
     - name: install dependencies
-      run: brew install openssl opencore-amr swig sipp
+      run: brew install openssl opencore-amr vo-amrwbenc swig sipp
     - name: set up Python
       uses: actions/setup-python@v4
       with:
@@ -146,7 +146,7 @@ jobs:
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h
     - name: configure
-      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) -fPIC" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb)" CXXFLAGS="-g -fPIC" ./configure
+      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) $(pkg-config --cflags opencore-amrwb) $(pkg-config --cflags vo-amrwbenc) -fPIC" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) $(pkg-config --libs-only-L opencore-amrwb) $(pkg-config --libs-only-L vo-amrwbenc)" CXXFLAGS="-g -fPIC" ./configure
     - name: make
       run: $MAKE_FAST
     - name: disable firewall
@@ -364,11 +364,11 @@ jobs:
         git clone --depth 1 https://github.com/pjsip/cirunner.git
         cirunner/installmac.sh
     - name: install dependencies
-      run: brew install openssl openh264 libvpx opencore-amr swig sipp
+      run: brew install openssl openh264 libvpx opencore-amr vo-amrwbenc swig sipp
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
     - name: configure
-      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) -DHAS_VID_CODEC_TEST=0 -fPIC -fsanitize=address" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) -fsanitize=address" CXXFLAGS="-g -fPIC -fsanitize=address" ./configure
+      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) $(pkg-config --cflags opencore-amrwb) $(pkg-config --cflags vo-amrwbenc) -DHAS_VID_CODEC_TEST=0 -fPIC -fsanitize=address" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) $(pkg-config --libs-only-L opencore-amrwb) $(pkg-config --libs-only-L vo-amrwbenc) -fsanitize=address" CXXFLAGS="-g -fPIC -fsanitize=address" ./configure
     - name: make
       run: $MAKE_FAST
     - name: set up Python
@@ -550,7 +550,7 @@ jobs:
         git clone --depth 1 https://github.com/pjsip/cirunner.git
         cirunner/installmac.sh
     - name: install dependencies
-      run: brew install openssl opencore-amr sipp
+      run: brew install openssl opencore-amr vo-amrwbenc sipp
     - name: set up Python
       uses: actions/setup-python@v4
       with:
@@ -568,7 +568,7 @@ jobs:
     - name: config site
       run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo -e "#define PJ_IOQUEUE_CALLBACK_NO_LOCK 0\n" >> config_site.h
     - name: configure
-      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) -fPIC" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb)" CXXFLAGS="-g -fPIC" ./configure
+      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) $(pkg-config --cflags opencore-amrwb) $(pkg-config --cflags vo-amrwbenc) -fPIC" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) $(pkg-config --libs-only-L opencore-amrwb) $(pkg-config --libs-only-L vo-amrwbenc)" CXXFLAGS="-g -fPIC" ./configure
     - name: make
       run: $MAKE_FAST
     - name: disable firewall

--- a/tests/pjsua/scripts-pesq/200_codec_speex_32000.py
+++ b/tests/pjsua/scripts-pesq/200_codec_speex_32000.py
@@ -1,0 +1,23 @@
+#
+from inc_cfg import *
+
+ADD_PARAM = ""
+
+if (HAS_SND_DEV == 0):
+	ADD_PARAM += "--null-audio"
+
+# Call with Speex/32000 (UWB) codec.
+# Note: the PESQ tool only scores 8kHz/16kHz WAV files, so the conference
+# bridge/device clock rate is kept at 16000 (input/output WAVs stay
+# xxx.16.wav) while the codec itself negotiates and runs at its native
+# 32000 clock rate; PJMEDIA transparently resamples between the two.
+test_param = TestParam(
+		"PESQ codec Speex UWB",
+		[
+			InstanceParam("UA1", ADD_PARAM + " --max-calls=1 --clock-rate 16000 --add-codec speex/32000 --play-file wavs/input.16.wav --no-vad"),
+			InstanceParam("UA2", "--null-audio --max-calls=1 --clock-rate 16000 --add-codec speex/32000 --rec-file  wavs/tmp.16.wav --auto-answer 200")
+		]
+		)
+
+pesq_threshold = 3.4
+visqol_threshold = 3.8

--- a/tests/pjsua/scripts-pesq/201_codec_speex_32000.py
+++ b/tests/pjsua/scripts-pesq/201_codec_speex_32000.py
@@ -1,0 +1,20 @@
+#
+from inc_cfg import *
+
+# Call with Speex/32000 (UWB) codec.
+# Note: the PESQ tool only scores 8kHz/16kHz WAV files, so the conference
+# bridge/device clock rate is kept at 16000 (input/output WAVs stay
+# xxx.16.wav) while the codec itself negotiates and runs at its native
+# 32000 clock rate; PJMEDIA transparently resamples between the two.
+test_param = TestParam(
+		"PESQ codec Speex UWB (RX side uses snd dev)",
+		[
+			InstanceParam("UA1", "--max-calls=1 --clock-rate 16000 --add-codec speex/32000 --play-file wavs/input.16.wav --null-audio"),
+			InstanceParam("UA2", "--max-calls=1 --clock-rate 16000 --add-codec speex/32000 --rec-file  wavs/tmp.16.wav   --auto-answer 200")
+		]
+		)
+
+if (HAS_SND_DEV == 0):
+	test_param.skip = True
+
+pesq_threshold = 2.8

--- a/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate.py
+++ b/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate.py
@@ -1,0 +1,34 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer for codec G722.1 (32kHz/Siren14) should contain fmtp bitrate
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 99 100 102 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:99 G7221/32000
+a=fmtp:99 bitrate=24000
+a=rtpmap:100 G7221/32000
+a=fmtp:100 bitrate=32000
+a=rtpmap:102 G7221/32000
+a=fmtp:102 bitrate=48000
+a=sendrecv
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec G7221"
+extra_headers = ""
+include = ["fmtp:[\d]+ bitrate="]	# response must include fmtp bitrate
+exclude = []
+
+sendto_cfg = sip.SendtoCfg("Answer should contain fmtp bitrate for codec G722.1 32kHz", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate_24000.py
+++ b/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate_24000.py
@@ -1,0 +1,33 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer with codec G722.1 (32kHz/Siren14) should choose the same bitrate
+# which in this test is 24000
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 100 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:100 G7221/32000
+a=fmtp:100 bitrate=24000
+a=sendrecv
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec G7221"
+extra_headers = ""
+include = ["a=rtpmap:[\d]+ G7221/32000",  # response must choose G722.1 32kHz
+	   "fmtp:[\d]+ bitrate=24000"	  # response must choose the same bitrate
+	  ]
+exclude = []
+
+sendto_cfg = sip.SendtoCfg("Answer with G722.1 32kHz should choose bitrate 24000", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate_32000.py
+++ b/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate_32000.py
@@ -1,0 +1,33 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer with codec G722.1 (32kHz/Siren14) should choose the same bitrate
+# which in this test is 32000
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 100 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:100 G7221/32000
+a=fmtp:100 bitrate=32000
+a=sendrecv
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec G7221"
+extra_headers = ""
+include = ["a=rtpmap:[\d]+ G7221/32000",  # response must choose G722.1 32kHz
+	   "fmtp:[\d]+ bitrate=32000"	  # response must choose the same bitrate
+	  ]
+exclude = []
+
+sendto_cfg = sip.SendtoCfg("Answer with G722.1 32kHz should choose bitrate 32000", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate_48000.py
+++ b/tests/pjsua/scripts-sendto/402_fmtp_g7221_uwb_with_bitrate_48000.py
@@ -1,0 +1,33 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer with codec G722.1 (32kHz/Siren14) should choose the same bitrate
+# which in this test is 48000
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 100 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:100 G7221/32000
+a=fmtp:100 bitrate=48000
+a=sendrecv
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec G7221"
+extra_headers = ""
+include = ["a=rtpmap:[\d]+ G7221/32000",  # response must choose G722.1 32kHz
+	   "fmtp:[\d]+ bitrate=48000"	  # response must choose the same bitrate
+	  ]
+exclude = []
+
+sendto_cfg = sip.SendtoCfg("Answer with G722.1 32kHz should choose bitrate 48000", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/413_fmtp_amrwb_offer_octet_align.py
+++ b/tests/pjsua/scripts-sendto/413_fmtp_amrwb_offer_octet_align.py
@@ -1,0 +1,30 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer for codec AMR-WB should contain fmtp octet-align=1
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 99 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:99 AMR-WB/16000
+a=fmtp:99 octet-align=1
+a=sendrecv
+a=rtpmap:101 telephone-event/16000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec AMR-WB"
+extra_headers = ""
+include = ["octet-align=1"]	# response must include 'octet-align=1'
+exclude = []
+
+sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should response with fmtp 'octet-align=1'", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/413_fmtp_amrwb_offer_octet_align.py
+++ b/tests/pjsua/scripts-sendto/413_fmtp_amrwb_offer_octet_align.py
@@ -25,6 +25,6 @@ extra_headers = ""
 include = ["octet-align=1"]	# response must include 'octet-align=1'
 exclude = []
 
-sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should response with fmtp 'octet-align=1'", pjsua_args, sdp, 200,
+sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should respond with fmtp 'octet-align=1'", pjsua_args, sdp, 200,
 			   extra_headers=extra_headers,
 			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/414_fmtp_amrwb_offer_band_eff.py
+++ b/tests/pjsua/scripts-sendto/414_fmtp_amrwb_offer_band_eff.py
@@ -24,6 +24,6 @@ extra_headers = ""
 include = [""]
 exclude = ["octet-align=1"]	# response must not include fmtp 'octet-align=1'
 
-sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should not contain 'octet-align=1'", pjsua_args, sdp, 200,
+sendto_cfg = sip.SendtoCfg("AMR-WB negotiation (offer without octet-align) should not contain 'octet-align=1'", pjsua_args, sdp, 200,
 			   extra_headers=extra_headers,
 			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/414_fmtp_amrwb_offer_band_eff.py
+++ b/tests/pjsua/scripts-sendto/414_fmtp_amrwb_offer_band_eff.py
@@ -1,0 +1,29 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer for codec AMR-WB should not contain fmtp octet-align=1
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 99 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:99 AMR-WB/16000
+a=sendrecv
+a=rtpmap:101 telephone-event/16000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec AMR-WB"
+extra_headers = ""
+include = [""]
+exclude = ["octet-align=1"]	# response must not include fmtp 'octet-align=1'
+
+sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should not contain 'octet-align=1'", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/415_fmtp_amrwb_offer_band_eff2.py
+++ b/tests/pjsua/scripts-sendto/415_fmtp_amrwb_offer_band_eff2.py
@@ -25,6 +25,6 @@ extra_headers = ""
 include = [""]
 exclude = ["octet-align=1"]	# response must not include fmtp 'octet-align=1'
 
-sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should not contain 'octet-align=1'", pjsua_args, sdp, 200,
+sendto_cfg = sip.SendtoCfg("AMR-WB negotiation (offer with octet-align=0) should not contain 'octet-align=1'", pjsua_args, sdp, 200,
 			   extra_headers=extra_headers,
 			   resp_inc=include, resp_exc=exclude)

--- a/tests/pjsua/scripts-sendto/415_fmtp_amrwb_offer_band_eff2.py
+++ b/tests/pjsua/scripts-sendto/415_fmtp_amrwb_offer_band_eff2.py
@@ -1,0 +1,30 @@
+import inc_sip as sip
+import inc_sdp as sdp
+
+# Answer for codec AMR-WB should not contain fmtp octet-align=1
+
+sdp = \
+"""
+v=0
+o=- 3428650655 3428650655 IN IP4 192.168.1.9
+s=pjmedia
+c=IN IP4 192.168.1.9
+t=0 0
+a=X-nat:0
+m=audio 4000 RTP/AVP 99 101
+a=rtcp:4001 IN IP4 192.168.1.9
+a=rtpmap:99 AMR-WB/16000
+a=fmtp:99 octet-align=0
+a=sendrecv
+a=rtpmap:101 telephone-event/16000
+a=fmtp:101 0-15
+"""
+
+pjsua_args = "--null-audio --auto-answer 200 --add-codec AMR-WB"
+extra_headers = ""
+include = [""]
+exclude = ["octet-align=1"]	# response must not include fmtp 'octet-align=1'
+
+sendto_cfg = sip.SendtoCfg("AMR-WB negotiation should not contain 'octet-align=1'", pjsua_args, sdp, 200,
+			   extra_headers=extra_headers,
+			   resp_inc=include, resp_exc=exclude)


### PR DESCRIPTION
## Summary
Adds automated test coverage for codecs/modes that were implemented in pjmedia but had no (or incomplete) test coverage:

- **AMR-WB fmtp negotiation** (`scripts-sendto/413-415`): octet-aligned vs bandwidth-efficient mode, mirroring the existing AMR-NB tests (`410-412`).
- **Speex/32000 (UWB) audio quality** (`scripts-pesq/200-201`): PESQ/ViSQOL loopback test. Since the PESQ tool only scores 8kHz/16kHz WAVs, the conference bridge/device clock rate is kept at 16000 while the codec itself negotiates and runs at its native 32000 clock rate; PJMEDIA transparently resamples between the two (documented in the test file comments).
- **G.722.1 32kHz (Siren14) bitrate fmtp negotiation** (`scripts-sendto/402_fmtp_g7221_uwb_*`): mirrors the existing 16kHz G.722.1 fmtp tests (`400`, `401`), covering all three standard 32kHz-mode bitrates (24000/32000/48000).
- **CI workflow updates** (`ci-linux.yml`, `ci-mac.yml`): install `opencore-amrwb`/`vo-amrwbenc` (and Linux equivalents) in the jobs that run `make pjsua-test`, so `PJMEDIA_HAS_OPENCORE_AMRWB_CODEC` is actually enabled and the new AMR-WB tests exercise a real registered codec rather than failing to find it. G.722.1 needed no CI changes since `PJMEDIA_HAS_G7221_CODEC` is already enabled in `config_site_test.h`.

## Test plan
- [ ] CI run on this PR builds successfully with the new AMR-WB packages on both Linux and macOS
- [ ] `ensure AMR-WB codec is installed` capability check passes in `default-full-bundle-1` / `vid-openh264-1` (Linux)
- [ ] New `scripts-sendto` tests (402, 413-415) pass under `make pjsua-test`
- [ ] New `scripts-pesq` tests (200/201 Speex/32000) pass; PESQ/ViSQOL thresholds may need tuning based on actual measured scores from the first real run (I could not run the PESQ tooling locally to calibrate them empirically)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>