### PR TITLE
pjsua: fix fixed-size array buffer overflows in proxy config and video menu

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -795,6 +795,10 @@ static pj_status_t parse_args(int argc, char *argv[],
                           "in proxy argument", pj_optarg));
                 return PJ_EINVAL;
             }
+            if (cur_acc->proxy_cnt >= PJ_ARRAY_SIZE(cur_acc->proxy)) {
+                PJ_LOG(1,(THIS_FILE, "Error: too many proxies"));
+                return PJ_ETOOMANY;
+            }
             cur_acc->proxy[cur_acc->proxy_cnt++] = pj_str(pj_optarg);
             break;
 
@@ -805,7 +809,14 @@ static pj_status_t parse_args(int argc, char *argv[],
                           "in outbound proxy argument", pj_optarg));
                 return PJ_EINVAL;
             }
-            cfg->cfg.outbound_proxy[cfg->cfg.outbound_proxy_cnt++] = pj_str(pj_optarg);
+            if (cfg->cfg.outbound_proxy_cnt >=
+                PJ_ARRAY_SIZE(cfg->cfg.outbound_proxy))
+            {
+                PJ_LOG(1,(THIS_FILE, "Error: too many outbound proxies"));
+                return PJ_ETOOMANY;
+            }
+            cfg->cfg.outbound_proxy[cfg->cfg.outbound_proxy_cnt++] =
+                pj_str(pj_optarg);
             break;
 
         case OPT_REGISTRAR:   /* registrar */

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -322,6 +322,8 @@ static void vid_handle_menu(char *menuin)
     argv[argc] = strtok(menuin, " \t\r\n");
     while (argv[argc] && *argv[argc]) {
         argc++;
+        if (argc >= (int)PJ_ARRAY_SIZE(argv))
+            break;
         argv[argc] = strtok(NULL, " \t\r\n");
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1241,7 +1241,8 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
     PJ_ASSERT_RETURN(acc_id>=0 && acc_id<(int)PJ_ARRAY_SIZE(pjsua_var.acc),
                      PJ_EINVAL);
-    PJ_ASSERT_RETURN(cfg->proxy_cnt <= PJSUA_ACC_MAX_PROXIES, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg && cfg->proxy_cnt <= PJSUA_ACC_MAX_PROXIES,
+                     PJ_EINVAL);
 
 #if !PJ_HAS_IPV6
     PJ_ASSERT_RETURN(cfg->ipv6_sip_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -785,6 +785,7 @@ PJ_DEF(pj_status_t) pjsua_acc_add( const pjsua_acc_config *cfg,
     pj_status_t status = PJ_SUCCESS;
 
     PJ_ASSERT_RETURN(cfg, PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg->proxy_cnt <= PJSUA_ACC_MAX_PROXIES, PJ_EINVAL);
 
     if (pjsua_var.acc_cnt >= PJ_ARRAY_SIZE(pjsua_var.acc))
         return PJ_ETOOMANY;
@@ -1240,6 +1241,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
     PJ_ASSERT_RETURN(acc_id>=0 && acc_id<(int)PJ_ARRAY_SIZE(pjsua_var.acc),
                      PJ_EINVAL);
+    PJ_ASSERT_RETURN(cfg->proxy_cnt <= PJSUA_ACC_MAX_PROXIES, PJ_EINVAL);
 
 #if !PJ_HAS_IPV6
     PJ_ASSERT_RETURN(cfg->ipv6_sip_use == PJSUA_IPV6_DISABLED, PJ_EINVAL);

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1097,8 +1097,9 @@ PJ_DEF(pj_status_t) pjsua_init( const pjsua_config *ua_cfg,
         media_cfg = &default_media_cfg;
     }
 
-    PJ_ASSERT_RETURN(ua_cfg->outbound_proxy_cnt <=
-                      PJ_ARRAY_SIZE(ua_cfg->outbound_proxy), PJ_EINVAL);
+    PJ_ASSERT_ON_FAIL(ua_cfg->outbound_proxy_cnt <=
+                      PJ_ARRAY_SIZE(ua_cfg->outbound_proxy),
+                      { status = PJ_EINVAL; goto on_error; });
 
     /* Initialize logging first so that info/errors can be captured */
     if (log_cfg) {

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1097,6 +1097,9 @@ PJ_DEF(pj_status_t) pjsua_init( const pjsua_config *ua_cfg,
         media_cfg = &default_media_cfg;
     }
 
+    PJ_ASSERT_RETURN(ua_cfg->outbound_proxy_cnt <=
+                      PJ_ARRAY_SIZE(ua_cfg->outbound_proxy), PJ_EINVAL);
+
     /* Initialize logging first so that info/errors can be captured */
     if (log_cfg) {
         status = pjsua_reconfigure_logging(log_cfg);

--- a/pjsip/src/pjsua-lib/pjsua_dump.c
+++ b/pjsip/src/pjsua-lib/pjsua_dump.c
@@ -519,7 +519,7 @@ static void dump_media_session(const char *indent,
             pj_ansi_snprintf(s, sizeof(s), "%d", v)
 
 #   define VALIDATE_PRINT_BUF() \
-        if (len < 1 || len >= end-p) { *p = '\0'; return; } \
+        if (len < 1 || len >= (end-p)-1) { *p = '\0'; return; } \
         p += len; *p++ = '\n'; *p = '\0'
 
 


### PR DESCRIPTION
## Summary

Fixes four fixed-size array/buffer overflows found in the `pjsua` sample app and the `pjsua` library's account/outbound proxy handling. In each case, an unchecked count (`proxy_cnt`, `outbound_proxy_cnt`, or a token count) is used to write into a fixed-size array without verifying it stays within bounds.

## Changes

### 1. Account proxy overflow (`pjsua_app_config.c`, `pjsua_acc.c`)
- The CLI `--proxy` parser wrote into `cur_acc->proxy[PJSUA_ACC_MAX_PROXIES]` (size 8) without checking `proxy_cnt` first — a 9th `--proxy` argument overflowed the array.
- `pjsua_acc_modify()` copied `cfg->proxy_cnt` entries into a stack array `acc_proxy[PJSUA_ACC_MAX_PROXIES]` with no bound check, and `pjsua_acc_add()` had the same exposure via `pjsua_acc_config_dup()`. Both now validate `proxy_cnt <= PJSUA_ACC_MAX_PROXIES` up front.

### 2. Outbound proxy overflow (`pjsua_app_config.c`, `pjsua_core.c`)
- Same issue as above but for the global `--outbound-proxy` CLI option and `pjsua_config.outbound_proxy[4]`.
- `pjsua_init()` now validates `outbound_proxy_cnt` against the array size before it's used — this closes both an out-of-bounds read in `pjsua_init`'s own route-parsing loop and a later out-of-bounds write in `pjsua_call_subsys_init()` → `pjsua_config_dup()`.

### 3. One-byte overflow in media dump formatting (`pjsua_dump.c`)
- `VALIDATE_PRINT_BUF()` accepted `len == (end - p) - 1` as valid, then wrote both `'\n'` and `'\0'` — the second write landed one byte past the caller-provided buffer. The bound check now reserves room for both trailing bytes.

### 4. Video menu tokenizer overflow (`pjsua_app_legacy.c`)
- `vid_handle_menu()`'s tokenizer stored tokens into a fixed `char *argv[8]` with no bound check. Entering a `vid ...` command with 9+ whitespace-separated tokens wrote past `argv[8]`. The loop now stops once `argv` is full, silently dropping any excess tokens (no existing `vid` command uses anywhere near 8 arguments).

## Files changed
- `pjsip-apps/src/pjsua/pjsua_app_config.c`
- `pjsip-apps/src/pjsua/pjsua_app_legacy.c`
- `pjsip/src/pjsua-lib/pjsua_acc.c`
- `pjsip/src/pjsua-lib/pjsua_core.c`
- `pjsip/src/pjsua-lib/pjsua_dump.c`