### PR TITLE
tests/pjsua: add ICE+STUN no-host call test

### DIFF
--- a/tests/pjsua/runall.py
+++ b/tests/pjsua/runall.py
@@ -23,6 +23,7 @@ excluded_tests = [
     "scripts-call/150_srtp_2_3.py",                  # disabled because #1267 wontfix
     "scripts-call/301_ice_public_a.py",              # Unreliable, proxy returns 408 sometimes
     "scripts-call/301_ice_public_b.py",              # Doesn't work because OpenSER modifies SDP
+    "scripts-call/310_ice_stun_no_host.py",          # Needs public STUN + NAT hairpinning (srflx-only)
     "scripts-pres/200_publish.py",                   # Ok from cmdline, error from runall.py
     "scripts-media-playrec/100_resample_lf_8_11.py", # related to clock-rate 11 kHz problem
     "scripts-media-playrec/100_resample_lf_8_22.py", # related to clock-rate 22 kHz problem

--- a/tests/pjsua/scripts-call/310_ice_stun_no_host.py
+++ b/tests/pjsua/scripts-call/310_ice_stun_no_host.py
@@ -1,0 +1,13 @@
+#
+from inc_cfg import *
+
+# ICE with STUN but no host candidates (srflx candidates only).
+# Both sides suppress host candidates with --ice-max-hosts 0, so the only
+# candidates gathered are the server reflexive ones obtained from STUN.
+test_param = TestParam(
+		"Callee=use ICE+STUN (no host), caller=use ICE+STUN (no host)",
+		[
+			InstanceParam("callee", "--null-audio --max-calls=1 --use-ice --ice-max-hosts 0 --stun-srv stun.pjsip.org"),
+			InstanceParam("caller", "--null-audio --max-calls=1 --use-ice --ice-max-hosts 0 --stun-srv stun.pjsip.org")
+		]
+		)


### PR DESCRIPTION
## Summary

Adds an application-level pjsua call test for the **ICE + STUN, no host candidates** scenario, which previously had no end-to-end coverage (it existed only as a pjnath unit-test code path, and that path is commented out).

## What's added

- **`tests/pjsua/scripts-call/310_ice_stun_no_host.py`** — a two-instance call test where both sides run with:
  ```
  --use-ice --ice-max-hosts 0 --stun-srv stun.pjsip.org
  ```
  `--ice-max-hosts 0` suppresses all host candidates, so the only candidates gathered are the server-reflexive (srflx) ones obtained from STUN. It reuses `mod_call.py`'s generic call flow (call → hold/reinvite → UPDATE → DTMF media checks → hangup).

- **`tests/pjsua/runall.py`** — excludes the new test from the automated suite, alongside the existing `301_ice_public_*` exclusions.

## Why excluded from `runall.py`

Unlike the `330_*` STUN tests (where local host candidates win the media path and STUN is not actually on the critical path), suppressing host candidates forces both local instances to advertise only their public srflx address. ICE connectivity and the DTMF media checks then require **NAT hairpinning** and a reachable public `stun.pjsip.org` — the same network dependence that keeps `301_ice_public_*` out of the automated run.

Run it explicitly:
```
cd tests/pjsua && python3 run.py mod_call.py scripts-call/310_ice_stun_no_host.py
```

Co-Authored-By Claude Code