### PR TITLE
Fix DNS resolver use-after-free when a query completes after the resolution has been reported

### DIFF
--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -117,9 +117,10 @@ static void dns_callback(void *user_data,
  * time is still not protected: another thread may complete the resolution,
  * and the application may then release the query job, while the queries are
  * being started here. That is not specific to the deferral though, the query
- * job has no locking at all, so it is up to the application to serialize the
- * completion against its use of the query job, as the SIP resolver does with
- * its own group lock.
+ * job has no locking at all, so its fields are updated from the DNS callbacks
+ * without any synchronization anyway. Protecting it would require mutual
+ * exclusion between the completion and the functions starting the queries,
+ * which the deferral cannot provide by itself.
  */
 static void complete_query(pj_dns_srv_async_query *query_job,
                            pj_status_t status)

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -82,6 +82,7 @@ struct pj_dns_srv_async_query
 
     /* Deferred completion, see complete_query() */
     unsigned                 busy;          /**< Query job is being used.   */
+    pj_thread_t             *busy_thread;   /**< Thread using the job.      */
     pj_bool_t                deferred_cb;   /**< Callback is deferred.      */
     pj_status_t              deferred_status;/**< Status of deferred cb.    */
 };
@@ -100,12 +101,17 @@ static void dns_callback(void *user_data,
  * invoked, hence the query job must not be accessed anymore after this
  * function returns.
  *
- * If the query job is currently being used by one of the functions starting
- * the DNS queries (i.e. it is 'busy'), the invocation is deferred to that
- * function, otherwise that function would access the query job after the
- * application callback has released it. This happens when a DNS response is
- * available in the cache, in which case the DNS callback is invoked
+ * If we are called by one of the functions starting the DNS queries (i.e.
+ * the query job is 'busy' in this very thread), the invocation is deferred
+ * to that function, otherwise that function would access the query job after
+ * the application callback has released it. This happens when a DNS response
+ * is available in the cache, in which case the DNS callback is invoked
  * synchronously by pj_dns_resolver_start_query().
+ *
+ * Note that the deferral is deliberately limited to the thread which is
+ * starting the queries, so that the deferred state is only ever accessed by
+ * that thread, i.e. a completion reported by another thread can never get
+ * lost in the handoff.
  */
 static void complete_query(pj_dns_srv_async_query *query_job,
                            pj_status_t status)
@@ -113,10 +119,10 @@ static void complete_query(pj_dns_srv_async_query *query_job,
     pj_dns_srv_record srv_rec;
     unsigned i;
 
-    if (query_job->busy) {
-        /* Only a single completion can ever be deferred, since any pending
-         * query is cancelled on failure and the successful completion is
-         * only reported once all queries have completed.
+    if (query_job->busy && query_job->busy_thread == pj_thread_this()) {
+        /* Only a single completion can ever be deferred, since a query job
+         * is only completed once, either successfully after all its queries
+         * have completed, or with an error.
          */
         query_job->deferred_cb = PJ_TRUE;
         query_job->deferred_status = status;
@@ -184,7 +190,8 @@ static void complete_query(pj_dns_srv_async_query *query_job,
  */
 static void set_busy(pj_dns_srv_async_query *query_job)
 {
-    ++query_job->busy;
+    if (query_job->busy++ == 0)
+        query_job->busy_thread = pj_thread_this();
 }
 
 
@@ -194,11 +201,16 @@ static void set_busy(pj_dns_srv_async_query *query_job)
  */
 static void unset_busy(pj_dns_srv_async_query *query_job)
 {
-    pj_assert(query_job->busy > 0);
+    pj_assert(query_job->busy > 0 &&
+              query_job->busy_thread == pj_thread_this());
 
-    if (--query_job->busy == 0 && query_job->deferred_cb) {
-        query_job->deferred_cb = PJ_FALSE;
-        complete_query(query_job, query_job->deferred_status);
+    if (--query_job->busy == 0) {
+        query_job->busy_thread = NULL;
+
+        if (query_job->deferred_cb) {
+            query_job->deferred_cb = PJ_FALSE;
+            complete_query(query_job, query_job->deferred_status);
+        }
     }
 }
 

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -80,6 +80,10 @@ struct pj_dns_srv_async_query
     /* Number of hosts in SRV records that the IP address has been resolved */
     unsigned                 host_resolved;
 
+    /* Deferred completion, see complete_query() */
+    unsigned                 busy;          /**< Query job is being used.   */
+    pj_bool_t                deferred_cb;   /**< Callback is deferred.      */
+    pj_status_t              deferred_status;/**< Status of deferred cb.    */
 };
 
 
@@ -88,6 +92,115 @@ static void dns_callback(void *user_data,
                          pj_status_t status,
                          pj_dns_parsed_packet *pkt);
 
+
+/* Complete the query job by invoking the application callback.
+ *
+ * The query job is normally allocated from a pool owned by the application,
+ * which the application is free to release once this callback has been
+ * invoked, hence the query job must not be accessed anymore after this
+ * function returns.
+ *
+ * If the query job is currently being used by one of the functions starting
+ * the DNS queries (i.e. it is 'busy'), the invocation is deferred to that
+ * function, otherwise that function would access the query job after the
+ * application callback has released it. This happens when a DNS response is
+ * available in the cache, in which case the DNS callback is invoked
+ * synchronously by pj_dns_resolver_start_query().
+ */
+static void complete_query(pj_dns_srv_async_query *query_job,
+                           pj_status_t status)
+{
+    pj_dns_srv_record srv_rec;
+    unsigned i;
+
+    if (query_job->busy) {
+        /* Only a single completion can ever be deferred, since any pending
+         * query is cancelled on failure and the successful completion is
+         * only reported once all queries have completed.
+         */
+        query_job->deferred_cb = PJ_TRUE;
+        query_job->deferred_status = status;
+        return;
+    }
+
+    if (status != PJ_SUCCESS) {
+        /* Cancel any pending query */
+        pj_dns_srv_cancel_query(query_job, PJ_FALSE);
+
+        (*query_job->cb)(query_job->token, status, NULL);
+        return;
+    }
+
+    /* Build server addresses and call callback */
+    srv_rec.count = 0;
+    for (i=0; i<query_job->srv_cnt; ++i) {
+        unsigned j;
+        struct srv_target *srv2 = &query_job->srv[i];
+        pj_dns_addr_record *s = &srv_rec.entry[srv_rec.count].server;
+
+        srv_rec.entry[srv_rec.count].priority = srv2->priority;
+        srv_rec.entry[srv_rec.count].weight = srv2->weight;
+        srv_rec.entry[srv_rec.count].port = (pj_uint16_t)srv2->port ;
+
+        srv_rec.entry[srv_rec.count].server.name = srv2->target_name;
+        srv_rec.entry[srv_rec.count].server.alias = srv2->cname;
+        srv_rec.entry[srv_rec.count].server.addr_count = 0;
+
+        pj_assert(srv2->addr_cnt <= PJ_DNS_MAX_IP_IN_A_REC);
+
+        for (j=0; j<srv2->addr_cnt; ++j) {
+            s->addr[j].af = srv2->addr[j].addr.sa_family;
+            if (s->addr[j].af == pj_AF_INET())
+                s->addr[j].ip.v4 = srv2->addr[j].ipv4.sin_addr;
+            else
+                s->addr[j].ip.v6 = srv2->addr[j].ipv6.sin6_addr;
+            ++s->addr_count;
+        }
+
+        if (srv2->addr_cnt > 0) {
+            ++srv_rec.count;
+            if (srv_rec.count == PJ_DNS_SRV_MAX_ADDR)
+                break;
+        }
+    }
+
+    PJ_LOG(5,(query_job->objname,
+              "Server resolution complete, %d server entry(s) found",
+              srv_rec.count));
+
+    if (srv_rec.count == 0) {
+        status = query_job->last_error;
+        if (status == PJ_SUCCESS)
+            status = PJLIB_UTIL_EDNSNOANSWERREC;
+    }
+
+    (*query_job->cb)(query_job->token, status, &srv_rec);
+}
+
+
+/* Mark the query job as being used, so that the application callback won't
+ * be invoked (and the query job won't be released with it) while we are
+ * still using the query job.
+ */
+static void set_busy(pj_dns_srv_async_query *query_job)
+{
+    ++query_job->busy;
+}
+
+
+/* The counterpart of set_busy(), which will invoke the application callback
+ * if its invocation has been deferred. Note that the query job must not be
+ * accessed anymore after this function returns.
+ */
+static void unset_busy(pj_dns_srv_async_query *query_job)
+{
+    pj_assert(query_job->busy > 0);
+
+    if (--query_job->busy == 0 && query_job->deferred_cb) {
+        query_job->deferred_cb = PJ_FALSE;
+        complete_query(query_job, query_job->deferred_status);
+    }
+}
 
 
 /*
@@ -150,17 +263,36 @@ PJ_DEF(pj_status_t) pj_dns_srv_resolve( const pj_str_t *domain_name,
                (int)target_name.slen, target_name.ptr,
                def_port));
 
-    status = pj_dns_resolver_start_query(resolver, &target_name, 
-                                         query_job->dns_state, 0, 
+    /* The DNS callback may be invoked synchronously, i.e. when the response
+     * is available in the cache, in which case the whole resolution may be
+     * completed before pj_dns_resolver_start_query() returns. Defer the
+     * completion until we are done using the query job below.
+     */
+    set_busy(query_job);
+
+    status = pj_dns_resolver_start_query(resolver, &target_name,
+                                         query_job->dns_state, 0,
                                          &dns_callback,
                                          query_job, &query_job->q_srv);
+    if (status != PJ_SUCCESS) {
+        /* Failed to start the query, so no callback can have been invoked
+         * and there is nothing to complete.
+         */
+        pj_assert(!query_job->deferred_cb);
+        --query_job->busy;
+        return status;
+    }
+
     if (query_job->q_srv)
         p_q = query_job;
 
-    if (status==PJ_SUCCESS && p_query)
+    if (p_query)
         *p_query = p_q;
 
-    return status;
+    /* Note that the query job may be released by the callback here. */
+    unset_busy(query_job);
+
+    return PJ_SUCCESS;
 }
 
 
@@ -485,6 +617,13 @@ static pj_status_t resolve_hostnames(pj_dns_srv_async_query *query_job)
 
     query_job->dns_state = PJ_DNS_TYPE_A;
 
+    /* The DNS callbacks may be invoked synchronously, i.e. when the responses
+     * are available in the cache, in which case the whole resolution may be
+     * completed before we are done starting the queries below. Defer the
+     * completion until then.
+     */
+    set_busy(query_job);
+
     for (i=0; i<query_job->srv_cnt; ++i) {
         struct srv_target *srv = &query_job->srv[i];
 
@@ -545,13 +684,55 @@ static pj_status_t resolve_hostnames(pj_dns_srv_async_query *query_job)
          * returning false error, so don't use that variable for counting errors.
          */
         if (status != PJ_SUCCESS) {
-            query_job->host_resolved++;
-            err_cnt++;
-            err = status;
+            /* Only count this server as resolved if it has no outstanding
+             * query, e.g. when only the DNS AAAA query failed to start, the
+             * pending DNS A query will count it once it completes. Otherwise
+             * the application callback may be invoked while a query is still
+             * outstanding, and the late callback of that query would then
+             * access an already released query job.
+             */
+            if (srv->q_a == NULL &&
+                (srv->q_aaaa == NULL ||
+                 srv->q_aaaa == (pj_dns_async_query*)0x1))
+            {
+                srv->q_aaaa = NULL;
+                query_job->host_resolved++;
+
+                /* Only treat this as an error if this server has no address
+                 * at all, e.g. the DNS A record may have been available in
+                 * the cache while only the DNS AAAA query failed to start.
+                 */
+                if (srv->addr_cnt == 0) {
+                    err_cnt++;
+                    err = status;
+                }
+            }
         }
     }
-    
-    return (err_cnt == query_job->srv_cnt) ? err : PJ_SUCCESS;
+
+    if (err_cnt == query_job->srv_cnt) {
+        /* All queries failed to start. Let the caller report the error, no
+         * callback can have been invoked so the query job is still alive.
+         */
+        --query_job->busy;
+        return err;
+    }
+
+    /* All hostnames may already have been resolved here, e.g. when the only
+     * remaining query failed to start, in which case the completion has not
+     * been reported by any DNS callback yet.
+     */
+    if (!query_job->deferred_cb &&
+        query_job->host_resolved == query_job->srv_cnt)
+    {
+        query_job->deferred_cb = PJ_TRUE;
+        query_job->deferred_status = PJ_SUCCESS;
+    }
+
+    /* Note that the query job may be released by the callback here. */
+    unset_busy(query_job);
+
+    return PJ_SUCCESS;
 }
 
 /* 
@@ -800,56 +981,10 @@ static void dns_callback(void *user_data,
 
     /* Check if all hosts have been resolved */
     if (query_job->host_resolved == query_job->srv_cnt) {
-        /* Got all answers, build server addresses */
-        pj_dns_srv_record srv_rec;
-
-        srv_rec.count = 0;
-        for (i=0; i<query_job->srv_cnt; ++i) {
-            unsigned j;
-            struct srv_target *srv2 = &query_job->srv[i];
-            pj_dns_addr_record *s = &srv_rec.entry[srv_rec.count].server;
-
-            srv_rec.entry[srv_rec.count].priority = srv2->priority;
-            srv_rec.entry[srv_rec.count].weight = srv2->weight;
-            srv_rec.entry[srv_rec.count].port = (pj_uint16_t)srv2->port ;
-
-            srv_rec.entry[srv_rec.count].server.name = srv2->target_name;
-            srv_rec.entry[srv_rec.count].server.alias = srv2->cname;
-            srv_rec.entry[srv_rec.count].server.addr_count = 0;
-
-            pj_assert(srv2->addr_cnt <= PJ_DNS_MAX_IP_IN_A_REC);
-
-            for (j=0; j<srv2->addr_cnt; ++j) {          
-                s->addr[j].af = srv2->addr[j].addr.sa_family;
-                if (s->addr[j].af == pj_AF_INET())
-                    s->addr[j].ip.v4 = srv2->addr[j].ipv4.sin_addr;
-                else
-                    s->addr[j].ip.v6 = srv2->addr[j].ipv6.sin6_addr;
-                ++s->addr_count;
-            }
-
-            if (srv2->addr_cnt > 0) {
-                ++srv_rec.count;
-                if (srv_rec.count == PJ_DNS_SRV_MAX_ADDR)
-                    break;
-            }
-        }
-
-        PJ_LOG(5,(query_job->objname, 
-                  "Server resolution complete, %d server entry(s) found",
-                  srv_rec.count));
-
-
-        if (srv_rec.count > 0)
-            status = PJ_SUCCESS;
-        else {
-            status = query_job->last_error;
-            if (status == PJ_SUCCESS)
-                status = PJLIB_UTIL_EDNSNOANSWERREC;
-        }
-
-        /* Call the callback */
-        (*query_job->cb)(query_job->token, status, &srv_rec);
+        /* Got all answers, report them to the application. Note that the
+         * query job may be released by the callback.
+         */
+        complete_query(query_job, PJ_SUCCESS);
     }
 
 
@@ -864,10 +999,10 @@ on_error:
                      (int)query_job->domain_part.slen,
                      query_job->domain_part.ptr));
 
-        /* Cancel any pending query */
-        pj_dns_srv_cancel_query(query_job, PJ_FALSE);
-
-        (*query_job->cb)(query_job->token, status, NULL);
+        /* Cancel any pending query and report the error. Note that the query
+         * job may be released by the callback.
+         */
+        complete_query(query_job, status);
         return;
     }
 }

--- a/pjlib-util/src/pjlib-util/srv_resolver.c
+++ b/pjlib-util/src/pjlib-util/srv_resolver.c
@@ -112,6 +112,14 @@ static void dns_callback(void *user_data,
  * starting the queries, so that the deferred state is only ever accessed by
  * that thread, i.e. a completion reported by another thread can never get
  * lost in the handoff.
+ *
+ * It does mean that a query job which is used by several threads at the same
+ * time is still not protected: another thread may complete the resolution,
+ * and the application may then release the query job, while the queries are
+ * being started here. That is not specific to the deferral though, the query
+ * job has no locking at all, so it is up to the application to serialize the
+ * completion against its use of the query job, as the SIP resolver does with
+ * its own group lock.
  */
 static void complete_query(pj_dns_srv_async_query *query_job,
                            pj_status_t status)
@@ -201,8 +209,7 @@ static void set_busy(pj_dns_srv_async_query *query_job)
  */
 static void unset_busy(pj_dns_srv_async_query *query_job)
 {
-    pj_assert(query_job->busy > 0 &&
-              query_job->busy_thread == pj_thread_this());
+    pj_assert(query_job->busy > 0);
 
     if (--query_job->busy == 0) {
         query_job->busy_thread = NULL;

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -215,22 +215,33 @@ static pj_bool_t can_report_result(struct query *query)
 
 /*
  * Internal:
+ *  get the status of the resolution, which is a failure if no address has
+ *  been resolved. Note that the queries may all have succeeded without
+ *  yielding any usable address, e.g. when a DNS A response only contains
+ *  records of another type, in which case no error has been recorded.
+ */
+static pj_status_t get_result_status(struct query *query)
+{
+    if (query->server.count > 0)
+        return PJ_SUCCESS;
+
+    return query->last_error != PJ_SUCCESS? query->last_error:
+                                            PJLIB_UTIL_EDNSNOANSWERREC;
+}
+
+
+/*
+ * Internal:
  *  report the result of the resolution to the caller. The query state must
  *  not be accessed anymore after this, since the caller may release the pool
  *  containing it.
  */
 static void report_result(struct query *query)
 {
-    if (query->server.count > 0) {
-        (*query->cb)(PJ_SUCCESS, query->token, &query->server);
-    } else {
-        pj_status_t status = query->last_error;
+    pj_status_t status = get_result_status(query);
 
-        if (status == PJ_SUCCESS)
-            status = PJLIB_UTIL_EDNSNOANSWERREC;
-
-        (*query->cb)(status, query->token, NULL);
-    }
+    (*query->cb)(status, query->token,
+                 status == PJ_SUCCESS? &query->server: NULL);
 }
 #endif  /* PJSIP_HAS_RESOLVER */
 
@@ -616,22 +627,24 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
      * in another thread.
      */
     report = can_report_result(query);
+
+    if (!report && status != PJ_SUCCESS) {
+        /* Note that this must be logged before releasing the group lock: the
+         * outstanding query may complete as soon as it is released, and the
+         * caller may then release the pool which contains both the query
+         * state and the target host name.
+         */
+        PJ_PERROR(4,(THIS_FILE, status,
+                     "Failed to start DNS query for '%.*s', waiting for the "
+                     "outstanding query to complete",
+                     (int)target->addr.host.slen,
+                     target->addr.host.ptr));
+    }
+
     pj_grp_lock_release(query->grp_lock);
 
-    if (!report) {
-        /* Note that the query state must not be accessed here, since the
-         * outstanding query may have completed in another thread as soon as
-         * the group lock above was released.
-         */
-        if (status != PJ_SUCCESS) {
-            PJ_PERROR(4,(THIS_FILE, status,
-                         "Failed to start DNS query for '%.*s', waiting for "
-                         "the outstanding query to complete",
-                         (int)target->addr.host.slen,
-                         target->addr.host.ptr));
-        }
+    if (!report)
         return;
-    }
 
     /* All queries have completed, i.e. either the responses were available in
      * the cache, or no query could be started at all. Note that the failure
@@ -640,7 +653,7 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
      * failed to start.
      */
     if (query->server.count == 0) {
-        PJ_PERROR(4,(THIS_FILE, query->last_error,
+        PJ_PERROR(4,(THIS_FILE, get_result_status(query),
                      "Failed to resolve '%.*s'",
                      (int)target->addr.host.slen,
                      target->addr.host.ptr));

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -54,6 +54,12 @@ struct query
     pj_grp_lock_t           *grp_lock;
     pj_status_t              last_error;
 
+    /* Number of DNS queries which have not completed yet, and whether the
+     * queries are still being started, see report_result().
+     */
+    unsigned                 pending_cnt;
+    pj_bool_t                starting;
+
     /* Original request: */
     struct {
         pjsip_host_info      target;
@@ -185,6 +191,50 @@ PJ_DEF(void) pjsip_resolver_destroy(pjsip_resolver_t *resolver)
     }
 }
 
+#if PJSIP_HAS_RESOLVER
+/*
+ * Internal:
+ *  check whether the result of the resolution can be reported now, which is
+ *  only the case once all the DNS queries have completed and none of them can
+ *  still be started.
+ *
+ * The query state is allocated from the caller's pool, and the caller is free
+ * to release that pool as soon as it has been notified, so the result must
+ * never be reported while a DNS query is still outstanding, nor while
+ * pjsip_resolve() is still starting the queries and using the query state.
+ *
+ * Must be called with the resolver group lock held, which serializes this
+ * against pjsip_resolve() and against the DNS callbacks of the other
+ * queries.
+ */
+static pj_bool_t can_report_result(struct query *query)
+{
+    return query->pending_cnt == 0 && !query->starting;
+}
+
+
+/*
+ * Internal:
+ *  report the result of the resolution to the caller. The query state must
+ *  not be accessed anymore after this, since the caller may release the pool
+ *  containing it.
+ */
+static void report_result(struct query *query)
+{
+    if (query->server.count > 0) {
+        (*query->cb)(PJ_SUCCESS, query->token, &query->server);
+    } else {
+        pj_status_t status = query->last_error;
+
+        if (status == PJ_SUCCESS)
+            status = PJLIB_UTIL_EDNSNOANSWERREC;
+
+        (*query->cb)(status, query->token, NULL);
+    }
+}
+#endif  /* PJSIP_HAS_RESOLVER */
+
+
 /*
  * Internal:
  *  determine if an address is a valid IP address, and if it is,
@@ -225,6 +275,7 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
     pj_status_t status = PJ_SUCCESS;
     int ip_addr_ver;
     struct query *query;
+    pj_bool_t report;
     pjsip_transport_type_e type = target->type;
     int af = pj_AF_UNSPEC();
 
@@ -479,6 +530,20 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
                pjsip_transport_get_type_name(target->type),
                target->addr.port));
 
+    /* Acquire the resolver group lock, which is also acquired by the DNS
+     * callbacks, so that the result of the resolution cannot be reported
+     * while we are still starting the queries below and using the query
+     * state. Note that a DNS callback is invoked synchronously by
+     * pj_dns_resolver_start_query() when the response is available in the
+     * cache, and that the callback of a query which has just been started
+     * may already be running in another thread, e.g. when the query has
+     * been merged into an outstanding query which completes at that very
+     * moment. The group lock is recursive, so it may be held while calling
+     * the DNS resolver.
+     */
+    pj_grp_lock_acquire(query->grp_lock);
+    query->starting = PJ_TRUE;
+
     if (query->query_type == PJ_DNS_TYPE_SRV) {
         int opt = 0;
 
@@ -490,38 +555,38 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
         else /* af == pj_AF_INET() */
             opt = PJ_DNS_SRV_FALLBACK_A;
 
+        ++query->pending_cnt;
         status = pj_dns_srv_resolve(&query->naptr[0].name,
                                     &query->naptr[0].res_type,
                                     query->req.def_port, pool, resolver->res,
                                     opt, query, &srv_resolver_cb, NULL);
+        if (status != PJ_SUCCESS)
+            --query->pending_cnt;
 
     } else if (query->query_type == PJ_DNS_TYPE_A) {
 
         /* Resolve DNS A record if address family is not fixed to IPv6 */
         if (af != pj_AF_INET6()) {
-
-            /* If there will be DNS AAAA query too, let's setup a dummy one
-             * here, otherwise app callback may be called immediately (before
-             * DNS AAAA query is sent) when DNS A record is available in the
-             * cache.
-             */
-            if (af == pj_AF_UNSPEC())
-                query->object6 = (pj_dns_async_query*)0x1;
-
-            status = pj_dns_resolver_start_query(resolver->res, 
+            ++query->pending_cnt;
+            status = pj_dns_resolver_start_query(resolver->res,
                                                  &query->naptr[0].name,
-                                                 PJ_DNS_TYPE_A, 0, 
+                                                 PJ_DNS_TYPE_A, 0,
                                                  &dns_a_callback,
                                                  query, &query->object);
+            if (status != PJ_SUCCESS)
+                --query->pending_cnt;
         }
 
         /* Resolve DNS AAAA record if address family is not fixed to IPv4 */
         if (af != pj_AF_INET() && status == PJ_SUCCESS) {
-            status = pj_dns_resolver_start_query(resolver->res, 
+            ++query->pending_cnt;
+            status = pj_dns_resolver_start_query(resolver->res,
                                                  &query->naptr[0].name,
-                                                 PJ_DNS_TYPE_AAAA, 0, 
+                                                 PJ_DNS_TYPE_AAAA, 0,
                                                  &dns_aaaa_callback,
                                                  query, &query->object6);
+            if (status != PJ_SUCCESS)
+                --query->pending_cnt;
         }
 
     } else {
@@ -529,57 +594,60 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
         status = PJ_EBUG;
     }
 
-    if (status != PJ_SUCCESS) {
-        /* Clear the dummy DNS AAAA query, if any, otherwise the DNS A
-         * callback will never report the result of the resolution.
-         */
-        if (query->object6 == (pj_dns_async_query*)0x1)
-            query->object6 = NULL;
+    if (status != PJ_SUCCESS)
+        query->last_error = status;
 
-        /* If a query is still outstanding, e.g. only the DNS AAAA query
-         * failed to start, the callback of that query will report the result
-         * of the resolution later. The failure must not be reported here,
-         * since the caller may release the pool containing this query state
-         * as soon as it is notified, while the outstanding query still
-         * refers to this query state (see #5142).
-         *
-         * Note that cancelling the outstanding query instead would not be
-         * reliable, as the DNS resolver invokes the callbacks after having
-         * released its group lock, so its callback may already be running
-         * or about to run in another thread.
-         */
-        if (query->object || query->object6) {
-            PJ_PERROR(4,(query->objname, status,
-                         "Failed to start DNS query, waiting for the "
-                         "outstanding DNS %s query to complete",
-                         pj_dns_get_type_name(query->object? PJ_DNS_TYPE_A:
-                                                             PJ_DNS_TYPE_AAAA)));
+    query->starting = PJ_FALSE;
 
-            query->last_error = status;
-            return;
+    /* If a query is still outstanding, e.g. only the DNS AAAA query failed to
+     * start, its callback will report the result of the resolution later. It
+     * must not be reported here, since the caller may release the pool
+     * containing the query state as soon as it is notified, while the
+     * outstanding query still refers to it (see #5142).
+     *
+     * Note that cancelling the outstanding query instead would not be
+     * reliable, as the DNS resolver invokes the callbacks after having
+     * released its group lock, so its callback may already be about to run
+     * in another thread.
+     */
+    report = can_report_result(query);
+    pj_grp_lock_release(query->grp_lock);
+
+    if (!report) {
+        /* Note that the query state must not be accessed here, since the
+         * outstanding query may have completed in another thread as soon as
+         * the group lock above was released.
+         */
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(4,(THIS_FILE, status,
+                         "Failed to start DNS query for '%.*s', waiting for "
+                         "the outstanding query to complete",
+                         (int)target->addr.host.slen,
+                         target->addr.host.ptr));
         }
-
-        /* If some addresses have already been resolved, e.g. the DNS A
-         * record was available in the cache, report them instead of failing.
-         */
-        if (query->server.count > 0) {
-            PJ_PERROR(4,(query->objname, status,
-                         "Ignoring failure in starting DNS query, %d "
-                         "address(es) have been resolved",
-                         query->server.count));
-
-            (*cb)(PJ_SUCCESS, token, &query->server);
-            return;
-        }
-
-        goto on_error;
+        return;
     }
 
+    /* All queries have completed, i.e. either the responses were available in
+     * the cache, or no query could be started at all. Note that the failure
+     * is only reported if nothing has been resolved, since the DNS A record
+     * may have been available in the cache while only the DNS AAAA query
+     * failed to start.
+     */
+    if (query->server.count == 0) {
+        PJ_PERROR(4,(THIS_FILE, query->last_error,
+                     "Failed to resolve '%.*s'",
+                     (int)target->addr.host.slen,
+                     target->addr.host.ptr));
+    }
+
+    report_result(query);
     return;
 
 #else /* PJSIP_HAS_RESOLVER */
     PJ_UNUSED_ARG(pool);
     PJ_UNUSED_ARG(query);
+    PJ_UNUSED_ARG(report);
 #endif /* PJSIP_HAS_RESOLVER */
 
 on_error:
@@ -604,11 +672,14 @@ static void dns_a_callback(void *user_data,
 {
     struct query *query = (struct query*) user_data;
     pjsip_server_addresses *srv = &query->server;
+    pj_grp_lock_t *grp_lock = query->grp_lock;
+    pj_bool_t report;
 
-    pj_grp_lock_acquire(query->grp_lock);
+    pj_grp_lock_acquire(grp_lock);
 
     /* Reset outstanding job */
     query->object = NULL;
+    --query->pending_cnt;
 
     if (status == PJ_SUCCESS) {
         pj_dns_addr_record rec;
@@ -653,15 +724,16 @@ static void dns_a_callback(void *user_data,
         query->last_error = status;
     }
 
-    /* Call the callback if all DNS queries have been completed */
-    if (query->object == NULL && query->object6 == NULL) {
-        if (srv->count > 0)
-            (*query->cb)(PJ_SUCCESS, query->token, &query->server);
-        else
-            (*query->cb)(query->last_error, query->token, NULL);
-    }
+    /* Report the result if all DNS queries have been completed. Note that
+     * this is done after having released the group lock, since the caller
+     * may release the pool containing the query state, and the query state
+     * cannot be accessed by any other thread anymore at this point.
+     */
+    report = can_report_result(query);
+    pj_grp_lock_release(grp_lock);
 
-    pj_grp_lock_release(query->grp_lock);
+    if (report)
+        report_result(query);
 }
 
 
@@ -674,11 +746,14 @@ static void dns_aaaa_callback(void *user_data,
 {
     struct query *query = (struct query*) user_data;
     pjsip_server_addresses *srv = &query->server;
+    pj_grp_lock_t *grp_lock = query->grp_lock;
+    pj_bool_t report;
 
-    pj_grp_lock_acquire(query->grp_lock);
+    pj_grp_lock_acquire(grp_lock);
 
     /* Reset outstanding job */
     query->object6 = NULL;
+    --query->pending_cnt;
 
     if (status == PJ_SUCCESS) {
         pj_dns_addr_record rec;
@@ -724,15 +799,14 @@ static void dns_aaaa_callback(void *user_data,
         query->last_error = status;
     }
 
-    /* Call the callback if all DNS queries have been completed */
-    if (query->object == NULL && query->object6 == NULL) {
-        if (srv->count > 0)
-            (*query->cb)(PJ_SUCCESS, query->token, &query->server);
-        else
-            (*query->cb)(query->last_error, query->token, NULL);
-    }
+    /* Report the result if all DNS queries have been completed, see the
+     * note in dns_a_callback().
+     */
+    report = can_report_result(query);
+    pj_grp_lock_release(grp_lock);
 
-    pj_grp_lock_release(query->grp_lock);
+    if (report)
+        report_result(query);
 }
 
 
@@ -742,51 +816,61 @@ static void srv_resolver_cb(void *user_data,
                             const pj_dns_srv_record *rec)
 {
     struct query *query = (struct query*) user_data;
-    pjsip_server_addresses srv;
+    pjsip_server_addresses *srv = &query->server;
+    pj_grp_lock_t *grp_lock = query->grp_lock;
+    pj_bool_t report;
     unsigned i;
+
+    pj_grp_lock_acquire(grp_lock);
+
+    /* Reset outstanding job */
+    --query->pending_cnt;
 
     if (status != PJ_SUCCESS) {
         PJ_PERROR(4,(query->objname, status,
                      "DNS A/AAAA record resolution failed"));
 
-        /* Call the callback */
-        (*query->cb)(status, query->token, NULL);
-        return;
+        query->last_error = status;
+        goto on_return;
     }
 
-    /* Build server addresses and call callback */
-    srv.count = 0;
+    /* Build server addresses */
     for (i=0; i<rec->count; ++i) {
         const pj_dns_addr_record *s = &rec->entry[i].server;
         unsigned j;
 
         for (j = 0; j < s->addr_count &&
-                    srv.count < PJSIP_MAX_RESOLVED_ADDRESSES; ++j)
+                    srv->count < PJSIP_MAX_RESOLVED_ADDRESSES; ++j)
         {
-            srv.entry[srv.count].name = rec->entry[i].server.name;
-            srv.entry[srv.count].type = query->naptr[0].type;
-            srv.entry[srv.count].priority = rec->entry[i].priority;
-            srv.entry[srv.count].weight = rec->entry[i].weight;
+            srv->entry[srv->count].name = rec->entry[i].server.name;
+            srv->entry[srv->count].type = query->naptr[0].type;
+            srv->entry[srv->count].priority = rec->entry[i].priority;
+            srv->entry[srv->count].weight = rec->entry[i].weight;
             pj_sockaddr_init(s->addr[j].af,
-                             &srv.entry[srv.count].addr,
+                             &srv->entry[srv->count].addr,
                              0, (pj_uint16_t)rec->entry[i].port);
             if (s->addr[j].af == pj_AF_INET6())
-                srv.entry[srv.count].addr.ipv6.sin6_addr = s->addr[j].ip.v6;
+                srv->entry[srv->count].addr.ipv6.sin6_addr = s->addr[j].ip.v6;
             else
-                srv.entry[srv.count].addr.ipv4.sin_addr = s->addr[j].ip.v4;
-            srv.entry[srv.count].addr_len =
-                            pj_sockaddr_get_len(&srv.entry[srv.count].addr);
+                srv->entry[srv->count].addr.ipv4.sin_addr = s->addr[j].ip.v4;
+            srv->entry[srv->count].addr_len =
+                          pj_sockaddr_get_len(&srv->entry[srv->count].addr);
 
             /* Update transport type if this is IPv6 */
             if (s->addr[j].af == pj_AF_INET6())
-                srv.entry[srv.count].type |= PJSIP_TRANSPORT_IPV6;
+                srv->entry[srv->count].type |= PJSIP_TRANSPORT_IPV6;
 
-            ++srv.count;
+            ++srv->count;
         }
     }
 
-    /* Call the callback */
-    (*query->cb)(PJ_SUCCESS, query->token, &srv);
+on_return:
+    /* Report the result, see the note in dns_a_callback(). */
+    report = can_report_result(query);
+    pj_grp_lock_release(grp_lock);
+
+    if (report)
+        report_result(query);
 }
 
 #endif  /* PJSIP_HAS_RESOLVER */

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -185,33 +185,6 @@ PJ_DEF(void) pjsip_resolver_destroy(pjsip_resolver_t *resolver)
     }
 }
 
-#if PJSIP_HAS_RESOLVER
-/*
- * Internal:
- *  cancel any DNS query which is still outstanding.
- *
- * The query state is allocated from the caller's pool, and the caller is
- * free to release that pool as soon as our callback has been invoked, so
- * no DNS callback must be invoked on this query state after that.
- */
-static void cancel_queries(struct query *query)
-{
-    if (query->object) {
-        pj_dns_resolver_cancel_query(query->object, PJ_FALSE);
-        query->object = NULL;
-    }
-
-    if (query->object6) {
-        /* Check if it is a dummy query. */
-        if (query->object6 != (pj_dns_async_query*)0x1)
-            pj_dns_resolver_cancel_query(query->object6, PJ_FALSE);
-
-        query->object6 = NULL;
-    }
-}
-#endif  /* PJSIP_HAS_RESOLVER */
-
-
 /*
  * Internal:
  *  determine if an address is a valid IP address, and if it is,
@@ -557,12 +530,34 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
     }
 
     if (status != PJ_SUCCESS) {
-        /* One of the queries failed to start. Cancel the query which has
-         * been started, if any, otherwise its callback may be invoked long
-         * after we have reported the failure below, at which time the query
-         * state may have been freed along with the caller's pool.
+        /* Clear the dummy DNS AAAA query, if any, otherwise the DNS A
+         * callback will never report the result of the resolution.
          */
-        cancel_queries(query);
+        if (query->object6 == (pj_dns_async_query*)0x1)
+            query->object6 = NULL;
+
+        /* If a query is still outstanding, e.g. only the DNS AAAA query
+         * failed to start, the callback of that query will report the result
+         * of the resolution later. The failure must not be reported here,
+         * since the caller may release the pool containing this query state
+         * as soon as it is notified, while the outstanding query still
+         * refers to this query state (see #5142).
+         *
+         * Note that cancelling the outstanding query instead would not be
+         * reliable, as the DNS resolver invokes the callbacks after having
+         * released its group lock, so its callback may already be running
+         * or about to run in another thread.
+         */
+        if (query->object || query->object6) {
+            PJ_PERROR(4,(query->objname, status,
+                         "Failed to start DNS query, waiting for the "
+                         "outstanding DNS %s query to complete",
+                         pj_dns_get_type_name(query->object? PJ_DNS_TYPE_A:
+                                                             PJ_DNS_TYPE_AAAA)));
+
+            query->last_error = status;
+            return;
+        }
 
         /* If some addresses have already been resolved, e.g. the DNS A
          * record was available in the cache, report them instead of failing.

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -66,6 +66,13 @@ struct query
 
     /* Query result */
     pjsip_server_addresses   server;
+
+    /* Buffers to keep the names in 'server' above. The names in the DNS
+     * address records are only valid inside the DNS callbacks, while the
+     * server addresses may only be reported to the application later, i.e.
+     * when the other DNS query completes.
+     */
+    char                     name_buf[2][PJ_MAX_HOSTNAME];
 };
 
 
@@ -177,6 +184,33 @@ PJ_DEF(void) pjsip_resolver_destroy(pjsip_resolver_t *resolver)
         resolver->grp_lock = NULL;
     }
 }
+
+#if PJSIP_HAS_RESOLVER
+/*
+ * Internal:
+ *  cancel any DNS query which is still outstanding.
+ *
+ * The query state is allocated from the caller's pool, and the caller is
+ * free to release that pool as soon as our callback has been invoked, so
+ * no DNS callback must be invoked on this query state after that.
+ */
+static void cancel_queries(struct query *query)
+{
+    if (query->object) {
+        pj_dns_resolver_cancel_query(query->object, PJ_FALSE);
+        query->object = NULL;
+    }
+
+    if (query->object6) {
+        /* Check if it is a dummy query. */
+        if (query->object6 != (pj_dns_async_query*)0x1)
+            pj_dns_resolver_cancel_query(query->object6, PJ_FALSE);
+
+        query->object6 = NULL;
+    }
+}
+#endif  /* PJSIP_HAS_RESOLVER */
+
 
 /*
  * Internal:
@@ -522,8 +556,29 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
         status = PJ_EBUG;
     }
 
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+        /* One of the queries failed to start. Cancel the query which has
+         * been started, if any, otherwise its callback may be invoked long
+         * after we have reported the failure below, at which time the query
+         * state may have been freed along with the caller's pool.
+         */
+        cancel_queries(query);
+
+        /* If some addresses have already been resolved, e.g. the DNS A
+         * record was available in the cache, report them instead of failing.
+         */
+        if (query->server.count > 0) {
+            PJ_PERROR(4,(query->objname, status,
+                         "Ignoring failure in starting DNS query, %d "
+                         "address(es) have been resolved",
+                         query->server.count));
+
+            (*cb)(PJ_SUCCESS, token, &query->server);
+            return;
+        }
+
         goto on_error;
+    }
 
     return;
 
@@ -562,11 +617,18 @@ static void dns_a_callback(void *user_data,
 
     if (status == PJ_SUCCESS) {
         pj_dns_addr_record rec;
+        pj_str_t name;
         unsigned i;
 
         /* Parse the response */
         rec.addr_count = 0;
         status = pj_dns_parse_addr_response(pkt, &rec);
+
+        /* Keep a copy of the name, since the DNS record is only valid
+         * inside this callback.
+         */
+        name.ptr = query->name_buf[0];
+        pj_strncpy(&name, &rec.name, sizeof(query->name_buf[0]));
 
         /* Build server addresses and call callback */
         for (i = 0; i < rec.addr_count &&
@@ -576,7 +638,7 @@ static void dns_a_callback(void *user_data,
             if (rec.addr[i].af != pj_AF_INET())
                 continue;
 
-            srv->entry[srv->count].name = rec.name;
+            srv->entry[srv->count].name = name;
             srv->entry[srv->count].type = query->naptr[0].type;
             srv->entry[srv->count].priority = 0;
             srv->entry[srv->count].weight = 0;
@@ -625,11 +687,18 @@ static void dns_aaaa_callback(void *user_data,
 
     if (status == PJ_SUCCESS) {
         pj_dns_addr_record rec;
+        pj_str_t name;
         unsigned i;
 
         /* Parse the response */
         rec.addr_count = 0;
         status = pj_dns_parse_addr_response(pkt, &rec);
+
+        /* Keep a copy of the name, since the DNS record is only valid
+         * inside this callback.
+         */
+        name.ptr = query->name_buf[1];
+        pj_strncpy(&name, &rec.name, sizeof(query->name_buf[1]));
 
         /* Build server addresses and call callback */
         for (i = 0; i < rec.addr_count &&
@@ -639,7 +708,7 @@ static void dns_aaaa_callback(void *user_data,
             if (rec.addr[i].af != pj_AF_INET6())
                 continue;
 
-            srv->entry[srv->count].name = rec.name;
+            srv->entry[srv->count].name = name;
             srv->entry[srv->count].type = query->naptr[0].type |
                                           PJSIP_TRANSPORT_IPV6;
             srv->entry[srv->count].priority = 0;

--- a/pjsip/src/pjsip/sip_resolve.c
+++ b/pjsip/src/pjsip/sip_resolve.c
@@ -538,8 +538,13 @@ PJ_DEF(void) pjsip_resolve( pjsip_resolver_t *resolver,
      * cache, and that the callback of a query which has just been started
      * may already be running in another thread, e.g. when the query has
      * been merged into an outstanding query which completes at that very
-     * moment. The group lock is recursive, so it may be held while calling
-     * the DNS resolver.
+     * moment.
+     *
+     * Note that this is the lock of the SIP resolver, not the one of the DNS
+     * resolver, so holding it while starting the queries below doesn't invert
+     * any lock order: the DNS resolver always releases its own group lock
+     * before invoking the callbacks. And since the lock is recursive, the
+     * callbacks may also acquire it in this very thread.
      */
     pj_grp_lock_acquire(query->grp_lock);
     query->starting = PJ_TRUE;

--- a/pjsip/src/test/dns_test.c
+++ b/pjsip/src/test/dns_test.c
@@ -400,6 +400,22 @@ static int test_resolve(const char *title,
                 PJ_LOG(3,(THIS_FILE, "  test_resolve() error 50: transport type mismatch"));
                 return 50;
             }
+            /* Only check the name if the reference specifies one. Note that
+             * the name is filled in by the DNS A callback while the result
+             * may only be reported by the DNS AAAA callback, so this also
+             * verifies that the name is still valid by then.
+             */
+            if (ref->entry[i].name.slen &&
+                pj_strcmp(&ref->entry[i].name, &result.servers.entry[i].name))
+            {
+                PJ_LOG(3,(THIS_FILE, "  test_resolve() error 60: name mismatch: "
+                          "expecting '%.*s' but got '%.*s'",
+                          (int)ref->entry[i].name.slen,
+                          ref->entry[i].name.ptr,
+                          (int)result.servers.entry[i].name.slen,
+                          result.servers.entry[i].name.ptr));
+                return 60;
+            }
         }
     }
 
@@ -521,6 +537,7 @@ static void add_ref(pjsip_server_addresses *r,
     pj_sockaddr_in *a;
     pj_str_t tmp;
 
+    pj_bzero(&r->entry[r->count], sizeof(r->entry[r->count]));
     r->entry[r->count].type = type;
     r->entry[r->count].priority = 0;
     r->entry[r->count].weight = 0;
@@ -583,6 +600,7 @@ int resolve_test(void)
     {
         pjsip_server_addresses ref;
         create_ref(&ref, PJSIP_TRANSPORT_UDP, "1.1.1.1", 5060);
+        ref.entry[0].name = pj_str("1.1.1.1");
         status = test_resolve("IP address with explicit port", pool, PJSIP_TRANSPORT_UNSPECIFIED, "1.1.1.1", 5060, &ref);
         if (status != PJ_SUCCESS)
             return -110;
@@ -606,6 +624,7 @@ int resolve_test(void)
     {
         pjsip_server_addresses ref;
         create_ref(&ref, PJSIP_TRANSPORT_UDP, "5.5.5.5", 5060);
+        ref.entry[0].name = pj_str("example.com");
         status = test_resolve("domain name with port should resolve to A record", pool, PJSIP_TRANSPORT_UNSPECIFIED, "example.com", 5060, &ref);
         if (status != PJ_SUCCESS)
             return -140;
@@ -617,6 +636,7 @@ int resolve_test(void)
     {
         pjsip_server_addresses ref;
         create_ref(&ref, PJSIP_TRANSPORT_UDP, "2.2.2.2", 5060);
+        ref.entry[0].name = pj_str("sip02.example.com");
         status = test_resolve("failure with SRV fallback to A record", pool, PJSIP_TRANSPORT_UNSPECIFIED, "sip02.example.com", 0, &ref);
         if (status != PJ_SUCCESS)
             return -150;
@@ -626,6 +646,7 @@ int resolve_test(void)
     {
         pjsip_server_addresses ref;
         create_ref(&ref, PJSIP_TRANSPORT_TLS, "2.2.2.2", 5061);
+        ref.entry[0].name = pj_str("sip02.example.com");
         status = test_resolve("failure with SRV fallback to A record (for TLS)", pool, PJSIP_TRANSPORT_TLS, "sip02.example.com", 0, &ref);
         if (status != PJ_SUCCESS)
             return -150;


### PR DESCRIPTION
Fixes #5142.

## Problem

The SIP resolver query state is allocated from the caller's pool (normally `tdata->pool`, see `pjsip_resolve()`), and the caller is free to release that pool as soon as the resolution has been reported to it. For example `stateless_send_resolver_callback()` releases its `tdata` reference immediately when the resolution fails. Hence the resolution must not be reported while a DNS query which refers to that query state is still outstanding.

`pjsip_resolve()` however starts up to two DNS queries, and if the second one fails to start, it reports the failure to the caller while the first query is still outstanding:

```c
    status = pj_dns_resolver_start_query(..., PJ_DNS_TYPE_A, ..., &query->object);
    if (af != pj_AF_INET() && status == PJ_SUCCESS)
        status = pj_dns_resolver_start_query(..., PJ_DNS_TYPE_AAAA, ..., &query->object6);
    if (status != PJ_SUCCESS)
        goto on_error;      /* reports the failure, query->object still pending */
```

When that query completes or times out later, its callback dereferences the freed query state, which is the crash reported in #5142:

```
 0  grp_lock_acquire [lock.c : 293]          <-- SIGSEGV, x0 = 0x0
 1  pj_grp_lock_acquire [lock.c : 486]
 2  dns_a_callback [sip_resolve.c : 552]     <-- pj_grp_lock_acquire(query->grp_lock)
 3  on_timeout [resolver.c : 1617]           <-- DNS query timeout
 4  pj_timer_heap_poll [timer.c : 912]
```

This is easily triggered when the configured DNS server is unreachable, as in the report: every query then runs to the resolver timeout, and starting a query fails with `PJLIB_UTIL_EDNSNOWORKINGNS` while the nameserver is considered bad (`PJ_DNS_RESOLVER_BAD_NS_TTL`), while starting the DNS A query still succeeds when it is merged into an outstanding query for the same resource (in which case it needs no transmission).

Note that moving the query state to a pool owned by the resolver would not be enough: the late callback would then invoke the application callback a second time, with a token pointing to the already released `pjsip_send_state`. Cancelling the outstanding query is not reliable either, since the DNS resolver invokes its callbacks after having released its group lock, so the callback may already be running in another thread.

## Changes

**`pjsip_resolve()`**: the result of the resolution is now only reported once no DNS query is outstanding anymore, either by the callback of the last query which completed, or by `pjsip_resolve()` itself when all the responses were available in the cache or no query could be started at all. To make that decision reliable, the resolver group lock, which is also acquired by the DNS callbacks, is now held from before starting the queries until it has been decided whether the result can be reported:

```c
    pj_grp_lock_acquire(query->grp_lock);
    query->starting = PJ_TRUE;
    ... start the DNS SRV query, or the DNS A and AAAA queries ...
    query->starting = PJ_FALSE;

    report = can_report_result(query);   /* pending_cnt == 0 && !starting */
    pj_grp_lock_release(query->grp_lock);

    if (report)
        report_result(query);
```

A callback which is dispatched while the lock is held blocks until it is released, and its query object is by definition not cleared yet at that point, so the query is seen as outstanding and the reporting is left to it. A callback which has already completed, i.e. the response was available in the cache so it was invoked synchronously by `pj_dns_resolver_start_query()` in this very thread (the group lock is recursive), did not report the result because `starting` was set, so it is reported by `pjsip_resolve()`. Either way the result is reported exactly once, and never while a callback can still refer to the query state.

This removes the need for the dummy DNS AAAA query object (`(pj_dns_async_query*)0x1`), which was a partial version of the same idea, and it gives the DNS SRV path the same protection, which it needed just as much. The result is reported after releasing the group lock, which is required since the caller releases the pool containing the query state, so it must not be accessed afterwards, not even to release the lock.

Note that cancelling the outstanding query instead of waiting for it would not be reliable, since the DNS resolver invokes its callbacks after having released its group lock, so the callback of the query being cancelled may already be running.

Note also that nothing owned by the caller may be accessed after the group lock has been released, not just the query state: the target host name is allocated from the caller's pool as well (`pjsip_process_route_set()`), so the failure to start a query is logged before releasing the lock, i.e. while the outstanding query still cannot complete.

Lastly, the status of the resolution is now determined in a single place, so that the log and the status reported to the caller cannot disagree, and a resolution which ends up without any address while none of the queries reported an error is failed with `PJLIB_UTIL_EDNSNOANSWERREC` instead of being reported as successful with an empty address list.

**`resolve_hostnames()` (DNS SRV)**: the same problem exists here. A server whose query failed to start is counted as resolved, so the completion of the queries of the other servers may report the resolution to the application while a query is still outstanding for that server, and its late callback then accesses the released query job. Fixed by only counting a server as resolved once it has no outstanding query.

Additionally, when the other servers had all been resolved from the additional records of the SRV response, `resolve_hostnames()` would return `PJ_SUCCESS` with nothing pending and the application callback would never be invoked at all, stalling the request and leaking the caller's `tdata` reference. Fixed by reporting the resolution when the last query fails to start.

**Deferred completion (DNS SRV)**: since the application callback normally releases the pool containing the query job, the query job must not be accessed after the callback has been invoked either. The DNS callback is invoked synchronously by `pj_dns_resolver_start_query()` when a response is available in the cache, so a resolution can complete while `pj_dns_srv_resolve()`/`resolve_hostnames()` are still starting queries and using the query job. Completion is now deferred until they are done with it, which also fixes the existing read of `query_job->q_srv` after `pj_dns_resolver_start_query()` in `pj_dns_srv_resolve()` (same class as #1974 and #3990). The deferral is limited to the thread which is starting the queries, so that its state is only ever accessed by that thread.

**Resolved names**: the names in the DNS address records are only valid inside the DNS callbacks, but the addresses resolved by the DNS A query are reported to the application by the DNS AAAA callback and vice versa, so `pjsip_server_addresses.entry[].name` (added in #4256, and used for TLS SNI and certificate verification) could point to a stack buffer that is out of scope. Keep a copy of the names in the query state instead.

## Not covered: a query job used by several threads at the same time

A DNS SRV query job remains unprotected against being used by several threads at the same time. This is pre-existing and is deliberately left out of this fix, but since it is the same class of bug as #5142, here is what a future fix needs to deal with.

**The scenario.** `resolve_hostnames()` runs from the DNS SRV callback, i.e. on whichever thread polls the response, and starts the DNS A/AAAA queries of the SRV targets one by one. If one of those queries completes in another thread while the loop is still starting the remaining ones, that thread reaches `host_resolved == srv_cnt`, completes the resolution, and the application releases the pool containing the query job (`tdata->pool` in the SIP resolver's case) while the loop is still using it. The loop then keeps reading `query_job->srv_cnt`, `query_job->option` etc. from released memory, and so does the tail of `pj_dns_srv_resolve()` when it reads `query_job->q_srv`.

It is reachable because a query which is merged into an outstanding query for the same host needs no transmission, so its callback can be invoked immediately, and because `host_resolved` may already account for all the other targets, e.g. when they were resolved from the additional records of the SRV response. Beside the use-after-free, all the query job fields (`host_resolved`, `srv[].q_a`, `srv[].addr_cnt`, `q_srv`, ...) are read and written from the DNS callbacks without any synchronization, so they can be lost or torn as well.

**What this PR does and does not do about it.** Completion is deferred while the queries are being started, but only when both happen in the same thread, which is the case of a response being available in the cache: `pj_dns_resolver_start_query()` then invokes the DNS callback synchronously. That is what makes the completion reported by `resolve_hostnames()` (when the last query fails to start) and the read of `query_job->q_srv` in `pj_dns_srv_resolve()` safe. It does nothing for the other threads. Note that the SIP resolver's group lock does not cover them either: it is held across `pj_dns_srv_resolve()`, hence across a resolution which completes synchronously from the cache, but not across the DNS A/AAAA queries which are started later, from the DNS SRV callback.

**Why it needs a lock.** Exactly-once completion cannot be achieved by ordering the counters alone. With the counter update and the "am I the last one" test of the completing thread interleaved with those of the starting thread, there is always an interleaving in which both threads complete the resolution, or one in which neither does, depending on the chosen order. A "completed" flag has the same problem, so the query job needs actual mutual exclusion between the completion and the functions starting the queries.

**Design of a fix.** Use the group lock of the DNS resolver the queries belong to, which is currently private to `resolver.c` and would need an accessor, e.g. `pj_dns_resolver_get_grp_lock()`:

- acquire it in `pj_dns_srv_resolve()`, `dns_callback()` and `pj_dns_srv_cancel_query()`, i.e. around every access to the query job, and release it before invoking the application callback, which is required to keep the current lock order: the DNS resolver deliberately invokes its callbacks without holding its own group lock (#1108, #1565), and the application callback may acquire locks of its own, e.g. the SIP resolver's group lock in `srv_resolver_cb()`. The resulting order, SIP resolver lock → DNS resolver lock, is then the same as the one `pjsip_resolve()` already establishes by calling the DNS resolver while holding its own lock.
- `pj_dns_resolver_start_query()` acquires the same group lock, but group locks are recursive, so it can be called with the lock held.
- keep deferring the completion for the thread which is starting the queries: a synchronous DNS callback runs nested inside that thread's lock, so releasing the lock there does not actually release it, and the application callback must still not be invoked from there.

This would also make the query job field updates safe, and would let `pj_dns_srv_cancel_query()` stop racing with the callbacks of the queries it cancels.

## Testing

Built with `-Wall` (no new warnings) and ASan. `pjlib-util-test resolver_test` and `pjsip-test resolve_test` pass, also with `ASAN_OPTIONS=detect_stack_use_after_return=1`, and the full `pjsip-test` suite passes (26/26).

Note that one `pjsip-test` run aborted in `rt_on_rx_response()` (`transport_test.c:538`) when running the suite with 3 worker threads under ASan, on a late response finding the transmission timer already armed. That is unrelated to this change: those tests resolve IP addresses with no DNS resolver configured on the endpoint, so `pjsip_resolve()` returns before any of the modified code. `transport_udp_test`, `transport_loop_test` and `transport_tcp_test` all pass individually, and the failure did not recur in the subsequent runs of the whole suite.

`resolve_test` now also verifies the queried name of the reported addresses, for the DNS A/AAAA path, the DNS SRV fallback path and the IP address path. In the DNS A/AAAA case the mock DNS server answers the DNS AAAA query with an empty record, so the name is filled in by `dns_a_callback()` while the result is only reported once `dns_aaaa_callback()` has completed. Verified that this catches a regression to the stack-backed name, deterministically so with `ASAN_OPTIONS=detect_stack_use_after_return=1`.

The race conditions themselves remain untested: they need `pj_dns_resolver_start_query()` to fail for the second query while the first one is pending, and the callback of that first query to run in another thread at that very moment, which the DNS test scaffolding cannot force.

Co-Authored-By Claude Code
