### PR TITLE
pjlib: os_core hardening (naming, mutexattr leak, sleep, event/barrier)

### DIFF
--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -175,6 +175,7 @@ struct pj_barrier_t {
     pthread_cond_t      cond;
     unsigned            count;
     unsigned            trip_count;
+    unsigned            generation;
 #endif
 };
 
@@ -2397,17 +2398,24 @@ PJ_DEF(pj_status_t) pj_barrier_create(pj_pool_t *pool, unsigned trip_count, pj_b
 PJ_DEF(pj_int32_t) pj_barrier_wait(pj_barrier_t *barrier, pj_uint32_t flags) 
 {
     pj_bool_t is_last = PJ_FALSE;
-    int status;
+    int status = 0;
 
     PJ_UNUSED_ARG(flags);
 
     pthread_mutex_lock(&barrier->mutex.mutex);
     if (++barrier->count >= barrier->trip_count) {
         barrier->count = 0;
+        ++barrier->generation;
         status = pthread_cond_broadcast(&barrier->cond);
         is_last = PJ_TRUE;
     } else {
-        status = pthread_cond_wait(&barrier->cond, &barrier->mutex.mutex);
+        unsigned gen = barrier->generation;
+        /* Loop to guard against spurious wakeups and barrier reuse: return
+         * only once this generation has been released by the last waiter,
+         * instead of returning on any wakeup.
+         */
+        while (gen == barrier->generation && status == 0)
+            status = pthread_cond_wait(&barrier->cond, &barrier->mutex.mutex);
     }
     pthread_mutex_unlock(&barrier->mutex.mutex);
 

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -655,7 +655,7 @@ PJ_DEF(pj_status_t) pj_thread_register ( const char *cstr_thread_name,
          */
         if (p && *(p+1)=='p' && *(p+2)=='\0')
             pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
-                             cstr_thread_name, thread->thread);
+                             cstr_thread_name, (void*)thread->thread);
         else
             pj_ansi_strxcpy(thread->obj_name, cstr_thread_name,
                             sizeof(thread->obj_name));

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -2165,11 +2165,22 @@ PJ_DEF(pj_status_t) pj_event_create(pj_pool_t *pool, const char *name,
                                     pj_event_t **ptr_event)
 {
     pj_event_t *event;
+    pj_status_t rc;
+    int prc;
 
     event = PJ_POOL_ALLOC_T(pool, pj_event_t);
+    PJ_ASSERT_RETURN(event, PJ_ENOMEM);
 
-    init_mutex(&event->mutex, name, PJ_MUTEX_SIMPLE);
-    pthread_cond_init(&event->cond, 0);
+    rc = init_mutex(&event->mutex, name, PJ_MUTEX_SIMPLE);
+    if (rc != PJ_SUCCESS)
+        return rc;
+
+    prc = pthread_cond_init(&event->cond, 0);
+    if (prc != 0) {
+        pj_mutex_destroy(&event->mutex);
+        return PJ_RETURN_OS_ERROR(prc);
+    }
+
     event->auto_reset = !manual_reset;
     event->threads_waiting = 0;
 

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -647,12 +647,21 @@ PJ_DEF(pj_status_t) pj_thread_register ( const char *cstr_thread_name,
     thread->signature1 = SIGNATURE1;
     thread->signature2 = SIGNATURE2;
 
-    if(cstr_thread_name && pj_strlen(&thread_name) < sizeof(thread->obj_name)-1)
-        pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
-                         cstr_thread_name, thread->thread);
-    else
+    if (cstr_thread_name && pj_strlen(&thread_name) < sizeof(thread->obj_name)-1) {
+        const char *p = pj_ansi_strchr(cstr_thread_name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0')
+            pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
+                             cstr_thread_name, thread->thread);
+        else
+            pj_ansi_strxcpy(thread->obj_name, cstr_thread_name,
+                            sizeof(thread->obj_name));
+    } else {
         pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
                          "thr%p", (void*)thread->thread);
+    }
 
     rc = pj_thread_local_set(thread_tls_id, thread);
     if (rc != PJ_SUCCESS) {
@@ -794,7 +803,7 @@ static pj_status_t create_thread(const char *thread_name,
         thread_name = "thr%p";
 
     ch = pj_ansi_strchr(thread_name, '%');
-    if (ch && *(ch+1) == 'p') {
+    if (ch && *(ch+1) == 'p' && *(ch+2) == '\0') {
         pj_ansi_snprintf(rec->obj_name, PJ_MAX_OBJ_NAME, thread_name, rec);
     } else {
         pj_ansi_strxcpy(rec->obj_name, thread_name, PJ_MAX_OBJ_NAME);
@@ -1109,7 +1118,15 @@ PJ_DEF(pj_status_t) pj_thread_sleep(unsigned msec)
 
     pj_set_os_error(0);
 
-    usleep(msec * 1000);
+    /* Sleep in sub-second chunks to avoid overflow of msec*1000 for large
+     * values, and to keep each usleep() argument below 1000000, which POSIX
+     * requires.
+     */
+    while (msec > 0) {
+        unsigned chunk = (msec > 500)? 500 : msec;
+        usleep(chunk * 1000);
+        msec -= chunk;
+    }
 
     /* MacOS X (reported on 10.5) seems to always set errno to ETIMEDOUT.
      * It does so because usleep() is declared to return int, and we're
@@ -1525,11 +1542,13 @@ static pj_status_t init_mutex(pj_mutex_t *mutex, const char *name, int type)
     }
 
     if (rc != 0) {
+        pthread_mutexattr_destroy(&attr);
         return PJ_RETURN_OS_ERROR(rc);
     }
 
     rc = pthread_mutex_init(&mutex->mutex, &attr);
     if (rc != 0) {
+        pthread_mutexattr_destroy(&attr);
         return PJ_RETURN_OS_ERROR(rc);
     }
 
@@ -1551,10 +1570,16 @@ static pj_status_t init_mutex(pj_mutex_t *mutex, const char *name, int type)
     if (!name) {
         name = "mtx%p";
     }
-    if (strchr(name, '%')) {
-        pj_ansi_snprintf(mutex->obj_name, PJ_MAX_OBJ_NAME, name, mutex);
-    } else {
-        pj_ansi_strxcpy(mutex->obj_name, name, PJ_MAX_OBJ_NAME);
+    {
+        const char *p = strchr(name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            pj_ansi_snprintf(mutex->obj_name, PJ_MAX_OBJ_NAME, name, mutex);
+        } else {
+            pj_ansi_strxcpy(mutex->obj_name, name, PJ_MAX_OBJ_NAME);
+        }
     }
 
     PJ_LOG(6, (mutex->obj_name, "Mutex created"));
@@ -1972,10 +1997,16 @@ PJ_DEF(pj_status_t) pj_sem_create( pj_pool_t *pool,
     if (!name) {
         name = "sem%p";
     }
-    if (strchr(name, '%')) {
-        pj_ansi_snprintf(sem->obj_name, PJ_MAX_OBJ_NAME, name, sem);
-    } else {
-        pj_ansi_strxcpy(sem->obj_name, name, PJ_MAX_OBJ_NAME);
+    {
+        const char *p = strchr(name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            pj_ansi_snprintf(sem->obj_name, PJ_MAX_OBJ_NAME, name, sem);
+        } else {
+            pj_ansi_strxcpy(sem->obj_name, name, PJ_MAX_OBJ_NAME);
+        }
     }
 
     PJ_LOG(6, (sem->obj_name, "Semaphore created"));

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -462,12 +462,21 @@ PJ_DEF(pj_status_t) pj_thread_register ( const char *cstr_thread_name,
     PJ_UNUSED_ARG(stack_ptr);
 #endif
 
-    if (cstr_thread_name && pj_strlen(&thread_name) < sizeof(thread->obj_name)-1)
-        pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name), 
-                         cstr_thread_name, thread->idthread);
-    else
-        pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name), 
+    if (cstr_thread_name && pj_strlen(&thread_name) < sizeof(thread->obj_name)-1) {
+        const char *p = pj_ansi_strchr(cstr_thread_name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0')
+            pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
+                             cstr_thread_name, thread->idthread);
+        else
+            pj_ansi_strxcpy(thread->obj_name, cstr_thread_name,
+                            sizeof(thread->obj_name));
+    } else {
+        pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
                          "thr%p", (void*)(pj_ssize_t)thread->idthread);
+    }
     
     rc = pj_thread_local_set(thread_tls_id, thread);
     if (rc != PJ_SUCCESS)
@@ -714,10 +723,16 @@ static pj_status_t create_thread(const char *thread_name,
     if (!thread_name)
         thread_name = "thr%p";
 
-    if (strchr(thread_name, '%')) {
-        pj_ansi_snprintf(rec->obj_name, PJ_MAX_OBJ_NAME, thread_name, rec);
-    } else {
-        pj_ansi_strxcpy(rec->obj_name, thread_name, PJ_MAX_OBJ_NAME);
+    {
+        const char *p = strchr(thread_name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            pj_ansi_snprintf(rec->obj_name, PJ_MAX_OBJ_NAME, thread_name, rec);
+        } else {
+            pj_ansi_strxcpy(rec->obj_name, thread_name, PJ_MAX_OBJ_NAME);
+        }
     }
 
     PJ_LOG(6, (rec->obj_name, "Thread created"));
@@ -1213,10 +1228,16 @@ static pj_status_t init_mutex(pj_mutex_t *mutex, const char *name)
     if (!name) {
         name = "mtx%p";
     }
-    if (strchr(name, '%')) {
-        pj_ansi_snprintf(mutex->obj_name, PJ_MAX_OBJ_NAME, name, mutex);
-    } else {
-        pj_ansi_strxcpy(mutex->obj_name, name, PJ_MAX_OBJ_NAME);
+    {
+        const char *p = strchr(name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            pj_ansi_snprintf(mutex->obj_name, PJ_MAX_OBJ_NAME, name, mutex);
+        } else {
+            pj_ansi_strxcpy(mutex->obj_name, name, PJ_MAX_OBJ_NAME);
+        }
     }
 
     PJ_LOG(6, (mutex->obj_name, "Mutex created"));
@@ -1468,10 +1489,16 @@ PJ_DEF(pj_status_t) pj_sem_create( pj_pool_t *pool,
     if (!name) {
         name = "sem%p";
     }
-    if (strchr(name, '%')) {
-        pj_ansi_snprintf(sem->obj_name, PJ_MAX_OBJ_NAME, name, sem);
-    } else {
-        pj_ansi_strxcpy(sem->obj_name, name, PJ_MAX_OBJ_NAME);
+    {
+        const char *p = strchr(name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            pj_ansi_snprintf(sem->obj_name, PJ_MAX_OBJ_NAME, name, sem);
+        } else {
+            pj_ansi_strxcpy(sem->obj_name, name, PJ_MAX_OBJ_NAME);
+        }
     }
 
     LOG_MUTEX((sem->obj_name, "Semaphore created"));
@@ -1608,10 +1635,16 @@ PJ_DEF(pj_status_t) pj_event_create( pj_pool_t *pool,
     if (!name) {
         name = "evt%p";
     }
-    if (strchr(name, '%')) {
-        pj_ansi_snprintf(event->obj_name, PJ_MAX_OBJ_NAME, name, event);
-    } else {
-        pj_ansi_strxcpy(event->obj_name, name, PJ_MAX_OBJ_NAME);
+    {
+        const char *p = strchr(name, '%');
+        /* Only expand the "%p" object-id convention; never treat an
+         * arbitrary name as a printf format string.
+         */
+        if (p && *(p+1)=='p' && *(p+2)=='\0') {
+            pj_ansi_snprintf(event->obj_name, PJ_MAX_OBJ_NAME, name, event);
+        } else {
+            pj_ansi_strxcpy(event->obj_name, name, PJ_MAX_OBJ_NAME);
+        }
     }
 
     PJ_LOG(6, (event->obj_name, "Event created"));

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -469,7 +469,7 @@ PJ_DEF(pj_status_t) pj_thread_register ( const char *cstr_thread_name,
          */
         if (p && *(p+1)=='p' && *(p+2)=='\0')
             pj_ansi_snprintf(thread->obj_name, sizeof(thread->obj_name),
-                             cstr_thread_name, thread->idthread);
+                             cstr_thread_name, (void*)(pj_ssize_t)thread->idthread);
         else
             pj_ansi_strxcpy(thread->obj_name, cstr_thread_name,
                             sizeof(thread->obj_name));


### PR DESCRIPTION
Robustness fixes in the OS abstraction (POSIX + Win32), from a code review.

- **Object naming** (mutex / thread / pj_thread_register / semaphore / event): only expand the exact `...%p` object-id convention; never pass an arbitrary name as a printf format (matches pj_pool_init_int). Applied to os_core_unix.c and os_core_win32.c.
- **init_mutex**: destroy the `pthread_mutexattr_t` on the settype / mutex_init error paths (resource leak).
- **pj_thread_sleep**: sleep in sub-second chunks to avoid `msec*1000` overflow and the POSIX `usleep()` 1,000,000 limit for sleeps >= 1s.
- **pj_event_create**: check `init_mutex()` / `pthread_cond_init()` return values instead of returning PJ_SUCCESS with an uninitialized object.
- **Emulated barrier** (platforms without pthread_barrier): generation counter + predicate loop in `pj_barrier_wait()` to guard against spurious wakeups and barrier reuse.

Validated: unix `make` clean; `mutex_test` / `thread_test` / `sleep_test` pass. The Win32 name changes mirror the unix ones (Windows CI to validate). The emulated-barrier path is gated by the system `_POSIX_BARRIERS` macro (not built on glibc); compile-validated by temporarily forcing that branch.

Co-Authored-By Claude Code
