### PR TITLE
ci: relieve queue via macOS test de-dup and cancel-in-progress on all platforms

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -5,6 +5,13 @@ on:
       - 'master'
   pull_request:
     types: [opened, synchronize, reopened]
+
+# Cancel superseded runs on the same ref (e.g. a force-push to a PR) so they
+# stop holding CI runner slots.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_ARGS: -w 3 --shuffle --stdout-buf 1
   CI_MODE: --ci-mode

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -5,6 +5,13 @@ on:
       - 'master'
   pull_request:
     types: [opened, synchronize, reopened]
+
+# Cancel superseded runs on the same ref (e.g. a force-push to a PR) so they
+# stop holding the scarce concurrent macOS runner slots.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_ARGS: -w 2 --shuffle --stdout-buf 1
   CI_MODE: --ci-mode
@@ -227,14 +234,24 @@ jobs:
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep SSL
     - name: verify openssl is used
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+1'
-    - name: pjlib-test
-      run: make pjlib-test
-    - name: pjlib-util-test
-      run: make pjlib-util-test
+    # CI de-dup: the full pjlib-test, pjlib-util-test and pjnath-test suites
+    # already run once in the Default jobs. Only the SSL-backend-dependent
+    # tests need to run per backend here: ssl_sock_test + ssl_sock_stress_test
+    # from pjlib-test, and turn_sock_test (which covers TURN-over-TLS) from
+    # pjnath-test. pjlib-util-test has no SSL dependency and is dropped.
+    # Restore the commented-out steps below to run the full suites here again.
+    - name: pjlib-test (ssl_sock only)
+      run: cd pjlib/build && ../bin/pjlib-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS ssl_sock_test ssl_sock_stress_test
+    # - name: pjlib-test
+    #   run: make pjlib-test
+    # - name: pjlib-util-test
+    #   run: make pjlib-util-test
     - name: pjmedia-test
       run: make pjmedia-test
-    - name: pjnath-test
-      run: make pjnath-test
+    - name: pjnath-test (turn_sock_test only)
+      run: cd pjnath/build && ../bin/pjnath-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS turn_sock_test
+    # - name: pjnath-test
+    #   run: make pjnath-test
     - name: upload artifacts on failure
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4
@@ -305,14 +322,24 @@ jobs:
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep SSL
     - name: verify gnu tls is used
       run: pjlib/bin/pjlib-test-`make infotarget` --config --list | grep -E 'PJ_SSL_SOCK_IMP\s+:\s+2'
-    - name: pjlib-test
-      run: make pjlib-test
-    - name: pjlib-util-test
-      run: make pjlib-util-test
+    # CI de-dup: the full pjlib-test, pjlib-util-test and pjnath-test suites
+    # already run once in the Default jobs. Only the SSL-backend-dependent
+    # tests need to run per backend here: ssl_sock_test + ssl_sock_stress_test
+    # from pjlib-test, and turn_sock_test (which covers TURN-over-TLS) from
+    # pjnath-test. pjlib-util-test has no SSL dependency and is dropped.
+    # Restore the commented-out steps below to run the full suites here again.
+    - name: pjlib-test (ssl_sock only)
+      run: cd pjlib/build && ../bin/pjlib-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS ssl_sock_test ssl_sock_stress_test
+    # - name: pjlib-test
+    #   run: make pjlib-test
+    # - name: pjlib-util-test
+    #   run: make pjlib-util-test
     - name: pjmedia-test
       run: make pjmedia-test
-    - name: pjnath-test
-      run: make pjnath-test
+    - name: pjnath-test (turn_sock_test only)
+      run: cd pjnath/build && ../bin/pjnath-test-`make -s -C ../.. infotarget` $CI_MODE $CI_ARGS turn_sock_test
+    # - name: pjnath-test
+    #   run: make pjnath-test
     - name: upload artifacts on failure
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4
@@ -398,39 +425,43 @@ jobs:
         name: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.run_id }}
         path: artifacts
 
-  video-openh264-2:
-    needs: [detect-changes]
-    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
-    runs-on: macos-latest
-    name: Openh264+VPX / pjlib,util,pjnath
-    steps:
-    - uses: actions/checkout@v2
-    - name: install cirunner
-      run: |
-        git clone --depth 1 https://github.com/pjsip/cirunner.git
-        cirunner/installmac.sh
-    - name: install dependencies
-      run: brew install openssl openh264 libvpx opencore-amr
-    - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
-    - name: configure
-      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) -fsanitize=address" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) -fsanitize=address" CXXFLAGS="-fsanitize=address" ./configure
-    - name: make
-      run: $MAKE_FAST
-    - name: disable firewall
-      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
-    - name: pjlib-test
-      run: make pjlib-test
-    - name: pjlib-util-test
-      run: make pjlib-util-test
-    - name: pjnath-test
-      run: make pjnath-test
-    - name: upload artifacts on failure
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.run_id }}
-        path: artifacts
+# CI de-dup: this job ran only pjlib-test, pjlib-util-test and pjnath-test,
+# all of which are codec-independent and already run once in the Default jobs.
+# It is therefore entirely redundant and disabled to free a macOS runner slot.
+# Uncomment to restore.
+#  video-openh264-2:
+#    needs: [detect-changes]
+#    if: github.event_name == 'push' || needs.detect-changes.outputs.mac_full_tests == 'true'
+#    runs-on: macos-latest
+#    name: Openh264+VPX / pjlib,util,pjnath
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: install cirunner
+#      run: |
+#        git clone --depth 1 https://github.com/pjsip/cirunner.git
+#        cirunner/installmac.sh
+#    - name: install dependencies
+#      run: brew install openssl openh264 libvpx opencore-amr
+#    - name: config site
+#      run: cd pjlib/include/pj && cp config_site_test.h config_site.h && echo "#define PJMEDIA_HAS_VIDEO 1" >> config_site.h
+#    - name: configure
+#      run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) -fsanitize=address" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) -fsanitize=address" CXXFLAGS="-fsanitize=address" ./configure
+#    - name: make
+#      run: $MAKE_FAST
+#    - name: disable firewall
+#      run: sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+#    - name: pjlib-test
+#      run: make pjlib-test
+#    - name: pjlib-util-test
+#      run: make pjlib-util-test
+#    - name: pjnath-test
+#      run: make pjnath-test
+#    - name: upload artifacts on failure
+#      if: ${{ failure() }}
+#      uses: actions/upload-artifact@v4
+#      with:
+#        name: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.run_id }}
+#        path: artifacts
 
   video-openh264-3:
     needs: [detect-changes]

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -5,6 +5,13 @@ on:
       - 'master'
   pull_request:
     types: [opened, synchronize, reopened]
+
+# Cancel superseded runs on the same ref (e.g. a force-push to a PR) so they
+# stop holding CI runner slots.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_WIN_ARGS: -w 3 --shuffle
   CI_MODE: --ci-mode


### PR DESCRIPTION
The CI queue — especially macOS — is frequently very long: GitHub caps concurrent runners (org-wide, shared across all repos), and the macOS job matrix re-ran several suites that a given variant can't actually affect. A single flaky timing test (e.g. `sleep_test`) then failed a whole matrix of jobs at once and forced a full re-queue behind that long queue.

### 1. Cancel superseded runs — all platforms (macOS, Ubuntu, Windows)
Add a `concurrency` group with `cancel-in-progress` to `ci-mac.yml`, `ci-linux.yml`, `ci-win.yml`, so a force-push to a PR stops the superseded run from holding scarce runner slots (which return to the shared pool immediately).

### 2. macOS test de-dup
Principle: a variant job should run only the tests its variant actually changes. The full `pjlib-test`, `pjlib-util-test` and `pjnath-test` suites run **once** in the Default jobs; the OpenSSL/GnuTLS jobs keep only the parts that genuinely differ by SSL backend:

- **`pjlib-test`** → Default runs the full suite (incl. the timing tests `sleep`/`timer`/`timestamp`). The OpenSSL/GnuTLS jobs run only `ssl_sock_test` + `ssl_sock_stress_test` (the backend-dependent parts), run directly as `ioq-cb-with-lock` already does.
- **`pjnath-test`** → Default runs the full suite. The OpenSSL/GnuTLS jobs run only `turn_sock_test`, which covers TURN-over-TLS (`turn_sock_test` variant 2 → `PJ_TURN_TP_TLS`, exercising `pj_ssl_sock_t`) — the only SSL-backend-dependent surface in pjnath.
- **`pjlib-util-test`** → dropped from the SSL jobs entirely; it has no SSL/https path (verified in `http_client.c`) and is codec-independent, so the single Default run suffices.
- **`Openh264+VPX / pjlib,util,pjnath`** job ran only those three suites, all already covered by the Default jobs and unaffected by the video codec → **disabled** (commented out), freeing a runner slot.

Removed/narrowed macOS steps are **commented out with the rationale inline**, so they're trivial to restore. `pjmedia-test`, `pjsip-test`, `pjsua-test` runs are intentionally **left unchanged** (conservative scope).

> The initial revision over-narrowed pjlib/pjnath; Copilot flagged the dropped `ssl_sock_stress_test` and TURN-over-TLS coverage, both verified and restored in the current revision. Thanks @copilot.

### Effect
- The flaky timing tests (`sleep`/`timer`/`timestamp`, which live in the full `pjlib-test`) go from **4 runs → 1** per macOS CI run — so one timing blip can no longer fail the whole matrix.
- Removes most of ~2 h of redundant full-suite runner time per macOS CI run: `pjnath-test` (~17 min) and `pjlib-test` (~10 min) no longer run 3× each — the Default run stays, the two SSL jobs run only small backend-specific subsets, and the fully-redundant job is dropped.
- One fewer macOS job (16 → 15). Under the slot-limited scheduler, less slot-occupancy = the queue drains faster on every platform.

### Note on status checks (no action needed)
I checked the repo: `master` has **no branch protection and no required status checks** (the only ruleset, "Copilot review for default branch", is disabled). So disabling the `Openh264+VPX / pjlib,util,pjnath` job does not block any PR — nothing to update. Recording it only for the future: if required status checks are ever enabled, that job's check name should not be added to the required list (it no longer reports); all other check names are unchanged.

Related: the `sleep_test` tolerance fix is #5095 (merged) — complementary: that reduces the failure rate, this reduces the blast radius.

Co-Authored-By Claude Code
