### PR TITLE
pjsip: fix double dialog teardown race in pjsip_dlg_dec_lock

### DIFF
--- a/pjsip/include/pjsip/sip_dialog.h
+++ b/pjsip/include/pjsip/sip_dialog.h
@@ -174,6 +174,9 @@ struct pjsip_dialog
     /** Transaction counter. */
     int                 tsx_count;  /**< Number of pending transactions.    */
 
+    /** Teardown guard, set once destruction has started (see #1886). */
+    pj_bool_t           destroying; /**< Dialog is being destroyed?         */
+
     /** Transport selector. */
     pjsip_tpselector    tp_sel;
 

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -1046,7 +1046,14 @@ PJ_DEF(void) pjsip_dlg_dec_lock(pjsip_dialog *dlg)
     pj_assert(dlg->sess_count > 0);
     --dlg->sess_count;
 
-    if (dlg->sess_count==0 && dlg->tsx_count==0) {
+    if (dlg->sess_count==0 && dlg->tsx_count==0 && !dlg->destroying) {
+        /* Claim the teardown before dropping the lock. Another thread
+         * holding a reference (e.g. a concurrent transaction's
+         * on_tsx_state) can acquire the group lock during the
+         * release/acquire window below and also observe zero counts;
+         * this flag makes sure only one thread destroys the dialog.
+         */
+        dlg->destroying = PJ_TRUE;
         pj_grp_lock_release(dlg->grp_lock_);
         pj_grp_lock_acquire(dlg->grp_lock_);
         /* We are holding the dialog group lock here, so before we destroy

--- a/pjsip/src/pjsip/sip_dialog.c
+++ b/pjsip/src/pjsip/sip_dialog.c
@@ -922,6 +922,14 @@ PJ_DEF(pj_status_t) pjsip_dlg_terminate( pjsip_dialog *dlg )
     /* MUST not have pending transactions. */
     PJ_ASSERT_RETURN(dlg->tsx_count==0, PJ_EINVALIDOP);
 
+    /* Claim the teardown. If another path (e.g. pjsip_dlg_dec_lock() or a
+     * repeated terminate) has already started destroying this dialog, do
+     * not unregister/destroy it again. See #1886.
+     */
+    if (dlg->destroying)
+        return PJ_SUCCESS;
+    dlg->destroying = PJ_TRUE;
+
     return unregister_and_destroy_dialog(dlg, PJ_FALSE);
 }
 

--- a/pjsip/src/pjsip/sip_ua_layer.c
+++ b/pjsip/src/pjsip/sip_ua_layer.c
@@ -399,11 +399,6 @@ PJ_DEF(pj_status_t) pjsip_ua_unregister_dlg( pjsip_user_agent *ua,
     /* Remove this dialog from the list. */
     pj_list_erase(dlg);
 
-    /* Mark as unregistered so a stray repeat unregistration is a no-op
-     * rather than an assertion failure.
-     */
-    dlg->dlg_set = NULL;
-
     /* If dialog list is empty, remove the dialog set from the hash table. */
     if (pj_list_empty(&dlg_set->dlg_list)) {
 

--- a/pjsip/src/pjsip/sip_ua_layer.c
+++ b/pjsip/src/pjsip/sip_ua_layer.c
@@ -399,6 +399,11 @@ PJ_DEF(pj_status_t) pjsip_ua_unregister_dlg( pjsip_user_agent *ua,
     /* Remove this dialog from the list. */
     pj_list_erase(dlg);
 
+    /* Mark as unregistered so a stray repeat unregistration is a no-op
+     * rather than an assertion failure.
+     */
+    dlg->dlg_set = NULL;
+
     /* If dialog list is empty, remove the dialog set from the hash table. */
     if (pj_list_empty(&dlg_set->dlg_list)) {
 


### PR DESCRIPTION
## Problem

The `stress / asan` CI job aborts intermittently with:

```
sip_ua_layer.c:394: pjsip_ua_unregister_dlg: Assertion `!"Dialog is not registered!"' failed.
```

Backtrace (from a stress run):

```
unregister_and_destroy_dialog   sip_dialog.c:900
  (via) pjsip_dlg_dec_lock      sip_dialog.c:1056
mod_ua_on_tsx_state             sip_ua_layer.c:186
tsx_set_state                   sip_transaction.c:1516
tsx_on_state_completed_uac      sip_transaction.c:3813
tsx_timer_callback              sip_transaction.c:1436
```

The same dialog is unregistered and destroyed **twice**.

## Root cause

`pjsip_dlg_dec_lock()` releases and reacquires the dialog group lock before destroying the dialog (ticket #1886):

```c
if (dlg->sess_count==0 && dlg->tsx_count==0) {
    pj_grp_lock_release(dlg->grp_lock_);   /* window opens */
    pj_grp_lock_acquire(dlg->grp_lock_);   /* reacquire, no re-check */
    unregister_and_destroy_dialog(dlg, PJ_TRUE);
}
```

During that release/acquire window a second worker thread holding a reference to the same dialog (e.g. a concurrent transaction's `on_tsx_state`) can acquire the group lock, also observe `sess_count==0 && tsx_count==0`, and run `unregister_and_destroy_dialog()` first. When the original thread reacquires it destroys the dialog again. Re-checking the counters after reacquire is not sufficient — they remain zero after the first teardown.

This is reproduced under re-INVITE glare (`491 Request Pending`), where a dialog has overlapping transactions that terminate near-simultaneously on different worker threads.

`destroy_dialog()` only does `pj_grp_lock_dec_ref()` (the pool free is deferred to the grp-lock handler), which is why the second pass hits a clean assertion rather than an immediate use-after-free — but the double `dec_ref` is a latent premature-free.

## Fix

- Add a `dlg->destroying` flag, set under the group lock **before** the release/acquire window, so exactly one thread runs the teardown.
- Clear `dlg->dlg_set` in `pjsip_ua_unregister_dlg()` after erasing the dialog from its set. This makes the existing #1924 guard (`if (dlg->dlg_set)`) distinguish "already unregistered" from "still registered", turning a stray repeat unregistration into a no-op instead of an assertion, and removes the latent double `grp_lock_dec_ref`.

## Testing

- `cd pjsip/build && make` — clean, no warnings (ASan build).
- `pjsip-test inv_offer_answer_test` (heavy dialog create/destroy under ASan) — passes.
- Ran the `pjsua-stress` binary locally under ASan — no assertions, no ASan errors.

Co-Authored-By Claude Code