### PR TITLE
pjmedia: fix signed 24-bit RTCP RR cumulative loss parsing

### DIFF
--- a/pjmedia/src/pjmedia/rtcp.c
+++ b/pjmedia/src/pjmedia/rtcp.c
@@ -549,6 +549,7 @@ static void parse_rtcp_report( pjmedia_rtcp_session *sess,
     const pjmedia_rtcp_rr *rr = NULL;
     const pjmedia_rtcp_sr *sr = NULL;
     pj_uint32_t last_loss, jitter_samp, jitter;
+    pj_int32_t tx_loss;
 
     /* Parse RTCP */
     if (common->pt == RTCP_SR) {
@@ -605,12 +606,22 @@ static void parse_rtcp_report( pjmedia_rtcp_session *sess,
 
     last_loss = sess->stat.tx.loss;
 
-    /* Get packet loss */
-    sess->stat.tx.loss = (rr->total_lost_2 << 16) +
-                         (rr->total_lost_1 << 8) +
-                          rr->total_lost_0;
+    /* Get packet loss. RFC 3550 6.4.1 defines cumulative number of packets
+     * lost as a signed 24-bit value; it may be negative when duplicate or
+     * late packets make received exceed expected. Sign-extend from bit 23.
+     */
+    tx_loss = (rr->total_lost_2 << 16) +
+              (rr->total_lost_1 << 8) +
+               rr->total_lost_0;
+    if (tx_loss & 0x800000)
+        tx_loss -= 0x1000000;
 
-    TRACE_((sess->name, "Rx RTCP RR: total_lost_2=%x, 1=%x, 0=%x, lost=%d", 
+    /* stat.tx.loss is unsigned, so clamp a negative cumulative loss (net
+     * gain from duplicates) to zero.
+     */
+    sess->stat.tx.loss = (tx_loss < 0) ? 0 : (pj_uint32_t)tx_loss;
+
+    TRACE_((sess->name, "Rx RTCP RR: total_lost_2=%x, 1=%x, 0=%x, lost=%d",
             (int)rr->total_lost_2,
             (int)rr->total_lost_1,
             (int)rr->total_lost_0,


### PR DESCRIPTION
## Problem

`pjsua_call_dump()` reports absurdly large TX packet loss — millions of packets — sometimes from the very start of a call, fluctuating non-monotonically (e.g. between ~1.4M and ~16.3M) even though the whole ~7-minute call only sends ~21,000 packets. Observed against a Ribbon SBC as the far end.

## Root cause

RFC 3550 §6.4.1 defines the RTCP RR *cumulative number of packets lost* field as a **signed 24-bit** value:

> ...packets that arrive late are not counted as lost, and the loss may be negative if there are duplicates.

It is `expected − received`, and `received` includes duplicates/late arrivals, so a small negative value (e.g. `-2`) is legitimate and expected on real networks.

In `pjmedia/src/pjmedia/rtcp.c`, the three loss bytes were reconstructed as **unsigned**:

```c
sess->stat.tx.loss = (rr->total_lost_2 << 16) +
                     (rr->total_lost_1 << 8) +
                      rr->total_lost_0;
```

A far-end value of `-2` becomes `16,777,214` instead of `-2`. That bogus value then:
- lands in `stat.tx.loss`,
- triggers the "loss increased" branch of the `loss_period` estimate (`stat.tx.loss > last_loss`),
- surfaces in `pjsua_call_dump()`.

The largest observed value (16,307,362) sits right near the 24-bit ceiling of 16,777,215, matching the theory.

## Fix

Reconstruct into a signed `pj_int32_t` and **sign-extend from bit 23**. Since the public `pjmedia_rtcp_stream_stat::loss` field is `unsigned` (changing its type would break ABI), a negative cumulative loss (net gain from duplicates) is **clamped to zero**.

```c
tx_loss = (rr->total_lost_2 << 16) +
          (rr->total_lost_1 << 8) +
           rr->total_lost_0;
if (tx_loss & 0x800000)
    tx_loss |= (pj_int32_t)0xFF000000;

sess->stat.tx.loss = (tx_loss < 0) ? 0 : (pj_uint32_t)tx_loss;
```

## Notes

- Related to (but distinct from) #5122, which fixes a separate 64-bit overflow in the interarrival jitter calculation — another source of "absurd stats" but on a different code path.

Co-Authored-By Claude Code