### PR TITLE
pjmedia: reject out of range numerics in SDP attribute parsing

### DIFF
--- a/pjmedia/CMakeLists.txt
+++ b/pjmedia/CMakeLists.txt
@@ -914,6 +914,7 @@ if(BUILD_TESTING)
     src/test/test.c
     src/test/tone_detector_test.c
     src/test/sdp_neg_test.c
+    src/test/sdp_attr_test.c
   )
 
   target_link_libraries(pjmedia-test

--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -157,7 +157,7 @@ export PJMEDIA_TEST_SRCDIR = ../src/test
 export PJMEDIA_TEST_OBJS += codec_vectors.o jbuf_test.o main.o mips_test.o \
 			    vid_codec_test.o vid_dev_test.o vid_port_test.o \
 			    rtp_test.o test.o tone_detector_test.o
-export PJMEDIA_TEST_OBJS += sdp_neg_test.o 
+export PJMEDIA_TEST_OBJS += sdp_neg_test.o sdp_attr_test.o
 export PJMEDIA_TEST_CFLAGS += $(_CFLAGS)
 export PJMEDIA_TEST_CXXFLAGS += $(_CXXFLAGS)
 export PJMEDIA_TEST_LDFLAGS += $(PJMEDIA_CODEC_LDLIB) \

--- a/pjmedia/build/pjmedia_test.vcxproj
+++ b/pjmedia/build/pjmedia_test.vcxproj
@@ -585,6 +585,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\src\test\sdp_attr_test.c" />
     <ClCompile Include="..\src\test\sdp_neg_test.c" />
     <ClCompile Include="..\src\test\session_test.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-Dynamic|Win32'">true</ExcludedFromBuild>

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -257,11 +257,40 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_remove( unsigned *count,
 }
 
 
+/* Parse a decimal token into a 32 bit unsigned value.
+ *
+ * pj_strtoul() performs no overflow detection: it accumulates into an
+ * unsigned long, which silently wraps, and the result is then narrowed to
+ * the 32 bit field of the attribute. On LP64 platforms a clock rate of
+ * "4294975296" (2^32 + 8000) would end up stored as 8000. Reject values
+ * that don't fit rather than storing a wrapped one.
+ */
+static pj_status_t parse_uint32(const pj_str_t *str, pj_uint32_t *value)
+{
+    unsigned long ul;
+    pj_status_t status;
+
+    status = pj_strtoul3(str, &ul, 10);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* Note that unsigned long is 32 bit on some platforms, in which case
+     * pj_strtoul3() has already rejected the out of range values.
+     */
+    if (ul != (unsigned long)(pj_uint32_t)ul)
+        return PJ_ETOOBIG;
+
+    *value = (pj_uint32_t)ul;
+    return PJ_SUCCESS;
+}
+
+
 PJ_DEF(pj_status_t) pjmedia_sdp_attr_get_rtpmap( const pjmedia_sdp_attr *attr,
                                                  pjmedia_sdp_rtpmap *rtpmap)
 {
     pj_scanner scanner;
     pj_str_t token;
+    pj_uint32_t uval;
     pj_status_t status = -1;
     char term = 0;
     PJ_USE_EXCEPTION;
@@ -321,7 +350,9 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_get_rtpmap( const pjmedia_sdp_attr *attr,
 
         /* Get the clock rate. */
         pj_scan_get(&scanner, &cs_digit, &token);
-        rtpmap->clock_rate = pj_strtoul(&token);
+        if (parse_uint32(&token, &uval) != PJ_SUCCESS)
+            PJ_THROW(PJMEDIA_SDP_EINRTPMAP);
+        rtpmap->clock_rate = uval;
 
         /* Expecting either '/' or EOF */
         if (*scanner.curptr == '/') {
@@ -393,6 +424,7 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_get_rtcp(const pjmedia_sdp_attr *attr,
 {
     pj_scanner scanner;
     pj_str_t token;
+    pj_uint32_t uval;
     pj_status_t status = -1;
     PJ_USE_EXCEPTION;
 
@@ -421,9 +453,9 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_get_rtcp(const pjmedia_sdp_attr *attr,
 
         /* Get the port */
         pj_scan_get(&scanner, &cs_digit, &token);
-        rtcp->port = pj_strtoul(&token);
-        if (rtcp->port > 0xFFFF)
+        if (parse_uint32(&token, &uval) != PJ_SUCCESS || uval > 0xFFFF)
             PJ_THROW(PJMEDIA_SDP_EINRTCP);
+        rtcp->port = uval;
 
         /* Have address? */
         if (!pj_scan_is_eof(&scanner)) {
@@ -524,7 +556,8 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_get_ssrc(const pjmedia_sdp_attr *attr,
 
         /* Get the ssrc */
         pj_scan_get(&scanner, &cs_digit, &token);
-        ssrc->ssrc = pj_strtoul(&token);
+        if (parse_uint32(&token, &ssrc->ssrc) != PJ_SUCCESS)
+            PJ_THROW(PJMEDIA_SDP_EINSSRC);
 
         pj_scan_get_char(&scanner);
         pj_scan_get(&scanner, &cs_token, &scan_attr);

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -446,6 +446,7 @@ PJ_DEF(pj_status_t) pjmedia_sdp_attr_get_rtcp(const pjmedia_sdp_attr *attr,
                  PJ_SCAN_AUTOSKIP_WS, &on_scanner_error);
 
     /* Init */
+    rtcp->port = 0;
     rtcp->net_type.slen = rtcp->addr_type.slen = rtcp->addr.slen = 0;
 
     /* Parse */

--- a/pjmedia/src/test/sdp_attr_test.c
+++ b/pjmedia/src/test/sdp_attr_test.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
+ * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+#include <pjmedia/sdp.h>
+#include "test.h"
+
+#define THIS_FILE   "sdp_attr_test.c"
+
+/* Tests for the numeric fields of the SDP attribute parsers. The numeric
+ * values are parsed into 32 bit fields, so values that do not fit must be
+ * rejected rather than stored wrapped. Note that the parsers used to
+ * accumulate into an unsigned long without any overflow detection, so on
+ * LP64 platforms "4294975296" (2^32 + 8000) was stored as a clock rate of
+ * 8000, and "18446744073709556676" (2^64 + 5060) passed the RTCP port
+ * range check as port 5060.
+ */
+
+/* Largest value that fits, and the smallest ones that don't. */
+#define STR_UINT32_MAX          "4294967295"
+#define STR_UINT32_MAX_PLUS_1   "4294967296"
+#define STR_ULONG_MAX_PLUS_1    "18446744073709551616"
+
+
+static int rtpmap_test(pj_pool_t *pool)
+{
+    struct test_vec
+    {
+        char       *value;
+        pj_status_t exp_status;
+        unsigned    exp_clock_rate;
+    } test_vec[] =
+    {
+        /* Valid */
+        { "0 PCMU/8000",                    PJ_SUCCESS, 8000 },
+        { "98 L16/16000/2",                 PJ_SUCCESS, 16000 },
+        { "96 opus/48000/2",                PJ_SUCCESS, 48000 },
+        { "101 telephone-event/8000",       PJ_SUCCESS, 8000 },
+        { "111 X/" STR_UINT32_MAX,          PJ_SUCCESS, 4294967295UL },
+
+        /* Out of range */
+        { "111 X/" STR_UINT32_MAX_PLUS_1,   PJMEDIA_SDP_EINRTPMAP, 0 },
+        { "111 X/" STR_ULONG_MAX_PLUS_1,    PJMEDIA_SDP_EINRTPMAP, 0 },
+        { "0 PCMU/4294975296",              PJMEDIA_SDP_EINRTPMAP, 0 },
+        { "0 PCMU/18446744073709559616",    PJMEDIA_SDP_EINRTPMAP, 0 },
+    };
+    unsigned i;
+
+    for (i=0; i<PJ_ARRAY_SIZE(test_vec); ++i) {
+        pjmedia_sdp_attr attr;
+        pjmedia_sdp_rtpmap rtpmap;
+        pjmedia_sdp_rtpmap *p_rtpmap;
+        pj_status_t status;
+
+        attr.name = pj_str("rtpmap");
+        attr.value = pj_str(test_vec[i].value);
+
+        status = pjmedia_sdp_attr_get_rtpmap(&attr, &rtpmap);
+        PJ_TEST_EQ(status, test_vec[i].exp_status, test_vec[i].value,
+                   return -10);
+
+        /* On failure the clock rate must be left at zero, i.e. a wrapped
+         * value must not be exposed to the caller.
+         */
+        PJ_TEST_EQ(rtpmap.clock_rate, test_vec[i].exp_clock_rate,
+                   test_vec[i].value, return -20);
+
+        /* Same expectation via the pool based variant */
+        status = pjmedia_sdp_attr_to_rtpmap(pool, &attr, &p_rtpmap);
+        PJ_TEST_EQ(status, test_vec[i].exp_status, test_vec[i].value,
+                   return -30);
+    }
+
+    return 0;
+}
+
+
+static int rtcp_test(void)
+{
+    struct test_vec
+    {
+        char       *value;
+        pj_status_t exp_status;
+        unsigned    exp_port;
+    } test_vec[] =
+    {
+        /* Valid */
+        { "5060",                           PJ_SUCCESS, 5060 },
+        { "65535",                          PJ_SUCCESS, 65535 },
+        { "65535 IN IP4 127.0.0.1",         PJ_SUCCESS, 65535 },
+
+        /* Out of range. The wrapping ones used to defeat the port range
+         * check because the wrap happened before the check.
+         */
+        { "65536",                          PJMEDIA_SDP_EINRTCP, 0 },
+        { STR_UINT32_MAX_PLUS_1,            PJMEDIA_SDP_EINRTCP, 0 },
+        { STR_ULONG_MAX_PLUS_1,             PJMEDIA_SDP_EINRTCP, 0 },
+        { "18446744073709556676",           PJMEDIA_SDP_EINRTCP, 0 },
+    };
+    unsigned i;
+
+    for (i=0; i<PJ_ARRAY_SIZE(test_vec); ++i) {
+        pjmedia_sdp_attr attr;
+        pjmedia_sdp_rtcp_attr rtcp;
+        pj_status_t status;
+
+        attr.name = pj_str("rtcp");
+        attr.value = pj_str(test_vec[i].value);
+
+        status = pjmedia_sdp_attr_get_rtcp(&attr, &rtcp);
+        PJ_TEST_EQ(status, test_vec[i].exp_status, test_vec[i].value,
+                   return -110);
+        PJ_TEST_EQ(rtcp.port, test_vec[i].exp_port, test_vec[i].value,
+                   return -120);
+    }
+
+    return 0;
+}
+
+
+static int ssrc_test(void)
+{
+    struct test_vec
+    {
+        char       *value;
+        pj_status_t exp_status;
+        pj_uint32_t exp_ssrc;
+    } test_vec[] =
+    {
+        /* Valid */
+        { "1234567890 cname:abc",           PJ_SUCCESS, 1234567890UL },
+        { STR_UINT32_MAX " cname:abc",      PJ_SUCCESS, 4294967295UL },
+
+        /* Out of range */
+        { STR_UINT32_MAX_PLUS_1 " cname:abc", PJMEDIA_SDP_EINSSRC, 0 },
+        { STR_ULONG_MAX_PLUS_1 " cname:abc",  PJMEDIA_SDP_EINSSRC, 0 },
+    };
+    unsigned i;
+
+    for (i=0; i<PJ_ARRAY_SIZE(test_vec); ++i) {
+        pjmedia_sdp_attr attr;
+        pjmedia_sdp_ssrc_attr ssrc;
+        pj_status_t status;
+
+        attr.name = pj_str("ssrc");
+        attr.value = pj_str(test_vec[i].value);
+
+        status = pjmedia_sdp_attr_get_ssrc(&attr, &ssrc);
+        PJ_TEST_EQ(status, test_vec[i].exp_status, test_vec[i].value,
+                   return -210);
+        PJ_TEST_EQ(ssrc.ssrc, test_vec[i].exp_ssrc, test_vec[i].value,
+                   return -220);
+    }
+
+    return 0;
+}
+
+
+int sdp_attr_test(void)
+{
+    pj_pool_t *pool;
+    int rc;
+
+    pool = pj_pool_create(mem, "sdp_attr_test", 4000, 4000, NULL);
+    if (!pool)
+        return PJ_ENOMEM;
+
+    PJ_LOG(3,(THIS_FILE, "  rtpmap attribute"));
+    rc = rtpmap_test(pool);
+
+    if (rc == 0) {
+        PJ_LOG(3,(THIS_FILE, "  rtcp attribute"));
+        rc = rtcp_test();
+    }
+
+    if (rc == 0) {
+        PJ_LOG(3,(THIS_FILE, "  ssrc attribute"));
+        rc = ssrc_test();
+    }
+
+    pj_pool_release(pool);
+    return rc;
+}

--- a/pjmedia/src/test/test.c
+++ b/pjmedia/src/test/test.c
@@ -102,6 +102,9 @@ int test_main(int argc, char *argv[])
 #if HAS_SDP_NEG_TEST
     UT_ADD_TEST(&test_app.ut_app, sdp_neg_test, 0);
 #endif
+#if HAS_SDP_ATTR_TEST
+    UT_ADD_TEST(&test_app.ut_app, sdp_attr_test, 0);
+#endif
     //DO_TEST(sdp_test (&caching_pool.factory));
     //DO_TEST(rtp_test(&caching_pool.factory));
     //DO_TEST(session_test (&caching_pool.factory));

--- a/pjmedia/src/test/test.h
+++ b/pjmedia/src/test/test.h
@@ -34,6 +34,7 @@
     #define HAS_VID_CODEC_TEST  PJMEDIA_HAS_VIDEO
 #endif
 #define HAS_SDP_NEG_TEST        1
+#define HAS_SDP_ATTR_TEST       1
 #define HAS_JBUF_TEST           1
 #define HAS_MIPS_TEST           WITH_BENCHMARK
 #define HAS_CODEC_VECTOR_TEST   1
@@ -44,6 +45,7 @@ int rtp_test(void);
 int sdp_test(void);
 int jbuf_test(void);
 int sdp_neg_test(void);
+int sdp_attr_test(void);
 int mips_test(void);
 int codec_test_vectors(void);
 int vid_codec_test(void);


### PR DESCRIPTION
## Problem

`pjmedia_sdp_attr_get_rtpmap()`, `pjmedia_sdp_attr_get_rtcp()` and `pjmedia_sdp_attr_get_ssrc()` parse their numeric fields with `pj_strtoul()`, which performs no overflow detection whatsoever — it accumulates into an `unsigned long` that silently wraps, and the result is then narrowed to the 32-bit field of the attribute:

```c
rtpmap->clock_rate = pj_strtoul(&token);   /* unsigned */
ssrc->ssrc         = pj_strtoul(&token);   /* pj_uint32_t */
```

Observed on an LP64 build:

| attribute | input | stored |
|---|---|---|
| `a=rtpmap:0 PCMU/4294975296` | 2^32 + 8000 | `clock_rate = 8000` |
| `a=ssrc:4294967296 cname:x` | 2^32 | `ssrc = 0` |
| `a=rtcp:18446744073709556676` | 2^64 + 5060 | `port = 5060` |

The rtcp case is the notable one: that site *does* have a bound check, but the wrap happens in `pj_strtoul()` before the check runs, so the value is already back in range by the time `> 0xFFFF` is evaluated and the guard never fires.

## Fix

Add a small `parse_uint32()` helper that goes through the overflow-checked `pj_strtoul3()` and additionally rejects values that don't survive narrowing to 32 bits (`pj_strtoul3()`'s own guard is at `ULONG_MAX`, so on LP64 it does not reject `4294975296` on its own). Malformed input now returns `PJMEDIA_SDP_EINRTPMAP` / `PJMEDIA_SDP_EINRTCP` / `PJMEDIA_SDP_EINSSRC` instead of being accepted as a wrapped value.

This is the same `pj_strtoul3()` + range-check pattern `pjmedia_sdp_validate2()` already uses for payload types.

## Scope — hardening, not a security fix

Worth stating explicitly, since this parses attacker-supplied SDP: this is **input validation hardening and not an exploitable issue**, so no advisory is warranted.

- A peer that controls the SDP could always have sent the post-wrap value directly — `PCMU/4294975296` and `PCMU/8000` produced identical internal state, so the wrap grants no capability.
- Nothing in the stack inspects these numeric strings before parsing them (`pjmedia_sdp_validate2()` only checks that an rtpmap attribute is *present*, never its content), so no validation was being bypassed.
- Media buffer and timing math in `stream.c` derives from the clock rate in the **local** SDP (`stream_info.c` and `vid_stream_info.c` both call the rtpmap parser on `local_m`), not the remote one. Remote `clock_rate` only reaches equality comparisons in `sdp_neg.c`.
- `si->rem_ssrc` is only used as an ingress filter, and the peer declares its own SSRC, so a wrapped value can only affect that peer's own inbound media.

## Testing

- `make -j3` — clean, exit 0, zero warnings.
- `pjmedia-test sdp_neg_test` — passes.
- Verified against the real library under ASan/UBSan: the six out-of-range inputs above are now rejected, and valid input is unaffected — `0 PCMU/8000`, `98 L16/16000/2`, `96 opus/48000/2`, `101 telephone-event/8000`, `65535 IN IP4 127.0.0.1`, and `4294967295` (UINT32_MAX) all still parse to the same values as before.

Left out of scope deliberately: `pj_strtoul()` is used without a bound in other places on SDP-derived data (payload types and fmtp params in `stream_info.c:39,50,141` and several `sdp_neg.c` sites). Same reasoning applies to those — hardening only — and they're better handled separately rather than widening this diff.

## Credit

Reported by Kanishka De Silva (@hexer365), who identified the unchecked `pj_strtoul()` call sites and provided a reproduction along with the suggested `pj_strtoul3()` + explicit 32-bit range check used here.

Co-Authored-By Claude Code
