### PR TITLE
Fixed NULL deref crash when TURN session is destroyed mid-loop in on_data_read()

### DIFF
--- a/pjnath/src/pjnath-test/server.c
+++ b/pjnath/src/pjnath-test/server.c
@@ -963,6 +963,26 @@ send_pkt:
             size += 8;
         }
 
+        /* Append two ChannelData packets to the ChannelBind response, so
+         * that the client processes the binding and both packets in a
+         * single read.
+         */
+        if (test_srv->turn_append_data_on_chbind && size + 16 <= MAX_STUN_PKT &&
+            PJ_STUN_IS_SUCCESS_RESPONSE(resp->hdr.type) &&
+            PJ_STUN_GET_METHOD(resp->hdr.type) == PJ_STUN_CHANNEL_BIND_METHOD)
+        {
+            pj_uint8_t *p = (pj_uint8_t*)data + size;
+            unsigned j;
+
+            for (j=0; j<2; ++j) {
+                p[0] = 0x40; p[1] = 0x00;
+                p[2] = 0x00; p[3] = 0x04;
+                p[4] = 't';  p[5] = 'e';  p[6] = 's';  p[7] = 't';
+                p += 8;
+            }
+            size += 16;
+        }
+
         len = size;
         switch (tp_type) {
         case PJ_TURN_TP_TCP:

--- a/pjnath/src/pjnath-test/server.c
+++ b/pjnath/src/pjnath-test/server.c
@@ -936,11 +936,32 @@ static pj_bool_t turn_on_data_read(test_server *test_srv,
 send_pkt:
     if (resp) {
         pj_turn_tp_type tp_type = get_turn_tp_type(test_srv->flags);
+        pj_stun_lifetime_attr *lf_attr;
 
         status = pj_stun_msg_encode(resp, (pj_uint8_t*)data, MAX_STUN_PKT, 
                                     0, &auth_key, &size);
         if (status != PJ_SUCCESS)
             goto on_return;
+
+        lf_attr = (pj_stun_lifetime_attr*)
+                  pj_stun_msg_find_attr(resp, PJ_STUN_ATTR_LIFETIME, 0);
+
+        /* Append a ChannelData packet to the deallocation response, so that
+         * the client processes both in a single read.
+         */
+        if (test_srv->turn_append_data_on_dealloc && lf_attr &&
+            lf_attr->value == 0 && size + 8 <= MAX_STUN_PKT &&
+            PJ_STUN_IS_SUCCESS_RESPONSE(resp->hdr.type) &&
+            PJ_STUN_GET_METHOD(resp->hdr.type) == PJ_STUN_REFRESH_METHOD)
+        {
+            pj_uint8_t *p = (pj_uint8_t*)data + size;
+
+            /* ChannelData, channel number 0x4000, 4 bytes of payload */
+            p[0] = 0x40; p[1] = 0x00;
+            p[2] = 0x00; p[3] = 0x04;
+            p[4] = 't';  p[5] = 'e';  p[6] = 's';  p[7] = 't';
+            size += 8;
+        }
 
         len = size;
         switch (tp_type) {

--- a/pjnath/src/pjnath-test/server.c
+++ b/pjnath/src/pjnath-test/server.c
@@ -116,6 +116,7 @@ pj_status_t create_test_server(pj_stun_config *stun_cfg,
     test_srv->passwd = pj_str(TURN_PASSWD);
 
     pj_ioqueue_op_key_init(&test_srv->send_key, sizeof(test_srv->send_key));
+    pj_ioqueue_op_key_init(&test_srv->send_key2, sizeof(test_srv->send_key2));
 
     if (flags & CREATE_DNS_SERVER) {
         status = pj_dns_server_create(stun_cfg->pf, test_srv->stun_cfg->ioqueue,
@@ -937,6 +938,7 @@ send_pkt:
     if (resp) {
         pj_turn_tp_type tp_type = get_turn_tp_type(test_srv->flags);
         pj_stun_lifetime_attr *lf_attr;
+        pj_bool_t send_extra = PJ_FALSE;
 
         status = pj_stun_msg_encode(resp, (pj_uint8_t*)data, MAX_STUN_PKT, 
                                     0, &auth_key, &size);
@@ -964,23 +966,26 @@ send_pkt:
         }
 
         /* Append two ChannelData packets to the ChannelBind response, so
-         * that the client processes the binding and both packets in a
-         * single read.
+         * that the client processes the binding and both packets in a single
+         * read. In split mode only the first one is appended, and the second
+         * is sent on its own below.
          */
         if (test_srv->turn_append_data_on_chbind && size + 16 <= MAX_STUN_PKT &&
             PJ_STUN_IS_SUCCESS_RESPONSE(resp->hdr.type) &&
             PJ_STUN_GET_METHOD(resp->hdr.type) == PJ_STUN_CHANNEL_BIND_METHOD)
         {
+            unsigned cnt = test_srv->turn_split_data_on_chbind? 1 : 2;
             pj_uint8_t *p = (pj_uint8_t*)data + size;
             unsigned j;
 
-            for (j=0; j<2; ++j) {
+            for (j=0; j<cnt; ++j) {
                 p[0] = 0x40; p[1] = 0x00;
                 p[2] = 0x00; p[3] = 0x04;
                 p[4] = 't';  p[5] = 'e';  p[6] = 's';  p[7] = 't';
                 p += 8;
             }
-            size += 16;
+            size += cnt * 8;
+            send_extra = test_srv->turn_split_data_on_chbind;
         }
 
         len = size;
@@ -999,6 +1004,29 @@ send_pkt:
             status = pj_activesock_sendto(test_srv->turn_sock, 
                                           &test_srv->send_key, data, 
                                           &len, 0, src_addr, addr_len);     
+        }
+
+        /* Send the second ChannelData on its own. It needs its own buffer and
+         * operation key, as the send above may still be pending.
+         */
+        if (status == PJ_SUCCESS && send_extra) {
+            pj_uint8_t *cd = test_srv->extra_data;
+            pj_ssize_t cd_len = sizeof(test_srv->extra_data);
+
+            cd[0] = 0x40; cd[1] = 0x00;
+            cd[2] = 0x00; cd[3] = 0x04;
+            cd[4] = 't';  cd[5] = 'e';  cd[6] = 's';  cd[7] = 't';
+
+            if (tp_type == PJ_TURN_TP_TCP) {
+                pj_activesock_send(test_srv->cl_turn_sock,
+                                   &test_srv->send_key2, cd, &cd_len, 0);
+            }
+#if USE_TLS
+            else if (tp_type == PJ_TURN_TP_TLS) {
+                pj_ssl_sock_send(test_srv->ssl_cl_sock,
+                                 &test_srv->send_key2, cd, &cd_len, 0);
+            }
+#endif
         }
     }
 

--- a/pjnath/src/pjnath-test/server.c
+++ b/pjnath/src/pjnath-test/server.c
@@ -1007,9 +1007,10 @@ send_pkt:
         }
 
         /* Send the second ChannelData on its own. It needs its own buffer and
-         * operation key, as the send above may still be pending.
+         * operation key, as the send above may still be pending, which is why
+         * PJ_EPENDING counts as sent here too.
          */
-        if (status == PJ_SUCCESS && send_extra) {
+        if ((status == PJ_SUCCESS || status == PJ_EPENDING) && send_extra) {
             pj_uint8_t *cd = test_srv->extra_data;
             pj_ssize_t cd_len = sizeof(test_srv->extra_data);
 

--- a/pjnath/src/pjnath-test/server.h
+++ b/pjnath/src/pjnath-test/server.h
@@ -109,6 +109,14 @@ struct test_server
      */
     pj_bool_t            turn_append_data_on_chbind;
 
+    /* Append only the first of the two ChannelData packets above, and send
+     * the second one separately, so that it is likely to arrive in a later
+     * read than the one that bound the channel.
+     */
+    pj_bool_t            turn_split_data_on_chbind;
+    pj_ioqueue_op_key_t  send_key2;
+    pj_uint8_t           extra_data[8];
+
     struct turn_stat {
         unsigned         rx_allocate_cnt;
         unsigned         rx_refresh_cnt;

--- a/pjnath/src/pjnath-test/server.h
+++ b/pjnath/src/pjnath-test/server.h
@@ -103,6 +103,12 @@ struct test_server
      */
     pj_bool_t            turn_append_data_on_dealloc;
 
+    /* Append two ChannelData packets to the ChannelBind response, so that a
+     * stream-oriented client processes both in the same read as the response
+     * that binds the channel. See turn_sock_test.c destroy_in_rx_data_test().
+     */
+    pj_bool_t            turn_append_data_on_chbind;
+
     struct turn_stat {
         unsigned         rx_allocate_cnt;
         unsigned         rx_refresh_cnt;

--- a/pjnath/src/pjnath-test/server.h
+++ b/pjnath/src/pjnath-test/server.h
@@ -97,6 +97,12 @@ struct test_server
     pj_bool_t            turn_respond_allocate;
     pj_bool_t            turn_respond_refresh;
 
+    /* Append a ChannelData packet to the deallocation (Refresh with
+     * LIFETIME=0) response, so that a stream-oriented client receives both
+     * in a single read. See turn_sock_test.c dealloc_multi_pkt_test().
+     */
+    pj_bool_t            turn_append_data_on_dealloc;
+
     struct turn_stat {
         unsigned         rx_allocate_cnt;
         unsigned         rx_refresh_cnt;

--- a/pjnath/src/pjnath-test/turn_sock_test.c
+++ b/pjnath/src/pjnath-test/turn_sock_test.c
@@ -671,7 +671,8 @@ static int dealloc_multi_pkt_test(pj_stun_config *stun_cfg,
  */
 static int destroy_in_rx_data_test(pj_stun_config *stun_cfg,
                                    pj_bool_t use_ipv6,
-                                   pj_turn_tp_type tp_type)
+                                   pj_turn_tp_type tp_type,
+                                   pj_bool_t split)
 {
     struct test_session_cfg test_cfg =
     {
@@ -694,7 +695,8 @@ static int destroy_in_rx_data_test(pj_stun_config *stun_cfg,
     struct test_result result;
     int rc;
 
-    PJ_LOG(3,("", "  destroy in on_rx_data test (%s) (%s)",
+    PJ_LOG(3,("", "  destroy in on_rx_data test, %s (%s) (%s)",
+              split? "split send" : "single send",
               use_ipv6?"IPv6":"IPv4",
               (tp_type==PJ_TURN_TP_TCP)?"TCP":"TLS"));
 
@@ -732,11 +734,14 @@ static int destroy_in_rx_data_test(pj_stun_config *stun_cfg,
         return -230;
     }
 
-    /* The server will coalesce two ChannelData packets with the ChannelBind
-     * response, and we destroy the socket while handling the first one.
+    /* The server sends two ChannelData packets along with the ChannelBind
+     * response, and we destroy the socket while handling the first one. In
+     * split mode the second one is sent separately, so that it is likely to
+     * arrive in a later read, which the delivery check must cover too.
      */
     sess->destroy_on_rx_data = PJ_TRUE;
     sess->test_srv->turn_append_data_on_chbind = PJ_TRUE;
+    sess->test_srv->turn_split_data_on_chbind = split;
 
     pj_sockaddr_init(GET_AF(use_ipv6), &peer_addr, NULL, 1234);
     if (use_ipv6)
@@ -833,9 +838,12 @@ int turn_sock_test(void *p)
         if (rc != 0)
             goto on_return;
 
-        rc = destroy_in_rx_data_test(&app_sess.stun_cfg, USE_IPV6, tp_type);
-        if (rc != 0)
-            goto on_return;
+        for (i=0; i<=1; ++i) {
+            rc = destroy_in_rx_data_test(&app_sess.stun_cfg, USE_IPV6,
+                                         tp_type, i);
+            if (rc != 0)
+                goto on_return;
+        }
     }
 
 on_return:

--- a/pjnath/src/pjnath-test/turn_sock_test.c
+++ b/pjnath/src/pjnath-test/turn_sock_test.c
@@ -534,6 +534,110 @@ static int destroy_test(pj_stun_config  *stun_cfg,
 
 /////////////////////////////////////////////////////////////////////
 
+/* Verify that a single read carrying the deallocation response followed by
+ * another packet does not crash. Processing the response destroys the TURN
+ * session synchronously and clears turn_sock->sess, so the next iteration of
+ * the packet loop in on_data_read() must not use it.
+ */
+static int dealloc_multi_pkt_test(pj_stun_config *stun_cfg,
+                                  pj_bool_t use_ipv6,
+                                  pj_turn_tp_type tp_type)
+{
+    struct test_session_cfg test_cfg =
+    {
+        {   /* Client cfg */
+            PJ_FALSE,       /* DNS SRV */
+            0xFFFF          /* Destroy on state */
+        },
+        {   /* Server cfg */
+            0xFFFFFFFF,     /* flags */
+            PJ_TRUE,        /* respond to allocate  */
+            PJ_TRUE         /* respond to refresh   */
+        }
+    };
+    enum { TIMEOUT = 60 };
+    pjlib_state pjlib_state;
+    pj_turn_session_info info;
+    struct test_session *sess;
+    pj_time_val tstart;
+    struct test_result result;
+    int rc;
+
+    PJ_LOG(3,("", "  deallocation with trailing packet test (%s) (%s)",
+              use_ipv6?"IPv6":"IPv4",
+              (tp_type==PJ_TURN_TP_TCP)?"TCP":"TLS"));
+
+    set_server_flag(&test_cfg, use_ipv6, tp_type);
+    capture_pjlib_state(stun_cfg, &pjlib_state);
+
+    rc = create_test_session(stun_cfg, &test_cfg, &sess);
+    if (rc != 0)
+        return rc;
+
+    /* Wait until state is READY */
+    pj_bzero(&info, sizeof(info));
+    pj_gettimeofday(&tstart);
+    while (sess->turn_sock) {
+        pj_time_val now;
+
+        poll_events(stun_cfg, 10, PJ_FALSE);
+        if (sess->turn_sock == NULL)
+            break;
+
+        if (pj_turn_sock_get_info(sess->turn_sock, &info) != PJ_SUCCESS)
+            break;
+
+        if (info.state >= PJ_TURN_STATE_READY)
+            break;
+
+        pj_gettimeofday(&now);
+        if (now.sec - tstart.sec > TIMEOUT)
+            break;
+    }
+
+    if (info.state != PJ_TURN_STATE_READY) {
+        PJ_LOG(3,("", "    error: state is not READY"));
+        destroy_session(sess);
+        return -200;
+    }
+
+    /* Make the server coalesce a ChannelData packet with the response to
+     * the Refresh with LIFETIME=0 that pj_turn_sock_destroy() triggers.
+     */
+    sess->test_srv->turn_append_data_on_dealloc = PJ_TRUE;
+
+    pj_turn_sock_destroy(sess->turn_sock);
+    poll_events(stun_cfg, 2000, PJ_FALSE);
+    sess->turn_sock = NULL;
+    pj_memcpy(&result, &sess->result, sizeof(result));
+    destroy_session(sess);
+
+    if ((result.state_called & (1<<PJ_TURN_STATE_DESTROYING)) == 0) {
+        PJ_LOG(3,("", "    error: PJ_TURN_STATE_DESTROYING is not called"));
+        return -210;
+    }
+
+    /* The trailing packet arrives after the session is gone, so it must be
+     * dropped rather than reported to the application.
+     */
+    if (result.rx_data_cnt != 0) {
+        PJ_LOG(3,("", "    error: trailing packet was not dropped"));
+        return -220;
+    }
+
+    poll_events(stun_cfg, 500, PJ_FALSE);
+    rc = check_pjlib_state(stun_cfg, &pjlib_state);
+    if (rc != 0) {
+        PJ_LOG(3,("", "    error: memory/timer-heap leak detected"));
+        return rc;
+    }
+
+    return 0;
+}
+
+
+/////////////////////////////////////////////////////////////////////
+
 int turn_sock_test(void *p)
 {
     unsigned n = (int)(intptr_t)p;
@@ -574,6 +678,13 @@ int turn_sock_test(void *p)
             if (rc != 0)
                 goto on_return;
         }
+    }
+
+    /* Only stream transports can deliver more than one packet in a read */
+    if (tp_type != PJ_TURN_TP_UDP) {
+        rc = dealloc_multi_pkt_test(&app_sess.stun_cfg, USE_IPV6, tp_type);
+        if (rc != 0)
+            goto on_return;
     }
 
 on_return:

--- a/pjnath/src/pjnath-test/turn_sock_test.c
+++ b/pjnath/src/pjnath-test/turn_sock_test.c
@@ -663,10 +663,11 @@ static int dealloc_multi_pkt_test(pj_stun_config *stun_cfg,
 
 /////////////////////////////////////////////////////////////////////
 
-/* Verify that destroying the socket from on_rx_data() stops the packet loop.
- * Destruction of an allocated session is graceful, so turn_sock->sess stays
- * set and the deallocation is still in progress when we return, hence the
- * loop cannot rely on the session alone here.
+/* Verify that destroying the socket from on_rx_data() stops any further data
+ * from being reported to the application. Destroying an allocated session is
+ * graceful, so turn_sock->sess stays set and packets keep being parsed until
+ * the deallocation completes, which means the session alone cannot tell us
+ * whether the application still wants the data.
  */
 static int destroy_in_rx_data_test(pj_stun_config *stun_cfg,
                                    pj_bool_t use_ipv6,

--- a/pjnath/src/pjnath-test/turn_sock_test.c
+++ b/pjnath/src/pjnath-test/turn_sock_test.c
@@ -39,6 +39,7 @@ struct test_session
 
     pj_bool_t            destroy_called;
     int                  destroy_on_state;
+    pj_bool_t            destroy_on_rx_data;
     struct test_result   result;
 };
 
@@ -222,6 +223,11 @@ static void turn_on_rx_data(pj_turn_sock *turn_sock,
         return;
 
     sess->result.rx_data_cnt++;
+
+    if (sess->destroy_on_rx_data && !sess->destroy_called) {
+        sess->destroy_called = PJ_TRUE;
+        pj_turn_sock_destroy(turn_sock);
+    }
 }
 
 
@@ -559,6 +565,7 @@ static int dealloc_multi_pkt_test(pj_stun_config *stun_cfg,
     pjlib_state pjlib_state;
     pj_turn_session_info info;
     struct test_session *sess;
+    pj_sockaddr peer_addr;
     pj_time_val tstart;
     struct test_result result;
     int rc;
@@ -601,6 +608,24 @@ static int dealloc_multi_pkt_test(pj_stun_config *stun_cfg,
         return -200;
     }
 
+    /* Bind the channel that the trailing ChannelData packet will use, so
+     * that it would actually reach on_rx_data() if it were processed.
+     */
+    pj_sockaddr_init(GET_AF(use_ipv6), &peer_addr, NULL, 1234);
+    if (use_ipv6)
+        peer_addr.ipv6.sin6_addr.s6_addr[15] = 1;
+    else
+        peer_addr.ipv4.sin_addr.s_addr = pj_htonl(0x7f000001);
+
+    rc = pj_turn_sock_bind_channel(sess->turn_sock, &peer_addr,
+                                   pj_sockaddr_get_len(&peer_addr));
+    if (rc != PJ_SUCCESS) {
+        PJ_LOG(3,("", "    error: unable to bind channel"));
+        destroy_session(sess);
+        return -205;
+    }
+    poll_events(stun_cfg, 1000, PJ_FALSE);
+
     /* Make the server coalesce a ChannelData packet with the response to
      * the Refresh with LIFETIME=0 that pj_turn_sock_destroy() triggers.
      */
@@ -623,6 +648,127 @@ static int dealloc_multi_pkt_test(pj_stun_config *stun_cfg,
     if (result.rx_data_cnt != 0) {
         PJ_LOG(3,("", "    error: trailing packet was not dropped"));
         return -220;
+    }
+
+    poll_events(stun_cfg, 500, PJ_FALSE);
+    rc = check_pjlib_state(stun_cfg, &pjlib_state);
+    if (rc != 0) {
+        PJ_LOG(3,("", "    error: memory/timer-heap leak detected"));
+        return rc;
+    }
+
+    return 0;
+}
+
+
+/////////////////////////////////////////////////////////////////////
+
+/* Verify that destroying the socket from on_rx_data() stops the packet loop.
+ * Destruction of an allocated session is graceful, so turn_sock->sess stays
+ * set and the deallocation is still in progress when we return, hence the
+ * loop cannot rely on the session alone here.
+ */
+static int destroy_in_rx_data_test(pj_stun_config *stun_cfg,
+                                   pj_bool_t use_ipv6,
+                                   pj_turn_tp_type tp_type)
+{
+    struct test_session_cfg test_cfg =
+    {
+        {   /* Client cfg */
+            PJ_FALSE,       /* DNS SRV */
+            0xFFFF          /* Destroy on state */
+        },
+        {   /* Server cfg */
+            0xFFFFFFFF,     /* flags */
+            PJ_TRUE,        /* respond to allocate  */
+            PJ_TRUE         /* respond to refresh   */
+        }
+    };
+    enum { TIMEOUT = 60 };
+    pjlib_state pjlib_state;
+    pj_turn_session_info info;
+    struct test_session *sess;
+    pj_sockaddr peer_addr;
+    pj_time_val tstart;
+    struct test_result result;
+    int rc;
+
+    PJ_LOG(3,("", "  destroy in on_rx_data test (%s) (%s)",
+              use_ipv6?"IPv6":"IPv4",
+              (tp_type==PJ_TURN_TP_TCP)?"TCP":"TLS"));
+
+    set_server_flag(&test_cfg, use_ipv6, tp_type);
+    capture_pjlib_state(stun_cfg, &pjlib_state);
+
+    rc = create_test_session(stun_cfg, &test_cfg, &sess);
+    if (rc != 0)
+        return rc;
+
+    /* Wait until state is READY */
+    pj_bzero(&info, sizeof(info));
+    pj_gettimeofday(&tstart);
+    while (sess->turn_sock) {
+        pj_time_val now;
+
+        poll_events(stun_cfg, 10, PJ_FALSE);
+        if (sess->turn_sock == NULL)
+            break;
+
+        if (pj_turn_sock_get_info(sess->turn_sock, &info) != PJ_SUCCESS)
+            break;
+
+        if (info.state >= PJ_TURN_STATE_READY)
+            break;
+
+        pj_gettimeofday(&now);
+        if (now.sec - tstart.sec > TIMEOUT)
+            break;
+    }
+
+    if (info.state != PJ_TURN_STATE_READY) {
+        PJ_LOG(3,("", "    error: state is not READY"));
+        destroy_session(sess);
+        return -230;
+    }
+
+    /* The server will coalesce two ChannelData packets with the ChannelBind
+     * response, and we destroy the socket while handling the first one.
+     */
+    sess->destroy_on_rx_data = PJ_TRUE;
+    sess->test_srv->turn_append_data_on_chbind = PJ_TRUE;
+
+    pj_sockaddr_init(GET_AF(use_ipv6), &peer_addr, NULL, 1234);
+    if (use_ipv6)
+        peer_addr.ipv6.sin6_addr.s6_addr[15] = 1;
+    else
+        peer_addr.ipv4.sin_addr.s_addr = pj_htonl(0x7f000001);
+
+    rc = pj_turn_sock_bind_channel(sess->turn_sock, &peer_addr,
+                                   pj_sockaddr_get_len(&peer_addr));
+    if (rc != PJ_SUCCESS) {
+        PJ_LOG(3,("", "    error: unable to bind channel"));
+        destroy_session(sess);
+        return -235;
+    }
+
+    poll_events(stun_cfg, 2000, PJ_FALSE);
+    sess->turn_sock = NULL;
+    pj_memcpy(&result, &sess->result, sizeof(result));
+    destroy_session(sess);
+
+    /* Only the first of the two packets may be reported */
+    if (result.rx_data_cnt != 1) {
+        PJ_LOG(3,("", "    error: expecting 1 rx data, got %d",
+                  result.rx_data_cnt));
+        return -240;
+    }
+
+    /* The graceful deallocation must still have completed, which means the
+     * loop kept processing the Refresh response of a shutting down socket.
+     */
+    if ((result.state_called & (1<<PJ_TURN_STATE_DESTROYING)) == 0) {
+        PJ_LOG(3,("", "    error: PJ_TURN_STATE_DESTROYING is not called"));
+        return -250;
     }
 
     poll_events(stun_cfg, 500, PJ_FALSE);
@@ -683,6 +829,10 @@ int turn_sock_test(void *p)
     /* Only stream transports can deliver more than one packet in a read */
     if (tp_type != PJ_TURN_TP_UDP) {
         rc = dealloc_multi_pkt_test(&app_sess.stun_cfg, USE_IPV6, tp_type);
+        if (rc != 0)
+            goto on_return;
+
+        rc = destroy_in_rx_data_test(&app_sess.stun_cfg, USE_IPV6, tp_type);
         if (rc != 0)
             goto on_return;
     }

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -1285,6 +1285,8 @@ PJ_DEF(pj_status_t) pj_turn_session_on_rx_pkt2(
     pj_status_t status;
     pj_bool_t is_datagram;
 
+    PJ_ASSERT_RETURN(sess && prm, PJ_EINVAL);
+
     /* Packet could be ChannelData or STUN message (response or
      * indication).
      */

--- a/pjnath/src/pjnath/turn_session.c
+++ b/pjnath/src/pjnath/turn_session.c
@@ -1285,7 +1285,7 @@ PJ_DEF(pj_status_t) pj_turn_session_on_rx_pkt2(
     pj_status_t status;
     pj_bool_t is_datagram;
 
-    PJ_ASSERT_RETURN(sess && prm, PJ_EINVAL);
+    PJ_ASSERT_RETURN(sess && prm && prm->pkt && prm->pkt_len, PJ_EINVAL);
 
     /* Packet could be ChannelData or STUN message (response or
      * indication).

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1596,11 +1596,17 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
         } else if (conn->state == DATACONN_STATE_CONN_BINDING) {
             /* Waiting for ConnectionBind response */
             pj_bool_t is_stun;
+            unsigned pkt_len;
             pj_turn_session_on_rx_pkt_param prm;
 
             /* Ignore if this is not a STUN message */
             is_stun = ((((pj_uint8_t*)data)[0] & 0xC0) == 0);
             if (!is_stun)
+                goto on_return;
+
+            /* Wait for more data if we don't have a complete packet yet */
+            pkt_len = has_packet(turn_sock, data, *remainder);
+            if (pkt_len == 0)
                 goto on_return;
 
             /* Session may already be gone, see on_data_read() */
@@ -1614,9 +1620,11 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
             prm.src_addr_len = conn->peer_addr_len;
             pj_turn_session_on_rx_pkt2(turn_sock->sess, &prm);
 
-            /* Insufficient fragment, wait for more data */
+            /* parsed_len may be zero if we have parsing error, so use our
+             * previous calculation to exhaust the bad packet.
+             */
             if (prm.parsed_len == 0)
-                goto on_return;
+                prm.parsed_len = pkt_len;
 
             /* Got remainder? */
             if (prm.parsed_len < *remainder) {

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -891,25 +891,16 @@ static pj_bool_t on_data_read(pj_turn_sock *turn_sock,
          */
         unsigned pkt_len;
 
-        /* Note that we must keep processing if destruction was already
-         * requested before this read, as it is the deallocation response
-         * that completes the teardown. Only a request made from one of the
-         * callbacks below stops us.
-         */
-        pj_bool_t shutdown_at_entry = turn_sock->is_shutting_down;
-
         //PJ_LOG(5,(turn_sock->pool->obj_name, 
         //        "Incoming data, %lu bytes total buffer", size));
 
         /* The session must be re-validated on every iteration, as processing
-         * a packet can tear it down on this same thread: an error or
+         * a packet can destroy it on this same thread: an error or
          * deallocation response drives it to DESTROYING and turn_on_state()
-         * clears turn_sock->sess, or the application destroys us from a
-         * callback. The group lock is re-entrant, so it does not prevent
-         * this.
+         * then clears turn_sock->sess. The group lock is re-entrant, so it
+         * does not prevent this.
          */
         while (turn_sock->sess &&
-               turn_sock->is_shutting_down == shutdown_at_entry &&
                (pkt_len=has_packet(turn_sock, data, size)) != 0)
         {
             pj_size_t parsed_len;
@@ -944,12 +935,9 @@ static pj_bool_t on_data_read(pj_turn_sock *turn_sock,
             //        "Buffer size now %lu bytes", size));
         }
 
-        /* Nothing will ever consume the leftover once we are gone */
-        if (!turn_sock->sess ||
-            turn_sock->is_shutting_down != shutdown_at_entry)
-        {
+        /* Nothing will ever consume the leftover once the session is gone */
+        if (!turn_sock->sess)
             *remainder = 0;
-        }
     } else if (status != PJ_SUCCESS) {
         if (turn_sock->conn_type == PJ_TURN_TP_UDP)
             sess_fail(turn_sock, "UDP connection closed", status);
@@ -1180,8 +1168,12 @@ static void turn_on_rx_data(pj_turn_session *sess,
 {
     pj_turn_sock *turn_sock = (pj_turn_sock*) 
                            pj_turn_session_get_user_data(sess);
-    if (turn_sock == NULL || turn_sock->is_destroying) {
-        /* We've been destroyed */
+    if (turn_sock == NULL || turn_sock->is_shutting_down) {
+        /* We've been destroyed, or are about to be. Note that we may still
+         * be processing packets at this point, as the deallocation response
+         * is what completes a graceful teardown, but the application is no
+         * longer interested in data.
+         */
         return;
     }
 
@@ -1610,8 +1602,8 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
     *remainder = size;
     while (*remainder > 0) {
         if (conn->state == DATACONN_STATE_READY) {
-            /* Application data */
-            if (turn_sock->cb.on_rx_data) {
+            /* Application data, dropped once we are shutting down */
+            if (turn_sock->cb.on_rx_data && !turn_sock->is_shutting_down) {
                 (*turn_sock->cb.on_rx_data)(turn_sock, data, (unsigned)*remainder,
                                             &conn->peer_addr,
                                             conn->peer_addr_len);

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -888,6 +888,16 @@ static pj_bool_t on_data_read(pj_turn_sock *turn_sock,
             pj_size_t parsed_len;
             //const pj_uint8_t *pkt = (const pj_uint8_t*)data;
 
+            /* The previous iteration may have destroyed the session, e.g.
+             * an error or deallocation response drives it to DESTROYING and
+             * turn_on_state() clears turn_sock->sess. The group lock is
+             * re-entrant, so it does not prevent this.
+             */
+            if (!turn_sock->sess || turn_sock->is_destroying) {
+                *remainder = 0;
+                break;
+            }
+
             //PJ_LOG(5,(turn_sock->pool->obj_name, 
             //        "Packet start: %02X %02X %02X %02X", 
             //        pkt[0], pkt[1], pkt[2], pkt[3]));

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -74,6 +74,13 @@ struct pj_turn_sock
     void                *user_data;
 
     pj_bool_t            is_destroying;
+
+    /* Set as soon as destruction is requested, which for a session that is
+     * still allocated happens well before is_destroying, since we first
+     * deallocate gracefully. Note that is_destroying cannot be set earlier
+     * instead, as that would stop us from sending the Refresh.
+     */
+    pj_bool_t            is_shutting_down;
     pj_grp_lock_t       *grp_lock;
 
     pj_turn_alloc_param  alloc_param;
@@ -399,6 +406,7 @@ static void destroy(pj_turn_sock *turn_sock)
     }
 
     turn_sock->is_destroying = PJ_TRUE;
+    turn_sock->is_shutting_down = PJ_TRUE;
     if (turn_sock->sess)
         pj_turn_session_shutdown(turn_sock->sess);
     if (turn_sock->active_sock)
@@ -425,6 +433,8 @@ static void turn_sock_destroy(pj_turn_sock *turn_sock,
         pj_grp_lock_release(turn_sock->grp_lock);
         return;
     }
+
+    turn_sock->is_shutting_down = PJ_TRUE;
 
     if (turn_sock->sess) {
         pj_turn_session_shutdown2(turn_sock->sess, last_err);
@@ -881,22 +891,29 @@ static pj_bool_t on_data_read(pj_turn_sock *turn_sock,
          */
         unsigned pkt_len;
 
+        /* Note that we must keep processing if destruction was already
+         * requested before this read, as it is the deallocation response
+         * that completes the teardown. Only a request made from one of the
+         * callbacks below stops us.
+         */
+        pj_bool_t shutdown_at_entry = turn_sock->is_shutting_down;
+
         //PJ_LOG(5,(turn_sock->pool->obj_name, 
         //        "Incoming data, %lu bytes total buffer", size));
 
-        while ((pkt_len=has_packet(turn_sock, data, size)) != 0) {
+        /* The session must be re-validated on every iteration, as processing
+         * a packet can tear it down on this same thread: an error or
+         * deallocation response drives it to DESTROYING and turn_on_state()
+         * clears turn_sock->sess, or the application destroys us from a
+         * callback. The group lock is re-entrant, so it does not prevent
+         * this.
+         */
+        while (turn_sock->sess &&
+               turn_sock->is_shutting_down == shutdown_at_entry &&
+               (pkt_len=has_packet(turn_sock, data, size)) != 0)
+        {
             pj_size_t parsed_len;
             //const pj_uint8_t *pkt = (const pj_uint8_t*)data;
-
-            /* The previous iteration may have destroyed the session, e.g.
-             * an error or deallocation response drives it to DESTROYING and
-             * turn_on_state() clears turn_sock->sess. The group lock is
-             * re-entrant, so it does not prevent this.
-             */
-            if (!turn_sock->sess || turn_sock->is_destroying) {
-                *remainder = 0;
-                break;
-            }
 
             //PJ_LOG(5,(turn_sock->pool->obj_name, 
             //        "Packet start: %02X %02X %02X %02X", 
@@ -925,6 +942,13 @@ static pj_bool_t on_data_read(pj_turn_sock *turn_sock,
 
             //PJ_LOG(5,(turn_sock->pool->obj_name, 
             //        "Buffer size now %lu bytes", size));
+        }
+
+        /* Nothing will ever consume the leftover once we are gone */
+        if (!turn_sock->sess ||
+            turn_sock->is_shutting_down != shutdown_at_entry)
+        {
+            *remainder = 0;
         }
     } else if (status != PJ_SUCCESS) {
         if (turn_sock->conn_type == PJ_TURN_TP_UDP)

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -845,6 +845,12 @@ static unsigned has_packet(pj_turn_sock *turn_sock, const void *buf, pj_size_t b
     if (turn_sock->conn_type == PJ_TURN_TP_UDP)
         return (unsigned)bufsize;
 
+    /* Both a STUN and a ChannelData header need at least 4 bytes, and the
+     * checks below read that many, so a smaller fragment must be kept as is.
+     */
+    if (bufsize < 4)
+        return 0;
+
     /* Quickly check if this is STUN message, by checking the first two bits and
      * size field which must be multiple of 4 bytes
      */
@@ -857,9 +863,6 @@ static unsigned has_packet(pj_turn_sock *turn_sock, const void *buf, pj_size_t b
     } else {
         /* This must be ChannelData. */
         pj_turn_channel_data cd;
-
-        if (bufsize < 4)
-            return 0;
 
         /* Decode ChannelData packet */
         pj_memcpy(&cd, buf, sizeof(pj_turn_channel_data));

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1635,6 +1635,21 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
             pkt_len = GETVAL16H((const pj_uint8_t*)data, 2) +
                       (unsigned)sizeof(pj_stun_msg_hdr);
 
+            /* A length we can never receive would stall this connection for
+             * good, as we would keep waiting while the read buffer fills up,
+             * so give up on it instead.
+             */
+            if (pkt_len > turn_sock->setting.max_pkt_size) {
+                PJ_LOG(4,(turn_sock->pool->obj_name,
+                          "Dropping data connection, ConnectionBind response "
+                          "declares %u bytes but we can only receive %u",
+                          pkt_len, turn_sock->setting.max_pkt_size));
+                dataconn_cleanup(conn);
+                --turn_sock->data_conn_cnt;
+                pj_grp_lock_release(turn_sock->grp_lock);
+                return PJ_FALSE;
+            }
+
             /* Wait for more data if we don't have a complete packet yet */
             if (pkt_len > *remainder)
                 goto on_return;

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1640,13 +1640,30 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
              * so give up on it instead.
              */
             if (pkt_len > turn_sock->setting.max_pkt_size) {
+                pj_uint32_t conn_id = conn->id;
+                unsigned peer_addr_len = conn->peer_addr_len;
+                pj_sockaddr peer_addr;
+
                 PJ_LOG(4,(turn_sock->pool->obj_name,
                           "Dropping data connection, ConnectionBind response "
                           "declares %u bytes but we can only receive %u",
                           pkt_len, turn_sock->setting.max_pkt_size));
+
+                pj_sockaddr_cp(&peer_addr, &conn->peer_addr);
                 dataconn_cleanup(conn);
                 --turn_sock->data_conn_cnt;
                 pj_grp_lock_release(turn_sock->grp_lock);
+
+                /* Once the connection is gone the pending ConnectionBind can
+                 * only end up as a stray event, so report the failure here to
+                 * avoid leaving the application waiting forever.
+                 */
+                if (turn_sock->cb.on_connection_status) {
+                    (*turn_sock->cb.on_connection_status)(turn_sock,
+                                                          PJ_ETOOBIG,
+                                                          conn_id, &peer_addr,
+                                                          peer_addr_len);
+                }
                 return PJ_FALSE;
             }
 

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1623,9 +1623,20 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
             if (!is_stun)
                 goto on_return;
 
+            /* Frame it using its own header. has_packet() cannot be used
+             * here: it only classifies a message as STUN when the encoded
+             * length is a multiple of 4, so a malformed one is framed as
+             * ChannelData instead, and we would consume just a part of it
+             * and leave the rest at the front of the stream forever.
+             */
+            if (*remainder < sizeof(pj_stun_msg_hdr))
+                goto on_return;
+
+            pkt_len = GETVAL16H((const pj_uint8_t*)data, 2) +
+                      (unsigned)sizeof(pj_stun_msg_hdr);
+
             /* Wait for more data if we don't have a complete packet yet */
-            pkt_len = has_packet(turn_sock, data, *remainder);
-            if (pkt_len == 0)
+            if (pkt_len > *remainder)
                 goto on_return;
 
             /* Session may already be gone, see on_data_read() */

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1603,18 +1603,29 @@ static pj_bool_t dataconn_on_data_read(pj_activesock_t *asock,
             if (!is_stun)
                 goto on_return;
 
+            /* Session may already be gone, see on_data_read() */
+            if (!turn_sock->sess || turn_sock->is_destroying)
+                goto on_return;
+
             pj_bzero(&prm, sizeof(prm));
             prm.pkt = data;
             prm.pkt_len = *remainder;
             prm.src_addr = &conn->peer_addr;
             prm.src_addr_len = conn->peer_addr_len;
-            pj_turn_session_on_rx_pkt2(conn->turn_sock->sess, &prm);
+            pj_turn_session_on_rx_pkt2(turn_sock->sess, &prm);
+
+            /* Insufficient fragment, wait for more data */
+            if (prm.parsed_len == 0)
+                goto on_return;
+
             /* Got remainder? */
-            if (prm.parsed_len < *remainder && prm.parsed_len > 0) {
+            if (prm.parsed_len < *remainder) {
+                *remainder -= prm.parsed_len;
                 pj_memmove(data, (pj_uint8_t*)data + prm.parsed_len,
                            *remainder);
+            } else {
+                *remainder = 0;
             }
-            *remainder -= prm.parsed_len;
         } else
             goto on_return;
     }


### PR DESCRIPTION
Fixes #5119.

## The crash

`on_data_read()` in `turn_sock.c` validates `turn_sock->sess` **once, before** the `while ((pkt_len = has_packet(...)) != 0)` loop, but re-reads it on **every** iteration:

```c
if (status == PJ_SUCCESS && turn_sock->sess && !turn_sock->is_destroying) {
    while ((pkt_len=has_packet(turn_sock, data, size)) != 0) {
        ...
        pj_turn_session_on_rx_pkt(turn_sock->sess, data, size, &parsed_len);
```

Processing a packet can destroy the session **synchronously on the same thread**:

```
on_data_read()                      [holds turn_sock->grp_lock]
 -> pj_turn_session_on_rx_pkt2()    [acquires sess->grp_lock]
 -> pj_stun_session_on_rx_pkt()
 -> on_session_fail()      (non-ALLOCATE error response)
    or on_allocate_success()  (Refresh with LIFETIME=0)
 -> set_state(DEALLOCATED) -> sess_shutdown() -> set_state(DESTROYING)
 -> sess->cb.on_state == turn_on_state()
 -> turn_sock->sess = NULL
```

Holding `turn_sock->grp_lock` does not help: `turn_on_state()` re-acquires the *same* group lock on the same thread, and it is re-entrant. The next iteration then calls `pj_turn_session_on_rx_pkt(NULL, ...)`, and `pj_turn_session_on_rx_pkt2()` dereferences `sess->grp_lock` with no NULL guard.

The reporter's coredump matches exactly — `mov 0x98(%rdi),%rdi` with `%rdi = 0`. On x86_64 LP64, `grp_lock` sits at offset 152 = `0x98` in `struct pj_turn_session` (`pool` 0, `obj_name` 8, `cb` 16 for 8 function pointers, `user_data` 80, `stun_cfg` 88 for 56 bytes, `is_destroying` 144 + 4 pad).

### When the loop iterates more than once

- **TCP/TLS**: routine. `has_packet()` is length-driven for stream transports, so a single read commonly delivers several messages — e.g. a Refresh/CreatePermission error response followed by relayed ChannelData in the same segment.
- **UDP**: via the ChannelData branch. `on_rx_pkt2()` sets `parsed_len = ((cd.length+3) & ~3) + 4` from the ChannelData header without requiring it to fill the datagram, so a short ChannelData leaves a remainder and `has_packet()` returns `bufsize` unconditionally for UDP. (The STUN branch cannot do this — `pj_stun_msg_check()` enforces `msg_len+20 == pdu_len` when `PJ_STUN_IS_DATAGRAM`.)

The pre-loop guard dates back to e00cbe02e (the #1617 group-lock overhaul); the in-loop reload has never been guarded. bd9db5fe8 (#3730) hardened `turn_on_state()` for a closely related race but did not touch this loop.

## Changes

### 1. The reported crash

- `turn_sock.c`: re-validate `turn_sock->sess` in the loop condition, ahead of `has_packet()`, and discard the leftover once the session is gone.
- `turn_session.c`: `PJ_ASSERT_RETURN(sess && prm && prm->pkt && prm->pkt_len, PJ_EINVAL)` in `pj_turn_session_on_rx_pkt2()`. This was the only public entry point in the file lacking a NULL guard — `pj_turn_session_get_info()`, `pj_turn_session_connection_bind()` and `pj_turn_session_shutdown2()` all have one, and `prm->pkt[0]` is read unconditionally a few lines down.

### 2. Callbacks after the application destroyed us

Related, and found while reviewing the above. `turn_sock_destroy()` does **not** set `is_destroying` while a session exists: it calls `pj_turn_session_shutdown2()`, which for a READY session sends a Refresh with LIFETIME=0 and moves to DEALLOCATING. So `turn_sock->sess` stays set and `is_destroying` stays false for the whole deallocation window, and `turn_on_rx_data()`'s existing `is_destroying` guard does not fire. An application that calls `pj_turn_sock_destroy()` from `on_rx_data()` kept receiving further packets, both from the rest of the current read and from later ones.

`is_destroying` cannot simply be set earlier, because `turn_on_send_pkt()` returns `PJ_EINVALIDOP` once it is set, which would stop the Refresh from ever going out and leave the allocation dangling on the server. So there is a separate `is_shutting_down`, set in both `destroy()` and `turn_sock_destroy()`.

The flag deliberately does **not** gate the receive loop. Destruction is usually already pending when a read arrives, and that read is the deallocation response that completes the teardown — gating the loop on the flag breaks graceful deallocation outright (it leaks the session and its timer). The distinction is not which read a packet arrives in, but that STUN must keep being parsed while application data must no longer be delivered. So the check lives at the delivery point, in `turn_on_rx_data()`, which covers ChannelData and Data indications for this read and every later one. The RFC 6062 `DATACONN_STATE_READY` branch invokes the callback directly and gets the same check.

Note this is a small behaviour change: relayed data arriving during the deallocation window is now dropped rather than delivered. Delivering it is a use-after-destroy hazard for the application, and pjnath's own test callbacks already guard against post-destroy delivery.

### 3. Same class of defect in the RFC 6062 data connection path

`dataconn_on_data_read()` had three problems, found while auditing the callers of `pj_turn_session_on_rx_pkt2()`:

- `pj_turn_session_on_rx_pkt2(conn->turn_sock->sess, &prm)` with **no** NULL check at all, not even a pre-loop one — same crash once the session is gone.
- Infinite loop: `pj_stun_msg_decode()` leaves `parsed_len` at zero for *any* decode failure, not just an incomplete message, so `*remainder -= 0` with `conn->state` unchanged spun forever in the ioqueue thread. It now frames the message from its own 20 byte STUN header, waiting only when the frame is incomplete and consuming the whole framed length when the decode fails.

  `has_packet()` is deliberately not used for that framing. It only classifies a message as STUN when the encoded length is a multiple of 4 and otherwise falls through to treating it as ChannelData — which cannot be right, since a first byte with the top two bits clear is never a channel number (those are 0x4000–0x7FFF). An encoded length of 1 is framed as 8 bytes, `pj_stun_msg_check()` then rejects the same message on `(msg_len & 0x03) != 0`, and only 8 bytes of the 21 byte message would be consumed, leaving the rest at the head of the stream and stalling the connection. Framing from the header is unambiguous once the two bits have identified it as STUN.
- Buffer over-read: `pj_memmove(data, data + parsed_len, *remainder)` copied `*remainder` bytes when only `*remainder - parsed_len` are valid, reading `parsed_len` bytes past the received data and potentially past the buffer when the read filled `max_pkt_size`.

`*remainder` is now clamped rather than decremented unconditionally, so a `parsed_len` larger than the buffer cannot underflow it.

An encoded length larger than `max_pkt_size` — the size the data connection's read buffer was started with — can never be satisfied, and once that buffer fills there is no read space left, so waiting would stall the connection for good. Such a frame now tears the data connection down instead, matching how `turn_on_connection_bind_status()` already handles a failed ConnectionBind. Discarding and continuing would leave the connection parked in `DATACONN_STATE_CONN_BINDING` waiting for a response the server has already botched, so it would stall anyway.

The control connection reached through `on_data_read()` has the same property via `has_packet()`, which returns zero until the declared length arrives. That is left alone: it is pre-existing, it is on the path every TURN client uses, and it is not what this PR is fixing.

### 4. `has_packet()` read past a short fragment

`has_packet()` read bytes 0, 2 and 3 before its `bufsize < 4` check, which only guarded the ChannelData branch. On a stream transport a 1–3 byte fragment therefore caused an uninitialised read of the tail of the activesock buffer. The result was harmless — the function still returned 0 for any `bufsize < 4`, since the STUN branch needs `msg_len+20 <= bufsize` — so the fragment was correctly preserved, but the read was real. Moved the length check above both header inspections, which fixes it for the pre-existing `on_data_read()` call site as well.

No ABI change.

## Testing

Two regression tests added in `pjnath/src/pjnath-test/`, both TCP and TLS only, since only a stream transport can deliver several packets in one read. Over UDP `pj_stun_msg_check()` enforces `msg_len+20 == pdu_len`, so an appended packet would just make the response unparseable instead of producing a second loop iteration.

- **`dealloc_multi_pkt_test()`** — the test server appends a ChannelData packet to the Refresh/LIFETIME=0 response in the same send, so the client receives the deallocation response and a trailing packet in one read. The test binds channel 0x4000 first, so the trailing packet is one that would really reach `on_rx_data()`.
- **`destroy_in_rx_data_test()`** — the server sends two ChannelData packets along with the ChannelBind response, so one read binds the channel and delivers them, and the test destroys the socket from the first `on_rx_data()`. It asserts exactly one packet is reported, and that DESTROYING is still reached, which pins down the "keep parsing while shutting down" half.

  It runs twice: once with both packets appended to the response, and once with the second sent separately. The second variant covers the case where the trailing packet arrives in a *later* read, which reaches the delivery check by a different route — past the pre-loop check, since a graceful destruction leaves the session set and `is_destroying` clear — and is the path an approach that tracked shutdown per read could not cover. Two sends make a separate read likely rather than certain, so this broadens coverage instead of guaranteeing it; the expected count holds under either segmentation, so it cannot become flaky.

Both were verified to actually catch their regressions, by reverting each guard individually:

- reverting the in-loop session check → `Assertion failed: (sess && prm && prm->pkt && prm->pkt_len), function pj_turn_session_on_rx_pkt2, turn_session.c:1288`. With the `turn_session.c` guard also removed, it is the original crash: `AddressSanitizer: SEGV turn_session.c:1295 in pj_turn_session_on_rx_pkt2`, with `x[0] = 0` (the NULL `sess`) and `x[9] = 0x98` — the same `grp_lock` offset as the reporter's x86_64 coredump, reproduced on arm64.
- reverting the `turn_on_rx_data()` gate → `error: expecting 1 rx data, got 2` on both TCP and TLS.

Full `pjnath-test` under ASan on macOS arm64, all green:

- `turn_sock_test` (UDP, TCP, TLS), `stun_test`, `sess_auth_test` — 5/5 pass
- `ice_test`, `concur_test` — 62/62 pass

The reporter independently verified the equivalent of the first change in production: Asterisk 22.10.1 with bundled pjproject 2.17 went from a crash every 1–2 minutes under concurrent WebRTC load (89+ identical coredumps over several days) to zero crashes, with TURN media flowing normally.

### Not covered

`dataconn_on_data_read()` itself has no test, so everything in section 3 — the NULL guard, the framing, the malformed-message consumption and the remainder clamp — rests on code tracing rather than on a failing-then-passing test. The pjnath test server has no RFC 6062 support at all: no `Connect` request handling, no `ConnectionAttempt` indication, no `ConnectionBind`, and `alloc_param.peer_conn_type` is never set to TCP anywhere in the tests. Covering it means first building peer-TCP support into the test server, which is a larger job than this fix; happy to do it as a follow-up.

Co-Authored-By Claude Code
