### PR TITLE
tests/pjsua: add video call tests (hold-recv, double-hold, BYE, CANCEL, re-INVITE, UPDATE)

### DIFF
--- a/tests/pjsua/inc_vid.py
+++ b/tests/pjsua/inc_vid.py
@@ -87,3 +87,11 @@ def make_video_call(caller, callee, callee_uri):
 
     caller.sync_stdout()
     callee.sync_stdout()
+
+
+# Hang up the call from 'hangup_by' and verify both endpoints disconnect
+# (i.e. exercise BYE). 'other' is the peer.
+def hangup_call(hangup_by, other):
+    hangup_by.send("call hangup")
+    hangup_by.expect(const.STATE_DISCONNECTED)
+    other.expect(const.STATE_DISCONNECTED)

--- a/tests/pjsua/inc_vid.py
+++ b/tests/pjsua/inc_vid.py
@@ -90,8 +90,11 @@ def make_video_call(caller, callee, callee_uri):
 
 
 # Hang up the call from 'hangup_by' and verify both endpoints disconnect
-# (i.e. exercise BYE). 'other' is the peer.
+# via BYE. 'other' is the peer. The peer receives the BYE before its own
+# disconnect log, so asserting it there confirms a BYE teardown (rather
+# than some other path that clears the call) without racing the disconnect.
 def hangup_call(hangup_by, other):
     hangup_by.send("call hangup")
+    other.expect("BYE sips?:")
     hangup_by.expect(const.STATE_DISCONNECTED)
     other.expect(const.STATE_DISCONNECTED)

--- a/tests/pjsua/scripts-call/510_video_call_hold_recv.py
+++ b/tests/pjsua/scripts-call/510_video_call_hold_recv.py
@@ -1,0 +1,39 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call, hold received by the caller (the callee initiates it). The
+# mirror of 500_video_call_hold.py, which tests the initiating side.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.make_video_call(caller, callee, t.inst_params[0].uri)
+
+    # Callee initiates hold; the caller receives it. The callee (initiator)
+    # reports Local hold on the video stream, the caller Remote hold.
+    callee.send("call hold")
+    callee.expect(const.VID_MEDIA_LOCAL_HOLD)
+    caller.expect(const.VID_MEDIA_REMOTE_HOLD)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call hold (receiving)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/520_video_call_hold_double.py
+++ b/tests/pjsua/scripts-call/520_video_call_hold_double.py
@@ -1,0 +1,47 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call double hold: the caller holds, then the callee also holds
+# while already held, so both sides have the video stream on hold.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.make_video_call(caller, callee, t.inst_params[0].uri)
+
+    # Caller holds first.
+    caller.send("call hold")
+    caller.expect(const.VID_MEDIA_LOCAL_HOLD)
+    callee.expect(const.VID_MEDIA_REMOTE_HOLD)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Callee also holds (double hold): it now has both a local hold and the
+    # caller's remote hold, so it reports Local hold.
+    callee.send("call hold")
+    callee.expect(const.VID_MEDIA_LOCAL_HOLD)
+    caller.expect(const.VID_MEDIA_HOLD)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call double hold",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/520_video_call_hold_double.py
+++ b/tests/pjsua/scripts-call/520_video_call_hold_double.py
@@ -22,11 +22,13 @@ def test_func(t):
     caller.sync_stdout()
     callee.sync_stdout()
 
-    # Callee also holds (double hold): it now has both a local hold and the
-    # caller's remote hold, so it reports Local hold.
+    # Callee also holds (double hold). Both sides now have their own local
+    # hold as well as the peer's remote hold; local hold takes precedence,
+    # so both report Local hold (asserting this catches a caller that
+    # wrongly flips to Remote hold).
     callee.send("call hold")
     callee.expect(const.VID_MEDIA_LOCAL_HOLD)
-    caller.expect(const.VID_MEDIA_HOLD)
+    caller.expect(const.VID_MEDIA_LOCAL_HOLD)
 
     caller.sync_stdout()
     callee.sync_stdout()

--- a/tests/pjsua/scripts-call/530_video_call_bye.py
+++ b/tests/pjsua/scripts-call/530_video_call_bye.py
@@ -1,0 +1,29 @@
+#
+import inc_vid as vid
+import inc_util as util
+from inc_cfg import *
+
+# Video call terminated with BYE (normal hangup).
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.make_video_call(caller, callee, t.inst_params[0].uri)
+
+    # Caller hangs up -> BYE; both endpoints disconnect.
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call BYE (hangup)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/540_video_call_cancel.py
+++ b/tests/pjsua/scripts-call/540_video_call_cancel.py
@@ -17,6 +17,11 @@ def test_func(t):
     caller.send("call new " + t.inst_params[0].uri)
     caller.expect(const.STATE_CALLING)
 
+    # Verify the callee actually received a video offer (enabled m=video
+    # with a non-zero port), so this exercises the video CANCEL case rather
+    # than passing for an audio-only INVITE.
+    callee.expect("m=video [1-9]")
+
     # Callee rings (180) but does not answer.
     callee.expect(const.EVENT_INCOMING_CALL)
     callee.send("call answer 180")

--- a/tests/pjsua/scripts-call/540_video_call_cancel.py
+++ b/tests/pjsua/scripts-call/540_video_call_cancel.py
@@ -1,0 +1,48 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call cancelled by the caller before it is answered (CANCEL). No
+# media is established, so no video device setup is needed; the INVITE
+# still carries the video offer.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    # Caller places the video call.
+    caller.send("call new " + t.inst_params[0].uri)
+    caller.expect(const.STATE_CALLING)
+
+    # Callee rings (180) but does not answer.
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 180")
+    caller.expect("SIP/2.0 180")
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Caller cancels before the call is answered -> CANCEL; both disconnect.
+    # Assert the CANCEL on the callee: it receives CANCEL before it
+    # disconnects, whereas on the caller the DISCONNECTED log precedes the
+    # outgoing CANCEL, so expecting CANCEL there would race the disconnect.
+    caller.send("call hangup")
+    callee.expect("CANCEL sip:")
+    caller.expect(const.STATE_DISCONNECTED)
+    callee.expect(const.STATE_DISCONNECTED)
+
+
+test_param = TestParam(
+        "Video call CANCEL (before answer)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/550_video_call_reinvite.py
+++ b/tests/pjsua/scripts-call/550_video_call_reinvite.py
@@ -1,0 +1,46 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call re-INVITE: put the call on hold, then resume it with a
+# re-INVITE and verify the video stream returns to Active on both ends.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.make_video_call(caller, callee, t.inst_params[0].uri)
+
+    # Hold, so the resume re-INVITE has an observable Active transition.
+    caller.send("call hold")
+    caller.expect(const.VID_MEDIA_LOCAL_HOLD)
+    callee.expect(const.VID_MEDIA_REMOTE_HOLD)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Resume via re-INVITE; the video stream goes back to Active on both.
+    caller.send("call reinvite")
+    caller.expect(const.VID_MEDIA_ACTIVE)
+    callee.expect(const.VID_MEDIA_ACTIVE)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call re-INVITE (resume from hold)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/550_video_call_reinvite.py
+++ b/tests/pjsua/scripts-call/550_video_call_reinvite.py
@@ -22,8 +22,12 @@ def test_func(t):
     caller.sync_stdout()
     callee.sync_stdout()
 
-    # Resume via re-INVITE; the video stream goes back to Active on both.
+    # Resume via re-INVITE. Assert the outgoing and incoming INVITE first,
+    # so a regression that resumed via UPDATE instead would be caught, then
+    # the video stream goes back to Active on both.
     caller.send("call reinvite")
+    caller.expect("INVITE sips?:")
+    callee.expect("INVITE sips?:")
     caller.expect(const.VID_MEDIA_ACTIVE)
     callee.expect(const.VID_MEDIA_ACTIVE)
 

--- a/tests/pjsua/scripts-call/560_video_call_update.py
+++ b/tests/pjsua/scripts-call/560_video_call_update.py
@@ -14,8 +14,12 @@ def test_func(t):
 
     vid.make_video_call(caller, callee, t.inst_params[0].uri)
 
-    # Caller sends UPDATE; both endpoints re-report the video stream Active.
+    # Caller sends UPDATE. Assert the outgoing and incoming UPDATE first,
+    # so a regression that used re-INVITE instead would be caught, then
+    # both endpoints re-report the video stream Active.
     caller.send("call update")
+    caller.expect("UPDATE sips?:")
+    callee.expect("UPDATE sips?:")
     caller.expect(const.VID_MEDIA_ACTIVE)
     callee.expect(const.VID_MEDIA_ACTIVE)
 

--- a/tests/pjsua/scripts-call/560_video_call_update.py
+++ b/tests/pjsua/scripts-call/560_video_call_update.py
@@ -1,0 +1,38 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call UPDATE: send an UPDATE on the established call and verify the
+# video stream stays Active (re-negotiated) on both ends.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.make_video_call(caller, callee, t.inst_params[0].uri)
+
+    # Caller sends UPDATE; both endpoints re-report the video stream Active.
+    caller.send("call update")
+    caller.expect(const.VID_MEDIA_ACTIVE)
+    callee.expect(const.VID_MEDIA_ACTIVE)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call UPDATE",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True


### PR DESCRIPTION
## Summary

Extends video call test coverage beyond the hold-initiating scenario (added in #5144) to five more call operations, reusing the shared `inc_vid` helpers. Each is a two-instance pjsua↔pjsua video call that runs headless (colorbar capture, null renderer) and skips cleanly on non-video builds via `has_video()`.

## New tests (`tests/pjsua/scripts-call/`)

| Scenario | File | What it verifies |
|----------|------|------------------|
| **hold: receiving** | `510_video_call_hold_recv.py` | Callee initiates hold → callee `Local hold`, caller `Remote hold` (mirror of the initiating test) |
| **double hold** | `520_video_call_hold_double.py` | Caller holds, then callee also holds → both video streams on hold |
| **BYE** | `530_video_call_bye.py` | Establish a video call, hang up → both endpoints disconnect |
| **CANCEL** | `540_video_call_cancel.py` | Cancel before answer → callee receives `CANCEL`, both disconnect |
| **re-INVITE** | `550_video_call_reinvite.py` | Hold then resume via re-INVITE → video returns to `Active` on both |
| **UPDATE** | `560_video_call_update.py` | Send UPDATE on the live call → video re-reports `Active` on both |

Also adds `inc_vid.hangup_call()` (BYE + disconnect verification), reused by the media-flow tests.

## Notes

- Directional hold states are asserted per-side (`VID_MEDIA_LOCAL_HOLD` / `VID_MEDIA_REMOTE_HOLD`) so a regression that swaps them is caught.
- CANCEL is asserted on the callee, which receives `CANCEL` before it disconnects — on the caller the `DISCONNECTED` log precedes the outgoing CANCEL, so asserting it there would race the disconnect.
- Auto-discovered by `runall.py`; runs in the video-enabled CI job and skips elsewhere.

## Testing

All six pass on macOS (H264 via VideoToolbox); the double-hold state trace was verified against the actual media-state logs. No workflow/build-system changes needed.

Depends on the helpers merged in #5144.

Co-Authored-By Claude Code