### PR TITLE
pjmedia: hold stream group lock across transport rx callback

### DIFF
--- a/pjmedia/include/pjmedia/transport.h
+++ b/pjmedia/include/pjmedia/transport.h
@@ -617,6 +617,14 @@ typedef struct pjmedia_tp_cb_param
 /**
  * This structure describes the data passed when calling
  * #pjmedia_transport_attach2().
+ *
+ * The caller MUST zero-initialize this structure (e.g. with pj_bzero())
+ * before setting the members it needs. Optional members that are left zero
+ * take their documented default ("not set"), and new optional members added
+ * over time are always defined so that an all-zero value preserves the prior
+ * behavior. In particular \a grp_lock is dereferenced by the transport only
+ * when non-NULL, so zeroing keeps a caller written against an older revision
+ * of this structure safe after a rebuild.
  */
 struct pjmedia_transport_attach_param
 {

--- a/pjmedia/include/pjmedia/transport.h
+++ b/pjmedia/include/pjmedia/transport.h
@@ -675,6 +675,11 @@ struct pjmedia_transport_attach_param
      * so the callback owner cannot be destroyed by another thread while an
      * in-flight receive callback is still running on it. NULL (the default)
      * keeps the previous behavior.
+     *
+     * Honoring this requires the transport to implement the attach2() op;
+     * the legacy attach() op cannot carry it. #pjmedia_transport_attach2()
+     * therefore rejects a non-NULL grp_lock with #PJ_ENOTSUP when the
+     * transport only provides attach().
      */
     pj_grp_lock_t *grp_lock;
 
@@ -765,10 +770,19 @@ PJ_INLINE(pjmedia_transport*) pjmedia_transport_info_get_transport(
  * the transport if it is implemented, otherwise it calls <tt>attach()</tt>
  * member of the transport.
  *
+ * Note that the legacy <tt>attach()</tt> op cannot carry
+ * \a att_param->grp_lock (nor \a rtp_cb2), so it cannot honor the
+ * callback-owner lifetime guarantee that a non-NULL \a grp_lock requests.
+ * To avoid silently downgrading a caller that relies on that guarantee,
+ * this wrapper returns #PJ_ENOTSUP when \a grp_lock is set but the transport
+ * only implements the legacy <tt>attach()</tt> op.
+ *
  * @param tp        The media transport.
  * @param att_param The transport attach param.
  *
- * @return          PJ_SUCCESS on success, or the appropriate error code.
+ * @return          PJ_SUCCESS on success, PJ_ENOTSUP if att_param->grp_lock
+ *                  is set but the transport has no attach2() op, or the
+ *                  appropriate error code.
  */
 PJ_INLINE(pj_status_t) pjmedia_transport_attach2(pjmedia_transport *tp,
                                   pjmedia_transport_attach_param *att_param)
@@ -776,10 +790,12 @@ PJ_INLINE(pj_status_t) pjmedia_transport_attach2(pjmedia_transport *tp,
     if (tp->op->attach2) {
         return (*tp->op->attach2)(tp, att_param);
     } else {
-        return (*tp->op->attach)(tp, att_param->user_data, 
-                                 (pj_sockaddr_t*)&att_param->rem_addr, 
-                                 (pj_sockaddr_t*)&att_param->rem_rtcp, 
-                                 att_param->addr_len, att_param->rtp_cb, 
+        if (att_param->grp_lock)
+            return PJ_ENOTSUP;
+        return (*tp->op->attach)(tp, att_param->user_data,
+                                 (pj_sockaddr_t*)&att_param->rem_addr,
+                                 (pj_sockaddr_t*)&att_param->rem_rtcp,
+                                 att_param->addr_len, att_param->rtp_cb,
                                  att_param->rtcp_cb);
     }
 }

--- a/pjmedia/include/pjmedia/transport.h
+++ b/pjmedia/include/pjmedia/transport.h
@@ -676,6 +676,13 @@ struct pjmedia_transport_attach_param
      * in-flight receive callback is still running on it. NULL (the default)
      * keeps the previous behavior.
      *
+     * The transport only references this lock transiently, while dispatching
+     * a callback; it does not hold a reference between attach and detach.
+     * The caller therefore must keep its own reference on the lock alive
+     * until #pjmedia_transport_detach() returns, otherwise a receive that
+     * arrives after the last reference is dropped would reference a freed
+     * lock.
+     *
      * Honoring this requires the transport to implement the attach2() op;
      * the legacy attach() op cannot carry it. #pjmedia_transport_attach2()
      * therefore rejects a non-NULL grp_lock with #PJ_ENOTSUP when the
@@ -775,7 +782,12 @@ PJ_INLINE(pjmedia_transport*) pjmedia_transport_info_get_transport(
  * callback-owner lifetime guarantee that a non-NULL \a grp_lock requests.
  * To avoid silently downgrading a caller that relies on that guarantee,
  * this wrapper returns #PJ_ENOTSUP when \a grp_lock is set but the transport
- * only implements the legacy <tt>attach()</tt> op.
+ * only implements the legacy <tt>attach()</tt> op. This does not regress a
+ * working configuration: the media streams request the receive callback via
+ * \a rtp_cb2, which the legacy <tt>attach()</tt> op also cannot carry, so a
+ * stream could never receive RTP through an attach()-only transport in the
+ * first place. Callers that do not set \a grp_lock keep using the legacy
+ * path unchanged.
  *
  * @param tp        The media transport.
  * @param att_param The transport attach param.

--- a/pjmedia/include/pjmedia/transport.h
+++ b/pjmedia/include/pjmedia/transport.h
@@ -668,6 +668,16 @@ struct pjmedia_transport_attach_param
      */
     void (*rtp_cb2)(pjmedia_tp_cb_param *param);
 
+    /**
+     * Optional group lock of the entity owning the callbacks (e.g. the
+     * media stream). If set, the transport holds a reference on this group
+     * lock for the whole duration of each rtp_cb/rtp_cb2/rtcp_cb invocation,
+     * so the callback owner cannot be destroyed by another thread while an
+     * in-flight receive callback is still running on it. NULL (the default)
+     * keeps the previous behavior.
+     */
+    pj_grp_lock_t *grp_lock;
+
 };
 
 /**

--- a/pjmedia/include/pjmedia/transport_loop.h
+++ b/pjmedia/include/pjmedia/transport_loop.h
@@ -88,11 +88,23 @@ typedef struct pjmedia_loop_tp_setting
     pj_bool_t   disable_rx;
 
     /*
-     * Max number of attachments
+     * Max number of attachments. Must not exceed
+     * #PJMEDIA_LOOP_TP_MAX_ATTACH_CNT; a larger value is rejected at
+     * create time with PJ_ETOOMANY. Default is 4.
      */
     unsigned max_attach_cnt;
 
 } pjmedia_loop_tp_setting;
+
+/**
+ * The maximum number of streams that may attach to a single loop transport.
+ * The receive fan-out captures a stable stack snapshot of the recipients
+ * bounded by this value, so it is a hard, fail-fast upper bound rather than
+ * a silently clamped one.
+ */
+#ifndef PJMEDIA_LOOP_TP_MAX_ATTACH_CNT
+#   define PJMEDIA_LOOP_TP_MAX_ATTACH_CNT   32
+#endif
 
 
 /**

--- a/pjmedia/include/pjmedia/transport_loop.h
+++ b/pjmedia/include/pjmedia/transport_loop.h
@@ -88,23 +88,12 @@ typedef struct pjmedia_loop_tp_setting
     pj_bool_t   disable_rx;
 
     /*
-     * Max number of attachments. Must not exceed
-     * #PJMEDIA_LOOP_TP_MAX_ATTACH_CNT; a larger value is rejected at
-     * create time with PJ_ETOOMANY. Default is 4.
+     * Max number of attachments (streams) that may share this transport.
+     * Default is 4.
      */
     unsigned max_attach_cnt;
 
 } pjmedia_loop_tp_setting;
-
-/**
- * The maximum number of streams that may attach to a single loop transport.
- * The receive fan-out captures a stable stack snapshot of the recipients
- * bounded by this value, so it is a hard, fail-fast upper bound rather than
- * a silently clamped one.
- */
-#ifndef PJMEDIA_LOOP_TP_MAX_ATTACH_CNT
-#   define PJMEDIA_LOOP_TP_MAX_ATTACH_CNT   32
-#endif
 
 
 /**

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2346,6 +2346,11 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
 
     /* Only attach transport when stream is ready. */
     c_strm->transport = tp;
+    /* Let the transport hold a reference on the stream's group lock for the
+     * duration of each rx callback, so the stream cannot be destroyed by
+     * another thread while an in-flight RTP/RTCP callback is running on it.
+     */
+    att_param.grp_lock = c_strm->grp_lock;
     status = pjmedia_transport_attach2(tp, &att_param);
     if (status != PJ_SUCCESS)
         goto err_cleanup;

--- a/pjmedia/src/pjmedia/transport_ice.c
+++ b/pjmedia/src/pjmedia/transport_ice.c
@@ -101,6 +101,10 @@ struct transport_ice
     void               (*rtcp_cb)(void*,
                                   void*,
                                   pj_ssize_t);
+    pj_grp_lock_t       *cb_grp_lock;   /**< Callback owner's group lock, ref'd
+                                             across each rx callback so the
+                                             owner (stream) cannot be destroyed
+                                             while a callback is in flight. */
 };
 
 
@@ -2434,6 +2438,7 @@ static pj_status_t transport_attach2  (pjmedia_transport *tp,
     tp_ice->rtp_cb = att_param->rtp_cb;
     tp_ice->rtp_cb2 = att_param->rtp_cb2;
     tp_ice->rtcp_cb = att_param->rtcp_cb;
+    tp_ice->cb_grp_lock = att_param->grp_lock;
 
     if (tp->grp_lock)
         pj_grp_lock_release(tp->grp_lock);
@@ -2470,6 +2475,7 @@ static void transport_detach(pjmedia_transport *tp,
     tp_ice->rtp_cb2 = NULL;
     tp_ice->rtcp_cb = NULL;
     tp_ice->stream = NULL;
+    tp_ice->cb_grp_lock = NULL;
 
     if (tp->grp_lock)
         pj_grp_lock_release(tp->grp_lock);
@@ -2558,6 +2564,7 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
     void (*rtp_cb2)(pjmedia_tp_cb_param*);
     void (*rtcp_cb)(void*, void*, pj_ssize_t);
     void *stream;
+    pj_grp_lock_t *cb_grp_lock;
 
     tp_ice = (struct transport_ice*) pj_ice_strans_get_user_data(ice_st);
     if (!tp_ice) {
@@ -2566,7 +2573,10 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
     }
 
     /* Snapshot callback pointers under lock to avoid race with
-     * transport_detach() clearing them.
+     * transport_detach() clearing them, and hold a reference on the callback
+     * owner's group lock across the up-call: transport_detach() clears these
+     * under the same lock before the owner (stream) drops its own reference,
+     * so a non-NULL cb here means the owner is still alive and safe to ref.
      */
     if (tp_ice->base.grp_lock)
         pj_grp_lock_acquire(tp_ice->base.grp_lock);
@@ -2575,6 +2585,9 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
     rtp_cb2 = tp_ice->rtp_cb2;
     rtcp_cb = tp_ice->rtcp_cb;
     stream = tp_ice->stream;
+    cb_grp_lock = tp_ice->cb_grp_lock;
+    if (cb_grp_lock)
+        pj_grp_lock_add_ref(cb_grp_lock);
 
     if (tp_ice->base.grp_lock)
         pj_grp_lock_release(tp_ice->base.grp_lock);
@@ -2595,6 +2608,8 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
                 PJ_LOG(5,(tp_ice->base.name,
                           "RX RTP packet dropped because of pkt lost "
                           "simulation"));
+                if (cb_grp_lock)
+                    pj_grp_lock_dec_ref(cb_grp_lock);
                 return;
             }
         }
@@ -2698,6 +2713,9 @@ static void ice_on_rx_data(pj_ice_strans *ice_st, unsigned comp_id,
         if (!discard)
             (*rtcp_cb)(stream, pkt, size);
     }
+
+    if (cb_grp_lock)
+        pj_grp_lock_dec_ref(cb_grp_lock);
 
     PJ_UNUSED_ARG(src_addr_len);
 }

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -27,15 +27,9 @@
 #include <pj/string.h>
 
 
-/* Upper bound on the number of simultaneously attached users, so the receive
- * fan-out can take a stable stack snapshot of the recipient list. A
- * max_attach_cnt above this is rejected at create time (fail-fast, not
- * silently clamped). Exposed publicly as PJMEDIA_LOOP_TP_MAX_ATTACH_CNT. */
-#define LOOP_MAX_USERS  PJMEDIA_LOOP_TP_MAX_ATTACH_CNT
-
-
 struct tp_user
 {
+    pj_bool_t           active;         /**< Slot is in use?                */
     pj_bool_t           rx_disabled;    /**< Doesn't want to receive pkt?   */
     void               *user_data;      /**< Only valid when attached       */
     void  (*rtp_cb)(    void*,          /**< To report incoming RTP.        */
@@ -55,8 +49,7 @@ struct transport_loop
 
     pj_pool_t          *pool;           /**< Memory pool                    */
     unsigned            max_attach_cnt; /**< Max number of attachments      */
-    unsigned            user_cnt;       /**< Number of attachments          */
-    struct tp_user     *users;          /**< Array of users.                */
+    struct tp_user     *users;          /**< Array of users (stable slots). */
     pj_bool_t           disable_rx;     /**< Disable RX.                    */
 
     pjmedia_loop_tp_setting setting;    /**< Setting.                       */
@@ -180,13 +173,6 @@ pjmedia_transport_loop_create2(pjmedia_endpt *endpt,
     /* Sanity check */
     PJ_ASSERT_RETURN(endpt && p_tp, PJ_EINVAL);
 
-    /* The receive fan-out snapshots recipients into a fixed-size buffer, so
-     * reject an over-limit attach count up front rather than clamping it and
-     * surprising the caller with PJ_ETOOMANY at a later attach.
-     */
-    PJ_ASSERT_RETURN(!opt || opt->max_attach_cnt <= PJMEDIA_LOOP_TP_MAX_ATTACH_CNT,
-                     PJ_ETOOMANY);
-
     /* Create transport structure */
     pool = pjmedia_endpt_create_pool(endpt, "tploop", 512, 512);
     if (!pool)
@@ -221,7 +207,7 @@ pjmedia_transport_loop_create2(pjmedia_endpt *endpt,
     if (tp->setting.port == 0)
         tp->setting.port = 4000;
 
-    /* alloc users array (count validated <= LOOP_MAX_USERS above) */
+    /* alloc users array (fixed slots; detach marks a slot free in place) */
     tp->max_attach_cnt = tp->setting.max_attach_cnt;
     if (tp->max_attach_cnt == 0)
         tp->max_attach_cnt = 1;
@@ -245,8 +231,8 @@ PJ_DEF(pj_status_t) pjmedia_transport_loop_disable_rx( pjmedia_transport *tp,
      * send-side snapshot via the transport group lock.
      */
     pj_grp_lock_acquire(tp->grp_lock);
-    for (i=0; i<loop->user_cnt; ++i) {
-        if (loop->users[i].user_data == user) {
+    for (i=0; i<loop->max_attach_cnt; ++i) {
+        if (loop->users[i].active && loop->users[i].user_data == user) {
             loop->users[i].rx_disabled = disabled;
             status = PJ_SUCCESS;
             break;
@@ -316,7 +302,7 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
                                        pj_grp_lock_t *cb_grp_lock)
 {
     struct transport_loop *loop = (struct transport_loop*) tp;
-    unsigned i;
+    unsigned i, slot;
     const pj_sockaddr *rtcp_addr;
 
     /* Validate arguments */
@@ -325,30 +311,37 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
     PJ_UNUSED_ARG(rem_rtcp);
     PJ_UNUSED_ARG(rtcp_addr);
 
-    /* "Attach" the application under the transport group lock. The
-     * duplicate-user and capacity checks run under the same lock as the
-     * append (and detach's erase / the send-side snapshot), so two
-     * concurrent attaches sharing the last free slot cannot both pass the
-     * capacity check and overrun users[].
+    /* "Attach" the application under the transport group lock, so the
+     * duplicate-user check and the slot claim are atomic with respect to a
+     * concurrent attach/detach and the send-side snapshot. Slots are never
+     * shifted: a detached slot is left in place (marked inactive) and reused
+     * here, so the send fan-out can iterate by index without a concurrent
+     * detach skipping a still-attached recipient.
      */
     pj_grp_lock_acquire(tp->grp_lock);
-    for (i=0; i<loop->user_cnt; ++i) {
+    slot = loop->max_attach_cnt;
+    for (i=0; i<loop->max_attach_cnt; ++i) {
+        if (!loop->users[i].active) {
+            if (slot == loop->max_attach_cnt)
+                slot = i;
+            continue;
+        }
         if (loop->users[i].user_data == user_data) {
             pj_grp_lock_release(tp->grp_lock);
             return PJ_EINVALIDOP;
         }
     }
-    if (loop->user_cnt >= loop->max_attach_cnt) {
+    if (slot == loop->max_attach_cnt) {
         pj_grp_lock_release(tp->grp_lock);
         return PJ_ETOOMANY;
     }
-    loop->users[loop->user_cnt].rtp_cb = rtp_cb;
-    loop->users[loop->user_cnt].rtp_cb2 = rtp_cb2;
-    loop->users[loop->user_cnt].rtcp_cb = rtcp_cb;
-    loop->users[loop->user_cnt].user_data = user_data;
-    loop->users[loop->user_cnt].cb_grp_lock = cb_grp_lock;
-    loop->users[loop->user_cnt].rx_disabled = loop->disable_rx;
-    ++loop->user_cnt;
+    loop->users[slot].rtp_cb = rtp_cb;
+    loop->users[slot].rtp_cb2 = rtp_cb2;
+    loop->users[slot].rtcp_cb = rtcp_cb;
+    loop->users[slot].user_data = user_data;
+    loop->users[slot].cb_grp_lock = cb_grp_lock;
+    loop->users[slot].rx_disabled = loop->disable_rx;
+    loop->users[slot].active = PJ_TRUE;
     pj_grp_lock_release(tp->grp_lock);
 
     return PJ_SUCCESS;
@@ -393,67 +386,20 @@ static void transport_detach( pjmedia_transport *tp,
     pj_assert(tp);
 
     /* Serialize the users[] mutation with the send-side snapshot below via
-     * the transport group lock, so a concurrent send cannot read/ref an
-     * entry (and its owner group lock) while it is being erased.
+     * the transport group lock. Mark the slot inactive in place rather than
+     * compacting the array, so a concurrent send iterating by index does not
+     * have a still-attached recipient shifted past its cursor and skipped.
      */
     pj_grp_lock_acquire(tp->grp_lock);
 
-    for (i=0; i<loop->user_cnt; ++i) {
-        if (loop->users[i].user_data == user_data)
+    for (i=0; i<loop->max_attach_cnt; ++i) {
+        if (loop->users[i].active && loop->users[i].user_data == user_data) {
+            pj_bzero(&loop->users[i], sizeof(loop->users[i]));
             break;
-    }
-
-    /* Remove this user */
-    if (i != loop->user_cnt) {
-        pj_array_erase(loop->users, sizeof(loop->users[0]),
-                       loop->user_cnt, i);
-        --loop->user_cnt;
+        }
     }
 
     pj_grp_lock_release(tp->grp_lock);
-}
-
-
-/* A stable snapshot of one receiving user, taken under the transport group
- * lock so the fan-out below can invoke callbacks without holding the lock and
- * without a concurrent detach shifting users[] under the iteration. */
-struct loop_rcpt {
-    void  (*rtp_cb)(void*, void*, pj_ssize_t);
-    void  (*rtp_cb2)(pjmedia_tp_cb_param*);
-    void  (*rtcp_cb)(void*, void*, pj_ssize_t);
-    void   *user_data;
-    pj_grp_lock_t *cb_grp_lock;
-};
-
-/* Snapshot all rx-enabled users into rcpt[] (capacity LOOP_MAX_USERS, which
- * bounds loop->max_attach_cnt) under the group lock, add_ref'ing each user's
- * owner group lock. Returns the count. Each returned entry's cb_grp_lock (if
- * any) must be dec_ref'd by the caller after the callback. Because the whole
- * recipient set is captured under a single lock hold, a detach that erases
- * (and left-shifts) an entry during the subsequent callbacks cannot cause a
- * still-attached user to be skipped, and the owner ref keeps each callback
- * target alive across its up-call.
- */
-static unsigned loop_snapshot_users(struct transport_loop *loop,
-                                    struct loop_rcpt *rcpt)
-{
-    unsigned i, n = 0;
-
-    pj_grp_lock_acquire(loop->base.grp_lock);
-    for (i=0; i<loop->user_cnt && n<LOOP_MAX_USERS; ++i) {
-        if (loop->users[i].rx_disabled)
-            continue;
-        rcpt[n].rtp_cb = loop->users[i].rtp_cb;
-        rcpt[n].rtp_cb2 = loop->users[i].rtp_cb2;
-        rcpt[n].rtcp_cb = loop->users[i].rtcp_cb;
-        rcpt[n].user_data = loop->users[i].user_data;
-        rcpt[n].cb_grp_lock = loop->users[i].cb_grp_lock;
-        if (rcpt[n].cb_grp_lock)
-            pj_grp_lock_add_ref(rcpt[n].cb_grp_lock);
-        ++n;
-    }
-    pj_grp_lock_release(loop->base.grp_lock);
-    return n;
 }
 
 
@@ -463,8 +409,7 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
                                        pj_size_t size)
 {
     struct transport_loop *loop = (struct transport_loop*)tp;
-    struct loop_rcpt rcpt[LOOP_MAX_USERS];
-    unsigned i, n;
+    unsigned i;
 
     /* Simulate packet lost on TX direction */
     if (loop->tx_drop_pct) {
@@ -488,25 +433,44 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
 
     pj_grp_lock_add_ref(tp->grp_lock);
 
-    /* Distribute to a stable snapshot of the recipients (see
-     * loop_snapshot_users()); the group lock is not held across the up-calls.
+    /* Distribute to users. Slots are stable indices (detach marks a slot
+     * inactive without shifting), so iterating by index cannot skip a
+     * still-attached recipient. Each slot's callbacks and owner group lock
+     * are snapshotted under the group lock (add_ref'ing the owner), which is
+     * then released before the up-call so it is never held across an
+     * application callback; the owner ref keeps the target alive meanwhile.
      */
-    n = loop_snapshot_users(loop, rcpt);
-    for (i=0; i<n; ++i) {
-        if (rcpt[i].rtp_cb2) {
+    for (i=0; i<loop->max_attach_cnt; ++i) {
+        void (*rtp_cb)(void*, void*, pj_ssize_t) = NULL;
+        void (*rtp_cb2)(pjmedia_tp_cb_param*) = NULL;
+        void *user_data = NULL;
+        pj_grp_lock_t *cb_grp_lock = NULL;
+
+        pj_grp_lock_acquire(tp->grp_lock);
+        if (loop->users[i].active && !loop->users[i].rx_disabled) {
+            rtp_cb = loop->users[i].rtp_cb;
+            rtp_cb2 = loop->users[i].rtp_cb2;
+            user_data = loop->users[i].user_data;
+            cb_grp_lock = loop->users[i].cb_grp_lock;
+            if (cb_grp_lock)
+                pj_grp_lock_add_ref(cb_grp_lock);
+        }
+        pj_grp_lock_release(tp->grp_lock);
+
+        if (rtp_cb2) {
             pjmedia_tp_cb_param param;
 
             pj_bzero(&param, sizeof(param));
-            param.user_data = rcpt[i].user_data;
+            param.user_data = user_data;
             param.pkt = (void *)pkt;
             param.size = size;
-            (*rcpt[i].rtp_cb2)(&param);
-        } else if (rcpt[i].rtp_cb) {
-            (*rcpt[i].rtp_cb)(rcpt[i].user_data, (void*)pkt, size);
+            (*rtp_cb2)(&param);
+        } else if (rtp_cb) {
+            (*rtp_cb)(user_data, (void*)pkt, size);
         }
 
-        if (rcpt[i].cb_grp_lock)
-            pj_grp_lock_dec_ref(rcpt[i].cb_grp_lock);
+        if (cb_grp_lock)
+            pj_grp_lock_dec_ref(cb_grp_lock);
     }
 
     pj_grp_lock_dec_ref(tp->grp_lock);
@@ -531,24 +495,39 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
                                         pj_size_t size)
 {
     struct transport_loop *loop = (struct transport_loop*)tp;
-    struct loop_rcpt rcpt[LOOP_MAX_USERS];
-    unsigned i, n;
+    unsigned i;
 
     PJ_UNUSED_ARG(addr_len);
     PJ_UNUSED_ARG(addr);
 
     pj_grp_lock_add_ref(tp->grp_lock);
 
-    /* Distribute to a stable snapshot of the recipients (see
-     * loop_snapshot_users()); the group lock is not held across the up-calls.
+    /* Distribute to users. See transport_send_rtp() for why each stable slot
+     * is snapshotted and its owner group lock referenced under the group
+     * lock, then released before the up-call.
      */
-    n = loop_snapshot_users(loop, rcpt);
-    for (i=0; i<n; ++i) {
-        if (rcpt[i].rtcp_cb)
-            (*rcpt[i].rtcp_cb)(rcpt[i].user_data, (void*)pkt, size);
+    for (i=0; i<loop->max_attach_cnt; ++i) {
+        void (*rtcp_cb)(void*, void*, pj_ssize_t) = NULL;
+        void *user_data = NULL;
+        pj_grp_lock_t *cb_grp_lock = NULL;
 
-        if (rcpt[i].cb_grp_lock)
-            pj_grp_lock_dec_ref(rcpt[i].cb_grp_lock);
+        pj_grp_lock_acquire(tp->grp_lock);
+        if (loop->users[i].active && !loop->users[i].rx_disabled &&
+            loop->users[i].rtcp_cb)
+        {
+            rtcp_cb = loop->users[i].rtcp_cb;
+            user_data = loop->users[i].user_data;
+            cb_grp_lock = loop->users[i].cb_grp_lock;
+            if (cb_grp_lock)
+                pj_grp_lock_add_ref(cb_grp_lock);
+        }
+        pj_grp_lock_release(tp->grp_lock);
+
+        if (rtcp_cb)
+            (*rtcp_cb)(user_data, (void*)pkt, size);
+
+        if (cb_grp_lock)
+            pj_grp_lock_dec_ref(cb_grp_lock);
     }
 
     pj_grp_lock_dec_ref(tp->grp_lock);

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -315,6 +315,16 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
      * serialized with the send-side snapshot and detach's erase.
      */
     pj_grp_lock_acquire(tp->grp_lock);
+    for (i=0; i<loop->user_cnt; ++i) {
+        if (loop->users[i].user_data == user_data) {
+            pj_grp_lock_release(tp->grp_lock);
+            return PJ_EINVALIDOP;
+        }
+    }
+    if (loop->user_cnt >= loop->max_attach_cnt) {
+        pj_grp_lock_release(tp->grp_lock);
+        return PJ_ETOOMANY;
+    }
     loop->users[loop->user_cnt].rtp_cb = rtp_cb;
     loop->users[loop->user_cnt].rtp_cb2 = rtp_cb2;
     loop->users[loop->user_cnt].rtcp_cb = rtcp_cb;

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -38,6 +38,8 @@ struct tp_user
     void  (*rtcp_cb)(   void*,          /**< To report incoming RTCP.       */
                         void*,
                         pj_ssize_t);
+    pj_grp_lock_t      *cb_grp_lock;    /**< Callback owner's group lock,
+                                             ref'd across each rx callback. */
 };
 
 struct transport_loop
@@ -287,7 +289,8 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
                                        void (*rtp_cb2)(pjmedia_tp_cb_param*),
                                        void (*rtcp_cb)(void*,
                                                        void*,
-                                                       pj_ssize_t))
+                                                       pj_ssize_t),
+                                       pj_grp_lock_t *cb_grp_lock)
 {
     struct transport_loop *loop = (struct transport_loop*) tp;
     unsigned i;
@@ -313,6 +316,7 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
     loop->users[loop->user_cnt].rtp_cb2 = rtp_cb2;
     loop->users[loop->user_cnt].rtcp_cb = rtcp_cb;
     loop->users[loop->user_cnt].user_data = user_data;
+    loop->users[loop->user_cnt].cb_grp_lock = cb_grp_lock;
     loop->users[loop->user_cnt].rx_disabled = loop->disable_rx;
     ++loop->user_cnt;
 
@@ -332,18 +336,19 @@ static pj_status_t transport_attach(   pjmedia_transport *tp,
                                                        pj_ssize_t))
 {
     return tp_attach(tp, user_data, rem_addr, rem_rtcp, addr_len,
-                     rtp_cb, NULL, rtcp_cb);
+                     rtp_cb, NULL, rtcp_cb, NULL);
 }
 
 static pj_status_t transport_attach2(pjmedia_transport *tp,
                                      pjmedia_transport_attach_param *att_param)
 {
-    return tp_attach(tp, att_param->user_data, 
-                            (pj_sockaddr_t*)&att_param->rem_addr, 
-                            (pj_sockaddr_t*)&att_param->rem_rtcp, 
+    return tp_attach(tp, att_param->user_data,
+                            (pj_sockaddr_t*)&att_param->rem_addr,
+                            (pj_sockaddr_t*)&att_param->rem_rtcp,
                             att_param->addr_len, att_param->rtp_cb,
-                            att_param->rtp_cb2, 
-                            att_param->rtcp_cb);
+                            att_param->rtp_cb2,
+                            att_param->rtcp_cb,
+                            att_param->grp_lock);
 }
 
 
@@ -402,7 +407,10 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
 
     /* Distribute to users */
     for (i=0; i<loop->user_cnt; ++i) {
+        pj_grp_lock_t *cb_grp_lock = loop->users[i].cb_grp_lock;
         if (loop->users[i].rx_disabled) continue;
+        if (cb_grp_lock)
+            pj_grp_lock_add_ref(cb_grp_lock);
         if (loop->users[i].rtp_cb2) {
             pjmedia_tp_cb_param param;
 
@@ -412,9 +420,11 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
             param.size = size;
             (*loop->users[i].rtp_cb2)(&param);
         } else if (loop->users[i].rtp_cb) {
-            (*loop->users[i].rtp_cb)(loop->users[i].user_data, (void*)pkt, 
+            (*loop->users[i].rtp_cb)(loop->users[i].user_data, (void*)pkt,
                                      size);
         }
+        if (cb_grp_lock)
+            pj_grp_lock_dec_ref(cb_grp_lock);
     }
 
     pj_grp_lock_dec_ref(tp->grp_lock);
@@ -448,9 +458,15 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
 
     /* Distribute to users */
     for (i=0; i<loop->user_cnt; ++i) {
-        if (!loop->users[i].rx_disabled && loop->users[i].rtcp_cb)
-            (*loop->users[i].rtcp_cb)(loop->users[i].user_data, (void*)pkt,
-                                      size);
+        pj_grp_lock_t *cb_grp_lock = loop->users[i].cb_grp_lock;
+        if (loop->users[i].rx_disabled || !loop->users[i].rtcp_cb)
+            continue;
+        if (cb_grp_lock)
+            pj_grp_lock_add_ref(cb_grp_lock);
+        (*loop->users[i].rtcp_cb)(loop->users[i].user_data, (void*)pkt,
+                                  size);
+        if (cb_grp_lock)
+            pj_grp_lock_dec_ref(cb_grp_lock);
     }
 
     pj_grp_lock_dec_ref(tp->grp_lock);

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -27,13 +27,11 @@
 #include <pj/string.h>
 
 
-#define THIS_FILE   "transport_loop.c"
-
 /* Upper bound on the number of simultaneously attached users, so the receive
- * fan-out can take a stable stack snapshot of the recipient list. This is a
- * loopback transport used only by tests, which attach a small handful of
- * streams; max_attach_cnt is clamped to this at create time. */
-#define LOOP_MAX_USERS  32
+ * fan-out can take a stable stack snapshot of the recipient list. A
+ * max_attach_cnt above this is rejected at create time (fail-fast, not
+ * silently clamped). Exposed publicly as PJMEDIA_LOOP_TP_MAX_ATTACH_CNT. */
+#define LOOP_MAX_USERS  PJMEDIA_LOOP_TP_MAX_ATTACH_CNT
 
 
 struct tp_user
@@ -182,6 +180,13 @@ pjmedia_transport_loop_create2(pjmedia_endpt *endpt,
     /* Sanity check */
     PJ_ASSERT_RETURN(endpt && p_tp, PJ_EINVAL);
 
+    /* The receive fan-out snapshots recipients into a fixed-size buffer, so
+     * reject an over-limit attach count up front rather than clamping it and
+     * surprising the caller with PJ_ETOOMANY at a later attach.
+     */
+    PJ_ASSERT_RETURN(!opt || opt->max_attach_cnt <= PJMEDIA_LOOP_TP_MAX_ATTACH_CNT,
+                     PJ_ETOOMANY);
+
     /* Create transport structure */
     pool = pjmedia_endpt_create_pool(endpt, "tploop", 512, 512);
     if (!pool)
@@ -216,15 +221,10 @@ pjmedia_transport_loop_create2(pjmedia_endpt *endpt,
     if (tp->setting.port == 0)
         tp->setting.port = 4000;
 
-    /* alloc users array */
+    /* alloc users array (count validated <= LOOP_MAX_USERS above) */
     tp->max_attach_cnt = tp->setting.max_attach_cnt;
     if (tp->max_attach_cnt == 0)
         tp->max_attach_cnt = 1;
-    if (tp->max_attach_cnt > LOOP_MAX_USERS) {
-        PJ_LOG(3,(THIS_FILE, "Loop transport max_attach_cnt %u clamped to %u",
-                  tp->max_attach_cnt, (unsigned)LOOP_MAX_USERS));
-        tp->max_attach_cnt = LOOP_MAX_USERS;
-    }
     tp->users = (struct tp_user *)pj_pool_calloc(pool, tp->max_attach_cnt, sizeof(struct tp_user));
 
     /* Done */

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -225,15 +225,24 @@ PJ_DEF(pj_status_t) pjmedia_transport_loop_disable_rx( pjmedia_transport *tp,
 {
     struct transport_loop *loop = (struct transport_loop*) tp;
     unsigned i;
+    pj_status_t status = PJ_ENOTFOUND;
 
+    /* Serialize the users[] search/update with attach/detach and the
+     * send-side snapshot via the transport group lock.
+     */
+    pj_grp_lock_acquire(tp->grp_lock);
     for (i=0; i<loop->user_cnt; ++i) {
         if (loop->users[i].user_data == user) {
             loop->users[i].rx_disabled = disabled;
-            return PJ_SUCCESS;
+            status = PJ_SUCCESS;
+            break;
         }
     }
-    pj_assert(!"Invalid stream user");
-    return PJ_ENOTFOUND;
+    pj_grp_lock_release(tp->grp_lock);
+
+    if (status != PJ_SUCCESS)
+        pj_assert(!"Invalid stream user");
+    return status;
 }
 
 
@@ -299,20 +308,14 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
     /* Validate arguments */
     PJ_ASSERT_RETURN(tp && rem_addr && addr_len, PJ_EINVAL);
 
-    /* Must not be "attached" to same user */
-    for (i=0; i<loop->user_cnt; ++i) {
-        PJ_ASSERT_RETURN(loop->users[i].user_data != user_data,
-                         PJ_EINVALIDOP);
-    }
-    PJ_ASSERT_RETURN(loop->user_cnt != loop->max_attach_cnt, PJ_ETOOMANY);
-
     PJ_UNUSED_ARG(rem_rtcp);
     PJ_UNUSED_ARG(rtcp_addr);
 
-    /* "Attach" the application: */
-
-    /* Save the new user under the transport group lock so the append is
-     * serialized with the send-side snapshot and detach's erase.
+    /* "Attach" the application under the transport group lock. The
+     * duplicate-user and capacity checks run under the same lock as the
+     * append (and detach's erase / the send-side snapshot), so two
+     * concurrent attaches sharing the last free slot cannot both pass the
+     * capacity check and overrun users[].
      */
     pj_grp_lock_acquire(tp->grp_lock);
     for (i=0; i<loop->user_cnt; ++i) {

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -27,6 +27,15 @@
 #include <pj/string.h>
 
 
+#define THIS_FILE   "transport_loop.c"
+
+/* Upper bound on the number of simultaneously attached users, so the receive
+ * fan-out can take a stable stack snapshot of the recipient list. This is a
+ * loopback transport used only by tests, which attach a small handful of
+ * streams; max_attach_cnt is clamped to this at create time. */
+#define LOOP_MAX_USERS  32
+
+
 struct tp_user
 {
     pj_bool_t           rx_disabled;    /**< Doesn't want to receive pkt?   */
@@ -211,6 +220,11 @@ pjmedia_transport_loop_create2(pjmedia_endpt *endpt,
     tp->max_attach_cnt = tp->setting.max_attach_cnt;
     if (tp->max_attach_cnt == 0)
         tp->max_attach_cnt = 1;
+    if (tp->max_attach_cnt > LOOP_MAX_USERS) {
+        PJ_LOG(3,(THIS_FILE, "Loop transport max_attach_cnt %u clamped to %u",
+                  tp->max_attach_cnt, (unsigned)LOOP_MAX_USERS));
+        tp->max_attach_cnt = LOOP_MAX_USERS;
+    }
     tp->users = (struct tp_user *)pj_pool_calloc(pool, tp->max_attach_cnt, sizeof(struct tp_user));
 
     /* Done */
@@ -400,18 +414,62 @@ static void transport_detach( pjmedia_transport *tp,
 }
 
 
+/* A stable snapshot of one receiving user, taken under the transport group
+ * lock so the fan-out below can invoke callbacks without holding the lock and
+ * without a concurrent detach shifting users[] under the iteration. */
+struct loop_rcpt {
+    void  (*rtp_cb)(void*, void*, pj_ssize_t);
+    void  (*rtp_cb2)(pjmedia_tp_cb_param*);
+    void  (*rtcp_cb)(void*, void*, pj_ssize_t);
+    void   *user_data;
+    pj_grp_lock_t *cb_grp_lock;
+};
+
+/* Snapshot all rx-enabled users into rcpt[] (capacity LOOP_MAX_USERS, which
+ * bounds loop->max_attach_cnt) under the group lock, add_ref'ing each user's
+ * owner group lock. Returns the count. Each returned entry's cb_grp_lock (if
+ * any) must be dec_ref'd by the caller after the callback. Because the whole
+ * recipient set is captured under a single lock hold, a detach that erases
+ * (and left-shifts) an entry during the subsequent callbacks cannot cause a
+ * still-attached user to be skipped, and the owner ref keeps each callback
+ * target alive across its up-call.
+ */
+static unsigned loop_snapshot_users(struct transport_loop *loop,
+                                    struct loop_rcpt *rcpt)
+{
+    unsigned i, n = 0;
+
+    pj_grp_lock_acquire(loop->base.grp_lock);
+    for (i=0; i<loop->user_cnt && n<LOOP_MAX_USERS; ++i) {
+        if (loop->users[i].rx_disabled)
+            continue;
+        rcpt[n].rtp_cb = loop->users[i].rtp_cb;
+        rcpt[n].rtp_cb2 = loop->users[i].rtp_cb2;
+        rcpt[n].rtcp_cb = loop->users[i].rtcp_cb;
+        rcpt[n].user_data = loop->users[i].user_data;
+        rcpt[n].cb_grp_lock = loop->users[i].cb_grp_lock;
+        if (rcpt[n].cb_grp_lock)
+            pj_grp_lock_add_ref(rcpt[n].cb_grp_lock);
+        ++n;
+    }
+    pj_grp_lock_release(loop->base.grp_lock);
+    return n;
+}
+
+
 /* Called by application to send RTP packet */
 static pj_status_t transport_send_rtp( pjmedia_transport *tp,
                                        const void *pkt,
                                        pj_size_t size)
 {
     struct transport_loop *loop = (struct transport_loop*)tp;
-    unsigned i;
+    struct loop_rcpt rcpt[LOOP_MAX_USERS];
+    unsigned i, n;
 
     /* Simulate packet lost on TX direction */
     if (loop->tx_drop_pct) {
         if ((pj_rand() % 100) <= (int)loop->tx_drop_pct) {
-            PJ_LOG(5,(loop->base.name, 
+            PJ_LOG(5,(loop->base.name,
                       "TX RTP packet dropped because of pkt lost "
                       "simulation"));
             return PJ_SUCCESS;
@@ -421,7 +479,7 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
     /* Simulate packet lost on RX direction */
     if (loop->rx_drop_pct) {
         if ((pj_rand() % 100) <= (int)loop->rx_drop_pct) {
-            PJ_LOG(5,(loop->base.name, 
+            PJ_LOG(5,(loop->base.name,
                       "RX RTP packet dropped because of pkt lost "
                       "simulation"));
             return PJ_SUCCESS;
@@ -430,48 +488,25 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
 
     pj_grp_lock_add_ref(tp->grp_lock);
 
-    /* Distribute to users. Snapshot each entry (callbacks, user data and the
-     * owner group lock) under the transport group lock and take a reference
-     * on the owner lock before releasing it, so a concurrent detach cannot
-     * erase the entry and drop the owner's last reference between the read
-     * and the up-call. The group lock is released before the up-call to
-     * avoid holding it across application callbacks.
+    /* Distribute to a stable snapshot of the recipients (see
+     * loop_snapshot_users()); the group lock is not held across the up-calls.
      */
-    for (i=0; ; ++i) {
-        void (*rtp_cb)(void*, void*, pj_ssize_t) = NULL;
-        void (*rtp_cb2)(pjmedia_tp_cb_param*) = NULL;
-        void *user_data = NULL;
-        pj_grp_lock_t *cb_grp_lock = NULL;
-
-        pj_grp_lock_acquire(tp->grp_lock);
-        if (i >= loop->user_cnt) {
-            pj_grp_lock_release(tp->grp_lock);
-            break;
-        }
-        if (!loop->users[i].rx_disabled) {
-            rtp_cb = loop->users[i].rtp_cb;
-            rtp_cb2 = loop->users[i].rtp_cb2;
-            user_data = loop->users[i].user_data;
-            cb_grp_lock = loop->users[i].cb_grp_lock;
-            if (cb_grp_lock)
-                pj_grp_lock_add_ref(cb_grp_lock);
-        }
-        pj_grp_lock_release(tp->grp_lock);
-
-        if (rtp_cb2) {
+    n = loop_snapshot_users(loop, rcpt);
+    for (i=0; i<n; ++i) {
+        if (rcpt[i].rtp_cb2) {
             pjmedia_tp_cb_param param;
 
             pj_bzero(&param, sizeof(param));
-            param.user_data = user_data;
+            param.user_data = rcpt[i].user_data;
             param.pkt = (void *)pkt;
             param.size = size;
-            (*rtp_cb2)(&param);
-        } else if (rtp_cb) {
-            (*rtp_cb)(user_data, (void*)pkt, size);
+            (*rcpt[i].rtp_cb2)(&param);
+        } else if (rcpt[i].rtp_cb) {
+            (*rcpt[i].rtp_cb)(rcpt[i].user_data, (void*)pkt, size);
         }
 
-        if (cb_grp_lock)
-            pj_grp_lock_dec_ref(cb_grp_lock);
+        if (rcpt[i].cb_grp_lock)
+            pj_grp_lock_dec_ref(rcpt[i].cb_grp_lock);
     }
 
     pj_grp_lock_dec_ref(tp->grp_lock);
@@ -496,41 +531,24 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
                                         pj_size_t size)
 {
     struct transport_loop *loop = (struct transport_loop*)tp;
-    unsigned i;
+    struct loop_rcpt rcpt[LOOP_MAX_USERS];
+    unsigned i, n;
 
     PJ_UNUSED_ARG(addr_len);
     PJ_UNUSED_ARG(addr);
 
     pj_grp_lock_add_ref(tp->grp_lock);
 
-    /* Distribute to users. See transport_send_rtp() for why each entry is
-     * snapshotted and its owner group lock referenced under the transport
-     * group lock, then released before the up-call.
+    /* Distribute to a stable snapshot of the recipients (see
+     * loop_snapshot_users()); the group lock is not held across the up-calls.
      */
-    for (i=0; ; ++i) {
-        void (*rtcp_cb)(void*, void*, pj_ssize_t) = NULL;
-        void *user_data = NULL;
-        pj_grp_lock_t *cb_grp_lock = NULL;
+    n = loop_snapshot_users(loop, rcpt);
+    for (i=0; i<n; ++i) {
+        if (rcpt[i].rtcp_cb)
+            (*rcpt[i].rtcp_cb)(rcpt[i].user_data, (void*)pkt, size);
 
-        pj_grp_lock_acquire(tp->grp_lock);
-        if (i >= loop->user_cnt) {
-            pj_grp_lock_release(tp->grp_lock);
-            break;
-        }
-        if (!loop->users[i].rx_disabled && loop->users[i].rtcp_cb) {
-            rtcp_cb = loop->users[i].rtcp_cb;
-            user_data = loop->users[i].user_data;
-            cb_grp_lock = loop->users[i].cb_grp_lock;
-            if (cb_grp_lock)
-                pj_grp_lock_add_ref(cb_grp_lock);
-        }
-        pj_grp_lock_release(tp->grp_lock);
-
-        if (rtcp_cb)
-            (*rtcp_cb)(user_data, (void*)pkt, size);
-
-        if (cb_grp_lock)
-            pj_grp_lock_dec_ref(cb_grp_lock);
+        if (rcpt[i].cb_grp_lock)
+            pj_grp_lock_dec_ref(rcpt[i].cb_grp_lock);
     }
 
     pj_grp_lock_dec_ref(tp->grp_lock);

--- a/pjmedia/src/pjmedia/transport_loop.c
+++ b/pjmedia/src/pjmedia/transport_loop.c
@@ -311,7 +311,10 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
 
     /* "Attach" the application: */
 
-    /* Save the new user */
+    /* Save the new user under the transport group lock so the append is
+     * serialized with the send-side snapshot and detach's erase.
+     */
+    pj_grp_lock_acquire(tp->grp_lock);
     loop->users[loop->user_cnt].rtp_cb = rtp_cb;
     loop->users[loop->user_cnt].rtp_cb2 = rtp_cb2;
     loop->users[loop->user_cnt].rtcp_cb = rtcp_cb;
@@ -319,6 +322,7 @@ static pj_status_t tp_attach(   pjmedia_transport *tp,
     loop->users[loop->user_cnt].cb_grp_lock = cb_grp_lock;
     loop->users[loop->user_cnt].rx_disabled = loop->disable_rx;
     ++loop->user_cnt;
+    pj_grp_lock_release(tp->grp_lock);
 
     return PJ_SUCCESS;
 }
@@ -361,6 +365,12 @@ static void transport_detach( pjmedia_transport *tp,
 
     pj_assert(tp);
 
+    /* Serialize the users[] mutation with the send-side snapshot below via
+     * the transport group lock, so a concurrent send cannot read/ref an
+     * entry (and its owner group lock) while it is being erased.
+     */
+    pj_grp_lock_acquire(tp->grp_lock);
+
     for (i=0; i<loop->user_cnt; ++i) {
         if (loop->users[i].user_data == user_data)
             break;
@@ -372,6 +382,8 @@ static void transport_detach( pjmedia_transport *tp,
                        loop->user_cnt, i);
         --loop->user_cnt;
     }
+
+    pj_grp_lock_release(tp->grp_lock);
 }
 
 
@@ -405,24 +417,46 @@ static pj_status_t transport_send_rtp( pjmedia_transport *tp,
 
     pj_grp_lock_add_ref(tp->grp_lock);
 
-    /* Distribute to users */
-    for (i=0; i<loop->user_cnt; ++i) {
-        pj_grp_lock_t *cb_grp_lock = loop->users[i].cb_grp_lock;
-        if (loop->users[i].rx_disabled) continue;
-        if (cb_grp_lock)
-            pj_grp_lock_add_ref(cb_grp_lock);
-        if (loop->users[i].rtp_cb2) {
+    /* Distribute to users. Snapshot each entry (callbacks, user data and the
+     * owner group lock) under the transport group lock and take a reference
+     * on the owner lock before releasing it, so a concurrent detach cannot
+     * erase the entry and drop the owner's last reference between the read
+     * and the up-call. The group lock is released before the up-call to
+     * avoid holding it across application callbacks.
+     */
+    for (i=0; ; ++i) {
+        void (*rtp_cb)(void*, void*, pj_ssize_t) = NULL;
+        void (*rtp_cb2)(pjmedia_tp_cb_param*) = NULL;
+        void *user_data = NULL;
+        pj_grp_lock_t *cb_grp_lock = NULL;
+
+        pj_grp_lock_acquire(tp->grp_lock);
+        if (i >= loop->user_cnt) {
+            pj_grp_lock_release(tp->grp_lock);
+            break;
+        }
+        if (!loop->users[i].rx_disabled) {
+            rtp_cb = loop->users[i].rtp_cb;
+            rtp_cb2 = loop->users[i].rtp_cb2;
+            user_data = loop->users[i].user_data;
+            cb_grp_lock = loop->users[i].cb_grp_lock;
+            if (cb_grp_lock)
+                pj_grp_lock_add_ref(cb_grp_lock);
+        }
+        pj_grp_lock_release(tp->grp_lock);
+
+        if (rtp_cb2) {
             pjmedia_tp_cb_param param;
 
             pj_bzero(&param, sizeof(param));
-            param.user_data = loop->users[i].user_data;
+            param.user_data = user_data;
             param.pkt = (void *)pkt;
             param.size = size;
-            (*loop->users[i].rtp_cb2)(&param);
-        } else if (loop->users[i].rtp_cb) {
-            (*loop->users[i].rtp_cb)(loop->users[i].user_data, (void*)pkt,
-                                     size);
+            (*rtp_cb2)(&param);
+        } else if (rtp_cb) {
+            (*rtp_cb)(user_data, (void*)pkt, size);
         }
+
         if (cb_grp_lock)
             pj_grp_lock_dec_ref(cb_grp_lock);
     }
@@ -456,15 +490,32 @@ static pj_status_t transport_send_rtcp2(pjmedia_transport *tp,
 
     pj_grp_lock_add_ref(tp->grp_lock);
 
-    /* Distribute to users */
-    for (i=0; i<loop->user_cnt; ++i) {
-        pj_grp_lock_t *cb_grp_lock = loop->users[i].cb_grp_lock;
-        if (loop->users[i].rx_disabled || !loop->users[i].rtcp_cb)
-            continue;
-        if (cb_grp_lock)
-            pj_grp_lock_add_ref(cb_grp_lock);
-        (*loop->users[i].rtcp_cb)(loop->users[i].user_data, (void*)pkt,
-                                  size);
+    /* Distribute to users. See transport_send_rtp() for why each entry is
+     * snapshotted and its owner group lock referenced under the transport
+     * group lock, then released before the up-call.
+     */
+    for (i=0; ; ++i) {
+        void (*rtcp_cb)(void*, void*, pj_ssize_t) = NULL;
+        void *user_data = NULL;
+        pj_grp_lock_t *cb_grp_lock = NULL;
+
+        pj_grp_lock_acquire(tp->grp_lock);
+        if (i >= loop->user_cnt) {
+            pj_grp_lock_release(tp->grp_lock);
+            break;
+        }
+        if (!loop->users[i].rx_disabled && loop->users[i].rtcp_cb) {
+            rtcp_cb = loop->users[i].rtcp_cb;
+            user_data = loop->users[i].user_data;
+            cb_grp_lock = loop->users[i].cb_grp_lock;
+            if (cb_grp_lock)
+                pj_grp_lock_add_ref(cb_grp_lock);
+        }
+        pj_grp_lock_release(tp->grp_lock);
+
+        if (rtcp_cb)
+            (*rtcp_cb)(user_data, (void*)pkt, size);
+
         if (cb_grp_lock)
             pj_grp_lock_dec_ref(cb_grp_lock);
     }

--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -290,6 +290,10 @@ typedef struct transport_srtp
     void                (*rtcp_cb)(void *user_data,
                                    void *pkt,
                                    pj_ssize_t size);
+    pj_grp_lock_t       *cb_grp_lock; /**< Callback owner's group lock, ref'd
+                                           across each rx callback so the
+                                           owner (stream) cannot be destroyed
+                                           while a callback is in flight. */
 
     /* Transport information */
     pjmedia_transport   *member_tp; /**< Underlying transport.       */
@@ -1317,21 +1321,29 @@ static pj_status_t transport_attach2(pjmedia_transport *tp,
         srtp->rtp_cb2 = param->rtp_cb2;
         srtp->rtcp_cb = param->rtcp_cb;
         srtp->user_data = param->user_data;
+        srtp->cb_grp_lock = param->grp_lock;
     }
     pj_lock_release(srtp->mutex);
 
-    /* Attach self to member transport */
+    /* Attach self to member transport. The member reports to srtp_rtp_cb()/
+     * srtp_rtcp_cb() whose user_data is this SRTP transport (kept alive by
+     * the member's own group lock during the callback), so do not propagate
+     * the callback owner's group lock down — this SRTP layer is the one that
+     * holds it around the up-call to the owner.
+     */
     member_param = *param;
     member_param.user_data = srtp;
     member_param.rtp_cb = NULL;
     member_param.rtp_cb2 = &srtp_rtp_cb;
     member_param.rtcp_cb = &srtp_rtcp_cb;
+    member_param.grp_lock = NULL;
     status = pjmedia_transport_attach2(srtp->member_tp, &member_param);
     if (status != PJ_SUCCESS) {
         pj_lock_acquire(srtp->mutex);
         srtp->rtp_cb = NULL;
         srtp->rtcp_cb = NULL;
         srtp->user_data = NULL;
+        srtp->cb_grp_lock = NULL;
         pj_lock_release(srtp->mutex);
         return status;
     }
@@ -1361,6 +1373,7 @@ static void transport_detach(pjmedia_transport *tp, void *strm)
     srtp->rtp_cb2 = NULL;
     srtp->rtcp_cb = NULL;
     srtp->user_data = NULL;
+    srtp->cb_grp_lock = NULL;
     pj_lock_release(srtp->mutex);
     srtp->member_tp_attached = PJ_FALSE;
 }
@@ -1554,6 +1567,7 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
     void (*cb)(void*, void*, pj_ssize_t) = NULL;
     void (*cb2)(pjmedia_tp_cb_param*) = NULL;
     void *cb_data = NULL;
+    pj_grp_lock_t *cb_grp_lock = NULL;
 
     /* Guard against race with transport_detach()/destroy().
      * The underlying transport may invoke this callback after user_data
@@ -1563,14 +1577,32 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
         return;
 
     if (srtp->bypass_srtp) {
-        if (srtp->rtp_cb2) {
+        /* Snapshot the callbacks and hold a reference on the owner's group
+         * lock under the mutex. transport_detach() clears these under the
+         * same mutex before the owner (stream) drops its own group-lock
+         * reference, so a non-NULL cb here means the owner is still alive
+         * and safe to ref across the up-call below.
+         */
+        pj_lock_acquire(srtp->mutex);
+        cb = srtp->rtp_cb;
+        cb2 = srtp->rtp_cb2;
+        cb_data = srtp->user_data;
+        cb_grp_lock = srtp->cb_grp_lock;
+        if (cb_grp_lock)
+            pj_grp_lock_add_ref(cb_grp_lock);
+        pj_lock_release(srtp->mutex);
+
+        if (cb2) {
             pjmedia_tp_cb_param param2 = *param;
-            param2.user_data = srtp->user_data;
-            srtp->rtp_cb2(&param2);
+            param2.user_data = cb_data;
+            (*cb2)(&param2);
             param->rem_switch = param2.rem_switch;
-        } else if (srtp->rtp_cb) {
-            srtp->rtp_cb(srtp->user_data, pkt, size);
+        } else if (cb) {
+            (*cb)(cb_data, pkt, size);
         }
+
+        if (cb_grp_lock)
+            pj_grp_lock_dec_ref(cb_grp_lock);
         return;
     }
 
@@ -1741,6 +1773,9 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
         cb = srtp->rtp_cb;
         cb2 = srtp->rtp_cb2;
         cb_data = srtp->user_data;
+        cb_grp_lock = srtp->cb_grp_lock;
+        if (cb_grp_lock)
+            pj_grp_lock_add_ref(cb_grp_lock);
 
         /* Save SSRC after successful SRTP unprotect */
         srtp->rx_ssrc = rx_ssrc;
@@ -1758,6 +1793,9 @@ static void srtp_rtp_cb(pjmedia_tp_cb_param *param)
     } else if (cb) {
         (*cb)(cb_data, pkt, len);
     }
+
+    if (cb_grp_lock)
+        pj_grp_lock_dec_ref(cb_grp_lock);
 }
 
 /*
@@ -1770,6 +1808,7 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
     srtp_err_status_t err;
     void (*cb)(void*, void*, pj_ssize_t) = NULL;
     void *cb_data = NULL;
+    pj_grp_lock_t *cb_grp_lock = NULL;
 
     /* Guard against race with transport_detach()/destroy().
      * See comment in srtp_rtp_cb().
@@ -1778,8 +1817,19 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
         return;
 
     if (srtp->bypass_srtp) {
-        if (srtp->rtcp_cb)
-            srtp->rtcp_cb(srtp->user_data, pkt, size);
+        pj_lock_acquire(srtp->mutex);
+        cb = srtp->rtcp_cb;
+        cb_data = srtp->user_data;
+        cb_grp_lock = srtp->cb_grp_lock;
+        if (cb_grp_lock)
+            pj_grp_lock_add_ref(cb_grp_lock);
+        pj_lock_release(srtp->mutex);
+
+        if (cb)
+            (*cb)(cb_data, pkt, size);
+
+        if (cb_grp_lock)
+            pj_grp_lock_dec_ref(cb_grp_lock);
         return;
     }
 
@@ -1824,6 +1874,9 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
     } else {
         cb = srtp->rtcp_cb;
         cb_data = srtp->user_data;
+        cb_grp_lock = srtp->cb_grp_lock;
+        if (cb_grp_lock)
+            pj_grp_lock_add_ref(cb_grp_lock);
     }
 
     pj_lock_release(srtp->mutex);
@@ -1831,6 +1884,9 @@ static void srtp_rtcp_cb( void *user_data, void *pkt, pj_ssize_t size)
     if (cb) {
         (*cb)(cb_data, pkt, len);
     }
+
+    if (cb_grp_lock)
+        pj_grp_lock_dec_ref(cb_grp_lock);
 }
 
 

--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -1341,6 +1341,7 @@ static pj_status_t transport_attach2(pjmedia_transport *tp,
     if (status != PJ_SUCCESS) {
         pj_lock_acquire(srtp->mutex);
         srtp->rtp_cb = NULL;
+        srtp->rtp_cb2 = NULL;
         srtp->rtcp_cb = NULL;
         srtp->user_data = NULL;
         srtp->cb_grp_lock = NULL;

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -76,6 +76,8 @@ struct transport_udp
     void  (*rtcp_cb)(   void*,          /**< To report incoming RTCP.       */
                         void*,
                         pj_ssize_t);
+    pj_grp_lock_t      *cb_grp_lock;    /**< Callback owner's group lock,
+                                             ref'd across each rx callback. */
 
     unsigned            tx_drop_pct;    /**< Percent of tx pkts to drop.    */
     unsigned            rx_drop_pct;    /**< Percent of rx pkts to drop.    */
@@ -508,6 +510,7 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
     void (*cb)(void*,void*,pj_ssize_t);
     void (*cb2)(pjmedia_tp_cb_param*);
     void *user_data;
+    pj_grp_lock_t *cb_grp_lock;
 
     /* Snapshot callback pointers and the RTP source address under lock.
      * pj_ioqueue_lock_key() == pj_grp_lock_acquire() for the same group
@@ -517,6 +520,12 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
      * to be invoked without the key lock held — without the copy, a
      * concurrent attach could bzero rtp_src_addr after we passed a
      * pointer to it into the cb, and the cb would then see sa_family=0.
+     *
+     * Also hold a reference on the callback owner's group lock (if any)
+     * across the up-call: transport_detach() clears the callbacks under
+     * this same key lock before the owner drops its own reference, so a
+     * non-NULL cb here means the owner is still alive and safe to ref, and
+     * the ref keeps it alive for the whole up-call.
      */
     if (udp->base.grp_lock)
         pj_grp_lock_acquire(udp->base.grp_lock);
@@ -524,6 +533,9 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
     cb = udp->rtp_cb;
     cb2 = udp->rtp_cb2;
     user_data = udp->user_data;
+    cb_grp_lock = udp->cb_grp_lock;
+    if (cb_grp_lock)
+        pj_grp_lock_add_ref(cb_grp_lock);
     pj_memcpy(src_addr, &udp->rtp_src_addr, sizeof(*src_addr));
 
     if (udp->base.grp_lock)
@@ -546,6 +558,8 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
             src_addr->addr.sa_family != PJ_AF_INET &&
             src_addr->addr.sa_family != PJ_AF_INET6)
         {
+            if (cb_grp_lock)
+                pj_grp_lock_dec_ref(cb_grp_lock);
             return;
         }
 
@@ -561,6 +575,9 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
         /* Legacy cb doesn't consume src_addr; deliver unconditionally. */
         (*cb)(user_data, udp->rtp_pkt, bytes_read);
     }
+
+    if (cb_grp_lock)
+        pj_grp_lock_dec_ref(cb_grp_lock);
 }
 
 /* Call RTCP cb. */
@@ -568,6 +585,7 @@ static void call_rtcp_cb(struct transport_udp *udp, pj_ssize_t bytes_read)
 {
     void(*cb)(void*, void*, pj_ssize_t);
     void *user_data;
+    pj_grp_lock_t *cb_grp_lock;
 
     /* See comment in call_rtp_cb() above. */
     if (udp->base.grp_lock)
@@ -575,12 +593,18 @@ static void call_rtcp_cb(struct transport_udp *udp, pj_ssize_t bytes_read)
 
     cb = udp->rtcp_cb;
     user_data = udp->user_data;
+    cb_grp_lock = udp->cb_grp_lock;
+    if (cb_grp_lock)
+        pj_grp_lock_add_ref(cb_grp_lock);
 
     if (udp->base.grp_lock)
         pj_grp_lock_release(udp->base.grp_lock);
 
     if (cb)
         (*cb)(user_data, udp->rtcp_pkt, bytes_read);
+
+    if (cb_grp_lock)
+        pj_grp_lock_dec_ref(cb_grp_lock);
 }
 
 /* Notification from ioqueue about incoming RTP packet */
@@ -905,7 +929,8 @@ static pj_status_t tp_attach          (pjmedia_transport *tp,
                                        void (*rtp_cb2)(pjmedia_tp_cb_param*),
                                        void (*rtcp_cb)(void*,
                                                        void*,
-                                                       pj_ssize_t))
+                                                       pj_ssize_t),
+                                       pj_grp_lock_t *cb_grp_lock)
 {
     struct transport_udp *udp = (struct transport_udp*) tp;
     const pj_sockaddr *rtcp_addr;
@@ -975,6 +1000,7 @@ static pj_status_t tp_attach          (pjmedia_transport *tp,
     udp->rtp_cb2 = rtp_cb2;
     udp->rtcp_cb = rtcp_cb;
     udp->user_data = user_data;
+    udp->cb_grp_lock = cb_grp_lock;
 
     /* Save address length */
     udp->addr_len = rem_addr_len;
@@ -1053,19 +1079,20 @@ static pj_status_t transport_attach(   pjmedia_transport *tp,
                                                        pj_ssize_t))
 {
     return tp_attach(tp, user_data, rem_addr, rem_rtcp, addr_len,
-                     rtp_cb, NULL, rtcp_cb);
+                     rtp_cb, NULL, rtcp_cb, NULL);
 }
 
 
 static pj_status_t transport_attach2(pjmedia_transport *tp,
                                      pjmedia_transport_attach_param *att_param)
 {
-    return tp_attach(tp, att_param->user_data, 
-                            (pj_sockaddr_t*)&att_param->rem_addr, 
-                            (pj_sockaddr_t*)&att_param->rem_rtcp, 
+    return tp_attach(tp, att_param->user_data,
+                            (pj_sockaddr_t*)&att_param->rem_addr,
+                            (pj_sockaddr_t*)&att_param->rem_rtcp,
                             att_param->addr_len, att_param->rtp_cb,
-                            att_param->rtp_cb2, 
-                            att_param->rtcp_cb);
+                            att_param->rtp_cb2,
+                            att_param->rtcp_cb,
+                            att_param->grp_lock);
 }
 
 
@@ -1108,6 +1135,7 @@ static void transport_detach( pjmedia_transport *tp,
         udp->rtp_cb2 = NULL;
         udp->rtcp_cb = NULL;
         udp->user_data = NULL;
+        udp->cb_grp_lock = NULL;
 
         /* Unlock keys before clearing, to avoid deadlock with
          * PJ_IOQUEUE_CALLBACK_NO_LOCK. When that setting is enabled,

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -357,6 +357,11 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
     c_strm->port.grp_lock = c_strm->grp_lock;
 
     /* Only attach transport when stream is ready. */
+    /* Let the transport hold a reference on the stream's group lock across
+     * each rx callback, so the stream cannot be destroyed while an in-flight
+     * RTP/RTCP callback is running on it.
+     */
+    att_param.grp_lock = c_strm->grp_lock;
     status = pjmedia_transport_attach2(tp, &att_param);
     if (status != PJ_SUCCESS)
         goto err_cleanup;

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -1916,6 +1916,11 @@ PJ_DEF(pj_status_t) pjmedia_vid_stream_create(
     att_param.addr_len = pj_sockaddr_get_len(&info->rem_addr);
     att_param.rtp_cb2 = &on_rx_rtp;
     att_param.rtcp_cb = &on_rx_rtcp;
+    /* Let the transport hold a reference on the stream's group lock across
+     * each rx callback, so the stream cannot be destroyed while an in-flight
+     * RTP/RTCP callback is running on it.
+     */
+    att_param.grp_lock = c_strm->grp_lock;
 
     /* Only attach transport when stream is ready. */
     status = pjmedia_transport_attach2(tp, &att_param);

--- a/pjsip/src/test/pjsua_stress.c
+++ b/pjsip/src/test/pjsua_stress.c
@@ -36,6 +36,11 @@
  * pjlib/include/pj/config_site_stress.h.
  */
 
+/* For REG_RIP in <ucontext.h> on glibc; must precede any libc include. */
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#  define _GNU_SOURCE 1
+#endif
+
 #include <pjsua-lib/pjsua.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -46,6 +51,15 @@
 #  include <signal.h>
 #  include <unistd.h>
 #  define PJSUA_STRESS_HAS_BACKTRACE 1
+#endif
+
+/* ucontext gives the faulting PC; only wired up for Linux (the CI target),
+ * where <ucontext.h> needs no extra feature macro beyond _GNU_SOURCE above.
+ * macOS's copy requires _XOPEN_SOURCE and its plain backtrace already
+ * captures the crash site, so it is left on the fallback path. */
+#if defined(__linux__)
+#  include <ucontext.h>
+#  define PJSUA_STRESS_HAS_FAULT_PC 1
 #endif
 
 #define THIS_FILE  "pjsua_stress"
@@ -930,17 +944,48 @@ bad:
  *==========================================================================*/
 
 #ifdef PJSUA_STRESS_HAS_BACKTRACE
+/* Extract the faulting instruction pointer from the signal ucontext.
+ * Returns NULL if unavailable on this platform. Under TSan, backtrace()
+ * from the signal handler often unwinds only the signal-delivery frames
+ * (libtsan + this handler) and misses the interrupted thread, so the crash
+ * site never appears. The ucontext PC is the crash site regardless, so we
+ * prepend it to the dumped frames for addr2line to resolve. */
+static void *crash_fault_pc(void *uctx)
+{
+#if defined(PJSUA_STRESS_HAS_FAULT_PC) && defined(__x86_64__)
+    return (void*)((ucontext_t*)uctx)->uc_mcontext.gregs[REG_RIP];
+#elif defined(PJSUA_STRESS_HAS_FAULT_PC) && defined(__aarch64__)
+    return (void*)((ucontext_t*)uctx)->uc_mcontext.pc;
+#else
+    (void)uctx;
+    return NULL;
+#endif
+}
+
 /* Async-signal-safe handler: dumps a native backtrace, then re-raises
  * the signal with the default disposition so the process still dies
  * with the original status (e.g. 134 for SIGABRT). The build links
  * with -rdynamic so non-static symbols resolve to names. */
-static void crash_signal_handler(int sig)
+static void crash_signal_handler(int sig, siginfo_t *info, void *uctx)
 {
     static const char header[] = "\n=== pjsua_stress backtrace ===\n";
+    static const char pchdr[] = "faulting frame:\n";
     void *frames[64];
+    void *pc;
     int n;
 
+    PJ_UNUSED_ARG(info);
+
     (void)!write(STDERR_FILENO, header, sizeof(header) - 1);
+
+    /* Dump the faulting PC first; it is the crash site even when the
+     * backtrace below only captures the signal-delivery frames. */
+    pc = crash_fault_pc(uctx);
+    if (pc) {
+        (void)!write(STDERR_FILENO, pchdr, sizeof(pchdr) - 1);
+        backtrace_symbols_fd(&pc, 1, STDERR_FILENO);
+    }
+
     n = backtrace(frames, (int)(sizeof(frames) / sizeof(frames[0])));
     backtrace_symbols_fd(frames, n, STDERR_FILENO);
 
@@ -951,12 +996,18 @@ static void crash_signal_handler(int sig)
 
 static void install_crash_handler(void)
 {
+    struct sigaction sa;
     void *dummy[1];
     /* Prime the libgcc unwinder so backtrace() inside the handler
      * doesn't take the slow first-call path that may allocate. */
     backtrace(dummy, 1);
-    signal(SIGABRT, crash_signal_handler);
-    signal(SIGSEGV, crash_signal_handler);
+
+    pj_bzero(&sa, sizeof(sa));
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = &crash_signal_handler;
+    sigaction(SIGABRT, &sa, NULL);
+    sigaction(SIGSEGV, &sa, NULL);
 }
 #else
 static void install_crash_handler(void) {}


### PR DESCRIPTION
## Problem

`stress / tsan` SIGSEGVs (exit 139) in `pjmedia_stream_send_rtcp()`, reached from `on_rx_rtp()` on an ioqueue worker thread while dereferencing a dangling `c_strm->transport`. It is **not** a data race report but a hard use-after-free. It reproduces on the **weekly master** run (e.g. run 30731848468, 2026-08-02), so it is pre-existing and independent of any open feature PR.

Resolved crash stack:

```
pjmedia_stream_send_rtcp    stream_common.c   <- fault: c_strm->transport->grp_lock
send_rtcp                   stream_imp_common.c:257
on_rx_rtp                   stream_imp_common.c   <- initial RTCP RR send
srtp_rtp_cb                 transport_srtp.c      <- SRTP bypass up-call
call_rtp_cb                 transport_udp.c
on_rx_rtp                   transport_udp.c
ioqueue_dispatch_read_event ioqueue_common_abs.c
worker_proc / thread_main
```

## Root cause

Two independent group locks are in play:

- the **transport's** group lock (`c_strm->transport->grp_lock`), shared UDP↔SRTP;
- the **stream's own** group lock (`c_strm->grp_lock`), created in `*_stream_create()`.

`pj_ioqueue_poll()` holds a reference on the *transport* group lock across the whole dispatch, so the SRTP/UDP objects remain valid for the callback — `c_strm->transport` is **not** the freed object. **`c_strm` (the stream) is.** Nothing holds a reference on the *stream* group lock across the transport→stream receive up-call, so between the moment the transport latches the stream pointer and the moment `on_rx_rtp` runs, the stream can be fully torn down (conf port removed + `pjmedia_stream_destroy` → `on_destroy` → pool recycled). Taking the reference at the top of `on_rx_rtp` (#5103) is too late — the object is already gone. `PJ_IOQUEUE_CALLBACK_NO_LOCK=1` (the default, used by the stress config) runs the callback without the key lock, widening the window.

## Fix

Let the media transport hold a reference on the callback owner's (stream's) group lock for the whole duration of each rx up-call.

- New optional `pjmedia_transport_attach_param::grp_lock` — `NULL` keeps the previous behavior; all existing callers `pj_bzero` the struct, so the default is preserved.
- Audio/video/text `*_stream_create()` set `att_param.grp_lock = c_strm->grp_lock`.
- `transport_udp` (`call_rtp_cb`/`call_rtcp_cb`) and `transport_srtp` (`srtp_rtp_cb`/`srtp_rtcp_cb`, both the bypass and the SRTP paths) snapshot the owner group lock together with the callback pointers under the same lock `transport_detach()` uses to clear them, `add_ref` it, run the up-call, then `dec_ref`.

**Why it is safe:** `pjmedia_stream_destroy()` detaches from the transport (clearing the callbacks under the transport lock) *before* dropping the stream's own group-lock reference. So if a callback observes a non-NULL callback pointer under that lock, detach has not run yet, the stream's own reference is still held, and the `add_ref` pins a live object for the rest of the up-call — independent of conf-port-removal timing. SRTP does not propagate the owner group lock to its member transport (`member_param.grp_lock = NULL`), whose callback target is the SRTP transport itself (kept alive by the ioqueue's ref on the shared transport group lock).

## Testing

- `make` clean, no warnings, on all six touched files.
- Local `pjsua-stress -n 32 -v 8 -t 6 --duration 45` under ASan (macOS/kqueue): exit 0, clean shutdown, timer heap drains to 0 — confirms the `add_ref`/`dec_ref` balance (an imbalance would leak the stream/transport/lock and never tear down).
- The specific race is epoll/timing-dependent and did not reproduce locally on kqueue (same as #5103), so **CI `stress / tsan` is the authoritative validator**.

## Files

- `pjmedia/include/pjmedia/transport.h`
- `pjmedia/src/pjmedia/transport_udp.c`
- `pjmedia/src/pjmedia/transport_srtp.c`
- `pjmedia/src/pjmedia/stream.c`, `vid_stream.c`, `txt_stream.c`

Co-Authored-By Claude Code