### PR TITLE
Fix several Coverity issues

### DIFF
--- a/pjlib/src/pj/pool_policy_malloc.c
+++ b/pjlib/src/pj/pool_policy_malloc.c
@@ -42,13 +42,16 @@ static void *default_block_alloc(pj_pool_factory *factory, pj_size_t size)
             return NULL;
     }
 
-    /* Guard against overflow when adding the signature padding (only nonzero
-     * when PJ_SAFE_POOL is enabled).
-     */
+#if PJ_SAFE_POOL
+    /* Guard against overflow when adding the signature padding. */
     if (size > ((pj_size_t)-1) - (SIG_SIZE << 1))
         p = NULL;
     else
         p = malloc(size + (SIG_SIZE << 1));
+#else
+    /* No signature padding, so no overflow is possible here. */
+    p = malloc(size);
+#endif
 
     if (p == NULL) {
         if (factory->on_block_free) 

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -621,7 +621,7 @@ static pj_bool_t sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
         nbuf[name->slen] = '\0';
 
         idx = sess_cache_find(nbuf);
-        if (idx >= 0) {
+        if (idx >= 0 && (unsigned)idx < ossl_sess_cache_cnt) {
             SSL_SESSION_free(ossl_sess_cache[idx].sess);
             for (n = (unsigned)idx; n + 1 < ossl_sess_cache_cnt; ++n)
                 ossl_sess_cache[n] = ossl_sess_cache[n + 1];
@@ -667,7 +667,7 @@ static SSL_SESSION *sess_cache_get(const pj_str_t *name)
 
     pj_lock_acquire(ossl_sess_cache_lock);
     idx = sess_cache_find(nbuf);
-    if (idx >= 0) {
+    if (idx >= 0 && (unsigned)idx < ossl_sess_cache_cnt) {
         unsigned n;
         ossl_sess_cache_entry e = ossl_sess_cache[idx];
 

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -2313,8 +2313,10 @@ pj_status_t pjsua_app_run(pj_bool_t wait_telnet_cli)
         call_opt.vid_cnt = app_config.vid.vid_cnt;
         call_opt.txt_cnt = app_config.txt_cnt;
 
-        pjsua_call_make_call(current_acc, &uri_arg, &call_opt, NULL, 
-                             NULL, NULL);
+        status = pjsua_call_make_call(current_acc, &uri_arg, &call_opt, NULL,
+                                      NULL, NULL);
+        if (status != PJ_SUCCESS)
+            pjsua_perror(THIS_FILE, "Unable to make call", status);
     }   
 
     app_running = PJ_TRUE;

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -1920,6 +1920,7 @@ static pj_status_t cmd_make_single_call(pj_cli_cmd_val *cval)
     char out_str[128];
     pj_str_t tmp = pj_str(dest);
     pj_bool_t loop = PJ_FALSE;
+    pj_status_t status;
 
     pj_strncpy_with_null(&tmp, &cval->argv[1], sizeof(dest));
 
@@ -1958,8 +1959,10 @@ static pj_status_t cmd_make_single_call(pj_cli_cmd_val *cval)
 
         pjsua_msg_data_init(&msg_data);
         TEST_MULTIPART(&msg_data);
-        pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
-                             &msg_data, &current_call);
+        status = pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
+                                      &msg_data, &current_call);
+        if (status != PJ_SUCCESS)
+            pjsua_perror(THIS_FILE, "Unable to make call", status);
 
         result.nb_result++;
     } while (loop);

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -706,6 +706,7 @@ static void ui_make_new_call()
     input_result result;
     pj_str_t tmp;
     pj_bool_t loop = PJ_FALSE;
+    pj_status_t status;
 
     printf("(You currently have %d calls)\n", pjsua_call_get_count());
 
@@ -739,8 +740,10 @@ static void ui_make_new_call()
         if (app_config.enable_loam) {
             call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
         }
-        pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
-                             &msg_data_, &current_call);
+        status = pjsua_call_make_call(current_acc, &tmp, &call_opt, NULL,
+                                      &msg_data_, &current_call);
+        if (status != PJ_SUCCESS)
+            pjsua_perror(THIS_FILE, "Unable to make call", status);
 
         result.nb_result++;
     } while (loop);

--- a/pjsip/src/test/dns_test.c
+++ b/pjsip/src/test/dns_test.c
@@ -557,8 +557,14 @@ int resolve_test(void)
     pj_status_t status;
 
     pool = pjsip_endpt_create_pool(endpt, NULL, 4000, 4000);
+    if (!pool)
+        return -5;
 
     status = pjsip_endpt_create_resolver(endpt, &resv);
+    if (status != PJ_SUCCESS) {
+        pjsip_endpt_release_pool(endpt, pool);
+        return -7;
+    }
 
     nameserver = pj_str("192.168.0.106");
     pj_dns_resolver_set_ns(resv, 1, &nameserver, &port);


### PR DESCRIPTION
Fixes a batch of Coverity findings. All are low-risk; none change runtime behavior except the added error reporting in the pjsua apps.

### pjlib

- **`pool_policy_malloc.c`** (CID 1663960 CONSTANT_EXPRESSION_RESULT, CID 1663958 DEADCODE) — `SIG_SIZE` is zero unless `PJ_SAFE_POOL` is enabled, so `size > ((pj_size_t)-1) - (SIG_SIZE << 1)` is always false and the `p = NULL` branch is unreachable. The guard is now compiled only when `PJ_SAFE_POOL` is set; otherwise the code simply calls `malloc(size)`, which is what it did before.
- **`ssl_sock_ossl.c`** (CID 1663961 INTEGER_OVERFLOW) — `sess_cache_find()` cannot return an index outside the cache, but that is not provable at the use site, so Coverity flags the `(unsigned)idx` loop start. Added an explicit `(unsigned)idx < ossl_sess_cache_cnt` bound in `sess_cache_store()` and, for consistency, in `sess_cache_get()`. No runtime change.

### pjsip-apps

- **`pjsua_app.c`, `pjsua_app_cli.c`, `pjsua_app_legacy.c`** (CID 1664281, 1664280, 1664279 CHECKED_RETURN) — three `pjsua_call_make_call()` call sites discarded the return value while the neighboring multi-call loops in the same files already checked it. They now check the status and report it via `pjsua_perror()`.

### pjsip tests

- **`dns_test.c`** (CID 1664382 NULL_RETURNS) — `resolve_test()` passed a possibly-NULL pool to `test_resolve()`. Added the pool check, and also checked `pjsip_endpt_create_resolver()`, whose status was assigned but discarded while `resv` was used unconditionally.

### Testing

- `make -j3` clean, no warnings.
- pjlib: `pool_test`, `pool_perf_test`, `ssl_sock_test` pass.
- pjsip: full suite (26 tests) passes with `-w 4` under ASan, including `resolve_test`.

Co-Authored-By Claude Code