### PR TITLE
pjlib: document lack of overflow detection in pj_strtoul()/pj_strtoul2()

### DIFF
--- a/pjlib/include/pj/string.h
+++ b/pjlib/include/pj/string.h
@@ -673,6 +673,25 @@ PJ_DECL(pj_status_t) pj_strtol2(const pj_str_t *str, long *value);
  * soon as non-digit character is found or all the characters have
  * been processed.
  *
+ * Note that this function performs no overflow detection: the digits are
+ * accumulated into an unsigned long, which silently wraps once the value
+ * exceeds ULONG_MAX. Prefer pj_strtoul3() for input that is not trusted,
+ * such as data taken from the network.
+ *
+ * Also note that pj_strtoul3() only detects overflow of unsigned long
+ * itself, which is 64 bit on most platforms. When the parsed value is to
+ * be stored in a narrower field, the caller must range check it as well,
+ * for example:
+ *
+ * \code
+    unsigned long ul;
+
+    if (pj_strtoul3(&str, &ul, 10) != PJ_SUCCESS || ul > 0xFFFFFFFFUL)
+        return PJ_EINVAL;
+
+    field32 = (pj_uint32_t)ul;
+ * \endcode
+ *
  * @param str   the string.
  *
  * @return the unsigned integer.
@@ -684,7 +703,11 @@ PJ_DECL(unsigned long) pj_strtoul(const pj_str_t *str);
  * This function stops reading the string input either when the number
  * of characters has exceeded the length of the input or it has read 
  * the first character it cannot recognize as part of a number, that is
- * a character greater than or equal to base. 
+ * a character greater than or equal to base.
+ *
+ * Like pj_strtoul(), this function performs no overflow detection and will
+ * silently wrap past ULONG_MAX. See pj_strtoul() for the recommended way to
+ * parse untrusted input.
  *
  * @param str       The input string.
  * @param endptr    Optional pointer to receive the remainder/unparsed


### PR DESCRIPTION
`pj_strtoul()` and `pj_strtoul2()` fold digits in with `value = value * 10 + digit` and have no overflow check at any step, so the result silently wraps past `ULONG_MAX`. The existing doc comments describe only where parsing stops, so a caller reading them has no reason to suspect wrapping. `pj_strtoul3()` does check, but nothing in the docs steers callers toward it.

This adds that warning, plus a second one that is easy to miss: switching to `pj_strtoul3()` is not sufficient on its own when the parsed value is stored in a field narrower than `unsigned long`. Its guard operates at `unsigned long` width, which is 64 bit on LP64, so a value like `4294967396` is accepted and still overflows a 32-bit destination. The comment shows the range check callers need in that case — the same pattern used by `parse_uint32()` in #5150.

Docs only, no functional change. `cd pjlib/build && make` is clean.

Existing call sites are not changed here. The network-facing ones were reviewed and either range check the result already (`pj_sockaddr_parse2()` against 65535), validate the input first (SDES crypto tag), or narrow into a field where a wrapped value causes a negotiation to fail rather than anything memory unsafe. Migrating them is worth doing opportunistically, but it is a large mechanical diff with no fixed bug behind it, so it does not belong in this PR.

Reported by Kanishka De Silva (@hexer365), as the systemic follow-up to the SDP attribute parsing report fixed in #5150.

Co-Authored-By Claude Code