### PR TITLE
pjmedia: hold stream ref for the whole on_rx_rtp callback

### DIFF
--- a/pjmedia/src/pjmedia/stream_imp_common.c
+++ b/pjmedia/src/pjmedia/stream_imp_common.c
@@ -405,7 +405,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
                                     param->user_data;
     void *pkt = param->pkt;
     pj_ssize_t bytes_read = param->size;
-    pjmedia_channel *channel = c_strm->dec;
+    pjmedia_channel *channel;
     const pjmedia_rtp_hdr *hdr;
     const void *payload;
     unsigned payloadlen;
@@ -414,11 +414,19 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     pj_status_t status;
     pj_bool_t pkt_discarded = PJ_FALSE;
 
+    /* Hold a reference to the stream for the entire callback so it cannot
+     * be destroyed by another thread while we are reading and updating its
+     * state or sending RTCP below. The ref used to be taken further down,
+     * leaving this prologue (which also writes c_strm state) unprotected.
+     */
+    pj_grp_lock_add_ref(c_strm->grp_lock);
+    channel = c_strm->dec;
+
     /* Check for errors */
     if (bytes_read < 0) {
         status = (pj_status_t)-bytes_read;
         if (status == PJ_STATUS_FROM_OS(OSERR_EWOULDBLOCK)) {
-            return;
+            goto on_ret;
         }
 
         LOGERR_((c_strm->port.info.name.ptr, status,
@@ -429,12 +437,12 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
             publish_tp_event(PJMEDIA_EVENT_MEDIA_TP_ERR, status, PJ_TRUE,
                              PJMEDIA_DIR_DECODING, c_strm);
         }
-        return;
+        goto on_ret;
     }
 
     /* Ignore non-RTP keep-alive packets */
     if (bytes_read < (pj_ssize_t) sizeof(pjmedia_rtp_hdr))
-        return;
+        goto on_ret;
 
     /* Update RTP and RTCP session. */
     status = pjmedia_rtp_decode_rtp(&channel->rtp, pkt, (int)bytes_read,
@@ -442,13 +450,13 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     if (status != PJ_SUCCESS) {
         LOGERR_((c_strm->port.info.name.ptr, status, "RTP decode error"));
         c_strm->rtcp.stat.rx.discard++;
-        return;
+        goto on_ret;
     }
 
     /* Check if multiplexing is allowed and the payload indicates RTCP. */
     if (c_strm->si->rtcp_mux && hdr->pt >= 64 && hdr->pt <= 95) {
         on_rx_rtcp(c_strm, pkt, bytes_read);
-        return;
+        goto on_ret;
     }
 
     /* See if source address of RTP packet is different than the
@@ -484,7 +492,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
                      * - we have ever received packet with bad ssrc from
                      *   remote address and this packet also has bad ssrc.
                      */
-                    return;                 
+                    goto on_ret;
                 }
                 if (!badssrc && c_strm->rem_rtp_flag != 1)
                 {
@@ -512,9 +520,6 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
             }
         }
     }
-
-    /* Add ref counter to avoid premature destroy from callbacks */
-    pj_grp_lock_add_ref(c_strm->grp_lock);
 
     pj_bzero(&seq_st, sizeof(seq_st));
 
@@ -634,6 +639,7 @@ on_return:
         }
     }
 
+on_ret:
     pj_grp_lock_dec_ref(c_strm->grp_lock);
 }
 


### PR DESCRIPTION
## Problem

The `stress / tsan` job takes a fatal signal in the media RTP-receive path (seen on run 29793276473; distinct from the dialog assertion fixed in #5101):

```
crash_signal_handler         pjsua_stress.c:944
pjmedia_stream_send_rtcp     stream_common.c:631   <- fault (~+0x83)
send_rtcp                    stream_imp_common.c:257
on_rx_rtp                    stream_imp_common.c:627   <- "initial RTCP RR" send
srtp_rtp_cb                  transport_srtp.c:1570
call_rtp_cb                  transport_udp.c:558
on_rx_rtp                    transport_udp.c:637
ioqueue_dispatch_read_event  ioqueue_common_abs.c:886
worker_proc                  endpoint.c:352
```

An inbound RTP packet is dispatched UDP → SRTP → stream `on_rx_rtp`, which (after ≥10 received packets) sends an initial RTCP RR. The fault is on the first pointer chase in `pjmedia_stream_send_rtcp` (`c_strm->transport->grp_lock`), and coincides in the log with call 285's stream/transport being destroyed at the same millisecond — an in-flight RTP receive callback racing the destruction of the stream it runs on.

## Root cause addressed

`on_rx_rtp` takes its protective group-lock reference **too late**. The ~110-line prologue before the old `pj_grp_lock_add_ref` both reads and **writes** stream state:

```c
pjmedia_channel *channel = c_strm->dec;        /* read */
...
c_strm->rtcp.stat.rx.discard++;                /* write */
...
pj_sockaddr_cp(&c_strm->rem_rtp_addr, ...);    /* write */
c_strm->rtcp.peer_ssrc = ...;                  /* write */
...
pj_grp_lock_add_ref(c_strm->grp_lock);         /* ref only here (~line 517) */
```

With no reference held during that window, if the stream is freed concurrently the callback operates on freed memory. The comment at the old ref site even states its intent ("avoid premature destroy from callbacks") — the placement just left the prologue unguarded.

## Fix

Take `pj_grp_lock_add_ref(c_strm->grp_lock)` as the **first** action in `on_rx_rtp`, and release it at a single `on_ret:` exit that all early returns now `goto`. The reference now covers the entire callback, including the `send_rtcp` calls that crashed.

- Low risk: one add_ref/dec_ref pair per received packet (recursive grp-lock refcount), no lock-ordering change.
- No behavioral change to packet processing.

## Testing

- Builds clean (`-Wall`, ASan) for all three includers of `stream_imp_common.c`: audio `stream.c`, video `vid_stream.c`, text `txt_stream.c`.
- 90 s local stress with audio+video (`-n 64 -v 16 -t 8`) under ASan: no errors, clean shutdown.

## Honest status

This closes a real unprotected-access window in the exact function that crashed. The specific interleaving did **not** reproduce locally (macOS/kqueue vs. the CI's Linux/epoll), so **CI `stress / tsan` is the authoritative validator**. Ruled out along the way: the `clear_key` drain did not time out (no such log line), and the UDP keys are registered non-concurrent — so if the crash persists, the next candidate is transport-level serialization of detach against in-flight callbacks in `call_rtp_cb`, or the media-reinit path that juggles provisional transports.

Co-Authored-By Claude Code