### PR TITLE
Fix flaky sleep_test on busy CI runners by scaling tolerance with sleep duration

### DIFF
--- a/pjlib/src/pjlib-test/sleep.c
+++ b/pjlib/src/pjlib-test/sleep.c
@@ -88,21 +88,42 @@ static int simple_sleep_test(void)
     return 0;
 }
 
+/* Get the allowed slippage for the given sleep duration.
+ *
+ * Sleep slippage on a busy/oversubscribed CI runner has two parts: a
+ * roughly constant scheduler/wakeup latency (the OS taking a while to run
+ * our thread once the timer fires) that is largely independent of the
+ * sleep duration, plus a load-dependent part that grows with it. Allow the
+ * larger of an absolute floor (SLIP_MIN) and a percentage of the requested
+ * duration (SLIP_PCT) so both are covered. A flat tolerance was in fact
+ * stricter than the original percentage-based check for the longest (2s)
+ * sleep and kept failing on busy macOS runners; observed overshoots there
+ * reached ~400 ms in absolute terms and ~25% in relative terms.
+ */
+static unsigned max_slip(long duration)
+{
+    const unsigned SLIP_MIN = test_app.ut_app.prm_ci_mode? 400 : 20;
+    const unsigned SLIP_PCT = test_app.ut_app.prm_ci_mode? 30 : 0;
+
+    return PJ_MAX(SLIP_MIN, (unsigned)duration * SLIP_PCT / 100);
+}
+
 static int sleep_duration_test(void)
 {
-    const unsigned MAX_SLIP = test_app.ut_app.prm_ci_mode? 200 : 20;
     long duration[] = { 2000, 1000, 500, 200, 100 };
     unsigned i;
     unsigned avg_diff, max_diff;
+    pj_bool_t slip_exceeded;
     pj_status_t rc;
 
     PJ_LOG(3,(THIS_FILE, "..running sleep duration test"));
 
     /* Test pj_thread_sleep() and pj_gettimeofday() */
+    slip_exceeded = PJ_FALSE;
     for (i=0, avg_diff=0, max_diff=0; i<PJ_ARRAY_SIZE(duration); ++i) {
         pj_time_val start, stop;
         long msec;
-        unsigned diff;
+        unsigned diff, slip;
 
         /* Mark start of test. */
         rc = pj_gettimeofday(&start);
@@ -135,24 +156,27 @@ static int sleep_duration_test(void)
         diff = PJ_ABS(msec - duration[i]);
         avg_diff = ((avg_diff * i) + diff) / (i+1);
         max_diff = diff>max_diff ? diff : max_diff;
-        if (diff > MAX_SLIP) {
-            PJ_LOG(3,(THIS_FILE, 
+        slip = max_slip(duration[i]);
+        if (diff > slip) {
+            slip_exceeded = PJ_TRUE;
+            PJ_LOG(3,(THIS_FILE,
                       "...error: slept for %ld ms instead of %ld ms "
                       "(outside %d msec tolerance)",
-                      msec, duration[i], MAX_SLIP));
+                      msec, duration[i], slip));
         }
     }
-    PJ_LOG(3,(THIS_FILE, "...avg/max slippage: %d/%d ms", 
+    PJ_LOG(3,(THIS_FILE, "...avg/max slippage: %d/%d ms",
               avg_diff, max_diff));
-    if (max_diff > MAX_SLIP)
+    if (slip_exceeded)
         return -30;
 
     /* Test pj_thread_sleep() and pj_get_timestamp() and friends */
+    slip_exceeded = PJ_FALSE;
     for (i=0, avg_diff=0, max_diff=0; i<PJ_ARRAY_SIZE(duration); ++i) {
         pj_time_val t1, t2;
         pj_timestamp start, stop;
         long msec;
-        unsigned diff;
+        unsigned diff, slip;
 
         pj_thread_sleep(0);
 
@@ -192,21 +216,23 @@ static int sleep_duration_test(void)
         diff = PJ_ABS(msec - duration[i]);
         avg_diff = ((avg_diff * i) + diff) / (i+1);
         max_diff = diff>max_diff ? diff : max_diff;
-        if (diff > MAX_SLIP) {
-            PJ_LOG(3,(THIS_FILE, 
+        slip = max_slip(duration[i]);
+        if (diff > slip) {
+            slip_exceeded = PJ_TRUE;
+            PJ_LOG(3,(THIS_FILE,
                       "...error: slept for %ld ms instead of %ld ms "
                       "(outside %d msec tolerance)",
-                      msec, duration[i], MAX_SLIP));
+                      msec, duration[i], slip));
             PJ_TIME_VAL_SUB(t2, t1);
-            PJ_LOG(3,(THIS_FILE, 
+            PJ_LOG(3,(THIS_FILE,
                       "...info: gettimeofday() reported duration is "
                       "%ld msec",
                       PJ_TIME_VAL_MSEC(t2)));
         }
     }
-    PJ_LOG(3,(THIS_FILE, "...avg/max slippage: %d/%d ms", 
+    PJ_LOG(3,(THIS_FILE, "...avg/max slippage: %d/%d ms",
               avg_diff, max_diff));
-    if (max_diff > MAX_SLIP)
+    if (slip_exceeded)
         return -76;
 
     /* All done. */


### PR DESCRIPTION
`sleep_test` has been failing intermittently on GitHub CI, most often on the **macOS runners**, where the hosted VM is frequently heavily loaded — the macOS CI queue is regularly very long and the host is shared/oversubscribed, on top of the ASan overhead. Having a whole matrix of jobs fail on such a "simple" timing test, then having to re-queue behind a long macOS queue, is needlessly disruptive.

### Recent failures (2026-07-16 / 07-17)

Both runs below are `CI MacOS` on branch `harden/os-core`; `sleep_test` failed across the entire job matrix. Note the first run was created on 07-16 but its macOS jobs only finished on 07-17 — illustrating the long queue.

- Run [29476274307](https://github.com/pjsip/pjproject/actions/runs/29476274307) — all 4 jobs:
  [Default](https://github.com/pjsip/pjproject/actions/runs/29476274307/job/87788710915) (`1256 ms` vs 1000), [Openh264+VPX](https://github.com/pjsip/pjproject/actions/runs/29476274307/job/87788710926) (`2342` vs 2000), [GnuTLS](https://github.com/pjsip/pjproject/actions/runs/29476274307/job/87788710947) (`2399` vs 2000), [OpenSSL](https://github.com/pjsip/pjproject/actions/runs/29476274307/job/87788710958) (`2383` vs 2000)
- Run [29474500287](https://github.com/pjsip/pjproject/actions/runs/29474500287) — all 4 jobs:
  [GnuTLS](https://github.com/pjsip/pjproject/actions/runs/29474500287/job/87788574501) (`2230` vs 2000), [OpenSSL](https://github.com/pjsip/pjproject/actions/runs/29474500287/job/87788574506), [Openh264+VPX](https://github.com/pjsip/pjproject/actions/runs/29474500287/job/87788574514), [Default](https://github.com/pjsip/pjproject/actions/runs/29474500287/job/87788574526) (`2357` vs 2000)

```
...error: slept for 2342 ms instead of 2000 ms (outside 200 msec tolerance)
...error: slept for 1256 ms instead of 1000 ms (outside 200 msec tolerance)
```

### Why widening the tolerance is the right lever

`sleep_test` already runs as `PJ_TEST_EXCLUSIVE` on all platforms (`test.c`, since #4246), so no other pjlib test runs alongside it. The slippage therefore comes from **external load on the runner**, not from concurrent pjlib tests — there is nothing more to gain from test isolation, which leaves the tolerance as the only remaining lever.

### Root cause of the tightness

The ci-mode tolerance had been a **flat 200 ms absolute cap** since #3374, which replaced the original **±20% proportional** check. For the 2000 ms sleep, the flat cap is actually *stricter* than the old check (200 ms vs 400 ms), so the longest sleep is often the first to fail under load.

### Fix

Restore a duration-aware tolerance: allow the larger of

- an **absolute floor** — the roughly duration-independent scheduler/wakeup latency (the OS taking a while to run the thread once the timer fires; observed up to ~400 ms on loaded macOS runners), and
- a **percentage of the requested duration** — the load-dependent slippage that grows with the sleep length (observed up to ~25%).

In ci-mode this is `max(400 ms, 30%)`:

| duration | old tolerance | new tolerance |
|---|---|---|
| 2000 ms | 200 ms | **600 ms** |
| 1000 ms | 200 ms | 400 ms |
| ≤ 500 ms | 200 ms | 400 ms |

This covers every failure observed above with ≥36% margin. Non-ci mode is unchanged (flat 20 ms). A 30% band still catches gross regressions, which are off by far more than that.

Verified: clean build (`-Wall`, ASan) and `pjlib-test --ci-mode sleep_test` passes.

Co-Authored-By Claude Code
