### PR TITLE
pjsua: report media stream index in incoming text and DTMF callbacks

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -747,8 +747,9 @@ static void call_on_dtmf_callback2(pjsua_call_id call_id,
                          info->duration);
         break;
     };    
-    PJ_LOG(3,(THIS_FILE, "Incoming DTMF on call %d: %c%s, using %s method", 
-           call_id, info->digit, duration, method));
+    PJ_LOG(3,(THIS_FILE, "Incoming DTMF on call %d: %c%s, using %s method, "
+           "stream %d", call_id, info->digit, duration, method,
+           info->med_idx));
 }
 
 /* Incoming text stream callback. */

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -757,10 +757,10 @@ static void call_on_rx_text(pjsua_call_id call_id,
                             const pjsua_txt_stream_data *data)
 {
     if (data->text.slen == 0) {
-        PJ_LOG(4, (THIS_FILE, "Received empty T140 block on stream %u "
+        PJ_LOG(4, (THIS_FILE, "Received empty T140 block on stream %d "
                               "with seq %d", data->med_idx, data->seq));
     } else {
-        PJ_LOG(3, (THIS_FILE, "Incoming text on call %d stream %u, "
+        PJ_LOG(3, (THIS_FILE, "Incoming text on call %d stream %d, "
                               "seq %d: %.*s (%d bytes)",
                               call_id, data->med_idx, data->seq,
                               (int)data->text.slen, data->text.ptr,

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -756,11 +756,12 @@ static void call_on_rx_text(pjsua_call_id call_id,
                             const pjsua_txt_stream_data *data)
 {
     if (data->text.slen == 0) {
-        PJ_LOG(4, (THIS_FILE, "Received empty T140 block with seq %d",
-                              data->seq));
+        PJ_LOG(4, (THIS_FILE, "Received empty T140 block on stream %u "
+                              "with seq %d", data->med_idx, data->seq));
     } else {
-        PJ_LOG(3, (THIS_FILE, "Incoming text on call %d, seq %d: %.*s "
-                              "(%d bytes)", call_id, data->seq,
+        PJ_LOG(3, (THIS_FILE, "Incoming text on call %d stream %u, "
+                              "seq %d: %.*s (%d bytes)",
+                              call_id, data->med_idx, data->seq,
                               (int)data->text.slen, data->text.ptr,
                               (int)data->text.slen));
     }

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1051,6 +1051,12 @@ typedef struct pjsua_dtmf_info {
      */
     unsigned duration;
 
+    /**
+     * The media index of the audio stream that received the DTMF, or -1
+     * if the DTMF was not received via a media stream (e.g. SIP INFO).
+     */
+    int med_idx;
+
 } pjsua_dtmf_info;
 
 
@@ -1100,6 +1106,12 @@ typedef struct pjsua_dtmf_event {
      * an event with PJMEDIA_STREAM_DTMF_IS_END for every event.
      */
     unsigned flags;
+
+    /**
+     * The media index of the audio stream that received the DTMF, or -1
+     * if the DTMF was not received via a media stream (e.g. SIP INFO).
+     */
+    int med_idx;
 } pjsua_dtmf_event;
 
 
@@ -1563,7 +1575,7 @@ typedef struct pjsua_callback
     void (*on_dtmf_digit)(pjsua_call_id call_id, int digit);
 
     /**
-     * Notify application upon incoming DTMF digits using the method specified 
+     * Notify application upon incoming DTMF digits using the method specified
      * in \a pjsua_dtmf_method. This callback will not be called if app
      * implements \a on_dtmf_event().
      *
@@ -1573,7 +1585,7 @@ typedef struct pjsua_callback
     void (*on_dtmf_digit2)(pjsua_call_id call_id, const pjsua_dtmf_info *info);
 
     /**
-     * Notify application upon incoming DTMF digits using the method specified 
+     * Notify application upon incoming DTMF digits using the method specified
      * in \a pjsua_dtmf_method. Includes additional information about events
      * received via RTP.
      *

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1123,6 +1123,11 @@ typedef struct pjsua_txt_stream_data {
      */
     pj_str_t            text;
 
+    /**
+     * The index of the text media stream that received the text.
+     */
+    unsigned            med_idx;
+
 } pjsua_txt_stream_data;
 
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -1138,7 +1138,7 @@ typedef struct pjsua_txt_stream_data {
     /**
      * The index of the text media stream that received the text.
      */
-    unsigned            med_idx;
+    int                 med_idx;
 
 } pjsua_txt_stream_data;
 

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -123,24 +123,15 @@ struct pjsua_call_media
  */
 #define PJSUA_MAX_CALL_MEDIA            PJMEDIA_MAX_SDP_MEDIA
 
-/**
- * Immutable (call, media) slot identity, filled once in
- * pjsua_call_subsys_init() and constant afterwards, so media threads
- * can read it without locking, e.g. as stream callback user data.
- *
- * Do not move this into pjsua_call or pjsua_call_media: those are
- * zeroed by reset_call() and bulk-copied during media reprovisioning
- * while stream callbacks may still be running (stream destroy does
- * not wait for in-flight rx callbacks on all transports).
+/* Pack/extract call id (lower 16 bits) and media index (upper 16 bits)
+ * in media stream callback user data.
  */
-typedef struct pjsua_call_med_ctx
-{
-    pjsua_call_id        call_id;   /**< Call index.                        */
-    unsigned             med_idx;   /**< Media index in parent call.        */
-} pjsua_call_med_ctx;
-
-/** One row of the per-media context table: all contexts of one call. */
-typedef pjsua_call_med_ctx pjsua_call_med_ctx_row[PJSUA_MAX_CALL_MEDIA];
+#define PJSUA_MED_UDATA_PACK(call_id, med_idx) \
+            ((void*)(((pj_size_t)(med_idx) << 16) | (pj_size_t)(call_id)))
+#define PJSUA_MED_UDATA_CALL_ID(udata) \
+            ((pjsua_call_id)((pj_size_t)(udata) & 0xFFFF))
+#define PJSUA_MED_UDATA_MED_IDX(udata) \
+            ((unsigned)(((pj_size_t)(udata) >> 16) & 0xFFFF))
 
  /**
   * Maximum number of streams from an avi player.
@@ -646,8 +637,6 @@ struct pjsua_data
     pjsua_config         ua_cfg;                /**< UA config.         */
     unsigned             call_cnt;              /**< Call counter.      */
     pjsua_call          *calls;                 /**< Calls array.       */
-    pjsua_call_med_ctx_row *med_ctx;            /**< Per-media callback
-                                                     context, [call][med]*/
     pjsua_call_id        next_call_id;          /**< Next call id to use*/
 
     /* Buddy; */

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -129,15 +129,23 @@ struct pjsua_call_media
  * values so that an invalid -1 escaping the assertion in release
  * builds still decodes as -1 rather than 65535.
  */
-#define PJSUA_MED_UDATA_PACK(call_id, med_idx) \
-            (pj_assert((call_id) >= 0 && (call_id) <= 0x7FFF && \
-                       (med_idx) >= 0 && (med_idx) <= 0x7FFF), \
-             (void*)(((pj_size_t)(pj_uint16_t)(med_idx) << 16) | \
-                     (pj_size_t)(pj_uint16_t)(call_id)))
-#define PJSUA_MED_UDATA_CALL_ID(udata) \
-            ((pjsua_call_id)(pj_int16_t)((pj_size_t)(udata) & 0xFFFF))
-#define PJSUA_MED_UDATA_MED_IDX(udata) \
-            ((int)(pj_int16_t)(((pj_size_t)(udata) >> 16) & 0xFFFF))
+PJ_INLINE(void*) pjsua_med_udata_pack(pjsua_call_id call_id, int med_idx)
+{
+    pj_assert(call_id >= 0 && call_id <= 0x7FFF &&
+              med_idx >= 0 && med_idx <= 0x7FFF);
+    return (void*)(((pj_size_t)(pj_uint16_t)med_idx << 16) |
+                   (pj_size_t)(pj_uint16_t)call_id);
+}
+
+PJ_INLINE(pjsua_call_id) pjsua_med_udata_call_id(const void *udata)
+{
+    return (pjsua_call_id)(pj_int16_t)((pj_size_t)udata & 0xFFFF);
+}
+
+PJ_INLINE(int) pjsua_med_udata_med_idx(const void *udata)
+{
+    return (int)(pj_int16_t)(((pj_size_t)udata >> 16) & 0xFFFF);
+}
 
  /**
   * Maximum number of streams from an avi player.

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -123,6 +123,25 @@ struct pjsua_call_media
  */
 #define PJSUA_MAX_CALL_MEDIA            PJMEDIA_MAX_SDP_MEDIA
 
+/**
+ * Immutable (call, media) slot identity, filled once in
+ * pjsua_call_subsys_init() and constant afterwards, so media threads
+ * can read it without locking, e.g. as stream callback user data.
+ *
+ * Do not move this into pjsua_call or pjsua_call_media: those are
+ * zeroed by reset_call() and bulk-copied during media reprovisioning
+ * while stream callbacks may still be running (stream destroy does
+ * not wait for in-flight rx callbacks on all transports).
+ */
+typedef struct pjsua_call_med_ctx
+{
+    pjsua_call_id        call_id;   /**< Call index.                        */
+    unsigned             med_idx;   /**< Media index in parent call.        */
+} pjsua_call_med_ctx;
+
+/** One row of the per-media context table: all contexts of one call. */
+typedef pjsua_call_med_ctx pjsua_call_med_ctx_row[PJSUA_MAX_CALL_MEDIA];
+
  /**
   * Maximum number of streams from an avi player.
   */
@@ -627,6 +646,8 @@ struct pjsua_data
     pjsua_config         ua_cfg;                /**< UA config.         */
     unsigned             call_cnt;              /**< Call counter.      */
     pjsua_call          *calls;                 /**< Calls array.       */
+    pjsua_call_med_ctx_row *med_ctx;            /**< Per-media callback
+                                                     context, [call][med]*/
     pjsua_call_id        next_call_id;          /**< Next call id to use*/
 
     /* Buddy; */

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -131,7 +131,7 @@ struct pjsua_call_media
 #define PJSUA_MED_UDATA_CALL_ID(udata) \
             ((pjsua_call_id)((pj_size_t)(udata) & 0xFFFF))
 #define PJSUA_MED_UDATA_MED_IDX(udata) \
-            ((unsigned)(((pj_size_t)(udata) >> 16) & 0xFFFF))
+            ((int)(((pj_size_t)(udata) >> 16) & 0xFFFF))
 
  /**
   * Maximum number of streams from an avi player.

--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -124,14 +124,20 @@ struct pjsua_call_media
 #define PJSUA_MAX_CALL_MEDIA            PJMEDIA_MAX_SDP_MEDIA
 
 /* Pack/extract call id (lower 16 bits) and media index (upper 16 bits)
- * in media stream callback user data.
+ * in media stream callback user data. Valid input is [0, 0x7FFF] and
+ * asserted in debug builds. The fields are stored as signed 16-bit
+ * values so that an invalid -1 escaping the assertion in release
+ * builds still decodes as -1 rather than 65535.
  */
 #define PJSUA_MED_UDATA_PACK(call_id, med_idx) \
-            ((void*)(((pj_size_t)(med_idx) << 16) | (pj_size_t)(call_id)))
+            (pj_assert((call_id) >= 0 && (call_id) <= 0x7FFF && \
+                       (med_idx) >= 0 && (med_idx) <= 0x7FFF), \
+             (void*)(((pj_size_t)(pj_uint16_t)(med_idx) << 16) | \
+                     (pj_size_t)(pj_uint16_t)(call_id)))
 #define PJSUA_MED_UDATA_CALL_ID(udata) \
-            ((pjsua_call_id)((pj_size_t)(udata) & 0xFFFF))
+            ((pjsua_call_id)(pj_int16_t)((pj_size_t)(udata) & 0xFFFF))
 #define PJSUA_MED_UDATA_MED_IDX(udata) \
-            ((int)(((pj_size_t)(udata) >> 16) & 0xFFFF))
+            ((int)(pj_int16_t)(((pj_size_t)(udata) >> 16) & 0xFFFF))
 
  /**
   * Maximum number of streams from an avi player.

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -936,6 +936,12 @@ struct OnDtmfDigitParam
      * PJSUA_UNKNOWN_DTMF_DURATION.
      */
     unsigned            duration;
+
+    /**
+     * The media index of the audio stream that received the DTMF, or -1
+     * if the DTMF was not received via a media stream (e.g. SIP INFO).
+     */
+    int                 medIdx;
 };
 
 /**
@@ -986,6 +992,12 @@ struct OnDtmfEventParam
      * an event with PJMEDIA_STREAM_DTMF_IS_END for every event.
      */
     unsigned            flags;
+
+    /**
+     * The media index of the audio stream that received the DTMF, or -1
+     * if the DTMF was not received via a media stream (e.g. SIP INFO).
+     */
+    int                 medIdx;
 };
 
 /**

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -1025,7 +1025,7 @@ struct OnCallRxTextParam
     /**
      * The index of the text media stream that received the text.
      */
-    unsigned            medIdx;
+    int                 medIdx;
 
 public:
     /**

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -1010,6 +1010,11 @@ struct OnCallRxTextParam
      */
     string              text;
 
+    /**
+     * The index of the text media stream that received the text.
+     */
+    unsigned            medIdx;
+
 public:
     /**
      * Convert from pjsip

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -583,8 +583,8 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
 static void dtmf_callback(pjmedia_stream *strm, void *user_data,
                           int digit)
 {
-    const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const int med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
+    const pjsua_call_id call_id = pjsua_med_udata_call_id(user_data);
+    const int med_idx = pjsua_med_udata_med_idx(user_data);
 
     PJ_UNUSED_ARG(strm);
 
@@ -618,8 +618,8 @@ static void dtmf_callback(pjmedia_stream *strm, void *user_data,
 static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
                                 const pjmedia_stream_dtmf_event *event)
 {
-    const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const int med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
+    const pjsua_call_id call_id = pjsua_med_udata_call_id(user_data);
+    const int med_idx = pjsua_med_udata_med_idx(user_data);
     pjsua_dtmf_event evt;
 
     PJ_UNUSED_ARG(strm);
@@ -755,7 +755,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             pjmedia_stream_set_dtmf_event_callback(
                                  call_med->strm.a.stream,
                                  &dtmf_event_callback,
-                                 PJSUA_MED_UDATA_PACK(call->index, strm_idx));
+                                 pjsua_med_udata_pack(call->index, strm_idx));
         } else if (!call->hanging_up &&
                    (pjsua_var.ua_cfg.cb.on_dtmf_digit ||
                     pjsua_var.ua_cfg.cb.on_dtmf_digit2))
@@ -763,7 +763,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             pjmedia_stream_set_dtmf_callback(
                                  call_med->strm.a.stream,
                                  &dtmf_callback,
-                                 PJSUA_MED_UDATA_PACK(call->index, strm_idx));
+                                 pjsua_med_udata_pack(call->index, strm_idx));
         }
 
         /* Get the port interface of the first stream in the session.

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -584,7 +584,7 @@ static void dtmf_callback(pjmedia_stream *strm, void *user_data,
                           int digit)
 {
     const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const int med_idx = (int)PJSUA_MED_UDATA_MED_IDX(user_data);
+    const int med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
 
     PJ_UNUSED_ARG(strm);
 
@@ -619,7 +619,7 @@ static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
                                 const pjmedia_stream_dtmf_event *event)
 {
     const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const int med_idx = (int)PJSUA_MED_UDATA_MED_IDX(user_data);
+    const int med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
     pjsua_dtmf_event evt;
 
     PJ_UNUSED_ARG(strm);

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -583,12 +583,11 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
 static void dtmf_callback(pjmedia_stream *strm, void *user_data,
                           int digit)
 {
-    pjsua_call_id call_id;
+    const pjsua_call_med_ctx *ctx = (const pjsua_call_med_ctx *)user_data;
 
     PJ_UNUSED_ARG(strm);
 
-    call_id = (pjsua_call_id)(pj_ssize_t)user_data;
-    if (pjsua_var.calls[call_id].hanging_up)
+    if (pjsua_var.calls[ctx->call_id].hanging_up)
         return;
 
     pj_log_push_indent();
@@ -599,13 +598,14 @@ static void dtmf_callback(pjmedia_stream *strm, void *user_data,
         info.method = PJSUA_DTMF_METHOD_RFC2833;
         info.digit = digit;
         info.duration = PJSUA_UNKNOWN_DTMF_DURATION;
-        (*pjsua_var.ua_cfg.cb.on_dtmf_digit2)(call_id, &info);
+        info.med_idx = (int)ctx->med_idx;
+        (*pjsua_var.ua_cfg.cb.on_dtmf_digit2)(ctx->call_id, &info);
     } else if (pjsua_var.ua_cfg.cb.on_dtmf_digit) {
         /* For discussions about call mutex protection related to this
          * callback, please see ticket #460:
          *      https://github.com/pjsip/pjproject/issues/460#comment:4
-         */    
-        (*pjsua_var.ua_cfg.cb.on_dtmf_digit)(call_id, digit);
+         */
+        (*pjsua_var.ua_cfg.cb.on_dtmf_digit)(ctx->call_id, digit);
     }
 
     pj_log_pop_indent();
@@ -617,13 +617,12 @@ static void dtmf_callback(pjmedia_stream *strm, void *user_data,
 static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
                                 const pjmedia_stream_dtmf_event *event)
 {
-    pjsua_call_id call_id;
+    const pjsua_call_med_ctx *ctx = (const pjsua_call_med_ctx *)user_data;
     pjsua_dtmf_event evt;
 
     PJ_UNUSED_ARG(strm);
 
-    call_id = (pjsua_call_id)(pj_ssize_t)user_data;
-    if (pjsua_var.calls[call_id].hanging_up)
+    if (pjsua_var.calls[ctx->call_id].hanging_up)
         return;
 
     pj_log_push_indent();
@@ -634,7 +633,8 @@ static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
         evt.digit = event->digit;
         evt.duration = event->duration;
         evt.flags = event->flags;
-        (*pjsua_var.ua_cfg.cb.on_dtmf_event)(call_id, &evt);
+        evt.med_idx = (int)ctx->med_idx;
+        (*pjsua_var.ua_cfg.cb.on_dtmf_event)(ctx->call_id, &evt);
     }
 
     pj_log_pop_indent();
@@ -750,16 +750,18 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
          * callback to the session.
          */
         if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_dtmf_event) {
-            pjmedia_stream_set_dtmf_event_callback(call_med->strm.a.stream,
-                                              &dtmf_event_callback,
-                                              (void*)(pj_ssize_t)(call->index));
+            pjmedia_stream_set_dtmf_event_callback(
+                                 call_med->strm.a.stream,
+                                 &dtmf_event_callback,
+                                 &pjsua_var.med_ctx[call->index][strm_idx]);
         } else if (!call->hanging_up &&
-                   (pjsua_var.ua_cfg.cb.on_dtmf_digit || 
+                   (pjsua_var.ua_cfg.cb.on_dtmf_digit ||
                     pjsua_var.ua_cfg.cb.on_dtmf_digit2))
         {
-            pjmedia_stream_set_dtmf_callback(call_med->strm.a.stream,
-                                             &dtmf_callback,
-                                             (void*)(pj_ssize_t)(call->index));
+            pjmedia_stream_set_dtmf_callback(
+                                 call_med->strm.a.stream,
+                                 &dtmf_callback,
+                                 &pjsua_var.med_ctx[call->index][strm_idx]);
         }
 
         /* Get the port interface of the first stream in the session.

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -583,11 +583,12 @@ void pjsua_aud_stop_stream(pjsua_call_media *call_med)
 static void dtmf_callback(pjmedia_stream *strm, void *user_data,
                           int digit)
 {
-    const pjsua_call_med_ctx *ctx = (const pjsua_call_med_ctx *)user_data;
+    const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
+    const int med_idx = (int)PJSUA_MED_UDATA_MED_IDX(user_data);
 
     PJ_UNUSED_ARG(strm);
 
-    if (pjsua_var.calls[ctx->call_id].hanging_up)
+    if (pjsua_var.calls[call_id].hanging_up)
         return;
 
     pj_log_push_indent();
@@ -598,14 +599,14 @@ static void dtmf_callback(pjmedia_stream *strm, void *user_data,
         info.method = PJSUA_DTMF_METHOD_RFC2833;
         info.digit = digit;
         info.duration = PJSUA_UNKNOWN_DTMF_DURATION;
-        info.med_idx = (int)ctx->med_idx;
-        (*pjsua_var.ua_cfg.cb.on_dtmf_digit2)(ctx->call_id, &info);
+        info.med_idx = med_idx;
+        (*pjsua_var.ua_cfg.cb.on_dtmf_digit2)(call_id, &info);
     } else if (pjsua_var.ua_cfg.cb.on_dtmf_digit) {
         /* For discussions about call mutex protection related to this
          * callback, please see ticket #460:
          *      https://github.com/pjsip/pjproject/issues/460#comment:4
          */
-        (*pjsua_var.ua_cfg.cb.on_dtmf_digit)(ctx->call_id, digit);
+        (*pjsua_var.ua_cfg.cb.on_dtmf_digit)(call_id, digit);
     }
 
     pj_log_pop_indent();
@@ -617,12 +618,13 @@ static void dtmf_callback(pjmedia_stream *strm, void *user_data,
 static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
                                 const pjmedia_stream_dtmf_event *event)
 {
-    const pjsua_call_med_ctx *ctx = (const pjsua_call_med_ctx *)user_data;
+    const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
+    const int med_idx = (int)PJSUA_MED_UDATA_MED_IDX(user_data);
     pjsua_dtmf_event evt;
 
     PJ_UNUSED_ARG(strm);
 
-    if (pjsua_var.calls[ctx->call_id].hanging_up)
+    if (pjsua_var.calls[call_id].hanging_up)
         return;
 
     pj_log_push_indent();
@@ -633,8 +635,8 @@ static void dtmf_event_callback(pjmedia_stream *strm, void *user_data,
         evt.digit = event->digit;
         evt.duration = event->duration;
         evt.flags = event->flags;
-        evt.med_idx = (int)ctx->med_idx;
-        (*pjsua_var.ua_cfg.cb.on_dtmf_event)(ctx->call_id, &evt);
+        evt.med_idx = med_idx;
+        (*pjsua_var.ua_cfg.cb.on_dtmf_event)(call_id, &evt);
     }
 
     pj_log_pop_indent();
@@ -753,7 +755,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             pjmedia_stream_set_dtmf_event_callback(
                                  call_med->strm.a.stream,
                                  &dtmf_event_callback,
-                                 &pjsua_var.med_ctx[call->index][strm_idx]);
+                                 PJSUA_MED_UDATA_PACK(call->index, strm_idx));
         } else if (!call->hanging_up &&
                    (pjsua_var.ua_cfg.cb.on_dtmf_digit ||
                     pjsua_var.ua_cfg.cb.on_dtmf_digit2))
@@ -761,7 +763,7 @@ pj_status_t pjsua_aud_channel_update(pjsua_call_media *call_med,
             pjmedia_stream_set_dtmf_callback(
                                  call_med->strm.a.stream,
                                  &dtmf_callback,
-                                 &pjsua_var.med_ctx[call->index][strm_idx]);
+                                 PJSUA_MED_UDATA_PACK(call->index, strm_idx));
         }
 
         /* Get the port interface of the first stream in the session.

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -234,6 +234,22 @@ pj_status_t pjsua_call_subsys_init(const pjsua_config *cfg)
     for (i = 0U; i < pjsua_var.ua_cfg.max_calls; ++i)
         reset_call(i);
 
+    /* Init per-media callback contexts, immutable from here on. */
+    pjsua_var.med_ctx = (pjsua_call_med_ctx_row *)
+                        pj_pool_zalloc(pjsua_var.pool,
+                                       sizeof(*pjsua_var.med_ctx) *
+                                       pjsua_var.ua_cfg.max_calls);
+    if (!pjsua_var.med_ctx)
+        return PJ_ENOMEM;
+
+    for (i = 0U; i < pjsua_var.ua_cfg.max_calls; ++i) {
+        unsigned j;
+        for (j = 0U; j < PJSUA_MAX_CALL_MEDIA; ++j) {
+            pjsua_var.med_ctx[i][j].call_id = i;
+            pjsua_var.med_ctx[i][j].med_idx = j;
+        }
+    }
+
     /* Check the route URI's and force loose route if required */
     for (i=0; i<pjsua_var.ua_cfg.outbound_proxy_cnt; ++i) {
         status = normalize_route_uri(pjsua_var.pool,

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -6922,6 +6922,7 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
 
                         if (is_handled) {
                             info.method = PJSUA_DTMF_METHOD_SIP_INFO;
+                            info.med_idx = -1;
                             if (pjsua_var.ua_cfg.cb.on_dtmf_event) {
                                 pjsua_dtmf_event evt;
                                 pj_timestamp begin_of_time, timestamp;
@@ -6939,6 +6940,7 @@ static void pjsua_call_on_tsx_state_changed(pjsip_inv_session *inv,
                                  * duration of the digit.
                                  */
                                 evt.flags = PJMEDIA_STREAM_DTMF_IS_END;
+                                evt.med_idx = -1;
                                 (*pjsua_var.ua_cfg.cb.on_dtmf_event)(call->index,
                                                                      &evt);
                             } else {

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -234,22 +234,6 @@ pj_status_t pjsua_call_subsys_init(const pjsua_config *cfg)
     for (i = 0U; i < pjsua_var.ua_cfg.max_calls; ++i)
         reset_call(i);
 
-    /* Init per-media callback contexts, immutable from here on. */
-    pjsua_var.med_ctx = (pjsua_call_med_ctx_row *)
-                        pj_pool_zalloc(pjsua_var.pool,
-                                       sizeof(*pjsua_var.med_ctx) *
-                                       pjsua_var.ua_cfg.max_calls);
-    if (!pjsua_var.med_ctx)
-        return PJ_ENOMEM;
-
-    for (i = 0U; i < pjsua_var.ua_cfg.max_calls; ++i) {
-        unsigned j;
-        for (j = 0U; j < PJSUA_MAX_CALL_MEDIA; ++j) {
-            pjsua_var.med_ctx[i][j].call_id = i;
-            pjsua_var.med_ctx[i][j].med_idx = j;
-        }
-    }
-
     /* Check the route URI's and force loose route if required */
     for (i=0; i<pjsua_var.ua_cfg.outbound_proxy_cnt; ++i) {
         status = normalize_route_uri(pjsua_var.pool,

--- a/pjsip/src/pjsua-lib/pjsua_txt.c
+++ b/pjsip/src/pjsua-lib/pjsua_txt.c
@@ -91,12 +91,13 @@ on_return:
 static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
                        const pjmedia_txt_stream_data *data)
 {
-    const pjsua_call_med_ctx *ctx = (const pjsua_call_med_ctx *)user_data;
+    const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
+    const unsigned med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
     pjsua_txt_stream_data txt;
 
     PJ_UNUSED_ARG(strm);
 
-    if (pjsua_var.calls[ctx->call_id].hanging_up)
+    if (pjsua_var.calls[call_id].hanging_up)
         return;
 
     pj_log_push_indent();
@@ -105,8 +106,8 @@ static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
         txt.seq = data->seq;
         txt.ts = data->ts;
         txt.text = data->text;
-        txt.med_idx = ctx->med_idx;
-        (*pjsua_var.ua_cfg.cb.on_call_rx_text)(ctx->call_id, &txt);
+        txt.med_idx = med_idx;
+        (*pjsua_var.ua_cfg.cb.on_call_rx_text)(call_id, &txt);
     }
 
     pj_log_pop_indent();
@@ -250,7 +251,7 @@ pj_status_t pjsua_txt_channel_update(pjsua_call_media *call_med,
         if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_call_rx_text) {
             pjmedia_txt_stream_set_rx_callback(
                 call_med->strm.t.stream, &rx_text_cb,
-                &pjsua_var.med_ctx[call->index][strm_idx], 0);
+                PJSUA_MED_UDATA_PACK(call->index, strm_idx), 0);
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_txt.c
+++ b/pjsip/src/pjsua-lib/pjsua_txt.c
@@ -91,8 +91,8 @@ on_return:
 static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
                        const pjmedia_txt_stream_data *data)
 {
-    const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const int med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
+    const pjsua_call_id call_id = pjsua_med_udata_call_id(user_data);
+    const int med_idx = pjsua_med_udata_med_idx(user_data);
     pjsua_txt_stream_data txt;
 
     PJ_UNUSED_ARG(strm);
@@ -251,7 +251,7 @@ pj_status_t pjsua_txt_channel_update(pjsua_call_media *call_med,
         if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_call_rx_text) {
             pjmedia_txt_stream_set_rx_callback(
                 call_med->strm.t.stream, &rx_text_cb,
-                PJSUA_MED_UDATA_PACK(call->index, strm_idx), 0);
+                pjsua_med_udata_pack(call->index, strm_idx), 0);
         }
     }
 

--- a/pjsip/src/pjsua-lib/pjsua_txt.c
+++ b/pjsip/src/pjsua-lib/pjsua_txt.c
@@ -92,7 +92,7 @@ static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
                        const pjmedia_txt_stream_data *data)
 {
     const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const int med_idx = (int)PJSUA_MED_UDATA_MED_IDX(user_data);
+    const int med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
     pjsua_txt_stream_data txt;
 
     PJ_UNUSED_ARG(strm);

--- a/pjsip/src/pjsua-lib/pjsua_txt.c
+++ b/pjsip/src/pjsua-lib/pjsua_txt.c
@@ -92,7 +92,7 @@ static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
                        const pjmedia_txt_stream_data *data)
 {
     const pjsua_call_id call_id = PJSUA_MED_UDATA_CALL_ID(user_data);
-    const unsigned med_idx = PJSUA_MED_UDATA_MED_IDX(user_data);
+    const int med_idx = (int)PJSUA_MED_UDATA_MED_IDX(user_data);
     pjsua_txt_stream_data txt;
 
     PJ_UNUSED_ARG(strm);

--- a/pjsip/src/pjsua-lib/pjsua_txt.c
+++ b/pjsip/src/pjsua-lib/pjsua_txt.c
@@ -91,13 +91,12 @@ on_return:
 static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
                        const pjmedia_txt_stream_data *data)
 {
-    pjsua_call_id call_id;
+    const pjsua_call_med_ctx *ctx = (const pjsua_call_med_ctx *)user_data;
     pjsua_txt_stream_data txt;
 
     PJ_UNUSED_ARG(strm);
 
-    call_id = (pjsua_call_id)(pj_ssize_t)user_data;
-    if (pjsua_var.calls[call_id].hanging_up)
+    if (pjsua_var.calls[ctx->call_id].hanging_up)
         return;
 
     pj_log_push_indent();
@@ -106,7 +105,8 @@ static void rx_text_cb(pjmedia_txt_stream *strm, void *user_data,
         txt.seq = data->seq;
         txt.ts = data->ts;
         txt.text = data->text;
-        (*pjsua_var.ua_cfg.cb.on_call_rx_text)(call_id, &txt);
+        txt.med_idx = ctx->med_idx;
+        (*pjsua_var.ua_cfg.cb.on_call_rx_text)(ctx->call_id, &txt);
     }
 
     pj_log_pop_indent();
@@ -250,7 +250,7 @@ pj_status_t pjsua_txt_channel_update(pjsua_call_media *call_med,
         if (!call->hanging_up && pjsua_var.ua_cfg.cb.on_call_rx_text) {
             pjmedia_txt_stream_set_rx_callback(
                 call_med->strm.t.stream, &rx_text_cb,
-                (void *)(pj_ssize_t)(call->index), 0);
+                &pjsua_var.med_ctx[call->index][strm_idx], 0);
         }
     }
 

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -435,6 +435,7 @@ void OnCallRxTextParam::fromPj(const pjsua_txt_stream_data &prm)
     seq = prm.seq;
     ts = prm.ts;
     text = pj2Str(prm.text);
+    medIdx = prm.med_idx;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -867,6 +867,7 @@ void Call::sendText(const CallSendTextParam &param) PJSUA2_THROW(Error)
     pjsua_call_send_text_param pj_param;
 
     pjsua_call_send_text_param_default(&pj_param);
+    pj_param.med_idx = param.medIdx;
     pj_param.text = str2Pj(param.text);
 
     PJSUA2_CHECK_EXPR(pjsua_call_send_text(id, &pj_param));

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1692,6 +1692,7 @@ void Endpoint::on_dtmf_digit(pjsua_call_id call_id, int digit)
     char buf[10];
     pj_ansi_snprintf(buf, sizeof(buf), "%c", digit);
     job->prm.digit = string(buf);
+    /* Media index is not available here. */
     job->prm.medIdx = -1;
 
     Endpoint::instance().utilAddPendingJob(job);

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1692,7 +1692,8 @@ void Endpoint::on_dtmf_digit(pjsua_call_id call_id, int digit)
     char buf[10];
     pj_ansi_snprintf(buf, sizeof(buf), "%c", digit);
     job->prm.digit = string(buf);
-    
+    job->prm.medIdx = -1;
+
     Endpoint::instance().utilAddPendingJob(job);
 }
 
@@ -1711,7 +1712,8 @@ void Endpoint::on_dtmf_digit2(pjsua_call_id call_id,
     job->prm.digit = string(buf);
     job->prm.method = info->method;
     job->prm.duration = info->duration;
-    
+    job->prm.medIdx = info->med_idx;
+
     Endpoint::instance().utilAddPendingJob(job);
 }
 
@@ -1743,6 +1745,7 @@ struct PendingOnDtmfEventCallback : public PendingJob
             prmBasic.method = prm.method;
             prmBasic.digit = prm.digit;
             prmBasic.duration = PJSUA_UNKNOWN_DTMF_DURATION;
+            prmBasic.medIdx = prm.medIdx;
             call->onDtmfDigit(prmBasic);
         }
     }
@@ -1765,6 +1768,7 @@ void Endpoint::on_dtmf_event(pjsua_call_id call_id,
     job->prm.digit = string(buf);
     job->prm.duration = event->duration;
     job->prm.flags = event->flags;
+    job->prm.medIdx = event->med_idx;
 
     Endpoint::instance().utilAddPendingJob(job);
 }

--- a/pjsip/src/test/pjsua_call_test.c
+++ b/pjsip/src/test/pjsua_call_test.c
@@ -87,8 +87,8 @@ typedef struct msg_size_saved
 /* Tweak library settings in order to bring down payload size */
 static void minimize_msg_size(msg_size_saved *sv)
 {
-    pjmedia_endpt *endpt = pjsua_get_pjmedia_endpt();
-    pj_bool_t no = PJ_FALSE;
+    pjmedia_endpt *pjendpt = pjsua_get_pjmedia_endpt();
+    const pj_bool_t no = PJ_FALSE;
     const pj_str_t all = pj_str("*");
     const pj_str_t pcmu = pj_str("PCMU/8000");
 
@@ -97,7 +97,7 @@ static void minimize_msg_size(msg_size_saved *sv)
     sv->compact_form        = pjsip_cfg()->endpt.use_compact_form;
     sv->rtpmap_static       = pjmedia_add_rtpmap_for_static_pt;
     sv->bandw_tias          = pjmedia_add_bandwidth_tias_in_sdp;
-    pjmedia_endpt_get_flag(endpt, PJMEDIA_ENDPT_HAS_TELEPHONE_EVENT_FLAG,
+    pjmedia_endpt_get_flag(pjendpt, PJMEDIA_ENDPT_HAS_TELEPHONE_EVENT_FLAG,
                            &sv->tel_event);
     sv->codec_count = PJ_ARRAY_SIZE(sv->codecs);
     if (pjsua_enum_codecs(sv->codecs, &sv->codec_count) != PJ_SUCCESS)
@@ -108,7 +108,7 @@ static void minimize_msg_size(msg_size_saved *sv)
     pjsip_cfg()->endpt.use_compact_form     = PJ_TRUE;
     pjmedia_add_rtpmap_for_static_pt        = PJ_FALSE;
     pjmedia_add_bandwidth_tias_in_sdp       = PJ_FALSE;
-    pjmedia_endpt_set_flag(endpt, PJMEDIA_ENDPT_HAS_TELEPHONE_EVENT_FLAG, &no);
+    pjmedia_endpt_set_flag(pjendpt, PJMEDIA_ENDPT_HAS_TELEPHONE_EVENT_FLAG, &no);
     /* codec wise, we'll disable everything and allow only PCMU */
     pjsua_codec_set_priority(&all,  PJMEDIA_CODEC_PRIO_DISABLED);
     pjsua_codec_set_priority(&pcmu, PJMEDIA_CODEC_PRIO_HIGHEST);
@@ -117,13 +117,13 @@ static void minimize_msg_size(msg_size_saved *sv)
 /* Restore original settings, so other tests are not affected */
 static void restore_msg_size(const msg_size_saved *sv)
 {
-    pjmedia_endpt *endpt = pjsua_get_pjmedia_endpt();
+    pjmedia_endpt *pjendpt = pjsua_get_pjmedia_endpt();
     unsigned i;
     pjsip_cfg()->endpt.disable_tcp_switch   = sv->disable_tcp_switch;
     pjsip_cfg()->endpt.use_compact_form     = sv->compact_form;
     pjmedia_add_rtpmap_for_static_pt        = sv->rtpmap_static;
     pjmedia_add_bandwidth_tias_in_sdp       = sv->bandw_tias;
-    pjmedia_endpt_set_flag(endpt, PJMEDIA_ENDPT_HAS_TELEPHONE_EVENT_FLAG,
+    pjmedia_endpt_set_flag(pjendpt, PJMEDIA_ENDPT_HAS_TELEPHONE_EVENT_FLAG,
                            &sv->tel_event);
     for (i = 0; i < sv->codec_count; ++i) {
         pjsua_codec_set_priority(&sv->codecs[i].codec_id,

--- a/tests/pjsua/inc_const.py
+++ b/tests/pjsua/inc_const.py
@@ -35,9 +35,11 @@ MEDIA_ACTIVE = "Call [0-9]+ media [0-9]+ .*, status is Active"
 # RX_DTMF
 RX_DTMF = "Incoming DTMF on call [0-9]+: "
 # Suffix logged after the digit when DTMF is received via SIP INFO
-# (as opposed to RFC 2833). Append after RX_DTMF + digit to assert the
+# (as opposed to RFC 2833), including the stream index,
+# which is -1 as SIP INFO is not stream-specific.
+# Append after RX_DTMF + digit to assert the
 # transport method, e.g. RX_DTMF + "1" + RX_DTMF_INFO_METHOD.
-RX_DTMF_INFO_METHOD = ".*using SIP INFO method"
+RX_DTMF_INFO_METHOD = ".*using SIP INFO method, stream -1"
 
 ##########################
 # MEDIA


### PR DESCRIPTION
I had most changes be generated after a back and forth with Claude, reviewed the changes and tested them in my testapp.
The call ID and media index are now packed into a scalar and provided as "user data" to the callback functions.
New helper macros have been introduced for packing/unpacking the parameters.

Fixes #5099.

Everything below this line was generated by Claude

---

pjsua_call_send_text() lets the sender select the text stream via med_idx,
but the receive callbacks could not tell the application which stream incoming text (or DTMF) arrived on
which is ambiguous for calls with multiple streams of the same type.

- Add med_idx to pjsua_txt_stream_data (corresponding to pjsua_call_send_text_param.med_idx on the send side), and to pjsua_dtmf_info / pjsua_dtmf_event (-1 when the DTMF was not stream-borne, i.e. SIP INFO).
- The call id and media index are packed into the stream callback user_data — call id in the lower 16 bits, media index in the upper 16. Internal helper macros (PJSUA_MED_UDATA_PACK,
PJSUA_MED_UDATA_CALL_ID, PJSUA_MED_UDATA_MED_IDX) do the packing/unpacking. The callbacks stay lock-free on the media thread and dereference no shared state, so the reported index stays correct across re-INVITE stream recreation and teardown; 32 packed bits fit the 
pointer on all supported platforms.
- PJSUA2: mirror as medIdx in OnCallRxTextParam, OnDtmfDigitParam, OnDtmfEventParam
- PJSUA2: fix Call::sendText() dropping CallSendTextParam.medIdx.
- pjsua app: log the stream index for received text/DTMF.
