### PR TITLE
pjnath: check packet buffer allocation in pj_stun_session_send_msg()

### DIFF
--- a/pjnath/src/pjnath/stun_session.c
+++ b/pjnath/src/pjnath/stun_session.c
@@ -974,6 +974,12 @@ PJ_DEF(pj_status_t) pj_stun_session_send_msg( pj_stun_session *sess,
     /* Allocate packet */
     tdata->max_len = PJ_STUN_MAX_PKT_LEN;
     tdata->pkt = pj_pool_zalloc(tdata->pool, tdata->max_len);
+    if (tdata->pkt == NULL) {
+        status = PJ_ENOMEM;
+        pj_stun_msg_destroy_tdata(sess, tdata);
+        LOG_ERR_(sess, "Error allocating packet buffer", status);
+        goto on_return;
+    }
 
     tdata->token = token;
     tdata->retransmit = retransmit;


### PR DESCRIPTION
## Description

Fixes #5111.

In `pjnath/src/pjnath/stun_session.c`, `pj_stun_session_send_msg()` allocated the outgoing packet buffer:

```c
tdata->pkt = pj_pool_zalloc(tdata->pool, tdata->max_len);
```

and then passed `tdata->pkt` straight to `pj_stun_msg_encode()` without a NULL check. With a soft-fail pool policy, `pj_pool_zalloc()` can return NULL under memory pressure, leading to a NULL dereference / crash.

## Fix

Check the allocation result and bail out through the function's existing error path — destroy the tdata, log the error, and return `PJ_ENOMEM` — consistent with the other failure handling (`apply_msg_options`, encode, etc.) in the same function.

## Testing

`make` builds `pjnath` cleanly (zero warnings). The failure path requires injecting an allocation failure into an internally-created pool, which isn't readily unit-testable without a mock pool factory, so no new automated test is added; the change is a localized defensive NULL check that follows the function's established error-handling pattern.

Co-Authored-By Claude Code