### PR TITLE
pjmedia: bound video send RC latency and enforce SDP bitrate on codec modify

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1860,6 +1860,51 @@
 
 
 /**
+ * Maximum sender-side pacing delay for the video send rate control in
+ * PJMEDIA_VID_STREAM_RC_SEND_THREAD mode, in milliseconds. The RC scheduler
+ * paces outgoing RTP to the (auto-derived or configured) bandwidth budget.
+ * If the encoder outpaces that budget - for example after the codec bitrate
+ * is raised mid-call via pjmedia_vid_stream_modify_codec_param() - the
+ * cumulative packet schedule would otherwise drift ahead of real time
+ * without bound. This macro caps that drift so sender latency stays bounded;
+ * the pacing baseline is re-anchored to real time once the cap is hit.
+ *
+ * Default: 1000
+ */
+#ifndef PJMEDIA_VID_STREAM_RC_MAX_DELAY_MSEC
+#   define PJMEDIA_VID_STREAM_RC_MAX_DELAY_MSEC             1000
+#endif
+
+
+/**
+ * Overhead margin, in percent, added to the auto-derived video send rate
+ * control budget (i.e. when pjmedia_vid_stream_rc_config.bandwidth is left at
+ * zero). The budget then becomes codec_max_bps * (100 + this) / 100. The
+ * margin is pacing headroom to absorb RTP/UDP/IP overhead and encoder
+ * burstiness so the pacer does not fall behind a compliant encoder; it is NOT
+ * a media bitrate increase (the encoder still runs at the codec/SDP bitrate).
+ * An application-pinned bandwidth is used as-is, without this margin.
+ *
+ * Default: 25
+ */
+#ifndef PJMEDIA_VID_STREAM_RC_OVERHEAD_PCT
+#   define PJMEDIA_VID_STREAM_RC_OVERHEAD_PCT               25
+#endif
+
+
+/**
+ * Minimum video send rate control bandwidth budget, in bps. This is a floor
+ * to guard against a zero budget (e.g. when a codec reports a zero maximum
+ * bitrate), which would otherwise cause a division by zero in the pacer.
+ *
+ * Default: 32000
+ */
+#ifndef PJMEDIA_VID_STREAM_RC_MIN_BANDWIDTH
+#   define PJMEDIA_VID_STREAM_RC_MIN_BANDWIDTH             32000
+#endif
+
+
+/**
  * Perform RTP payload type checking in the video stream. Normally the peer
  * MUST send RTP with payload type as we specified in our SDP. Certain
  * agents may not be able to follow this hence the only way to have

--- a/pjmedia/include/pjmedia/vid_stream.h
+++ b/pjmedia/include/pjmedia/vid_stream.h
@@ -168,6 +168,16 @@ typedef struct pjmedia_vid_stream_info
 
     pjmedia_vid_stream_sk_config sk_cfg;
                                     /**< Stream send keyframe settings.     */
+
+    /**
+     * Maximum outgoing bitrate negotiated with the remote in SDP, taken
+     * from the media-level "b=TIAS" (RFC 3890) or, as a fallback, "b=AS"
+     * (RFC 4566) line, in bps. Zero if the remote did not signal a limit.
+     * The stream will not transmit above this value even if the codec
+     * bitrate is later raised via #pjmedia_vid_stream_modify_codec_param();
+     * to legitimately use more, renegotiate with a higher "b=" line.
+     */
+    unsigned                     rem_max_bps;
 } pjmedia_vid_stream_info;
 
 

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -114,6 +114,11 @@ struct pjmedia_vid_stream
     unsigned                 frame_size;    /**< Size of encoded base frame.*/
     unsigned                 frame_ts_len;  /**< Frame length in timestamp. */
 
+    unsigned                 tx_max_bps;    /**< SDP-negotiated max TX bitrate
+                                                 in bps (0 = no limit).     */
+    pj_bool_t                rc_auto_bw;    /**< RC bandwidth budget was
+                                                 auto-derived from codec?   */
+
     unsigned                 rx_frame_cnt;  /**< # of array in rx_frames    */
     pjmedia_frame           *rx_frames;     /**< Temp. buffer for incoming
                                                  frame assembly.            */
@@ -192,6 +197,8 @@ typedef struct send_stream
     pj_size_t            rc_total;
     unsigned             rc_bandwidth;
     pj_timestamp         ts_freq;
+    pj_uint64_t          rc_max_delay;  /**< Max pacing delay, in ts_freq
+                                             ticks (0 = unbounded).         */
     unsigned             rtp_tx_err_cnt;
 
 #if TRACE_RC
@@ -445,6 +452,22 @@ static void send_rtp(send_stream *ss, send_entry *entry)
         pj_get_timestamp(&ss->rc_start);
     entry->send_ts = ss->rc_start;
     pj_add_timestamp(&entry->send_ts, &send_ts);
+
+    /* Bound the pacing debt. If the scheduled send time has drifted too far
+     * ahead of real time, the encoder is outpacing the RC budget (e.g. after
+     * a mid-call bitrate increase). Cap the delay and re-anchor the pacing
+     * baseline to real time, forgiving the excess debt, so sender-side
+     * latency cannot grow without bound.
+     */
+    if (ss->rc_max_delay) {
+        pj_timestamp now;
+        pj_get_timestamp(&now);
+        if (entry->send_ts.u64 > now.u64 + ss->rc_max_delay) {
+            entry->send_ts.u64 = now.u64 + ss->rc_max_delay;
+            ss->rc_start = entry->send_ts;
+            ss->rc_total = 0;
+        }
+    }
 
     /* Reset counter to avoid overflow in calculating timestamp */
     if (ss->rc_total > 0xFF000000) {
@@ -1697,8 +1720,27 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
 
     /* Initialize send rate states */
     pj_get_timestamp_freq(&stream->ts_freq);
-    if (info->rc_cfg.bandwidth == 0)
-        info->rc_cfg.bandwidth = vfd_enc->max_bps;
+
+    /* Remember the SDP-negotiated TX ceiling (0 = no limit) so that a later
+     * modify_codec_param() cannot raise the outgoing bitrate above it.
+     */
+    stream->tx_max_bps = info->rem_max_bps;
+
+    /* Auto-derive the pacing budget from the codec max bitrate when the app
+     * did not pin rc_cfg.bandwidth. A margin is added for RTP/UDP/IP overhead
+     * and encoder burstiness so the pacer does not fall behind a compliant
+     * encoder; this is pacing headroom only and does not raise the actual
+     * media bitrate (which stays bounded by the codec and the SDP ceiling).
+     */
+    stream->rc_auto_bw = (info->rc_cfg.bandwidth == 0);
+    if (info->rc_cfg.bandwidth == 0) {
+        pj_uint64_t bw = (pj_uint64_t)vfd_enc->max_bps +
+                         (pj_uint64_t)vfd_enc->max_bps *
+                         PJMEDIA_VID_STREAM_RC_OVERHEAD_PCT / 100;
+        /* Saturate to unsigned before storing. */
+        info->rc_cfg.bandwidth = (bw > 0xFFFFFFFFUL)? 0xFFFFFFFFU
+                                                    : (unsigned)bw;
+    }
 
     /* For simple blocking, need to have bandwidth large enough, otherwise
      * we can slow down the transmission too much
@@ -1708,6 +1750,12 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
     {
         info->rc_cfg.bandwidth = vfd_enc->avg_bps * 3;
     }
+
+    /* Guard against a zero budget (e.g. codec reported a zero max bitrate),
+     * which would divide by zero in the send rate control pacer.
+     */
+    if (info->rc_cfg.bandwidth == 0)
+        info->rc_cfg.bandwidth = PJMEDIA_VID_STREAM_RC_MIN_BANDWIDTH;
 
     /* Override the initial framerate in the decoding direction. This initial
      * value will be used by the renderer to configure its clock, and setting
@@ -1980,6 +2028,8 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
         ss->buf_size = c_strm->enc->buf_size;
         ss->ts_freq = stream->ts_freq;
         ss->rc_bandwidth = stream->info.rc_cfg.bandwidth;
+        ss->rc_max_delay = (pj_uint64_t)PJMEDIA_VID_STREAM_RC_MAX_DELAY_MSEC *
+                           stream->ts_freq.u64 / 1000;
         ss->name = c_strm->enc->port.info.name.ptr;
 
         status = attach_send_manager(ss, send_mgr);
@@ -2196,9 +2246,70 @@ PJ_DEF(pj_status_t)
 pjmedia_vid_stream_modify_codec_param(pjmedia_vid_stream *stream,
                                       const pjmedia_vid_codec_param *param)
 {
+    pjmedia_vid_codec_param mod_param;
+    pjmedia_video_format_detail *vfd;
+    pj_status_t status;
+
     PJ_ASSERT_RETURN(stream && param, PJ_EINVAL);
 
-    return pjmedia_vid_codec_modify(stream->codec, param);
+    mod_param = *param;
+    vfd = pjmedia_format_get_video_format_detail(&mod_param.enc_fmt, PJ_FALSE);
+
+    /* Do not allow the outgoing bitrate to exceed the bandwidth negotiated
+     * with the remote in SDP (b=TIAS/AS). Sending above what the peer agreed
+     * to receive is a protocol violation; the correct way to use more is to
+     * renegotiate (re-INVITE) with a higher "b=" line.
+     */
+    if (vfd && stream->tx_max_bps) {
+        /* max_bps == 0 means "unlimited" to some encoders and would bypass the
+         * SDP ceiling, so clamp both zero and over-limit values. */
+        if (vfd->max_bps == 0 || vfd->max_bps > stream->tx_max_bps) {
+            PJ_LOG(3,(THIS_FILE, "Requested TX max bitrate %u bps not within "
+                      "SDP-negotiated limit %u bps, clamping",
+                      vfd->max_bps, stream->tx_max_bps));
+            vfd->max_bps = stream->tx_max_bps;
+        }
+        if (vfd->avg_bps > stream->tx_max_bps)
+            vfd->avg_bps = stream->tx_max_bps;
+    }
+
+    status = pjmedia_vid_codec_modify(stream->codec, &mod_param);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* Recompute the send rate-control budget so the pacer tracks the new
+     * bitrate. Only when the pacer is in use and the budget was auto-derived
+     * (the app did not pin rc_cfg.bandwidth); an app-pinned budget is left
+     * untouched. Re-anchor the pacing baseline to avoid a scheduling jump.
+     */
+    if (vfd && stream->rc_auto_bw && stream->send_stream &&
+        stream->info.rc_cfg.method == PJMEDIA_VID_STREAM_RC_SEND_THREAD)
+    {
+        send_stream *ss = stream->send_stream;
+        pj_uint64_t bw64 = (pj_uint64_t)vfd->max_bps +
+                           (pj_uint64_t)vfd->max_bps *
+                           PJMEDIA_VID_STREAM_RC_OVERHEAD_PCT / 100;
+        unsigned bw = (bw64 > 0xFFFFFFFFUL)? 0xFFFFFFFFU : (unsigned)bw64;
+
+        if (bw < PJMEDIA_VID_STREAM_RC_MIN_BANDWIDTH)
+            bw = PJMEDIA_VID_STREAM_RC_MIN_BANDWIDTH;
+
+        pj_grp_lock_acquire(ss->grp_lock);
+        /* Re-anchor the pacing timeline to the current schedule high-water
+         * mark (computed with the old bandwidth) before applying the new
+         * bitrate, so packets already queued with a later send time are not
+         * reordered by the send worker.
+         */
+        if (ss->rc_start.u64 != 0) {
+            ss->rc_start.u64 += ss->rc_total * ss->ts_freq.u64 * 8 /
+                                ss->rc_bandwidth;
+        }
+        ss->rc_bandwidth = bw;
+        ss->rc_total = 0;
+        pj_grp_lock_release(ss->grp_lock);
+    }
+
+    return status;
 }
 
 

--- a/pjmedia/src/pjmedia/vid_stream_info.c
+++ b/pjmedia/src/pjmedia/vid_stream_info.c
@@ -141,17 +141,36 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
     if (si->codec_param && (si->dir & PJMEDIA_DIR_ENCODING) &&
         rem_m->bandw_count)
     {
-        unsigned i, bandw = 0;
+        unsigned i, bandw = 0, bandw_as = 0;
 
         for (i = 0; i < rem_m->bandw_count; ++i) {
             const pj_str_t STR_BANDW_MODIFIER_TIAS = { "TIAS", 4 };
+            const pj_str_t STR_BANDW_MODIFIER_AS = { "AS", 2 };
             if (!pj_stricmp(&rem_m->bandw[i]->modifier,
                 &STR_BANDW_MODIFIER_TIAS))
             {
                 bandw = rem_m->bandw[i]->value;
                 break;
+            } else if (!pj_stricmp(&rem_m->bandw[i]->modifier,
+                &STR_BANDW_MODIFIER_AS))
+            {
+                /* "AS" (RFC 4566, kbps) is the total RTP session bandwidth,
+                 * including RTP/UDP/IP overhead and ~5% RTCP; "TIAS" (RFC 3890,
+                 * bps) is the payload rate and is preferred. Derive a
+                 * conservative payload ceiling from AS - the inverse of the
+                 * conversion in pjsua_media.c: drop the ~5% RTCP and ~16 kbps
+                 * overhead. Kept as a fallback when no TIAS is present. Use
+                 * 64-bit to avoid overflow on large/garbage values.
+                 */
+                pj_uint64_t as = (pj_uint64_t)rem_m->bandw[i]->value * 1000;
+                as = as * 100 / 105;
+                as = (as > 16000)? (as - 16000) : 0;
+                bandw_as = (as > 0xFFFFFFFFUL)? 0xFFFFFFFFU : (unsigned)as;
             }
         }
+
+        if (!bandw)
+            bandw = bandw_as;
 
         if (bandw) {
             pjmedia_video_format_detail *enc_vfd;
@@ -161,6 +180,11 @@ static pj_status_t get_video_codec_info_param(pjmedia_vid_stream_info *si,
                 enc_vfd->avg_bps = bandw * 3 / 4;
             if (!enc_vfd->max_bps || enc_vfd->max_bps > bandw)
                 enc_vfd->max_bps = bandw;
+
+            /* Remember the negotiated ceiling so a later
+             * modify_codec_param() cannot exceed it.
+             */
+            si->rem_max_bps = bandw;
         }
     }
 


### PR DESCRIPTION
The video send rate control in `PJMEDIA_VID_STREAM_RC_SEND_THREAD` mode (the default) derives its bandwidth budget once at stream creation (codec `max_bps`) and never updates it, while `pjmedia_vid_stream_modify_codec_param()` only reconfigures the codec. When the codec bitrate is raised mid-call, the encoder outpaces the frozen budget and the cumulative packet schedule in `send_rtp()` (`send_ts = rc_start + rc_total*8/rc_bandwidth`) drifts ahead of real time without bound — frames leave the sender progressively late (easily several seconds), so the receiver cannot detect or correct it. Lowering the bitrate again drains the backlog.

Reported by **Giorgio Alfarano**, who hit it after raising outgoing H.264 bitrate on the fly (initial 300k/450k &rarr; 500k/768k) and also proposed the initial fix.

### Changes

- **Bound the pacing debt** to `PJMEDIA_VID_STREAM_RC_MAX_DELAY_MSEC` (default 1000) and re-anchor the pacing baseline to real time when the cap is hit, so sender-side latency stays bounded regardless of budget accuracy and self-drains once the encoder is back within budget. This is the primary safety net.
- **Overhead margin** on the auto-derived budget only, via `PJMEDIA_VID_STREAM_RC_OVERHEAD_PCT` (default 25%). An app-pinned `rc_cfg.bandwidth` is used as-is. The margin is pacing headroom for RTP/UDP/IP overhead and encoder burstiness — not a media-bitrate increase.
- **Recompute and re-anchor** the RC budget on codec modify.
- **Enforce the SDP-negotiated ceiling:** `modify_codec_param()` is clamped to the remote's `b=TIAS` (or `b=AS`) so the stream never transmits above what the peer agreed to receive. To use more, renegotiate with a higher `b=` line. Also now honors `b=AS` (kbps) in addition to `b=TIAS` (bps) when reading the remote ceiling.
- **Divide-by-zero floor** at `PJMEDIA_VID_STREAM_RC_MIN_BANDWIDTH` for codecs that report a zero max bitrate.

### Notes

- This changes the default auto pacing budget from `max_bps` to `max_bps + 25%` (looser pacing, and it removes the pre-existing slow drift caused by header overhead not being counted).
- Scope is `SEND_THREAD` (default). `SIMPLE_BLOCKING` is left unchanged: it back-pressures the encoder thread, so it self-limits and does not accumulate unbounded latency.
- Locking: all RC-field updates (create/modify/`send_rtp`) are done under the send-stream group lock; the re-anchor keeps `send_ts` monotonic (no RTP reordering).
- Compile-tested; runtime-validated by the reporter against the repro.

Co-Authored-By Claude Code
