### PR TITLE
sdp_neg: prevent same answerer format from matching multiple offer codecs

### DIFF
--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -1376,6 +1376,7 @@ static pj_status_t match_offer(pj_pool_t *pool,
     int o_red_level = 0;
     unsigned nclockrate = 0, clockrate[PJMEDIA_MAX_SDP_FMT];
     unsigned ntel_clockrate = 0, tel_clockrate[PJMEDIA_MAX_SDP_FMT];
+    pj_bool_t slave_used[PJMEDIA_MAX_SDP_FMT];
 
     /* A zero port normally disables an offered media section. RFC 9143
      * defines an exception for a valid bundle-only section, which must be
@@ -1405,6 +1406,11 @@ static pj_status_t match_offer(pj_pool_t *pool,
         master = preanswer;
         slave  = offer;
     }
+
+    /* Track which slave formats have been matched to prevent the same
+     * slave format from being consumed by multiple master formats.
+     */
+    pj_bzero(slave_used, sizeof(slave_used));
     
     /* With the addition of telephone-event and dodgy MS RTC SDP, 
      * the answer generation algorithm looks really shitty...
@@ -1438,9 +1444,12 @@ static pj_status_t match_offer(pj_pool_t *pool,
                 for (j=0; j<slave->desc.fmt_count; ++j) {
                     unsigned p;
                     p = pj_strtoul(&slave->desc.fmt[j]);
-                    if (p == pt && pj_isdigit(*slave->desc.fmt[j].ptr)) {
+                    if (p == pt && pj_isdigit(*slave->desc.fmt[j].ptr) &&
+                        !slave_used[j])
+                    {
                         unsigned k;
 
+                        slave_used[j] = PJ_TRUE;
                         found_matching_codec = 1;
                         pt_offer[pt_answer_count] = prefer_remote_codec_order?
                                                     master->desc.fmt[i]:
@@ -1494,6 +1503,8 @@ static pj_status_t match_offer(pj_pool_t *pool,
                  * encoding name and clock rate.
                  */
                 for (j=0; j<slave->desc.fmt_count; ++j) {
+                    if (slave_used[j])
+                        continue;
                     a = pjmedia_sdp_media_find_attr2(slave, "rtpmap", 
                                                      &slave->desc.fmt[j]);
                     if (a) {
@@ -1531,6 +1542,7 @@ static pj_status_t match_offer(pj_pool_t *pool,
                                 {
                                     continue;
                                 }
+
                                 found_matching_codec = 1;
 
                                 /* Take note of clock rate for tel-event */
@@ -1579,6 +1591,7 @@ static pj_status_t match_offer(pj_pool_t *pool,
                                                 prefer_remote_codec_order? 
                                                 preanswer->desc.fmt[j]:
                                                 preanswer->desc.fmt[i];
+                            slave_used[j] = PJ_TRUE;
                             break;
                         }
                     }
@@ -1763,6 +1776,7 @@ static pj_status_t match_offer(pj_pool_t *pool,
             if (!pj_strcmp(&answer->desc.fmt[j], &pt_answer[i]))
                 break;
         }
+
         pj_assert(j != answer->desc.fmt_count);
         str_swap(&answer->desc.fmt[i], &answer->desc.fmt[j]);
     }

--- a/pjmedia/src/test/sdp_neg_test.c
+++ b/pjmedia/src/test/sdp_neg_test.c
@@ -1452,7 +1452,7 @@ static struct test
             "s=SS VOIP\r\n"
             "c=IN IP4 10.186.98.37\r\n"
             "t=0 0\r\n"
-            "m=audio 4000 RTP/AVP 116 107 118 9 111 110\r\n"
+            "m=audio 4000 RTP/AVP 116 107 118 96 9 111 110\r\n"
             "b=AS:41\r\n"
             "b=RS:512\r\n"
             "b=RR:1537\r\n"
@@ -1462,10 +1462,8 @@ static struct test
             "a=fmtp:107 octet-align=1;mode-change-capability=2;max-red=220\r\n"
             "a=rtpmap:118 AMR/8000\r\n"
             "a=fmtp:118 octet-align=0;mode-change-capability=2;max-red=220\r\n"
-            /* For the following to work, pjmedia_codec_amr_match_sdp() must be registered first.
-               "a=rtpmap:96 AMR/8000\r\n"
-               "a=fmtp:96 octet-align=1;mode-change-capability=2;max-red=220\r\n"
-            */
+            "a=rtpmap:96 AMR/8000\r\n"
+            "a=fmtp:96 octet-align=1;mode-change-capability=2;max-red=220\r\n"
             "a=rtpmap:9 G722/8000\r\n"
             "a=rtpmap:111 telephone-event/16000\r\n"
             "a=fmtp:111 0-15\r\n"


### PR DESCRIPTION
Without codec-specific fmt_match callbacks (e.g. when PJMEDIA codecs are not loaded), multiple offer variants with the same encoding name but different FMTP could all match the same answerer slot, causing an assertion in the answer reorder loop.

This fix is especially useful when using PJSUA(2) as signaling plane B2BUA, which should only operate on the SIP message protocol layer, i.e. be transparent for SDP.