### PR TITLE
pjlib: fix race in pj_timer_heap_earliest_time and pj_timer_heap_count

### DIFF
--- a/pjlib/include/pj/timer.h
+++ b/pjlib/include/pj/timer.h
@@ -338,16 +338,17 @@ PJ_DECL(int) pj_timer_heap_cancel_if_active(pj_timer_heap_t *ht,
 PJ_DECL(pj_size_t) pj_timer_heap_count( pj_timer_heap_t *ht );
 
 /**
- * Get the earliest time registered in the timer heap. The timer heap
- * MUST have at least one timer being scheduled (application should use
- * #pj_timer_heap_count() before calling this function).
+ * Get the earliest time registered in the timer heap. If no entry is
+ * currently scheduled (e.g. the heap is empty, or was emptied by a
+ * concurrent cancellation), PJ_ENOTFOUND is returned and \a timeval is
+ * left untouched.
  *
  * @param ht        The timer heap.
  * @param timeval   The time deadline of the earliest timer entry.
  *
  * @return          PJ_SUCCESS, or PJ_ENOTFOUND if no entry is scheduled.
  */
-PJ_DECL(pj_status_t) pj_timer_heap_earliest_time( pj_timer_heap_t *ht, 
+PJ_DECL(pj_status_t) pj_timer_heap_earliest_time( pj_timer_heap_t *ht,
                                                   pj_time_val *timeval);
 
 /**

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -967,23 +967,34 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
 
 PJ_DEF(pj_size_t) pj_timer_heap_count( pj_timer_heap_t *ht )
 {
+    pj_size_t count;
+
     PJ_ASSERT_RETURN(ht, 0);
 
-    return ht->cur_size;
+    lock_timer_heap(ht);
+    count = ht->cur_size;
+    unlock_timer_heap(ht);
+
+    return count;
 }
 
 PJ_DEF(pj_status_t) pj_timer_heap_earliest_time( pj_timer_heap_t * ht,
                                                  pj_time_val *timeval)
 {
-    pj_assert(ht->cur_size != 0);
-    if (ht->cur_size == 0)
-        return PJ_ENOTFOUND;
+    pj_status_t status;
 
     lock_timer_heap(ht);
-    *timeval = ht->heap[0]->_timer_value;
+
+    if (ht->cur_size == 0) {
+        status = PJ_ENOTFOUND;
+    } else {
+        *timeval = ht->heap[0]->_timer_value;
+        status = PJ_SUCCESS;
+    }
+
     unlock_timer_heap(ht);
 
-    return PJ_SUCCESS;
+    return status;
 }
 
 #if PJ_TIMER_DEBUG

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -988,7 +988,11 @@ PJ_DEF(pj_status_t) pj_timer_heap_earliest_time( pj_timer_heap_t * ht,
     if (ht->cur_size == 0) {
         status = PJ_ENOTFOUND;
     } else {
+#if PJ_TIMER_USE_LINKED_LIST
+        *timeval = ht->head_list.next->_timer_value;
+#else
         *timeval = ht->heap[0]->_timer_value;
+#endif
         status = PJ_SUCCESS;
     }
 


### PR DESCRIPTION
## Summary
- Fix a race in `pj_timer_heap_earliest_time()`: the emptiness check (`cur_size == 0`) ran *before* acquiring the timer heap lock, then the function unconditionally read `heap[0]` after locking. A concurrent cancellation of the last scheduled timer between the check and the lock could shrink `cur_size` to 0 without clearing `heap[0]`, so the function could return `PJ_SUCCESS` with a stale/dangling timer value instead of `PJ_ENOTFOUND`.
- Move the emptiness check inside the lock, and drop the racy `pj_assert(ht->cur_size != 0)` (callers no longer need to call `pj_timer_heap_count()` first — the function safely reports `PJ_ENOTFOUND` on its own).
- Harden `pj_timer_heap_count()` to read `cur_size` under the lock instead of unlocked, for the same reason.
- Update the `pj_timer_heap_earliest_time()` doc comment in `timer.h` to reflect the new, safe-to-call-without-pre-checking contract.

## Why
`remove_node()` only decrements `cur_size` when removing the last heap entry — it doesn't clear `heap[0]`. So the old unlocked pre-check + locked-but-unconditional read was a genuine TOCTOU bug under multi-threaded use.