### PR TITLE
pjmedia: fix 64-bit overflow in RTCP interarrival jitter on long uptime

### DIFF
--- a/pjmedia/src/pjmedia/rtcp.c
+++ b/pjmedia/src/pjmedia/rtcp.c
@@ -408,9 +408,19 @@ PJ_DEF(void) pjmedia_rtcp_rx_rtp2(pjmedia_rtcp_session *sess,
      * (see RTP FAQ).
      */
     if (seq_st.diff == 1 && rtp_ts != sess->rtp_last_ts) {
-        /* Get arrival time and convert timestamp to samples */
+        /* Get arrival time and convert timestamp to samples.
+         *
+         * ts.u64 (raw high-res timestamp, e.g. nanoseconds since boot) grows
+         * with uptime, so "ts.u64 * clock_rate" can overflow 64-bit on
+         * long-running endpoints (e.g. seldom-rebooted mobiles), corrupting
+         * the arrival time and producing spurious huge jitter. Split the
+         * whole-second and fractional parts to keep the products within
+         * 64-bit; the result is identical when it does not overflow.
+         */
         pj_get_timestamp(&ts);
-        ts.u64 = ts.u64 * sess->clock_rate / sess->ts_freq.u64;
+        ts.u64 = (ts.u64 / sess->ts_freq.u64) * sess->clock_rate +
+                 (ts.u64 % sess->ts_freq.u64) * sess->clock_rate /
+                 sess->ts_freq.u64;
         arrival = ts.u32.lo;
 
         transit = arrival - rtp_ts;


### PR DESCRIPTION
The RX interarrival-jitter calculation in `pjmedia_rtcp_rx_rtp()` converts the packet arrival time to RTP clock units as:

```c
ts.u64 = ts.u64 * sess->clock_rate / sess->ts_freq.u64;
arrival = ts.u32.lo;
```

`ts.u64` is the raw high-resolution timestamp (nanoseconds since boot on POSIX, `ts_freq = 1e9`) and grows unbounded with uptime, so `ts.u64 * clock_rate` overflows 64-bit once the endpoint has been up long enough:

| Media clock | overflow at uptime |
|---|---|
| 90 kHz video | ~2.4 days |
| 16 kHz audio | ~13 days |
| 8 kHz audio | ~27 days |

Past that point, each time the product wraps 2^64 the derived `arrival` jumps, `transit` jumps, and the RFC 3550 jitter EWMA emits a spurious spike. That value is written into the outgoing RTCP RR (`sess->jitter >> 4`), so a **long-uptime peer reports absurd interarrival jitter for the stream it receives** — the other side then sees huge "Tx jitter" (hundreds of seconds) in `pjsua_call_dump`, while its own locally-measured Rx jitter looks normal. Seldom-rebooted mobiles are especially exposed because `CLOCK_BOOTTIME` keeps advancing across suspend, so uptime accrues in calendar days.

Reported by Yogesh Deshpande, who observed ~490-520 second average Tx jitter values that skewed QoS stats.

### Fix

Split the whole-second and fractional parts of the conversion so the intermediate products stay within 64-bit:

```c
ts.u64 = (ts.u64 / sess->ts_freq.u64) * sess->clock_rate +
         (ts.u64 % sess->ts_freq.u64) * sess->clock_rate / sess->ts_freq.u64;
```

The result is arithmetically identical to the old expression whenever the latter does not overflow, and only the low 32 bits (`arrival mod 2^32`) are used downstream.

### Notes

- Sole affected site: sibling scalings were checked - `rtcp_xr.c` scales a *delta* (subtracts `rx_lrr_time` first), `clock_thread.c` already guards operand order for large timestamps, and `conference.c` scales a bounded media timestamp, not raw uptime.
- Platform-independent (shared `rtcp.c`), so the fix covers POSIX and Apple timestamp sources.
- The high Tx *loss* sometimes reported alongside is a separate, sequence-based metric and is unaffected by this.

Co-Authored-By Claude Code
