### PR TITLE
docs: add minimal-comments guidance to coding conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,6 +95,7 @@ https://github.com/pjsip/pjproject_docs
 - **4 spaces** indentation (no tabs). ~80 char lines.
 - **K&R braces**: same line for control statements, next line for functions/structs.
 - **`/* */` comments** for C code, `/** */` for Doxygen on public APIs.
+- **Minimal comments**: avoid adding code comments unless necessary (i.e. only if the code itself is not self explanatory). When necessary, code comments must be as brief as possible to ensure readability and avoid overbloating.
 - **Module prefixes**: `pj_` (pjlib), `pjsip_` (sip), `pjmedia_` (media), `pjnath_` (nat)
 - **Constants**: ALL_CAPS with prefix (`PJSIP_MAX_URL_SIZE`, `PJ_TRUE`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ https://github.com/pjsip/pjproject_docs
 - **4 spaces** indentation (no tabs). ~80 char lines.
 - **K&R braces**: same line for control statements, next line for functions/structs.
 - **`/* */` comments** for C code, `/** */` for Doxygen on public APIs.
+- **Minimal comments**: avoid adding code comments unless necessary (i.e. only if the code itself is not self explanatory). When necessary, code comments must be as brief as possible to ensure readability and avoid overbloating.
 - **Module prefixes**: `pj_` (pjlib), `pjsip_` (sip), `pjmedia_` (media), `pjnath_` (nat)
 - **Constants**: ALL_CAPS with prefix (`PJSIP_MAX_URL_SIZE`, `PJ_TRUE`)
 


### PR DESCRIPTION
Reading the code co-authored by AI agents starts giving me headache, due to their tendency to compose lengthy multi-line paragraphs of comments for every block of code. Compact should be preferable, to ensure code is still readable by humans.