### PR TITLE
pjlib: correctness fixes in string, array, and time helpers

### DIFF
--- a/pjlib/include/pj/string_i.h
+++ b/pjlib/include/pj/string_i.h
@@ -187,13 +187,13 @@ PJ_IDEF(int) pj_strncmp( const pj_str_t *str1, const pj_str_t *str2,
     pj_assert(str1->slen >= 0);
     pj_assert(str2->slen >= 0);
 
-    if (len < (unsigned)str1->slen && str1->slen > 0) {
+    if (len < (pj_size_t)str1->slen && str1->slen > 0) {
         copy1.ptr = str1->ptr;
         copy1.slen = len;
         str1 = &copy1;
     }
 
-    if (len < (unsigned)str2->slen && str2->slen > 0) {
+    if (len < (pj_size_t)str2->slen && str2->slen > 0) {
         copy2.ptr = str2->ptr;
         copy2.slen = len;
         str2 = &copy2;
@@ -344,13 +344,13 @@ PJ_IDEF(int) pj_strnicmp( const pj_str_t *str1, const pj_str_t *str2,
 {
     pj_str_t copy1, copy2;
 
-    if (len < (unsigned)str1->slen && str1->slen > 0) {
+    if (len < (pj_size_t)str1->slen && str1->slen > 0) {
         copy1.ptr = str1->ptr;
         copy1.slen = len;
         str1 = &copy1;
     }
 
-    if (len < (unsigned)str2->slen && str2->slen > 0) {
+    if (len < (pj_size_t)str2->slen && str2->slen > 0) {
         copy2.ptr = str2->ptr;
         copy2.slen = len;
         str2 = &copy2;

--- a/pjlib/src/pj/array.c
+++ b/pjlib/src/pj/array.c
@@ -28,11 +28,11 @@ PJ_DEF(void) pj_array_insert( void *array,
                               const void *value)
 {
     if (count && pos < count) {
-        pj_memmove( (char*)array + (pos+1)*elem_size,
-                    (char*)array + pos*elem_size,
+        pj_memmove( (char*)array + (pos+1)*(pj_size_t)elem_size,
+                    (char*)array + pos*(pj_size_t)elem_size,
                     (count-pos)*(pj_size_t)elem_size);
     }
-    pj_memmove((char*)array + pos*elem_size, value, elem_size);
+    pj_memmove((char*)array + pos*(pj_size_t)elem_size, value, elem_size);
 }
 
 PJ_DEF(void) pj_array_erase( void *array,
@@ -41,6 +41,11 @@ PJ_DEF(void) pj_array_erase( void *array,
                              unsigned pos)
 {
     pj_assert(count != 0);
+    /* Guard against count==0 in release builds: count-1 would wrap to a huge
+     * unsigned value and trigger an oversized pj_memmove.
+     */
+    if (count == 0)
+        return;
     if (pos < count-1) {
         pj_memmove( (char*)array + pos*elem_size,
                     (char*)array + (pos+1)*elem_size,

--- a/pjlib/src/pj/os_time_common.c
+++ b/pjlib/src/pj/os_time_common.c
@@ -64,8 +64,11 @@ PJ_DEF(pj_status_t) pj_time_encode(const pj_parsed_time *pt, pj_time_val *tv)
     local_time.tm_hour = pt->hour;
     local_time.tm_min = pt->min;
     local_time.tm_sec = pt->sec;
-    local_time.tm_isdst = 0;
-    
+    /* Let mktime() determine whether DST is in effect, otherwise the encoded
+     * time is off by one hour during DST.
+     */
+    local_time.tm_isdst = -1;
+
     tv->sec = mktime(&local_time);
     tv->msec = pt->msec;
 
@@ -87,6 +90,18 @@ static int get_tz_offset_secs()
 #endif
 
     offset_min = (ltime.tm_hour*60+ltime.tm_min) - (gtime.tm_hour*60+gtime.tm_min);
+
+    /* The local and GMT samples may fall on different calendar days for zones
+     * beyond +/-12h (e.g. UTC+13/+14) or across the date line. The two samples
+     * are at most one day apart, so adjust by a full day accordingly, otherwise
+     * the offset is wrong by 24h for those zones.
+     */
+    if (ltime.tm_year != gtime.tm_year) {
+        offset_min += (ltime.tm_year > gtime.tm_year) ? 24*60 : -24*60;
+    } else if (ltime.tm_yday != gtime.tm_yday) {
+        offset_min += (ltime.tm_yday > gtime.tm_yday) ? 24*60 : -24*60;
+    }
+
     return offset_min*60;
 }
 

--- a/pjlib/src/pj/string.c
+++ b/pjlib/src/pj/string.c
@@ -38,8 +38,13 @@ PJ_DEF(pj_ssize_t) pj_strspn(const pj_str_t *str, const pj_str_t *set_char)
             break;
 
         for (j = 0; j < set_char->slen; j++) {
-            if (str->ptr[i] == set_char->ptr[j])
+            if (str->ptr[i] == set_char->ptr[j]) {
+                /* Count this character only once, even if the set contains
+                 * duplicate characters.
+                 */
                 count++;
+                break;
+            }
         }
     }
     return count;
@@ -54,8 +59,13 @@ PJ_DEF(pj_ssize_t) pj_strspn2(const pj_str_t *str, const char *set_char)
             break;
 
         for (j = 0; set_char[j] != 0; j++) {
-            if (str->ptr[i] == set_char[j])
+            if (str->ptr[i] == set_char[j]) {
+                /* Count this character only once, even if the set contains
+                 * duplicate characters.
+                 */
                 count++;
+                break;
+            }
         }
     }
     return count;


### PR DESCRIPTION
Small, self-contained correctness fixes in pjlib's basic helpers, found during a code review.

- **pj_strspn/pj_strspn2**: count each input character at most once even when the character set has duplicates (`pj_strspn2("ab","aa")` returned 2 instead of 1, mis-tokenizing in pj_strtok).
- **pj_strncmp/pj_strnicmp**: compare against `(pj_size_t)slen` instead of `(unsigned)slen` (avoids 64-bit truncation on LP64).
- **pj_array_erase**: early-return on `count==0` (release builds wrapped `count-1` to UINT_MAX -> oversized memmove).
- **pj_array_insert**: cast element offsets to `pj_size_t`.
- **get_tz_offset_secs**: account for day rollover so zones beyond +/-12h (UTC+13/+14, date line) are not off by 24h.
- **pj_time_encode**: use `tm_isdst=-1` so mktime() detects DST.

Validated: `make` clean (-Wall); `string_test` / `timestamp_test` / `timer_test` pass.

Co-Authored-By Claude Code
