### PR TITLE
pjlib: fix timer next_delay (LL mode) and recycle ioqueue key on register error

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -547,7 +547,13 @@ on_return:
              * it (it was removed from the free list above). init_key() cannot
              * fail in SAFE_UNREG mode, so a non-NULL key here is fully
              * initialized and safe to recycle.
+             *
+             * This error path is reached before the key is added to the
+             * active list / epoll set, so no other thread references it;
+             * unlike the scan_closing_keys() recycle it is safe to clear
+             * grp_lock here (init_key() re-sets it on the next reuse).
              */
+            key->grp_lock = NULL;
             key->ref_count = 0;
             pj_list_push_back(&ioqueue->free_list, key);
             key = NULL;

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -524,8 +524,9 @@ PJ_DEF(pj_status_t) pj_ioqueue_register_sock2(pj_pool_t *pool,
     rc = os_epoll_ctl(ioqueue->epfd, EPOLL_CTL_ADD, sock, &key->ev);
     if (rc < 0) {
         status = pj_get_os_error();
-        pj_lock_destroy(key->lock);
-        key = NULL;
+        /* Do not destroy key->lock: it is a shared, pre-created lock owned by
+         * the ioqueue's key pool. Leave the key for on_return to recycle.
+         */
         PJ_PERROR(1,(THIS_FILE, status, "epol_ctl(ADD) error"));
         goto on_return;
     }
@@ -540,10 +541,22 @@ on_return:
     if (status != PJ_SUCCESS) {
         if (key && key->grp_lock)
             pj_grp_lock_dec_ref_dbg(key->grp_lock, "ioqueue", 0);
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+        if (key) {
+            /* Return the pre-created key to the free list instead of leaking
+             * it (it was removed from the free list above). init_key() cannot
+             * fail in SAFE_UNREG mode, so a non-NULL key here is fully
+             * initialized and safe to recycle.
+             */
+            key->ref_count = 0;
+            pj_list_push_back(&ioqueue->free_list, key);
+            key = NULL;
+        }
+#endif
     }
     *p_key = key;
     pj_lock_release(ioqueue->lock);
-    
+
     return status;
 }
 

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -432,10 +432,22 @@ on_return:
     if (rc != PJ_SUCCESS) {
         if (key && key->grp_lock)
             pj_grp_lock_dec_ref_dbg(key->grp_lock, "ioqueue", 0);
+#if PJ_IOQUEUE_HAS_SAFE_UNREG
+        if (key) {
+            /* Return the pre-created key to the free list instead of leaking
+             * it (it was removed from the free list above). init_key() cannot
+             * fail in SAFE_UNREG mode, so a non-NULL key here is fully
+             * initialized and safe to recycle.
+             */
+            key->ref_count = 0;
+            pj_list_push_back(&ioqueue->free_list, key);
+            key = NULL;
+        }
+#endif
     }
     *p_key = key;
     pj_lock_release(ioqueue->lock);
-    
+
     return rc;
 }
 

--- a/pjlib/src/pj/ioqueue_select.c
+++ b/pjlib/src/pj/ioqueue_select.c
@@ -438,7 +438,13 @@ on_return:
              * it (it was removed from the free list above). init_key() cannot
              * fail in SAFE_UNREG mode, so a non-NULL key here is fully
              * initialized and safe to recycle.
+             *
+             * This error path is reached before the key is added to the
+             * active list / fd_sets, so no other thread references it; unlike
+             * the scan_closing_keys() recycle it is safe to clear grp_lock
+             * here (init_key() re-sets it on the next reuse).
              */
+            key->grp_lock = NULL;
             key->ref_count = 0;
             pj_list_push_back(&ioqueue->free_list, key);
             key = NULL;

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -942,7 +942,14 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
         }
     }
     if (ht->cur_size && next_delay) {
+#if PJ_TIMER_USE_LINKED_LIST
+        /* In linked-list mode the earliest entry is the list head; heap[0]
+         * is not heap-ordered in this mode.
+         */
+        *next_delay = ht->head_list.next->_timer_value;
+#else
         *next_delay = ht->heap[0]->_timer_value;
+#endif
         if (count > 0)
             pj_gettickcount(&now);
         PJ_TIME_VAL_SUB(*next_delay, now);

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -944,7 +944,9 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
     if (ht->cur_size && next_delay) {
 #if PJ_TIMER_USE_LINKED_LIST
         /* In linked-list mode the earliest entry is the list head; heap[0]
-         * is not heap-ordered in this mode.
+         * is not heap-ordered in this mode. The enclosing "ht->cur_size"
+         * check guarantees the list is non-empty, so head_list.next is a
+         * real node.
          */
         *next_delay = ht->head_list.next->_timer_value;
 #else


### PR DESCRIPTION
Two fixes from a code review.

- **Timer (linked-list mode)**: `pj_timer_heap_poll()` computed the returned `next_delay` from `heap[0]`, which is not heap-ordered when `PJ_TIMER_USE_LINKED_LIST` is enabled; use the list head. Default heap mode is unchanged.
- **ioqueue register error**: `pj_ioqueue_register_sock2()` takes a pre-created key from the free list (PJ_IOQUEUE_HAS_SAFE_UNREG) but dropped it on a later registration error, permanently shrinking the key pool; recycle it in the `on_return` path. In the epoll backend, also remove an erroneous `pj_lock_destroy()` on the shared, pool-owned key lock.

Validated: `make` clean; `timer_test` + `udp_ioqueue_unreg_test` pass (select). Also checked with `PJ_IOQUEUE_IMP=EPOLL` (unreg test passes) and `PJ_TIMER_USE_LINKED_LIST=1` (compiles clean).

Co-Authored-By Claude Code
