### PR TITLE
pjsua: validate account Contact before storing it in acc_check_nat_addr()

### DIFF
--- a/pjsip/CMakeLists.txt
+++ b/pjsip/CMakeLists.txt
@@ -318,6 +318,7 @@ if(BUILD_TESTING)
     src/test/auth_async_test.c
     src/test/pjsua_auth_test.c
     src/test/pjsua_call_test.c
+    src/test/pjsua_acc_test.c
     src/test/${PJ_TEST_MAIN}
   )
 

--- a/pjsip/build/Makefile
+++ b/pjsip/build/Makefile
@@ -205,7 +205,8 @@ export TEST_OBJS += dlg_core_test.o dns_test.o msg_err_test.o \
 		    tsx_basic_test.o tsx_bench.o tsx_uac_test.o \
 		    tsx_uas_test.o txdata_test.o uri_test.o \
 		    inv_offer_answer_test.o auth_async_test.o \
-		    pjsua_auth_test.o pjsua_call_test.o
+		    pjsua_auth_test.o pjsua_call_test.o \
+		    pjsua_acc_test.o
 export TEST_CFLAGS += $(_CFLAGS) $(PJ_VIDEO_CFLAGS)
 export TEST_CXXFLAGS += $(_CXXFLAGS)
 export TEST_LDFLAGS += $(PJSUA_LIB_LDLIB) \

--- a/pjsip/build/pjsip_test.vcxproj
+++ b/pjsip/build/pjsip_test.vcxproj
@@ -550,6 +550,7 @@
     <ClCompile Include="..\src\test\auth_async_test.c" />
     <ClCompile Include="..\src\test\pjsua_auth_test.c" />
     <ClCompile Include="..\src\test\pjsua_call_test.c" />
+    <ClCompile Include="..\src\test\pjsua_acc_test.c" />
     <ClCompile Include="..\src\test\pjsua_stress.c">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -287,27 +287,19 @@ static pj_status_t set_contact( pjsip_regc *regc,
                                 const pj_str_t contact[] )
 {
     const pj_str_t CONTACT = { "Contact", 7 };
-    pjsip_contact_hdr *h;
+    pjsip_contact_hdr new_list;
+    pjsip_contact_hdr *h, *hdr;
     int i;
-    
-    /* Save existing contact list to removed_contact_hdr_list and
-     * clear contact_hdr_list.
-     */
-    pj_list_merge_last(&regc->removed_contact_hdr_list, 
-                       &regc->contact_hdr_list);
 
-    /* Set the expiration of Contacts in to removed_contact_hdr_list 
-     * zero.
+    /* Parse and validate every new Contact up front. Nothing below this
+     * point may fail, because from here on the current registration
+     * Contacts are moved to removed_contact_hdr_list with their
+     * expiration set to zero: bailing out midway would leave the
+     * registration with no active Contact and the old bindings queued
+     * for removal by the next REGISTER.
      */
-    h = regc->removed_contact_hdr_list.next;
-    while (h != &regc->removed_contact_hdr_list) {
-        h->expires = 0;
-        h = h->next;
-    }
-
-    /* Process new contacts */
+    pj_list_init(&new_list);
     for (i=0; i<contact_cnt; ++i) {
-        pjsip_contact_hdr *hdr;
         pj_str_t tmp;
 
         pj_strdup_with_null(regc->pool, &tmp, &contact[i]);
@@ -324,6 +316,29 @@ static pj_status_t set_contact( pjsip_regc *regc,
                      (int)tmp.slen, tmp.ptr));
             return PJSIP_EINVALIDURI;
         }
+
+        pj_list_push_back(&new_list, hdr);
+    }
+
+    /* Save existing contact list to removed_contact_hdr_list and
+     * clear contact_hdr_list.
+     */
+    pj_list_merge_last(&regc->removed_contact_hdr_list,
+                       &regc->contact_hdr_list);
+
+    /* Set the expiration of Contacts in to removed_contact_hdr_list
+     * zero.
+     */
+    h = regc->removed_contact_hdr_list.next;
+    while (h != &regc->removed_contact_hdr_list) {
+        h->expires = 0;
+        h = h->next;
+    }
+
+    /* Process new contacts */
+    while (!pj_list_empty(&new_list)) {
+        hdr = new_list.next;
+        pj_list_erase(hdr);
 
         /* Find the new contact in old contact list. If found, remove
          * the old header from the old header list.

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -313,8 +313,14 @@ static pj_status_t set_contact( pjsip_regc *regc,
         pj_strdup_with_null(regc->pool, &tmp, &contact[i]);
         hdr = (pjsip_contact_hdr*)
               pjsip_parse_hdr(regc->pool, &CONTACT, tmp.ptr, tmp.slen, NULL);
-        if (hdr == NULL) {
-            PJ_LOG(4,(THIS_FILE, "Invalid Contact: \"%.*s\"", 
+        /* A "Contact: *" header parses fine but carries no URI, and the
+         * registration Contacts are dereferenced as URIs below and in
+         * calculate_response_expiration(). Unregister-all is built
+         * separately by pjsip_regc_unregister_all(), so a starred Contact
+         * has no business being registered here.
+         */
+        if (hdr == NULL || hdr->uri == NULL) {
+            PJ_LOG(4,(THIS_FILE, "Invalid Contact: \"%.*s\"",
                      (int)tmp.slen, tmp.ptr));
             return PJSIP_EINVALIDURI;
         }

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2141,17 +2141,20 @@ done:
         if (len > acc->contact.slen) {
             reg_contact.ptr = (char*) pj_pool_alloc(acc->pool, len);
 
-            pj_strcpy(&reg_contact, &acc->contact);
-        
+            /* Must be NULL terminated: the buffer is parsed below and by
+             * pjsip_regc, and the parser requires a NULL terminated input.
+             */
+            pj_strncpy_with_null(&reg_contact, &acc->contact, len);
+
             /* Contact URI params */
             if (acc->cfg.reg_contact_uri_params.slen) {
                 pj_pool_t *pool;
                 pjsip_contact_hdr *contact_hdr;
-                pjsip_sip_uri *uri;
+                pjsip_sip_uri *uri = NULL;
                 pj_str_t uri_param = acc->cfg.reg_contact_uri_params;
                 const pj_str_t STR_CONTACT = { "Contact", 7 };
                 char tmp_uri[PJSIP_MAX_URL_SIZE];
-                pj_ssize_t tmp_len;
+                pj_ssize_t tmp_len = -1;
 
                 /* Get the URI string */
                 pool = pjsua_pool_create("tmp", 512, 512);
@@ -2159,25 +2162,41 @@ done:
                               pjsip_parse_hdr(pool, &STR_CONTACT,
                                               reg_contact.ptr,
                                               reg_contact.slen, NULL);
-                pj_assert(contact_hdr != NULL);
-                uri = (pjsip_sip_uri*) contact_hdr->uri;
-                pj_assert(uri != NULL);
-                uri = (pjsip_sip_uri*) pjsip_uri_get_uri(uri);
-                tmp_len = pjsip_uri_print(PJSIP_URI_IN_CONTACT_HDR,
-                                          uri, tmp_uri,
-                                          sizeof(tmp_uri));
-                pj_assert(tmp_len > 0);
+                if (contact_hdr && contact_hdr->uri)
+                    uri = (pjsip_sip_uri*)pjsip_uri_get_uri(contact_hdr->uri);
+                if (uri) {
+                    tmp_len = pjsip_uri_print(PJSIP_URI_IN_CONTACT_HDR,
+                                              uri, tmp_uri,
+                                              sizeof(tmp_uri));
+                }
                 pj_pool_release(pool);
 
-                /* Regenerate Contact */
-                reg_contact.slen = pj_ansi_snprintf(
+                if (tmp_len > 0) {
+                    pj_ssize_t new_len;
+
+                    /* Regenerate Contact */
+                    new_len = pj_ansi_snprintf(
                                             reg_contact.ptr, len,
                                             "<%.*s%.*s>%.*s",
                                             (int)tmp_len, tmp_uri,
                                             (int)uri_param.slen, uri_param.ptr,
                                             (int)acc->cfg.contact_params.slen,
                                             acc->cfg.contact_params.ptr);
-                pj_assert(reg_contact.slen > 0);
+                    if (new_len > 0 && new_len < len)
+                        reg_contact.slen = new_len;
+                    else
+                        tmp_len = -1;
+                }
+
+                if (tmp_len <= 0) {
+                    /* Leave reg_contact as the plain copy of acc->contact */
+                    PJ_LOG(1,(THIS_FILE,
+                              "Unable to apply registration Contact URI "
+                              "params of acc %d to Contact '%.*s'",
+                              acc->index, (int)acc->contact.slen,
+                              acc->contact.ptr));
+                    pj_strncpy_with_null(&reg_contact, &acc->contact, len);
+                }
             }
 
             /* Outbound */
@@ -2195,7 +2214,14 @@ done:
 
             /* Contact params */
             pj_strcat(&reg_contact, &acc->cfg.reg_contact_params);
-            
+
+            /* pj_strcat() does not NULL terminate, and the buffer is later
+             * parsed by pjsip_regc. The 'len' allowance guarantees room.
+             */
+            pj_assert(reg_contact.slen < len);
+            if (reg_contact.slen < len)
+                reg_contact.ptr[reg_contact.slen] = '\0';
+
             acc->reg_contact = reg_contact;
 
             PJ_LOG(4,(THIS_FILE,
@@ -2357,12 +2383,23 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
     /* Compare received and rport with the URI in our registration */
     pool = pjsua_pool_create("tmp", 512, 512);
     contact_hdr = (pjsip_contact_hdr*)
-                  pjsip_parse_hdr(pool, &STR_CONTACT, acc->contact.ptr, 
+                  pjsip_parse_hdr(pool, &STR_CONTACT, acc->contact.ptr,
                                   acc->contact.slen, NULL);
-    pj_assert(contact_hdr != NULL);
-    uri = (pjsip_sip_uri*) contact_hdr->uri;
-    pj_assert(uri != NULL);
-    uri = (pjsip_sip_uri*) pjsip_uri_get_uri(uri);
+    /* A "Contact: *" header parses fine but has no URI, and a non-SIP URI
+     * must not be cast to pjsip_sip_uri below.
+     */
+    if (contact_hdr == NULL || contact_hdr->uri == NULL ||
+        !(PJSIP_URI_SCHEME_IS_SIP(contact_hdr->uri) ||
+          PJSIP_URI_SCHEME_IS_SIPS(contact_hdr->uri)))
+    {
+        PJ_LOG(1,(THIS_FILE, "Unable to parse Contact of account %d ('%.*s'), "
+                             "skipping NAT address check",
+                             acc->index, (int)acc->contact.slen,
+                             acc->contact.ptr));
+        pj_pool_release(pool);
+        return PJ_FALSE;
+    }
+    uri = (pjsip_sip_uri*) pjsip_uri_get_uri(contact_hdr->uri);
 
     if (uri->port == 0) {
         pjsip_transport_type_e tp_type;
@@ -2448,12 +2485,6 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
               contact_rewrite_method == PJSUA_CONTACT_REWRITE_NO_UNREG ||
               contact_rewrite_method == PJSUA_CONTACT_REWRITE_ALWAYS_UPDATE);
 
-    if (contact_rewrite_method == PJSUA_CONTACT_REWRITE_UNREGISTER) {
-        /* Unregister current contact */
-        pjsua_acc_set_registration(acc->index, PJ_FALSE);
-        destroy_regc(acc, PJ_TRUE);
-    }
-
     /*
      * Build new Contact header
      */
@@ -2464,12 +2495,18 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
         char transport_param[32];
         int len;
         pj_bool_t secure;
+        pjsip_contact_hdr *new_hdr;
 
         secure = pjsip_transport_get_flag_from_type(tp->key.type) &
                  PJSIP_TRANSPORT_SECURE;
-        
-        /* Enclose IPv6 address in square brackets */
-        if ((tp->key.type & PJSIP_TRANSPORT_IPV6) && via_addr->ptr[0] != '[') {
+
+        /* Enclose IPv6 address in square brackets. Decide based on the
+         * address itself, not on the transport type: the Via "received"
+         * param is set by the registrar and may not match the transport.
+         */
+        if (via_addr->slen && pj_strchr(via_addr, ':') &&
+            via_addr->ptr[0] != '[')
+        {
             beginquote = "[";
             endquote = "]";
         } else {
@@ -2511,6 +2548,33 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
             pj_pool_release(pool);
             return PJ_FALSE;
         }
+
+        /* Make sure the new Contact is usable before committing it to the
+         * account. The Via "received" param it is built from is set by the
+         * registrar and may contain characters that are valid in a token
+         * but not in a SIP URI host, which would leave acc->contact
+         * permanently unparseable.
+         */
+        new_hdr = (pjsip_contact_hdr*)
+                  pjsip_parse_hdr(pool, &STR_CONTACT, tmp, len, NULL);
+        if (new_hdr == NULL || new_hdr->uri == NULL ||
+            !(PJSIP_URI_SCHEME_IS_SIP(new_hdr->uri) ||
+              PJSIP_URI_SCHEME_IS_SIPS(new_hdr->uri)))
+        {
+            PJ_LOG(1,(THIS_FILE, "Not rewriting Contact of account %d to "
+                                 "invalid value '%s'", acc->index, tmp));
+            pj_pool_release(pool);
+            return PJ_FALSE;
+        }
+
+        if (contact_rewrite_method == PJSUA_CONTACT_REWRITE_UNREGISTER) {
+            /* Unregister current contact. Must be done before acc->contact
+             * is replaced, as the unregister uses the old Contact.
+             */
+            pjsua_acc_set_registration(acc->index, PJ_FALSE);
+            destroy_regc(acc, PJ_TRUE);
+        }
+
         pj_strdup2_with_null(acc->pool, &acc->contact, tmp);
 
         update_regc_contact(acc);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2150,7 +2150,12 @@ done:
             if (acc->cfg.reg_contact_uri_params.slen) {
                 pj_pool_t *pool;
                 pjsip_contact_hdr *contact_hdr;
-                pjsip_sip_uri *uri = NULL;
+                /* Only ever handed to pjsip_uri_print(), which dispatches
+                 * on the URI's own vptr, so this must not be narrowed to
+                 * pjsip_sip_uri*: a Contact may legitimately hold another
+                 * scheme and no SIP specific field is read here.
+                 */
+                pjsip_uri *uri = NULL;
                 pj_str_t uri_param = acc->cfg.reg_contact_uri_params;
                 const pj_str_t STR_CONTACT = { "Contact", 7 };
                 char tmp_uri[PJSIP_MAX_URL_SIZE];
@@ -2163,7 +2168,7 @@ done:
                                               reg_contact.ptr,
                                               reg_contact.slen, NULL);
                 if (contact_hdr && contact_hdr->uri)
-                    uri = (pjsip_sip_uri*)pjsip_uri_get_uri(contact_hdr->uri);
+                    uri = (pjsip_uri*)pjsip_uri_get_uri(contact_hdr->uri);
                 if (uri) {
                     tmp_len = pjsip_uri_print(PJSIP_URI_IN_CONTACT_HDR,
                                               uri, tmp_uri,

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2496,6 +2496,7 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
         int len;
         pj_bool_t secure;
         pjsip_contact_hdr *new_hdr;
+        pj_in6_addr v6_addr;
 
         secure = pjsip_transport_get_flag_from_type(tp->key.type) &
                  PJSIP_TRANSPORT_SECURE;
@@ -2503,9 +2504,14 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
         /* Enclose IPv6 address in square brackets. Decide based on the
          * address itself, not on the transport type: the Via "received"
          * param is set by the registrar and may not match the transport.
+         * Only a genuine IPv6 literal is bracketed, so that any other
+         * colon bearing token (e.g. "foo:bar", which the Via param
+         * scanner accepts) stays unbracketed and is rejected by the
+         * validation below instead of being wrapped into a Contact that
+         * parses but is meaningless.
          */
-        if (via_addr->slen && pj_strchr(via_addr, ':') &&
-            via_addr->ptr[0] != '[')
+        if (via_addr->slen && via_addr->ptr[0] != '[' &&
+            pj_inet_pton(pj_AF_INET6(), via_addr, &v6_addr) == PJ_SUCCESS)
         {
             beginquote = "[";
             endquote = "]";

--- a/pjsip/src/test/pjsua_acc_test.c
+++ b/pjsip/src/test/pjsua_acc_test.c
@@ -41,8 +41,11 @@
  *   6. Accepted rewrite with reg_contact_uri_params, which sends
  *      update_regc_contact() through its parse-and-regenerate path.
  *   7. force_contact "*", which parses to a Contact with no URI.
- *   8. force_contact with a non-SIP URI, which must not be cast to
- *      pjsip_sip_uri* and read as one.
+ *   8. force_contact with a non-SIP URI, with reg_contact_uri_params set
+ *      so both the acc_check_nat_addr() entry guard and the
+ *      update_regc_contact() regeneration path see a non-SIP URI.
+ *   9. A Contact that pjsip_regc refuses must leave the existing
+ *      registration binding alone rather than queue it for removal.
  */
 
 #include "test.h"
@@ -616,7 +619,7 @@ int pjsua_acc_test(void)
              * pjsip_sip_uri* and read as one.
              */
             { "force_contact non-SIP URI",
-              "1.2.3.4", NULL, "<tel:+15551234>", NULL, 0, -2480 },
+              "1.2.3.4", NULL, "<tel:+15551234>", ";acc-test=1", 0, -2480 },
 
             /* A Contact that pjsip_regc refuses must leave the existing
              * registration binding untouched, not queued for removal.

--- a/pjsip/src/test/pjsua_acc_test.c
+++ b/pjsip/src/test/pjsua_acc_test.c
@@ -75,6 +75,7 @@ static struct {
     pjsip_module  mod;
     const char   *received;     /* forced Via received param, or NULL */
     unsigned      req_count;
+    char          last_contact[PJSIP_MAX_URL_SIZE];  /* as seen on the wire */
 } g_mock_reg = {
     {
         NULL, NULL,
@@ -99,6 +100,24 @@ static pj_bool_t mock_registrar_rx_request(pjsip_rx_data *rdata)
     }
 
     g_mock_reg.req_count++;
+
+    /* Record the whole Contact header as it arrived, so a test can tell
+     * whether a rejected pjsip_regc_update_contact() disturbed the
+     * binding. The header must be captured in full, not just the URI: a
+     * binding queued for removal is re-sent with the same URI and only
+     * ";expires=0" to distinguish it.
+     */
+    {
+        pjsip_contact_hdr *hc = (pjsip_contact_hdr*)
+                                pjsip_msg_find_hdr(msg, PJSIP_H_CONTACT,
+                                                   NULL);
+        g_mock_reg.last_contact[0] = '\0';
+        if (hc) {
+            int len = pjsip_hdr_print_on(hc, g_mock_reg.last_contact,
+                                         sizeof(g_mock_reg.last_contact)-1);
+            g_mock_reg.last_contact[len > 0? len : 0] = '\0';
+        }
+    }
 
     if (g_mock_reg.received) {
         pj_strdup2(rdata->tp_info.pool, &rdata->msg_info.via->recvd_param,
@@ -234,6 +253,7 @@ typedef struct {
     int         rewrite_method; /* 0 = leave at the default */
     int         err_base;
     pj_bool_t   expect_reg_fail;/* Contact cannot be registered at all */
+    pj_bool_t   probe_bad_update;/* poke regc with an invalid Contact */
 } rewrite_case;
 
 static int rewrite_test(pjsua_transport_id tp_id, int port,
@@ -334,6 +354,45 @@ static int rewrite_test(pjsua_transport_id tp_id, int port,
                    g_mock_reg.req_count));
         rc = err_base - 4;
         goto on_return;
+    }
+
+    if (c->probe_bad_update) {
+        pj_str_t star = pj_str("*");
+        char contact_before[PJSIP_MAX_URL_SIZE];
+
+        pj_ansi_snprintf(contact_before, sizeof(contact_before), "%s",
+                         g_mock_reg.last_contact);
+
+        /* An invalid Contact must be refused without disturbing the
+         * registration already in place. set_contact() moves the current
+         * Contacts to the removed list with expires=0 before it can fail,
+         * so validating only partway would silently unregister them on
+         * the next REGISTER.
+         */
+        status = pjsip_regc_update_contact(pjsua_var.acc[acc_id].regc,
+                                           1, &star);
+        if (status != PJSIP_EINVALIDURI) {
+            PJ_LOG(3, (THIS_FILE, "    error: update_contact with '*' "
+                       "returned %d, expected PJSIP_EINVALIDURI", status));
+            rc = err_base - 11;
+            goto on_return;
+        }
+
+        g_ctx.reg_done = PJ_FALSE;
+        pjsua_acc_set_registration(acc_id, PJ_TRUE);
+        if (wait_reg(10000) != 0) {
+            PJ_LOG(3, (THIS_FILE, "    error: registration after a rejected "
+                       "update timed out, last code %d", g_ctx.reg_code));
+            rc = err_base - 12;
+            goto on_return;
+        }
+        if (pj_ansi_strcmp(g_mock_reg.last_contact, contact_before) != 0) {
+            PJ_LOG(3, (THIS_FILE, "    error: rejected update changed the "
+                       "registered Contact: '%s' -> '%s'",
+                       contact_before, g_mock_reg.last_contact));
+            rc = err_base - 13;
+            goto on_return;
+        }
     }
 
     /* A Contact we generated or rewrote must always parse back, which is
@@ -558,6 +617,13 @@ int pjsua_acc_test(void)
              */
             { "force_contact non-SIP URI",
               "1.2.3.4", NULL, "<tel:+15551234>", NULL, 0, -2480 },
+
+            /* A Contact that pjsip_regc refuses must leave the existing
+             * registration binding untouched, not queued for removal.
+             */
+            { "rejected update_contact keeps the binding",
+              "1.2.3.4", "1.2.3.4", NULL, NULL, 0, -2490,
+              PJ_FALSE, PJ_TRUE },
         };
         unsigned i;
 

--- a/pjsip/src/test/pjsua_acc_test.c
+++ b/pjsip/src/test/pjsua_acc_test.c
@@ -36,6 +36,13 @@
  *   3. "received" with a token character that is not valid in a host
  *      -> rewrite declined, previous Contact retained.
  *   4. Colon bearing non-address token        -> rewrite declined.
+ *   5. As 3, with PJSUA_CONTACT_REWRITE_UNREGISTER: the declined rewrite
+ *      must not unregister and tear down the regc on the way.
+ *   6. Accepted rewrite with reg_contact_uri_params, which sends
+ *      update_regc_contact() through its parse-and-regenerate path.
+ *   7. force_contact "*", which parses to a Contact with no URI.
+ *   8. force_contact with a non-SIP URI, which must not be cast to
+ *      pjsip_sip_uri* and read as one.
  */
 
 #include "test.h"
@@ -170,6 +177,35 @@ static int get_acc_contact_host(pjsua_acc_id acc_id, char *host,
     return rc;
 }
 
+/* Check the registration Contact that update_regc_contact() produced:
+ * it must be NULL terminated (the scanner requires it) and parse back as
+ * a Contact header. Returns 0 on success.
+ */
+static int check_acc_reg_contact(pjsua_acc_id acc_id, pj_bool_t require_uri)
+{
+    const pj_str_t STR_CONTACT = { "Contact", 7 };
+    pjsua_acc *acc = &pjsua_var.acc[acc_id];
+    pjsip_contact_hdr *hdr;
+    pj_pool_t *pool;
+    int rc = -1;
+
+    if (acc->reg_contact.slen == 0 ||
+        acc->reg_contact.ptr[acc->reg_contact.slen] != '\0')
+    {
+        return -1;
+    }
+
+    pool = pjsua_pool_create("acctest", 512, 512);
+    hdr = (pjsip_contact_hdr*)
+          pjsip_parse_hdr(pool, &STR_CONTACT, acc->reg_contact.ptr,
+                          acc->reg_contact.slen, NULL);
+    if (hdr && (hdr->uri || !require_uri))
+        rc = 0;
+
+    pj_pool_release(pool);
+    return rc;
+}
+
 /* Pump the event loop until the pending registration completes. */
 static int wait_reg(unsigned max_ms)
 {
@@ -185,28 +221,38 @@ static int wait_reg(unsigned max_ms)
 
 /*****************************************************************************
  * Sub-test driver
- *
- * 'received'    : value forced into the response's Via received param.
- * 'expect_host' : Contact host expected afterwards, or NULL if the rewrite
- *                 must be declined and the original Contact retained.
  *****************************************************************************/
+
+typedef struct {
+    const char *title;
+    const char *received;       /* forced Via received param */
+    const char *expect_host;    /* Contact host expected afterwards, or
+                                 * NULL if the rewrite must be declined
+                                 * and the original Contact retained */
+    const char *force_contact;  /* acc_cfg.force_contact, or NULL */
+    const char *uri_params;     /* reg_contact_uri_params, or NULL */
+    int         rewrite_method; /* 0 = leave at the default */
+    int         err_base;
+    pj_bool_t   expect_reg_fail;/* Contact cannot be registered at all */
+} rewrite_case;
+
 static int rewrite_test(pjsua_transport_id tp_id, int port,
-                        const char *title, const char *received,
-                        const char *expect_host, int err_base)
+                        const rewrite_case *c)
 {
     pjsua_acc_config acc_cfg;
     pjsua_acc_id     acc_id;
     char             reg_uri[64];
     char             orig_contact[PJSIP_MAX_URL_SIZE];
     char             host[PJ_INET6_ADDRSTRLEN + 16];
+    const int        err_base = c->err_base;
     pj_status_t      status;
     unsigned         round;
     int              rc = 0;
 
-    PJ_LOG(3, (THIS_FILE, "  pjsua acc: %s", title));
+    PJ_LOG(3, (THIS_FILE, "  pjsua acc: %s", c->title));
 
     pj_bzero(&g_ctx, sizeof(g_ctx));
-    g_mock_reg.received  = received;
+    g_mock_reg.received  = c->received;
     g_mock_reg.req_count = 0;
 
     pj_ansi_snprintf(reg_uri, sizeof(reg_uri), "sip:127.0.0.1:%d", port);
@@ -222,6 +268,12 @@ static int rewrite_test(pjsua_transport_id tp_id, int port,
     acc_cfg.allow_contact_rewrite = 2;
     /* Keep the Via sent-by out of it; this test is about the Contact. */
     acc_cfg.allow_via_rewrite = PJ_FALSE;
+    if (c->rewrite_method)
+        acc_cfg.contact_rewrite_method = c->rewrite_method;
+    if (c->force_contact)
+        acc_cfg.force_contact = pj_str((char*)c->force_contact);
+    if (c->uri_params)
+        acc_cfg.reg_contact_uri_params = pj_str((char*)c->uri_params);
 
     status = pjsua_acc_add(&acc_cfg, PJ_FALSE, &acc_id);
     if (status != PJ_SUCCESS) {
@@ -234,6 +286,18 @@ static int rewrite_test(pjsua_transport_id tp_id, int port,
      */
     g_ctx.reg_done = PJ_FALSE;
     status = pjsua_acc_set_registration(acc_id, PJ_TRUE);
+    if (c->expect_reg_fail) {
+        /* The Contact cannot be registered at all. What matters is that
+         * building it did not dereference a NULL URI on the way, and that
+         * it is refused rather than half-registered.
+         */
+        if (status == PJ_SUCCESS) {
+            PJ_LOG(3, (THIS_FILE, "    error: registration unexpectedly "
+                       "accepted Contact '%s'", c->force_contact));
+            rc = err_base - 10;
+        }
+        goto on_return;
+    }
     if (status != PJ_SUCCESS) {
         PJ_LOG(3, (THIS_FILE, "    error: set_registration failed (%d)",
                    status));
@@ -272,21 +336,26 @@ static int rewrite_test(pjsua_transport_id tp_id, int port,
         goto on_return;
     }
 
-    /* The stored Contact must always be parseable, whether or not the
-     * rewrite was accepted.
+    /* A Contact we generated or rewrote must always parse back, which is
+     * the operation acc_check_nat_addr() performs on entry. A
+     * force_contact case deliberately starts from something that does
+     * not (e.g. "*"), and only has to survive being checked.
      */
-    if (get_acc_contact_host(acc_id, host, sizeof(host)) != 0) {
-        PJ_LOG(3, (THIS_FILE, "    error: account Contact is unparseable: "
-                   "'%.*s'", (int)pjsua_var.acc[acc_id].contact.slen,
-                   pjsua_var.acc[acc_id].contact.ptr));
-        rc = err_base - 5;
-        goto on_return;
+    if (!c->force_contact) {
+        if (get_acc_contact_host(acc_id, host, sizeof(host)) != 0) {
+            PJ_LOG(3, (THIS_FILE, "    error: account Contact is "
+                       "unparseable: '%.*s'",
+                       (int)pjsua_var.acc[acc_id].contact.slen,
+                       pjsua_var.acc[acc_id].contact.ptr));
+            rc = err_base - 5;
+            goto on_return;
+        }
     }
 
-    if (expect_host) {
-        if (pj_ansi_strcmp(host, expect_host) != 0) {
+    if (c->expect_host) {
+        if (pj_ansi_strcmp(host, c->expect_host) != 0) {
             PJ_LOG(3, (THIS_FILE, "    error: expected Contact host '%s', "
-                       "got '%s'", expect_host, host));
+                       "got '%s'", c->expect_host, host));
             rc = err_base - 6;
             goto on_return;
         }
@@ -300,6 +369,32 @@ static int rewrite_test(pjsua_transport_id tp_id, int port,
             rc = err_base - 7;
             goto on_return;
         }
+
+        /* A declined rewrite must not have unregistered and torn down
+         * the client registration on the way, which is why the
+         * PJSUA_CONTACT_REWRITE_UNREGISTER step runs after validation.
+         */
+        if (pjsua_var.acc[acc_id].regc == NULL) {
+            PJ_LOG(3, (THIS_FILE, "    error: regc was destroyed by a "
+                       "declined rewrite"));
+            rc = err_base - 8;
+            goto on_return;
+        }
+    }
+
+    /* The registration Contact derived from it must be well formed too.
+     * "Contact: *" has no URI by definition, so only require one when the
+     * account Contact was not forced to something exotic.
+     */
+    if (check_acc_reg_contact(acc_id, (pj_bool_t)(c->force_contact == NULL))
+        != 0)
+    {
+        PJ_LOG(3, (THIS_FILE, "    error: registration Contact is not NULL "
+                   "terminated or does not parse: '%.*s'",
+                   (int)pjsua_var.acc[acc_id].reg_contact.slen,
+                   pjsua_var.acc[acc_id].reg_contact.ptr));
+        rc = err_base - 9;
+        goto on_return;
     }
 
 on_return:
@@ -411,33 +506,66 @@ int pjsua_acc_test(void)
     }
 
     /* ---- Run sub-tests ---- */
+    {
+        static const rewrite_case cases[] = {
+            /* An IPv6 address seen by the registrar on a transport that
+             * is not typed IPv6 (dual stack SBC, NAT64). Must be
+             * bracketed, otherwise the stored Contact is
+             * <sip:user@2001:db8::1:PORT> and no longer parses.
+             */
+            { "IPv6 received over IPv4 transport",
+              "2001:db8::1", "2001:db8::1", NULL, NULL, 0, -2410 },
 
-    /* An IPv6 address seen by the registrar on a transport that is not
-     * typed IPv6 (dual stack SBC, NAT64). Must be bracketed, otherwise
-     * the stored Contact is <sip:user@2001:db8::1:PORT> and unparseable.
-     */
-    rc = rewrite_test(tp_id, (int)port, "IPv6 received over IPv4 transport",
-                      "2001:db8::1", "2001:db8::1", -2410);
-    if (rc != 0) goto on_return;
+            /* Plain IPv4: the ordinary rewrite must still happen. */
+            { "IPv4 received",
+              "1.2.3.4", "1.2.3.4", NULL, NULL, 0, -2420 },
 
-    /* Plain IPv4: the ordinary rewrite must still happen. */
-    rc = rewrite_test(tp_id, (int)port, "IPv4 received",
-                      "1.2.3.4", "1.2.3.4", -2420);
-    if (rc != 0) goto on_return;
+            /* '!' is accepted by the Via param scanner but not by the URI
+             * host scanner, so the rebuilt Contact would not parse back.
+             */
+            { "received with invalid host char",
+              "1.2.3.4!", NULL, NULL, NULL, 0, -2430 },
 
-    /* '!' is accepted by the Via param scanner but not by the URI host
-     * scanner, so the rebuilt Contact would not parse back.
-     */
-    rc = rewrite_test(tp_id, (int)port, "received with invalid host char",
-                      "1.2.3.4!", NULL, -2430);
-    if (rc != 0) goto on_return;
+            /* Colon bearing token that is not an IPv6 address: must not
+             * be bracketed into a Contact that parses but means nothing.
+             */
+            { "received with non-address colon",
+              "foo:bar", NULL, NULL, NULL, 0, -2440 },
 
-    /* Colon bearing token that is not an IPv6 address: must not be
-     * bracketed into a Contact that parses but means nothing.
-     */
-    rc = rewrite_test(tp_id, (int)port, "received with non-address colon",
-                      "foo:bar", NULL, -2440);
-    if (rc != 0) goto on_return;
+            /* Same rejection, but with PJSUA_CONTACT_REWRITE_UNREGISTER:
+             * the declined rewrite must leave the registration alone.
+             */
+            { "declined rewrite with UNREGISTER method",
+              "1.2.3.4!", NULL, NULL, NULL,
+              PJSUA_CONTACT_REWRITE_UNREGISTER, -2450 },
+
+            /* reg_contact_uri_params sends update_regc_contact() through
+             * its parse-and-regenerate path on the rewritten Contact.
+             */
+            { "accepted rewrite with reg_contact_uri_params",
+              "1.2.3.4", "1.2.3.4", NULL, ";acc-test=1", 0, -2460 },
+
+            /* "Contact: *" parses to a header with a NULL uri. Building
+             * the registration Contact from it must fall back instead of
+             * dereferencing it, and pjsip_regc must then refuse it rather
+             * than register a Contact it will later dereference.
+             */
+            { "force_contact star",
+              "1.2.3.4", NULL, "*", ";acc-test=1", 0, -2470, PJ_TRUE },
+
+            /* A non-SIP URI parses fine but must not be cast to
+             * pjsip_sip_uri* and read as one.
+             */
+            { "force_contact non-SIP URI",
+              "1.2.3.4", NULL, "<tel:+15551234>", NULL, 0, -2480 },
+        };
+        unsigned i;
+
+        for (i=0; i<PJ_ARRAY_SIZE(cases); ++i) {
+            rc = rewrite_test(tp_id, (int)port, &cases[i]);
+            if (rc != 0) goto on_return;
+        }
+    }
 
 on_return:
     if (g_mock_reg.mod.id != -1)

--- a/pjsip/src/test/pjsua_acc_test.c
+++ b/pjsip/src/test/pjsua_acc_test.c
@@ -1,0 +1,453 @@
+/*
+ * Copyright (C) 2026 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/*
+ * pjsua-level tests for the NAT Contact rewrite in acc_check_nat_addr().
+ *
+ * acc_check_nat_addr() rebuilds acc->contact from the Via "received"
+ * param of the registrar's response.  That param is remote controlled
+ * and is scanned with pjsip_VIA_PARAM_SPEC (TOKEN_SPEC plus "[:]"),
+ * which is a wider character set than a SIP URI host accepts.  A value
+ * that does not survive the round trip used to be stored anyway, and
+ * the pjsip_parse_hdr() at the top of the *next* acc_check_nat_addr()
+ * then returned NULL and was dereferenced.
+ *
+ * Each sub-test drives at least three REGISTER round trips, so that a
+ * Contact stored on the first response is parsed back on a later one.
+ *
+ * Scenarios covered:
+ *   1. IPv6 "received" over an IPv4 transport -> bracketed and stored.
+ *   2. IPv4 "received"                        -> stored as-is.
+ *   3. "received" with a token character that is not valid in a host
+ *      -> rewrite declined, previous Contact retained.
+ *   4. Colon bearing non-address token        -> rewrite declined.
+ */
+
+#include "test.h"
+#include <pjsua-lib/pjsua.h>
+#include <pjsua-lib/pjsua_internal.h>
+#include <pjsip.h>
+#include <pjlib.h>
+
+#define THIS_FILE   "pjsua_acc_test.c"
+
+/* SIP user name used to filter requests belonging to this test module */
+#define TEST_USER   "pjsua-acc-test"
+
+/* Expiration returned by the mock registrar */
+#define TEST_EXPIRES 300
+
+
+/*****************************************************************************
+ * Mock registrar
+ *
+ * Answers every REGISTER with 200 OK, after overwriting the Via "received"
+ * param of the request.  pjsip_endpt_create_response() clones the request's
+ * Via into the response, so this is what the account sees coming back and
+ * what acc_check_nat_addr() rewrites the Contact from.
+ *****************************************************************************/
+
+static pj_bool_t mock_registrar_rx_request(pjsip_rx_data *rdata);
+
+static struct {
+    pjsip_module  mod;
+    const char   *received;     /* forced Via received param, or NULL */
+    unsigned      req_count;
+} g_mock_reg = {
+    {
+        NULL, NULL,
+        { "mod-pjsua-acc-reg", 17 },
+        -1,
+        PJSIP_MOD_PRIORITY_APPLICATION,
+        NULL, NULL, NULL, NULL,
+        &mock_registrar_rx_request,
+        NULL, NULL, NULL, NULL,
+    }
+};
+
+static pj_bool_t mock_registrar_rx_request(pjsip_rx_data *rdata)
+{
+    pjsip_msg *msg = rdata->msg_info.msg;
+    pjsip_hdr  hdr_list;
+
+    if (msg->line.req.method.id != PJSIP_REGISTER_METHOD ||
+        !is_user_equal(rdata->msg_info.from, TEST_USER))
+    {
+        return PJ_FALSE;
+    }
+
+    g_mock_reg.req_count++;
+
+    if (g_mock_reg.received) {
+        pj_strdup2(rdata->tp_info.pool, &rdata->msg_info.via->recvd_param,
+                   g_mock_reg.received);
+    }
+
+    pj_list_init(&hdr_list);
+    pj_list_push_back(&hdr_list,
+                      pjsip_expires_hdr_create(rdata->tp_info.pool,
+                                               TEST_EXPIRES));
+
+    pjsip_endpt_respond_stateless(pjsua_get_pjsip_endpt(), rdata,
+                                  200, NULL, &hdr_list, NULL);
+    return PJ_TRUE;
+}
+
+
+/*****************************************************************************
+ * Test context
+ *****************************************************************************/
+
+static struct {
+    pj_bool_t   reg_done;
+    int         reg_code;
+    unsigned    reg_ok_count;
+} g_ctx;
+
+static void on_reg_state2(pjsua_acc_id acc_id, pjsua_reg_info *info)
+{
+    PJ_UNUSED_ARG(acc_id);
+
+    g_ctx.reg_code = info->cbparam->code;
+    if (info->cbparam->code / 100 == 2) {
+        g_ctx.reg_ok_count++;
+        g_ctx.reg_done = PJ_TRUE;
+    }
+}
+
+
+/*****************************************************************************
+ * Helpers
+ *****************************************************************************/
+
+/* Parse the account's current Contact and copy the URI host out of it.
+ * Returns 0 on success, -1 if the Contact is not a parseable SIP Contact.
+ * This is exactly the operation acc_check_nat_addr() performs on entry,
+ * so it detects a Contact that would have crashed the next check.
+ */
+static int get_acc_contact_host(pjsua_acc_id acc_id, char *host,
+                                unsigned host_size)
+{
+    const pj_str_t STR_CONTACT = { "Contact", 7 };
+    pjsua_acc *acc = &pjsua_var.acc[acc_id];
+    pjsip_contact_hdr *hdr;
+    pjsip_sip_uri *uri;
+    pj_pool_t *pool;
+    int rc = -1;
+
+    pool = pjsua_pool_create("acctest", 512, 512);
+    hdr = (pjsip_contact_hdr*)
+          pjsip_parse_hdr(pool, &STR_CONTACT, acc->contact.ptr,
+                          acc->contact.slen, NULL);
+    if (hdr && hdr->uri &&
+        (PJSIP_URI_SCHEME_IS_SIP(hdr->uri) ||
+         PJSIP_URI_SCHEME_IS_SIPS(hdr->uri)))
+    {
+        uri = (pjsip_sip_uri*) pjsip_uri_get_uri(hdr->uri);
+        if (uri->host.slen < (pj_ssize_t)host_size) {
+            pj_ansi_snprintf(host, host_size, "%.*s",
+                             (int)uri->host.slen, uri->host.ptr);
+            rc = 0;
+        }
+    }
+
+    pj_pool_release(pool);
+    return rc;
+}
+
+/* Pump the event loop until the pending registration completes. */
+static int wait_reg(unsigned max_ms)
+{
+    unsigned elapsed = 0;
+
+    while (elapsed < max_ms && !g_ctx.reg_done) {
+        pjsua_handle_events(50);
+        elapsed += 50;
+    }
+    return g_ctx.reg_done ? 0 : -1;
+}
+
+
+/*****************************************************************************
+ * Sub-test driver
+ *
+ * 'received'    : value forced into the response's Via received param.
+ * 'expect_host' : Contact host expected afterwards, or NULL if the rewrite
+ *                 must be declined and the original Contact retained.
+ *****************************************************************************/
+static int rewrite_test(pjsua_transport_id tp_id, int port,
+                        const char *title, const char *received,
+                        const char *expect_host, int err_base)
+{
+    pjsua_acc_config acc_cfg;
+    pjsua_acc_id     acc_id;
+    char             reg_uri[64];
+    char             orig_contact[PJSIP_MAX_URL_SIZE];
+    char             host[PJ_INET6_ADDRSTRLEN + 16];
+    pj_status_t      status;
+    unsigned         round;
+    int              rc = 0;
+
+    PJ_LOG(3, (THIS_FILE, "  pjsua acc: %s", title));
+
+    pj_bzero(&g_ctx, sizeof(g_ctx));
+    g_mock_reg.received  = received;
+    g_mock_reg.req_count = 0;
+
+    pj_ansi_snprintf(reg_uri, sizeof(reg_uri), "sip:127.0.0.1:%d", port);
+
+    pjsua_acc_config_default(&acc_cfg);
+    acc_cfg.id       = pj_str("sip:" TEST_USER "@pjsip.org");
+    acc_cfg.reg_uri  = pj_str(reg_uri);
+    acc_cfg.transport_id = tp_id;
+    acc_cfg.register_on_acc_add = PJ_FALSE;
+    /* 2 = always rewrite, which skips the private/public address
+     * heuristics and keeps the test independent of them.
+     */
+    acc_cfg.allow_contact_rewrite = 2;
+    /* Keep the Via sent-by out of it; this test is about the Contact. */
+    acc_cfg.allow_via_rewrite = PJ_FALSE;
+
+    status = pjsua_acc_add(&acc_cfg, PJ_FALSE, &acc_id);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(3, (THIS_FILE, "    error: pjsua_acc_add failed (%d)", status));
+        return err_base - 1;
+    }
+
+    /* First registration. The Contact is built here, snapshot it before
+     * any response can arrive (no worker threads in this test).
+     */
+    g_ctx.reg_done = PJ_FALSE;
+    status = pjsua_acc_set_registration(acc_id, PJ_TRUE);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(3, (THIS_FILE, "    error: set_registration failed (%d)",
+                   status));
+        rc = err_base - 2;
+        goto on_return;
+    }
+    pj_ansi_snprintf(orig_contact, sizeof(orig_contact), "%.*s",
+                     (int)pjsua_var.acc[acc_id].contact.slen,
+                     pjsua_var.acc[acc_id].contact.ptr);
+
+    /* Three round trips: the first response stores the rewritten Contact,
+     * a later one parses it back. That second parse is what used to
+     * dereference NULL.
+     */
+    for (round = 0; round < 3; ++round) {
+        if (round > 0) {
+            g_ctx.reg_done = PJ_FALSE;
+            /* A rewrite triggers its own re-registration; if one is
+             * already in flight this returns PJSIP_EBUSY and we simply
+             * wait for it instead.
+             */
+            pjsua_acc_set_registration(acc_id, PJ_TRUE);
+        }
+        if (wait_reg(10000) != 0) {
+            PJ_LOG(3, (THIS_FILE, "    error: registration %u timed out, "
+                       "last code %d", round, g_ctx.reg_code));
+            rc = err_base - 3;
+            goto on_return;
+        }
+    }
+
+    if (g_mock_reg.req_count < 3) {
+        PJ_LOG(3, (THIS_FILE, "    error: expected >=3 REGISTERs, got %u",
+                   g_mock_reg.req_count));
+        rc = err_base - 4;
+        goto on_return;
+    }
+
+    /* The stored Contact must always be parseable, whether or not the
+     * rewrite was accepted.
+     */
+    if (get_acc_contact_host(acc_id, host, sizeof(host)) != 0) {
+        PJ_LOG(3, (THIS_FILE, "    error: account Contact is unparseable: "
+                   "'%.*s'", (int)pjsua_var.acc[acc_id].contact.slen,
+                   pjsua_var.acc[acc_id].contact.ptr));
+        rc = err_base - 5;
+        goto on_return;
+    }
+
+    if (expect_host) {
+        if (pj_ansi_strcmp(host, expect_host) != 0) {
+            PJ_LOG(3, (THIS_FILE, "    error: expected Contact host '%s', "
+                       "got '%s'", expect_host, host));
+            rc = err_base - 6;
+            goto on_return;
+        }
+    } else {
+        /* Rewrite must have been declined, leaving the original intact */
+        if (pj_strcmp2(&pjsua_var.acc[acc_id].contact, orig_contact) != 0) {
+            PJ_LOG(3, (THIS_FILE, "    error: Contact should have been kept "
+                       "as '%s', got '%.*s'", orig_contact,
+                       (int)pjsua_var.acc[acc_id].contact.slen,
+                       pjsua_var.acc[acc_id].contact.ptr));
+            rc = err_base - 7;
+            goto on_return;
+        }
+    }
+
+on_return:
+    g_mock_reg.received = NULL;
+    pjsua_acc_del(acc_id);
+    pjsua_handle_events(500);
+    return rc;
+}
+
+
+/*****************************************************************************
+ * Main entry point
+ *****************************************************************************/
+
+/* Recreate the test framework's endpoint + tsx layer after pjsua_destroy. */
+static void restore_endpt(void)
+{
+    pj_status_t status;
+
+    status = pjsip_endpt_create(&caching_pool.factory, "endpt", &endpt);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(1, (THIS_FILE, status, "Error creating endpoint"));
+        return;
+    }
+    status = pjsip_tsx_layer_init_module(endpt);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(1, (THIS_FILE, status, "Error initializing tsx layer"));
+    }
+}
+
+int pjsua_acc_test(void)
+{
+    pjsua_config           ua_cfg;
+    pjsua_logging_config   log_cfg;
+    pjsua_transport_config tp_cfg;
+    pjsua_transport_id     tp_id;
+    pj_uint16_t            port;
+    pj_status_t            status;
+    int rc = 0;
+
+    PJ_LOG(3, (THIS_FILE, "pjsua account Contact rewrite test"));
+
+    /* The pjsip test framework's global endpoint owns the tsx layer
+     * singleton, which pjsua would try to register on its own endpoint.
+     * Destroy it here and recreate it via restore_endpt() afterwards.
+     */
+    pjsip_endpt_destroy(endpt);
+    endpt = NULL;
+
+    status = pjsua_create();
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(1, (THIS_FILE, "  pjsua_create failed (%d)", status));
+        restore_endpt();
+        return -2401;
+    }
+
+    pjsua_config_default(&ua_cfg);
+    ua_cfg.cb.on_reg_state2 = &on_reg_state2;
+    /* No worker threads: everything runs from pjsua_handle_events() so
+     * the Contact can be inspected at known points.
+     */
+    ua_cfg.thread_cnt = 0;
+
+    pjsua_logging_config_default(&log_cfg);
+    log_cfg.level         = 3;
+    log_cfg.console_level = 3;
+
+    status = pjsua_init(&ua_cfg, &log_cfg, NULL);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(1, (THIS_FILE, "  pjsua_init failed (%d)", status));
+        pjsua_destroy();
+        restore_endpt();
+        return -2402;
+    }
+
+    pjsua_transport_config_default(&tp_cfg);
+    tp_cfg.port = 0;  /* ephemeral */
+
+    status = pjsua_transport_create(PJSIP_TRANSPORT_UDP, &tp_cfg, &tp_id);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(1, (THIS_FILE, "  pjsua_transport_create failed (%d)", status));
+        pjsua_destroy();
+        restore_endpt();
+        return -2403;
+    }
+
+    status = pjsua_start();
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(1, (THIS_FILE, "  pjsua_start failed (%d)", status));
+        pjsua_destroy();
+        restore_endpt();
+        return -2404;
+    }
+
+    {
+        pjsua_transport_info ti;
+        pjsua_transport_get_info(tp_id, &ti);
+        port = pj_sockaddr_get_port(&ti.local_addr);
+    }
+
+    status = pjsip_endpt_register_module(pjsua_get_pjsip_endpt(),
+                                         &g_mock_reg.mod);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(1, (THIS_FILE, "  register mock registrar failed (%d)",
+                   status));
+        pjsua_destroy();
+        restore_endpt();
+        return -2405;
+    }
+
+    /* ---- Run sub-tests ---- */
+
+    /* An IPv6 address seen by the registrar on a transport that is not
+     * typed IPv6 (dual stack SBC, NAT64). Must be bracketed, otherwise
+     * the stored Contact is <sip:user@2001:db8::1:PORT> and unparseable.
+     */
+    rc = rewrite_test(tp_id, (int)port, "IPv6 received over IPv4 transport",
+                      "2001:db8::1", "2001:db8::1", -2410);
+    if (rc != 0) goto on_return;
+
+    /* Plain IPv4: the ordinary rewrite must still happen. */
+    rc = rewrite_test(tp_id, (int)port, "IPv4 received",
+                      "1.2.3.4", "1.2.3.4", -2420);
+    if (rc != 0) goto on_return;
+
+    /* '!' is accepted by the Via param scanner but not by the URI host
+     * scanner, so the rebuilt Contact would not parse back.
+     */
+    rc = rewrite_test(tp_id, (int)port, "received with invalid host char",
+                      "1.2.3.4!", NULL, -2430);
+    if (rc != 0) goto on_return;
+
+    /* Colon bearing token that is not an IPv6 address: must not be
+     * bracketed into a Contact that parses but means nothing.
+     */
+    rc = rewrite_test(tp_id, (int)port, "received with non-address colon",
+                      "foo:bar", NULL, -2440);
+    if (rc != 0) goto on_return;
+
+on_return:
+    if (g_mock_reg.mod.id != -1)
+        pjsip_endpt_unregister_module(pjsua_get_pjsip_endpt(),
+                                      &g_mock_reg.mod);
+
+    pjsua_handle_events(500);
+    pjsua_destroy2(PJSUA_DESTROY_NO_RX_MSG);
+
+    restore_endpt();
+
+    return rc;
+}

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -396,6 +396,11 @@ int test_main(int argc, char *argv[])
                 PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
 #endif
 
+#if INCLUDE_PJSUA_ACC_TEST
+    UT_ADD_TEST(&test_app.ut_app, pjsua_acc_test,
+                PJ_TEST_EXCLUSIVE | PJ_TEST_KEEP_LAST);
+#endif
+
     /* This needs to be exclusive, because there must NOT be any other
      * loop transport otherwise some test will fail (e.g. sending will
      * fallback to that transport)

--- a/pjsip/src/test/test.h
+++ b/pjsip/src/test/test.h
@@ -93,6 +93,7 @@ extern pj_caching_pool caching_pool;
 #define INCLUDE_AUTH_ASYNC_TEST INCLUDE_REGC_GROUP
 #define INCLUDE_PJSUA_AUTH_TEST INCLUDE_REGC_GROUP
 #define INCLUDE_PJSUA_CALL_TEST INCLUDE_REGC_GROUP
+#define INCLUDE_PJSUA_ACC_TEST  INCLUDE_REGC_GROUP
 #define INCLUDE_DLG_CORE_TEST   INCLUDE_MESSAGING_GROUP
 
 
@@ -115,6 +116,7 @@ int regc_test(void);
 int auth_async_test(void);
 int pjsua_auth_test(void);
 int pjsua_call_test(void);
+int pjsua_acc_test(void);
 int inv_offer_answer_test(void);
 int dlg_core_test(void);
 

--- a/tests/sanitizers/tsan.supp
+++ b/tests/sanitizers/tsan.supp
@@ -112,6 +112,36 @@ deadlock:pjsua_call_on_incoming
 #=============================================================================
 
 #=============================================================================
+# Lock-order-inversion between PJSUA_LOCK and a transaction's group lock
+# on the registration path, seen whenever a NAT Contact rewrite succeeds.
+#
+# Two orderings appear on the same thread:
+#   M0 -> M1: regc_cb() takes PJSUA_LOCK, then acc_check_nat_addr()
+#     rewrites the Contact and re-registers. pjsua_acc_set_registration()
+#     does PJSUA_UNLOCK() before pjsip_regc_send() precisely to avoid
+#     this, but PJSUA_LOCK is a recursive mutex (pjsua_core.c, created
+#     with pj_mutex_create_recursive) and regc_cb already holds it, so
+#     the unlock only decrements the recursion count. pjsip_regc_send()
+#     then reaches pjsip_tsx_set_transport() and takes the new
+#     transaction's grp_lock with PJSUA_LOCK still held.
+#   M1 -> M0: regc_cb() / regc_tsx_cb() are invoked from tsx_set_state()
+#     with the transaction grp_lock already held, and take PJSUA_LOCK.
+#
+# This is the same recursive-lock problem noted in the disabled
+# acc_delete_deferred_test in pjsua_auth_test.c. It is not specific to
+# the test that exposes it: every real contact rewrite takes this path,
+# since acc_check_nat_addr() re-registers for any contact_rewrite_method
+# below PJSUA_CONTACT_REWRITE_ALWAYS_UPDATE. Fixing it means deferring
+# the re-registration out of the callback, or making the unlock
+# recursion-aware - a PJSUA lock topology change, not a local one.
+#
+# Suppressed on acc_check_nat_addr because that frame is unique to this
+# cycle. regc_cb / regc_tsx_cb are deliberately left unsuppressed so
+# other deadlocks on the registration path still surface.
+deadlock:acc_check_nat_addr
+#=============================================================================
+
+#=============================================================================
 # Lock-order-inversion inside pjmedia event manager when an event
 # subscriber callback publishes another event (nested publish).
 #


### PR DESCRIPTION
## Problem

A field crash on Android arm64 (release build) with a NULL dereference in `acc_check_nat_addr()`:

```
#00  acc_check_nat_addr            pjsua_acc.c  (contact_hdr->uri)
#01  regc_cb                       pjsua_acc.c
#02  call_callback                 sip_reg.c:845
#03  regc_tsx_callback             sip_reg.c:1589
#04  mod_util_on_tsx_state         sip_util_statefull.c:80
```

`pjsip_parse_hdr()` returns NULL for the account's *own* stored Contact and the result is dereferenced under a `pj_assert()` that is compiled out in release.

The account's Contact becomes unparseable because `acc_check_nat_addr()` writes it itself, rebuilt from the Via `received`/`rport` of the registrar's response, with no validation:

* Via params are scanned with `pjsip_VIA_PARAM_SPEC` = `TOKEN_SPEC` + `"[:]"`, i.e. ``-.!%*_`'~+[:]`` (`sip_parser.c:388-390`, `TOKEN` at line 47), but a SIP URI host is scanned with `pjsip_HOST_SPEC` = alnum + `_-.` (`sip_parser.c:399-401`). Any of the extra characters in `received=` produces a Contact that cannot be parsed back.
* Square brackets for IPv6 were chosen from `tp->key.type & PJSIP_TRANSPORT_IPV6` rather than from the address itself. Note `int_parse_host()` strips brackets from `sent_by.host` and `pj_sockaddr_print(..., 0)` prints IPv6 unbracketed, so `via_addr` is essentially never bracketed on entry. An IPv6 `received` on a transport not typed IPv6 (dual-stack SBC, NAT64) was stored as `<sip:user@2001:db8::1:5060>`.

The poisoning pass does not crash — it parses the old, good Contact at the top and returns `PJ_TRUE`, which makes `regc_cb` return early with `contact_rewritten = PJ_TRUE`. The next response short-circuits the check and resets the flag. The crash lands two to three REGISTER round trips later, with nothing logged in between, which is consistent with an unreproducible field report.

`update_regc_contact()` has the identical unchecked pattern on the same string and is called from `acc_check_nat_addr()` *before* the crash site, so with `reg_contact_uri_params` configured it faults one round trip earlier.

## Changes

### `pjsua_acc.c` — stop producing the bad Contact

* Bracket the address only when `pj_inet_pton(PJ_AF_INET6, ...)` accepts it. A looser "contains a colon" test is not enough: `received=foo:bar` is a legal Via param token, and `int_parse_host()` accepts any non-empty bracket contents, so `[foo:bar]` would parse and be stored as a meaningless Contact instead of the previous one being kept.
* Parse the rebuilt Contact back and decline the rewrite unless it is a valid SIP/SIPS Contact, keeping the previous good value instead of poisoning the account.
* Move the `PJSUA_CONTACT_REWRITE_UNREGISTER` step below the validation, so a declined rewrite cannot leave the account unregistered with a destroyed regc. It still runs before `acc->contact` is replaced, as that branch requires.
* Replace the `pj_assert()`s on the parse result in both `acc_check_nat_addr()` and `update_regc_contact()` with real checks.
* Reject a non-SIP URI **in `acc_check_nat_addr()`**, which casts the result to `pjsip_sip_uri*` and then reads `uri->port` / `uri->host` as struct fields. A `Contact: *` parses to a header with a NULL `uri`, and a `tel:` URI (reachable via `pjsua_acc_config.force_contact`) parses to a `pjsip_other_uri` whose `->host` would be read out of a mismatched struct. `update_regc_contact()` deliberately does **not** get this guard — it only passes the URI to `pjsip_uri_print()`, which dispatches on the URI's own vptr, so no SIP-specific field is read there. The local is declared `pjsip_uri*` instead, to stop the inert cast reading as type confusion.
* NULL terminate the `reg_contact` buffer in `update_regc_contact()`. It is built with `pj_strcpy()`/`pj_strcat()` from `pj_pool_alloc()` memory and then passed to `pjsip_parse_hdr()`, whose scanner requires a NULL terminated input (`scanner.h:219-224`); byte `[slen]` was uninitialized. The `pj_ansi_snprintf()` result is also checked for truncation before being used as `slen` by the subsequent `pj_strcat()`s.

### `sip_reg.c` — two NULL/state bugs the new test exposed

Both are pre-existing and independent of the crash above; the second is widened by the first.

* `set_contact()` checked only for a NULL parse result, then dereferenced `hdr->uri` — NULL for `Contact: *` — when `add_xuid_param` is enabled. `calculate_response_expiration()` dereferences it too. Reject a URI-less Contact: registering one is meaningless, and `pjsip_regc_unregister_all()` builds its starred Contact directly on the tdata rather than through `set_contact()`. This reproduces only in a combined test run, because `regc_test` toggles that global and leaves it set, which is presumably why it went unnoticed.
* `set_contact()` also moved the current Contacts to `removed_contact_hdr_list` with `expires=0` *before* parsing the new ones, so any error return partway left the regc with no active Contact and the old bindings queued for removal — the next REGISTER unregisters them even though the update was refused. All new Contacts are now parsed and validated into a local list first, and the regc lists are only touched once nothing can fail.

### `tsan.supp` — one suppression, for a pre-existing inversion

The new test is the first thing in `pjsip-test` to drive a successful contact rewrite, which exposes a lock-order inversion that makes the TSan CI job exit 66 with all tests passing:

```
M0 -> M1  regc_cb() holds PJSUA_LOCK -> acc_check_nat_addr() ->
          pjsua_acc_set_registration() -> pjsip_regc_send() ->
          pjsip_tsx_set_transport() takes the tsx grp_lock
M1 -> M0  regc_cb() / regc_tsx_cb() are called from tsx_set_state()
          with the tsx grp_lock held, and take PJSUA_LOCK
```

`pjsua_acc_set_registration()` does `PJSUA_UNLOCK()` before `pjsip_regc_send()` to avoid exactly this, but `PJSUA_LOCK` is a recursive mutex (`pjsua_core.c:1021`) and `regc_cb` already holds it, so the unlock only decrements the recursion count. Same problem as the TODO on the disabled `acc_delete_deferred_test` in `pjsua_auth_test.c`.

**This is not a test artifact and this PR does not fix it.** `acc_check_nat_addr()` re-registers for any `contact_rewrite_method` below `ALWAYS_UPDATE`, so every real NAT contact rewrite takes this path. Suppressed the way the two existing PJSUA lock-topology inversions in that file are, keyed on `acc_check_nat_addr` since that frame is unique to the cycle; `regc_cb` and `regc_tsx_cb` are left unsuppressed so other registration-path deadlocks still surface. Fixing it properly means deferring the re-registration out of the callback or making the unlock recursion-aware — a PJSUA lock topology change. Happy to open a separate issue.

## Testing

New `pjsua_acc_test` (registered in all three build systems). A mock registrar overwrites the Via `received` param of the REGISTER, which `pjsip_endpt_create_response()` clones into the 200 OK, letting the test drive `acc_check_nat_addr()` with an arbitrary address as seen by the registrar. Each case runs three REGISTER round trips, so a Contact stored on the first response is parsed back on a later one — the sequence that crashes.

| Case | Guards | Fails without the fix |
|---|---|---|
| IPv6 `received` over IPv4 transport | `acc_check_nat_addr` bracketing | **yes** — aborts on `contact_hdr != NULL` |
| plain IPv4 `received` | ordinary rewrite still happens | no |
| `received=1.2.3.4!` | `acc_check_nat_addr` validation | **yes** — same abort |
| `received=foo:bar` | `pj_inet_pton` bracket gate | **yes** — same abort |
| declined rewrite, `UNREGISTER` method | the reorder; regc not torn down | no |
| accepted rewrite + `reg_contact_uri_params` | `update_regc_contact` regeneration | no |
| `force_contact = "*"` | `update_regc_contact` fallback, `set_contact` NULL uri | **yes** — aborts on `pj_assert(uri != NULL)` |
| `force_contact = "<tel:...>"` + uri params | `acc_check_nat_addr` scheme guard | **yes** — aborts in `pj_inet_pton()` on a `pj_str_t` read out of a `pjsip_other_uri` |
| rejected `update_contact` keeps the binding | `set_contact` validate-before-mutate | **yes** — binding re-sent with `;expires=0` |

Every row was checked by reverting the relevant fix and re-running, not inferred. Being explicit about the three "no" rows: they pin correct behaviour rather than reproduce a failure. Pre-fix, the UNREGISTER path happens to recover because the failed `regc_init` causes the Contact to be rebuilt on the next cycle. Likewise the `reg_contact.ptr[slen] == '\0'` assertion is correct but not a dependable detector of the NUL-termination bug, since the uninitialized pool byte is usually already zero.

Parser behaviour also verified directly against the built libraries:

```
<sip:u@2001:db8::1:5060>    -> hdr=NULL                  <- the crash input
<sip:u@1.2.3.4!:5060>       -> hdr=NULL                  <- token char legal in received=
<sip:u@[2001:db8::1]:5060>  -> ok, host='2001:db8::1'    <- what the fix emits
*                           -> hdr=ok, uri=NULL          <- covered by the uri check
<tel:+15551234>             -> hdr=ok, uri=ok, sip=0     <- covered by the scheme check
```

Locally: `regc_test auth_async_test pjsua_auth_test pjsua_call_test pjsua_acc_test` 5/5 under ASan, plus `transport_loop_test transport_udp_test tsx_destroy_test`. Build is warning-free. CI is green on f8b7316 across Ubuntu (including the TSan job), MacOS, Windows, CodeQL and CIFuzz.

Co-Authored-By Claude Code
