### PR TITLE
pjlib-util: harden pj_scan_get_quotes() buffer bound checks

### DIFF
--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -366,10 +366,17 @@ PJ_DEF(void) pj_scan_get_quotes(pj_scanner *scanner,
                                 int qsize, pj_str_t *out)
 {
     register char *s = scanner->curptr;
+    char *r;
+    unsigned nbackslash;
     int qpair = -1;
     int i;
 
     pj_assert(qsize > 0);
+
+    if (pj_scan_is_eof(scanner)) {
+        pj_scan_syntax_err(scanner);
+        return;
+    }
 
     /* Check and eat the begin_quote. */
     for (i = 0; i < qsize; ++i) {
@@ -392,32 +399,31 @@ PJ_DEF(void) pj_scan_get_quotes(pj_scanner *scanner,
             ++s;
         }
 
-        /* check that no backslash character precedes the end_quote. */
-        if (*s == end_quote[qpair]) {
-            if (*(s-1) == '\\') {
-                char *q = s-2;
-                char *r = s-2;
-
-                while (r != scanner->begin && *r == '\\') {
-                    --r;
-                }
-                /* break from main loop if we have odd number of backslashes */
-                if (((unsigned)(q-r) & 0x01) == 1) {
-                    break;
-                }
-                ++s;
-            } else {
-                /* end_quote is not preceeded by backslash. break now. */
-                break;
-            }
-        } else {
-            /* loop ended by non-end_quote character. break now. */
+        if (!PJ_SCAN_CHECK_EOF(s) || *s != end_quote[qpair]) {
+            /* loop ended by EOF or non-end_quote character. break now. */
             break;
         }
+
+        /* Count the backslashes immediately preceding the end_quote. Stop at
+         * the opening quote, so that neither the opening quote itself nor any
+         * input before it is mistaken for escaping content.
+         */
+        nbackslash = 0;
+        for (r = s; r > scanner->curptr + 1 && *(r-1) == '\\'; --r) {
+            ++nbackslash;
+        }
+
+        /* The end_quote is escaped only if it is preceded by an odd number of
+         * backslashes. Otherwise this is the real end_quote, so break now.
+         */
+        if ((nbackslash & 0x01) == 0) {
+            break;
+        }
+        ++s;
     } while (1);
 
     /* Check and eat the end quote. */
-    if (*s != end_quote[qpair]) {
+    if (!PJ_SCAN_CHECK_EOF(s) || *s != end_quote[qpair]) {
         pj_scan_syntax_err(scanner);
         return;
     }


### PR DESCRIPTION
## Background

`pj_scan_get_quotes()` was not among the functions covered by the scanner hardening in c4d34984e (GHSA-fq45-m3f7-3mhj / CVE-2022-39244), so it still dereferences the scanner pointer without an explicit EOF check, and it has an off-by-one in the loop that counts escaping backslashes.

This applies the same guards the sibling scanner functions already use.

## Changes

- Bail out with a syntax error if the scanner is already at EOF, before probing for the `begin_quote`.
- Check `PJ_SCAN_CHECK_EOF()` before testing for the `end_quote`, both inside the scan loop and in the final "eat the end quote" check.
- Count the preceding backslashes with a counter walking down from `s`, bounded by the opening quote at `scanner->curptr`, instead of forming `s-2` and walking down to `scanner->begin`.

## Is this a security issue?

**No, and no advisory is planned.** Worth stating explicitly since this touches the same function family as a previous CVE.

The scanner API requires a NUL terminated buffer of at least `buflen+1` bytes:

> Note that the input string buffer MUST be NULL terminated and have length at least buflen+1 (buflen MUST NOT include the NULL terminator).
> — `pjlib-util/include/pjlib-util/scanner.h`

The SIP receive path guarantees this by NUL terminating each message fragment before parsing and restoring the byte afterwards (`pjsip/src/pjsip/sip_transport.c`), so a dereference at `scanner->end` reads the in-bounds NUL sentinel and correctly falls through to the syntax error path. No remote input reaches this function with a non-terminated buffer, and all in-tree callers (`sip_parser.c`, `sip_auth_parser.c`, `xml.c`, `json.c`, `cli.c`, `http_client.c`) inherit the same contract.

The changes make the bounds explicit rather than relying on the sentinel, and correct the backslash-counting bound. The latter is not reachable from any in-tree caller, since it needs the backslash itself to be passed as a `begin_quote` character. Nothing here is remotely reachable.

## Testing

No behaviour change for valid input. Verified against SIP, XML, JSON and CLI style quote pairs that well-formed tokens parse identically before and after, and that malformed ones still raise a syntax error — covering simple, empty, escaped-quote, escaped-backslash, unterminated, embedded-newline, missing-begin-quote, empty-buffer, already-at-EOF and mismatched-pair inputs, plus backslash-delimiter and mid-buffer (`scanner->curptr > scanner->begin`) cases for the backslash-counting bound.

The one intentional behaviour change is for `begin_quote == end_quote == '\'`: the two-byte buffer `\\` is now read as an empty quoted token, the analogue of `""`, rather than raising a syntax error. Previously the opening delimiter was miscounted as an escape. No in-tree caller uses `\` as a delimiter.

- `pjlib-util-test xml_test json_test` — pass
- `pjsip-test multipart_test txdata_test` — pass (`uri_test`/`msg_test` are compiled out on Apple + ASan, see `pjsip/src/test/test.h`)
- Clean build, no new warnings

Reported by Kanishka De Silva ([@hexer365](https://github.com/hexer365)).

Co-Authored-By Claude Code
