### PR TITLE
tests/pjsua: add DTMF over SIP INFO call test

### DIFF
--- a/tests/pjsua/inc_const.py
+++ b/tests/pjsua/inc_const.py
@@ -34,6 +34,10 @@ MEDIA_ACTIVE = "Call [0-9]+ media [0-9]+ .*, status is Active"
 #MEDIA_ACTIVE = "Media for call [0-9]+ is active"
 # RX_DTMF
 RX_DTMF = "Incoming DTMF on call [0-9]+: "
+# Suffix logged after the digit when DTMF is received via SIP INFO
+# (as opposed to RFC 2833). Append after RX_DTMF + digit to assert the
+# transport method, e.g. RX_DTMF + "1" + RX_DTMF_INFO_METHOD.
+RX_DTMF_INFO_METHOD = ".*using SIP INFO method"
 
 ##########################
 # MEDIA

--- a/tests/pjsua/scripts-call/360_dtmf_info.py
+++ b/tests/pjsua/scripts-call/360_dtmf_info.py
@@ -1,0 +1,79 @@
+#
+import inc_const as const
+from inc_cfg import *
+
+
+# DTMF digits to send, each carried in its own SIP INFO request.
+DTMF_DIGITS = "1234"
+
+
+# Send DTMF via SIP INFO from 'sender', one digit at a time, verifying that
+# 'receiver' logs each digit (and that SIP INFO -- not RFC 2833 -- carried
+# it) before sending the next. This mirrors mod_call.py's check_media() --
+# which sends DTMF via the '#' command (RFC 2833) -- but drives the '*'
+# command / PJSUA_DTMF_METHOD_SIP_INFO path instead, the one call flow with
+# no other test coverage. We send digit-by-digit with event-driven sync
+# (rather than firing all digits at once) both because that is how DTMF is
+# used in practice and to keep the test robust on slow CI runners.
+def send_dtmf_info(sender, receiver):
+    for digit in DTMF_DIGITS:
+        if sender.use_telnet:
+            sender.send("* " + digit)
+        else:
+            sender.send("*")
+            sender.expect("DTMF")
+            sender.send(digit)
+        receiver.expect(const.RX_DTMF + digit + const.RX_DTMF_INFO_METHOD)
+        sender.sync_stdout()
+        receiver.sync_stdout()
+
+
+# Custom test function: mod_call.py's generic flow (hold/reinvite/update and
+# RFC 2833 DTMF) doesn't cover SIP INFO DTMF, so we supply our own.
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    # Caller places the call.
+    caller.send("call new " + t.inst_params[0].uri)
+    caller.expect(const.STATE_CALLING)
+
+    # Callee answers with 200/OK.
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 200")
+
+    # Wait until the call is connected on both endpoints.
+    caller.expect(const.STATE_CONFIRMED)
+    callee.expect(const.STATE_CONFIRMED)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Caller -> callee DTMF over SIP INFO.
+    send_dtmf_info(caller, callee)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Callee -> caller DTMF over SIP INFO (exercise the other direction).
+    send_dtmf_info(callee, caller)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Hangup call.
+    caller.send("call hangup")
+    caller.expect(const.STATE_DISCONNECTED)
+    callee.expect(const.STATE_DISCONNECTED)
+
+
+# Basic call exercising DTMF transmission over SIP INFO
+# (PJSUA_DTMF_METHOD_SIP_INFO), in both directions.
+test_param = TestParam(
+        "DTMF via SIP INFO",
+        [
+            InstanceParam("callee", "--null-audio --max-calls=1"),
+            InstanceParam("caller", "--null-audio --max-calls=1")
+        ],
+        func=test_func
+        )


### PR DESCRIPTION
## Summary

The pjsua application test suite exercises **DTMF via RFC 2833** in every generic call — `mod_call.py`'s `check_media()` sends digits with the `#` command — but the **SIP INFO** DTMF path (`PJSUA_DTMF_METHOD_SIP_INFO`, the `*` command) had no integration coverage. This PR closes that gap.

## Changes

- **`tests/pjsua/scripts-call/360_dtmf_info.py`** — a two-instance pjsua call test that:
  - places and connects a call,
  - sends DTMF via SIP INFO **in both directions** (caller→callee and callee→caller),
  - verifies each digit is received *and* that the log reports `using SIP INFO method` (so it cannot silently pass on the RFC 2833 path),
  - hangs up cleanly.

  Digits are sent one at a time with event-driven sync (rather than all at once) to reflect real DTMF usage and to stay robust on slow CI runners.

- **`tests/pjsua/inc_const.py`** — adds `RX_DTMF_INFO_METHOD` to assert the transport method in the received-DTMF log line.

The test is auto-discovered by `runall.py` (which globs `scripts-call/` under `mod_call.py`); no runner or build-system changes are required.

## Testing

Ran the new test against the built `pjsua` binary — 8 INFO requests sent, 8 digits received and matched, passing consistently across repeated runs.

Co-Authored-By Claude Code