### PR TITLE
pjsua: read timer entry fields under timer_mutex in timer_cb()

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -3590,11 +3590,28 @@ static void timer_cb( pj_timer_heap_t *th,
                       pj_timer_entry *entry)
 {
     pjsua_timer_list *tmr = (pjsua_timer_list *)entry->user_data;
-    void (*cb)(void *user_data) = tmr->cb;
-    void *user_data = tmr->user_data;
+    void (*cb)(void *user_data);
+    void *user_data;
 
     PJ_UNUSED_ARG(th);
 
+    /* The tmr fields are guarded by timer_mutex (they are assigned in
+     * pjsua_schedule_timer2() with the mutex held), so fetch them under
+     * the mutex.
+     */
+    pj_mutex_lock(pjsua_var.timer_mutex);
+    cb = tmr->cb;
+    user_data = tmr->user_data;
+    pj_mutex_unlock(pjsua_var.timer_mutex);
+
+    /* Invoke the callback without holding timer_mutex, since the callback
+     * may acquire it too (e.g. call_med_event_cb()) or acquire other locks,
+     * such as PJSUA_LOCK, which must not be nested under timer_mutex.
+     *
+     * Note that the entry deliberately stays in the active timer list until
+     * the callback returns: pjsua_vid.c scans that list to find out whether
+     * a pending media event callback has completed.
+     */
     if (cb)
         (*cb)(user_data);
 


### PR DESCRIPTION
Coverity CID 1663959 and CID 1663957 (MISSING_LOCK).

`pjsua_timer_list.cb` and `.user_data` are assigned in `pjsua_schedule_timer2()` with `timer_mutex` held, but `timer_cb()` read them with no lock at all. This fetches both fields under `timer_mutex`.

Two existing constraints shape how the lock can be taken, and both are preserved (and now documented in the code):

1. **The callback must not run under `timer_mutex`.** `timer_mutex` is recursive, but callbacks such as `call_med_event_cb()` re-acquire it, and others take `PJSUA_LOCK`. The established order is `PJSUA_LOCK` → `timer_mutex` (`pjsua_schedule_timer2()`, and `pjsua_vid.c` around the active timer list scan), so nesting `PJSUA_LOCK` under `timer_mutex` would invert it. The mutex is therefore released before invoking the callback.

2. **The entry must stay on `active_timer_list` until the callback returns.** `pjsua_vid.c` scans that list to determine whether a pending media event callback has completed before tearing down the stream. Recycling the entry before invoking `cb` would satisfy the locking complaint more neatly but would silently break that wait, so the relink stays where it was, after the callback.

There is no new lock nesting: the timer heap releases its own lock before dispatching (`pjlib/src/pj/timer.c`, `unlock_timer_heap()` precedes the `entry->cb` call), and the tail of `timer_cb()` already acquired `timer_mutex` at this point in the call.

### Testing

- `make -j3` clean, no warnings.
- pjsip: full suite (26 tests) passes with `-w 4` under ASan, including `pjsua_call_test`, `pjsua_auth_test`, and `inv_offer_answer_test`, which exercise `pjsua_schedule_timer2()`/`timer_cb()`.

Note: the Python `tests/pjsua` suite could not be run locally, as `run.py` imports `telnetlib`, which was removed in Python 3.13. CI covers it.

Co-Authored-By Claude Code