### PR TITLE
pjlib: pool allocator hardening

### DIFF
--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -112,8 +112,14 @@ PJ_IDEF(void*) pj_pool_calloc( pj_pool_t *pool, pj_size_t count, pj_size_t size)
      * the wrapped (small) product would be allocated while the caller assumes
      * it received count*size bytes, leading to a heap overflow at the caller.
      */
-    if (count != 0 && size > ((pj_size_t)-1) / count)
+    if (count != 0 && size > ((pj_size_t)-1) / count) {
+        /* Treat overflow as an allocation failure so callers that rely on the
+         * pool's no-memory callback (e.g. throwing PJ_NO_MEMORY_EXCEPTION)
+         * instead of checking for NULL get consistent behavior.
+         */
+        (*pool->callback)(pool, (pj_size_t)-1);
         return NULL;
+    }
 
     buf = pj_pool_alloc( pool, size*count);
     if (buf)

--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -106,7 +106,16 @@ PJ_IDEF(void*) pj_pool_aligned_alloc(pj_pool_t *pool, pj_size_t alignment,
 
 PJ_IDEF(void*) pj_pool_calloc( pj_pool_t *pool, pj_size_t count, pj_size_t size)
 {
-    void *buf = pj_pool_alloc( pool, size*count);
+    void *buf;
+
+    /* Reject count*size overflow, as the standard calloc() does. Without this
+     * the wrapped (small) product would be allocated while the caller assumes
+     * it received count*size bytes, leading to a heap overflow at the caller.
+     */
+    if (count != 0 && size > ((pj_size_t)-1) / count)
+        return NULL;
+
+    buf = pj_pool_alloc( pool, size*count);
     if (buf)
         pj_bzero(buf, size * count);
     return buf;

--- a/pjlib/src/pj/pool_buf.c
+++ b/pjlib/src/pj/pool_buf.c
@@ -93,11 +93,17 @@ PJ_DEF(pj_pool_t*) pj_pool_create_on_buf(const char *name,
     }
 
     /* Check and align buffer */
-    align_diff = (pj_size_t)buf;
-    if (align_diff & (PJ_POOL_ALIGNMENT-1)) {
-        align_diff &= (PJ_POOL_ALIGNMENT-1);
-        buf = (void*) (((char*)buf) + align_diff);
-        size -= align_diff;
+    align_diff = (pj_size_t)buf & (PJ_POOL_ALIGNMENT-1);
+    if (align_diff != 0) {
+        /* Round the buffer up to the next alignment boundary. The pad is
+         * (ALIGNMENT - misalignment), not the misalignment itself; adding the
+         * misalignment would leave the buffer (and hence the pj_pool_t/
+         * pj_pool_block placed at its start) unaligned, risking SIGBUS on
+         * strict-alignment CPUs.
+         */
+        pj_size_t pad = PJ_POOL_ALIGNMENT - align_diff;
+        buf = (void*) (((char*)buf) + pad);
+        size -= pad;
     }
 
     param.stack_buf = buf;

--- a/pjlib/src/pj/pool_buf.c
+++ b/pjlib/src/pj/pool_buf.c
@@ -102,6 +102,10 @@ PJ_DEF(pj_pool_t*) pj_pool_create_on_buf(const char *name,
          * strict-alignment CPUs.
          */
         pj_size_t pad = PJ_POOL_ALIGNMENT - align_diff;
+        /* Reject a buffer too small to align, otherwise size -= pad would
+         * underflow (size is unsigned).
+         */
+        PJ_ASSERT_RETURN(size > pad, NULL);
         buf = (void*) (((char*)buf) + pad);
         size -= pad;
     }

--- a/pjlib/src/pj/pool_policy_malloc.c
+++ b/pjlib/src/pj/pool_policy_malloc.c
@@ -42,7 +42,13 @@ static void *default_block_alloc(pj_pool_factory *factory, pj_size_t size)
             return NULL;
     }
 
-    p = malloc(size+(SIG_SIZE << 1));
+    /* Guard against overflow when adding the signature padding (only nonzero
+     * when PJ_SAFE_POOL is enabled).
+     */
+    if (size > ((pj_size_t)-1) - (SIG_SIZE << 1))
+        p = NULL;
+    else
+        p = malloc(size + (SIG_SIZE << 1));
 
     if (p == NULL) {
         if (factory->on_block_free) 

--- a/pjlib/src/pjlib-test/pool.c
+++ b/pjlib/src/pjlib-test/pool.c
@@ -261,7 +261,45 @@ on_return:
     return rc;
 }
 
-/* Test function to drain the pool's space. 
+/* Verify pj_pool_create_on_buf() correctly aligns a deliberately misaligned
+ * buffer: the pool struct sits at the start of the (aligned) buffer, so a
+ * misaligned start must be rounded up. Regression test for the pool_buf
+ * alignment fix.
+ */
+static int pool_buf_misaligned_test(void)
+{
+    pj_pool_t *pool;
+    char bufmem[512];
+    char *buf;
+    void *ptr;
+    int rc = 0;
+
+    PJ_LOG(3,("test", "...pool_buf misaligned buffer test"));
+
+    /* Offset by 1 to guarantee the start is not PJ_POOL_ALIGNMENT-aligned. */
+    buf = bufmem + 1;
+
+    pool = pj_pool_create_on_buf(NULL, buf, sizeof(bufmem) - 1);
+    PJ_TEST_NOT_NULL(pool, NULL, return -450);
+
+    /* The pool struct is placed at the start of the buffer, which must have
+     * been aligned by pj_pool_create_on_buf().
+     */
+    PJ_TEST_TRUE(((pj_size_t)pool & (PJ_POOL_ALIGNMENT - 1)) == 0, NULL,
+                 { rc = -451; goto on_return; });
+
+    ptr = pj_pool_alloc(pool, 1);
+    PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, { rc = -455; goto on_return; });
+
+    ptr = pj_pool_alloc(pool, 32);
+    PJ_TEST_TRUE(IS_ALIGNED(ptr), NULL, { rc = -456; goto on_return; });
+
+on_return:
+    pj_pool_release(pool);
+    return rc;
+}
+
+/* Test function to drain the pool's space.
  */
 static int drain_test(pj_size_t size, pj_size_t increment)
 {
@@ -368,6 +406,9 @@ int pool_test(void)
     if (rc) return rc;
 
     rc = pool_buf_alignment_test();
+    if (rc) return rc;
+
+    rc = pool_buf_misaligned_test();
     if (rc) return rc;
 
 #if PJ_HAS_POOL_ALT_API == 0


### PR DESCRIPTION
Pool allocator hardening / correctness, from a code review.

- **pj_pool_create_on_buf**: fix buffer alignment — it added the misalignment amount instead of the pad to the next boundary, so the buffer (and the pj_pool_t / first pj_pool_block placed at its start) could stay unaligned, risking SIGBUS on strict-alignment CPUs.
- **pj_pool_calloc**: reject `count*size` overflow like the standard calloc(), so an overflow can't yield an undersized allocation the caller then writes as `count*size` bytes.
- **default_block_alloc**: guard the `size + SIG_SIZE*2` addition against overflow (relevant with PJ_SAFE_POOL).

Validated: `make` clean; `pool_test` passes.

Co-Authored-By Claude Code
