### PR TITLE
tests/pjsua: add video call testing (reusable helpers + hold scenario)

### DIFF
--- a/tests/pjsua/inc_const.py
+++ b/tests/pjsua/inc_const.py
@@ -32,6 +32,14 @@ MEDIA_HOLD = "Call [0-9]+ media [0-9]+ .*, status is .* hold"
 # Media call is active
 MEDIA_ACTIVE = "Call [0-9]+ media [0-9]+ .*, status is Active"
 #MEDIA_ACTIVE = "Media for call [0-9]+ is active"
+# Same as above but restricted to the video stream (type=video), for
+# asserting on video media specifically in a video call. The directional
+# variants distinguish the hold initiator (Local hold) from the peer that
+# received the hold (Remote hold); VID_MEDIA_HOLD matches either.
+VID_MEDIA_ACTIVE = r"Call [0-9]+ media [0-9]+ \[type=video\], status is Active"
+VID_MEDIA_HOLD = r"Call [0-9]+ media [0-9]+ \[type=video\], status is .* hold"
+VID_MEDIA_LOCAL_HOLD = r"Call [0-9]+ media [0-9]+ \[type=video\], status is Local hold"
+VID_MEDIA_REMOTE_HOLD = r"Call [0-9]+ media [0-9]+ \[type=video\], status is Remote hold"
 # RX_DTMF
 RX_DTMF = "Incoming DTMF on call [0-9]+: "
 # Suffix logged after the digit when DTMF is received via SIP INFO

--- a/tests/pjsua/inc_util.py
+++ b/tests/pjsua/inc_util.py
@@ -30,6 +30,62 @@ def has_ssl_sock(exe):
    # the TLS/SIPS tests.
    return True
 
+def has_video(exe):
+   """Return True if the pjsua build under test has video support with at
+   least one usable video codec.
+
+   A video call test cannot negotiate a video stream otherwise -- either
+   the build has PJMEDIA_HAS_VIDEO=0 (only enabled in some CI jobs), or it
+   was built without any video codec library (VPX/OpenH264). Unlike
+   PJ_HAS_SSL_SOCK, video capability is not reported by pj_dump_config(),
+   so we probe the running binary: start it with --video and ask the
+   legacy console to list video codecs. A video-enabled build with a
+   codec prints "Found N video codecs" with N>=1.
+
+   --local-port 0 makes this auxiliary pjsua bind an ephemeral SIP port
+   instead of the default 5060, so the probe can't fail to start because
+   5060 (or a concurrently running pjsua) already holds that port.
+
+   A probe that could not run cleanly (couldn't launch, timed out, or
+   exited non-zero, e.g. pjsua crashed at startup) is distinct from a
+   build that ran fine but has no video. The former fails open (returns
+   True, like has_ssl_sock()) so the real test runs and surfaces the
+   problem rather than being silently skipped; only a probe that exits
+   cleanly yet reports no codec returns False. This is safe to gate on the
+   exit code because --video is not compiled out on a non-video build
+   (only the "vid" console commands are), so a non-video pjsua still
+   accepts --video and exits 0 -- it simply never prints "Found N".
+   """
+   # Use Popen().communicate(), not subprocess.run(): run() is Python 3.5+
+   # but this harness (see load_module_from_file() below) still supports
+   # 3.x < 3.5, and has_video() runs at config-load time, so a missing
+   # subprocess.run would raise before the test could even be skipped.
+   try:
+      proc = subprocess.Popen(exe + " --video --null-audio --local-port 0"
+                              " --max-calls=1",
+                              shell=True, stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT,
+                              universal_newlines=True)
+   except OSError:
+      # Couldn't launch at all -- not the same as "video disabled".
+      return True
+
+   try:
+      out, _ = proc.communicate(input="vid codec list\nq\n", timeout=30)
+   except (OSError, subprocess.SubprocessError):
+      # Includes TimeoutExpired. Probe couldn't complete: fail open.
+      proc.kill()
+      proc.wait()
+      return True
+
+   if proc.returncode != 0:
+      # pjsua didn't start/exit cleanly: probe unreliable, fail open.
+      return True
+
+   m = re.search(r'Found\s+(\d+)\s+video codecs', out or "")
+   return bool(m) and int(m.group(1)) > 0
+
 def load_module_from_file(module_name, module_path):
    if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
       import importlib.util

--- a/tests/pjsua/inc_vid.py
+++ b/tests/pjsua/inc_vid.py
@@ -1,0 +1,89 @@
+# Shared helpers for pjsua video call tests.
+#
+# Every video call test needs the same headless setup: run each instance
+# with --video and drive it onto software video devices -- the colorbar
+# generator for capture and the null renderer for output -- so no real
+# camera or display is touched. See the individual helpers below.
+import re
+import inc_const as const
+
+# Default pjsua args for a video-capable instance. --video makes pjsua set
+# vid_cnt=1, in_auto_show and out_auto_transmit, so a call between two such
+# instances negotiates an active, bidirectional video stream automatically
+# (no per-call "video enable" is needed).
+#
+# --no-tcp restricts each instance to a single (UDP) account. Without it,
+# --local-port creates both a UDP and a TCP account and leaves TCP as the
+# current one, while calls travel over UDP -- so the "video acc cap_id/
+# ren_id" pins below (which target the current account) might not apply to
+# the account the call actually uses, leaving it on the default camera/
+# renderer. One account keeps the headless device pinning deterministic.
+VIDEO_ARGS = "--null-audio --max-calls=1 --no-tcp --video"
+
+
+# Look up the ID of a software video device by name from the
+# "video device list" output.
+#
+# IDs can't be hardcoded: the colorbar and null devices register after the
+# platform's real devices, so their IDs differ across platforms (e.g.
+# macOS with a camera vs. a headless Linux CI runner). Hence the runtime
+# lookup. 'ua' is a run.py Expect instance; expect() returns the matched
+# line, from which we parse the leading device ID.
+def find_vid_dev(ua, name):
+    ua.send("video device list")
+    # Match only a non-negative device ID. The list first prints the
+    # default-alias rows ("-2 <name> (default ...)", "-1 <name>"), and on a
+    # headless build those aliases ARE the colorbar/null devices -- so an
+    # unanchored [0-9]+ would grab the "1"/"2" from "-1"/"-2" and select
+    # the wrong device (e.g. Null capture instead of Null renderer).
+    # Requiring whitespace -- not the '-' sign -- immediately before the
+    # digits skips the alias rows and selects the real positive device
+    # row. The same pattern is reused for the ID extraction.
+    pat = r"\s(\d+)\s+" + name
+    line = ua.expect(pat)
+    return re.search(pat, line).group(1)
+
+
+# Pin 'ua' onto headless-safe video devices: the colorbar generator for
+# capture and the null renderer for output. Call this on each instance
+# before it places or answers a video call, so the call runs without a
+# real camera or display.
+def setup_video_devices(ua):
+    cap = find_vid_dev(ua, "Colorbar generator")
+    ren = find_vid_dev(ua, "Null renderer")
+    ua.send("video acc cap_id " + cap)
+    ua.send("video acc ren_id " + ren)
+    ua.sync_stdout()
+
+
+# Establish a confirmed video call from 'caller' to 'callee' and verify
+# the video stream is Active on both ends. Pins headless video devices on
+# both instances first. 'callee_uri' is the SIP URI the caller dials
+# (normally t.inst_params[0].uri). Leaves both instances in a confirmed
+# call with an active bidirectional video stream, ready for the
+# scenario-specific action (hold, re-INVITE, DTMF, ...).
+def make_video_call(caller, callee, callee_uri):
+    setup_video_devices(caller)
+    setup_video_devices(callee)
+
+    caller.send("call new " + callee_uri)
+    caller.expect(const.STATE_CALLING)
+
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 200")
+
+    # The media-active log is emitted just before the call-state-changed-
+    # to-CONFIRMED log. Wait for the video stream to go Active first (this
+    # proves video negotiated), then for CONFIRMED -- which is still ahead
+    # in the stream, so expect() finds it. Both are required: we must not
+    # return before the dialog is CONFIRMED, otherwise a caller that
+    # immediately holds would race the CONFIRMED transition and
+    # pjsua_call_set_hold2() would reject the hold with PJSIP_ESESSIONSTATE
+    # (telnet-mode sync_stdout() is a no-op, so it can't cover the gap).
+    caller.expect(const.VID_MEDIA_ACTIVE)
+    callee.expect(const.VID_MEDIA_ACTIVE)
+    caller.expect(const.STATE_CONFIRMED)
+    callee.expect(const.STATE_CONFIRMED)
+
+    caller.sync_stdout()
+    callee.sync_stdout()

--- a/tests/pjsua/scripts-call/500_video_call_hold.py
+++ b/tests/pjsua/scripts-call/500_video_call_hold.py
@@ -1,0 +1,50 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call, hold initiated by the caller. Call setup and headless video
+# device selection are handled by the shared inc_vid helpers; this test
+# only drives the hold and verifies the video stream state.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    # Establish a confirmed video call with an active video stream.
+    vid.make_video_call(caller, callee, t.inst_params[0].uri)
+
+    # Caller initiates hold. The video stream goes on hold on both sides,
+    # and the states are directional: the caller (initiator) reports Local
+    # hold while the callee reports Remote hold. Assert each side's
+    # specific state so a regression that swaps them (or reports the same
+    # state on both) is caught.
+    caller.send("call hold")
+    caller.expect(const.VID_MEDIA_LOCAL_HOLD)
+    callee.expect(const.VID_MEDIA_REMOTE_HOLD)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Hangup.
+    caller.send("call hangup")
+    caller.expect(const.STATE_DISCONNECTED)
+    callee.expect(const.STATE_DISCONNECTED)
+
+
+test_param = TestParam(
+        "Video call hold (initiating)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+# Skip when the build under test has no usable video codec (e.g. built
+# without PJMEDIA_HAS_VIDEO, or without a video codec library) -- the call
+# can't negotiate a video stream in that case.
+if not util.has_video(G_EXE):
+    test_param.skip = True


### PR DESCRIPTION
## Summary

The pjsua application test suite has **no video-call coverage**: no `scripts-call` config enables `--video`, so the generic `mod_call.py` flow (hold / re-INVITE / UPDATE / DTMF) is audio-only. Video is otherwise only exercised at the SDP offer/answer layer (`scripts-sendto`, some SIPp XMLs), where an audio-only pjsua *declines* the video m-line. This PR adds the first real video-call test, covering **call hold (initiating)**, plus reusable helpers for the video scenarios to follow.

## Changes

- **`tests/pjsua/inc_vid.py`** (new) — shared video test helpers so upcoming scenario tests (hold receiving, double hold, re-INVITE, DTMF, ...) can reuse them:
  - `VIDEO_ARGS` — default `--video` instance args (sets `vid_cnt=1`, `in_auto_show`, `out_auto_transmit`, so two such instances negotiate an active bidirectional video stream automatically).
  - `find_vid_dev()` / `setup_video_devices()` — discover and pin the **colorbar** (capture) and **null** (render) software devices so the call runs headless. IDs are looked up at runtime from `video device list` because the software devices register after the platform's real devices, so their IDs differ across platforms (e.g. macOS with a camera vs. a headless Linux CI runner).
  - `make_video_call()` — establish a confirmed call and verify the video stream is `Active` on both ends.

- **`tests/pjsua/scripts-call/500_video_call_hold.py`** (new) — establishes a video call via the helpers, then the caller initiates hold; the test verifies the video stream goes to hold: **`Local hold` on the initiating caller, `Remote hold` on the callee**.

- **`tests/pjsua/inc_util.py`** — adds `has_video()`, a capability probe mirroring the existing `has_ssl_sock()`. The test skips when the build has no usable video codec (`PJMEDIA_HAS_VIDEO=0`, or no VPX/OpenH264), so it's a clean no-op in non-video `pjsua-test` jobs and runs for real in the video-enabled job.

- **`tests/pjsua/inc_const.py`** — adds `VID_MEDIA_ACTIVE` / `VID_MEDIA_HOLD` to assert on the `[type=video]` stream specifically.

## Design notes

- **Headless operation**: the colorbar/null device pinning avoids opening any real camera or display.
- **Auto-wired**: `scripts-call/` is auto-discovered by `runall.py`; no workflow changes are needed. The test runs in the video-enabled CI job (OpenH264+VPX / pjsua) and skips elsewhere.

## Testing

Passes repeatedly on macOS (H264 via VideoToolbox), observing:
```
callee: Call 0 media 1 [type=video], status is Active -> Remote hold
caller: Call 0 media 1 [type=video], status is Active -> Local hold
```
No regression in the existing audio call tests.

Co-Authored-By Claude Code