### PR TITLE
pjlib: fix pj_hash_create size overflow and pj_rbtree_min_height

### DIFF
--- a/pjlib/src/pj/hash.c
+++ b/pjlib/src/pj/hash.c
@@ -106,10 +106,12 @@ PJ_DEF(pj_hash_table_t*) pj_hash_create(pj_pool_t *pool, unsigned size)
      */
     table_size = 8;
     do {
-        table_size <<= 1;    
-    } while (table_size < size && table_size <= 0x40000000);
-    /* The upper bound above caps table_size at 2^31 so the left shift cannot
-     * overflow to 0 (which would loop forever) for a very large 'size'.
+        table_size <<= 1;
+    } while (table_size < size && table_size <= ((unsigned)-1 >> 1));
+    /* The upper bound (half the max value of table_size) stops before the
+     * left shift would overflow the unsigned table_size, which would loop
+     * forever. For an unreasonably large 'size' the table is capped at the
+     * largest representable power of two rather than growing unbounded.
      */
     table_size -= 1;
     

--- a/pjlib/src/pj/hash.c
+++ b/pjlib/src/pj/hash.c
@@ -107,7 +107,10 @@ PJ_DEF(pj_hash_table_t*) pj_hash_create(pj_pool_t *pool, unsigned size)
     table_size = 8;
     do {
         table_size <<= 1;    
-    } while (table_size < size);
+    } while (table_size < size && table_size <= 0x40000000);
+    /* The upper bound above caps table_size at 2^31 so the left shift cannot
+     * overflow to 0 (which would loop forever) for a very large 'size'.
+     */
     table_size -= 1;
     
     h->rows = table_size;

--- a/pjlib/src/pj/rbtree.c
+++ b/pjlib/src/pj/rbtree.c
@@ -419,8 +419,8 @@ PJ_DEF(unsigned) pj_rbtree_min_height( pj_rbtree *tree,
     if (node==NULL) 
         node=tree->root;
     
-    l = (node->left != tree->null) ? pj_rbtree_max_height(tree,node->left)+1 : 0;
-    r = (node->right != tree->null) ? pj_rbtree_max_height(tree,node->right)+1 : 0;
+    l = (node->left != tree->null) ? pj_rbtree_min_height(tree,node->left)+1 : 0;
+    r = (node->right != tree->null) ? pj_rbtree_min_height(tree,node->right)+1 : 0;
     return l > r ? r : l;
 }
 


### PR DESCRIPTION
Two container fixes from a code review.

- **pj_hash_create**: cap the table-size rounding so the left-shift loop cannot overflow to 0 (infinite loop) for a very large `size`.
- **pj_rbtree_min_height**: it recursed into `pj_rbtree_max_height()` for its subtrees, returning the wrong value; recurse into `pj_rbtree_min_height()`.

Validated: `make` clean; `hash_test` / `rbtree_test` pass.

Co-Authored-By Claude Code
