### PR TITLE
pjsua: retry registration without SIP outbound on 439 (PJSIP_SC_FIRST_HOP_LACKS_OUTBOUND_SUPPORT)

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua_internal.h
+++ b/pjsip/include/pjsua-lib/pjsua_internal.h
@@ -404,6 +404,12 @@ typedef struct pjsua_acc
     pj_str_t         rfc5626_instprm;/**< SIP outbound instance param.  */
     pj_str_t         rfc5626_regprm;/**< SIP outbound reg param.        */
     unsigned         rfc5626_flowtmr;/**< SIP outbound flow timer.      */
+    pj_bool_t        outbound_rejected;/**< First hop answered 439 to
+                                            outbound. Unlike
+                                            rfc5626_status this survives
+                                            destroy_regc(), so the
+                                            re-REGISTER is rebuilt
+                                            without outbound.           */
 
     unsigned         cred_cnt;      /**< Number of credentials.         */
     pjsip_cred_info  cred[PJSUA_ACC_MAX_PROXIES]; /**< Complete creds.  */

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -5003,6 +5003,13 @@ PJ_DEF(pj_status_t) pjsua_acc_set_transport( pjsua_acc_id acc_id,
     if (acc->cfg.transport_id == tp_id)
         return PJ_SUCCESS;
 
+    /* Moving the account to another transport may put it behind a different
+     * first hop, so a 439 recorded against the old one no longer applies.
+     * Applications can call this directly, without going through
+     * pjsua_acc_modify().
+     */
+    reset_outbound_rejection(acc);
+
     acc->cfg.transport_id = tp_id;
 
     if (acc->cfg.transport_id != PJSUA_INVALID_ID) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2940,6 +2940,8 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 {
 
     pjsua_acc *acc = (pjsua_acc*) param->token;
+    const pj_str_t tcp_param = pj_str(";transport=tcp");
+    const pj_str_t tls_param = pj_str(";transport=tls");
     pj_bool_t sent_outbound;
 
     PJSUA_LOCK();
@@ -2949,13 +2951,22 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
         return;
     }
 
-    /* Whether the REGISTER this callback reports on advertised SIP outbound.
-     * Captured up front because the failure paths below call destroy_regc(),
-     * which resets rfc5626_status. Needed to tell a 439 that rejects our
-     * outbound from one returned for an unrelated reason.
+    /* Whether the REGISTER this callback reports on could have advertised SIP
+     * outbound. Captured up front because destroy_regc() below clears
+     * acc->contact. Used to tell a 439 that rejects our outbound from one
+     * returned for an unrelated reason.
+     *
+     * This mirrors the test update_regc_contact() uses to decide whether to
+     * emit outbound at all. rfc5626_status is not usable here even if read
+     * before destroy_regc() resets it: update_rfc5626_status() drops it to
+     * OUTBOUND_NA on a 200 that omits "Require: outbound" -- the normal reply
+     * from a registrar without outbound support -- while the regc goes on
+     * sending the reg-id Contact and option tag it was initialised with, so a
+     * later 439 would be missed and the account left unregistered.
      */
-    sent_outbound = (acc->rfc5626_status == OUTBOUND_WANTED ||
-                     acc->rfc5626_status == OUTBOUND_ACTIVE);
+    sent_outbound = acc->cfg.use_rfc5626 &&
+                    (pj_stristr(&acc->contact, &tcp_param) != NULL ||
+                     pj_stristr(&acc->contact, &tls_param) != NULL);
 
     pj_log_push_indent();
 

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2940,6 +2940,7 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 {
 
     pjsua_acc *acc = (pjsua_acc*) param->token;
+    pj_bool_t sent_outbound;
 
     PJSUA_LOCK();
 
@@ -2947,6 +2948,14 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
         PJSUA_UNLOCK();
         return;
     }
+
+    /* Whether the REGISTER this callback reports on advertised SIP outbound.
+     * Captured up front because the failure paths below call destroy_regc(),
+     * which resets rfc5626_status. Needed to tell a 439 that rejects our
+     * outbound from one returned for an unrelated reason.
+     */
+    sent_outbound = (acc->rfc5626_status == OUTBOUND_WANTED ||
+                     acc->rfc5626_status == OUTBOUND_ACTIVE);
 
     pj_log_push_indent();
 
@@ -3159,9 +3168,15 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
      * next registration. cfg.use_rfc5626 is deliberately left untouched, so
      * the account's configured intent is preserved and outbound is tried
      * again once the path may have changed (see the resets of this flag).
+     *
+     * The sent_outbound check keeps this to requests that really did advertise
+     * outbound: use_rfc5626 may be enabled while update_regc_contact() still
+     * emits no reg-id, e.g. on a UDP account, and RFC 5626 section 6 permits
+     * a 439 only when reg-id and the outbound option tag were both present.
+     * A 439 to any other request is not ours to react to.
      */
     if (param->code == PJSIP_SC_FIRST_HOP_LACKS_OUTBOUND_SUPPORT &&
-        acc->cfg.use_rfc5626 && !acc->outbound_rejected)
+        acc->cfg.use_rfc5626 && !acc->outbound_rejected && sent_outbound)
     {
         PJ_LOG(3,(THIS_FILE, "Acc %d: first hop lacks outbound support, "
                              "will re-register without SIP outbound",

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3518,15 +3518,24 @@ static pj_status_t pjsua_regc_init(int acc_id)
         }
     }
 
-    /* If SIP outbound is used, add "Supported: outbound, path header".
-     * The outbound_rejected test is redundant while update_regc_contact()
-     * runs first and drives rfc5626_status to OUTBOUND_NA, but it keeps the
-     * option tag and the reg-id Contact param from ever disagreeing should
-     * that ordering change.
+    /* If SIP outbound is used, add "Supported: outbound, path" header.
+     *
+     * After a 439 only the "outbound" tag is withdrawn. "path" (RFC 3327) is
+     * a separate capability that the 439 says nothing about, and the edge
+     * proxy whose Path lacked an ";ob" parameter -- the very thing that
+     * provoked the 439 -- will keep inserting Path on the retry. RFC 3327
+     * section 5.3 recommends a registrar reject a REGISTER carrying Path from
+     * a UA that does not advertise "path" with 420 (Bad Extension), so
+     * dropping both tags together risks turning the 439 into a 420 with no
+     * further retry scheduled.
+     *
+     * Testing outbound_rejected rather than relying on rfc5626_status also
+     * keeps the option tag and the reg-id Contact parameter from disagreeing
+     * if the order in which they are decided ever changes.
      */
-    if ((acc->rfc5626_status == OUTBOUND_WANTED ||
-         acc->rfc5626_status == OUTBOUND_ACTIVE) &&
-        !acc->outbound_rejected)
+    if (acc->rfc5626_status == OUTBOUND_WANTED ||
+        acc->rfc5626_status == OUTBOUND_ACTIVE ||
+        acc->outbound_rejected)
     {
         pjsip_hdr hdr_list;
         pjsip_supported_hdr *hsup;
@@ -3535,9 +3544,14 @@ static pj_status_t pjsua_regc_init(int acc_id)
         hsup = pjsip_supported_hdr_create(pool);
         pj_list_push_back(&hdr_list, hsup);
 
-        hsup->count = 2;
-        hsup->values[0] = pj_str("outbound");
-        hsup->values[1] = pj_str("path");
+        if (acc->outbound_rejected) {
+            hsup->count = 1;
+            hsup->values[0] = pj_str("path");
+        } else {
+            hsup->count = 2;
+            hsup->values[0] = pj_str("outbound");
+            hsup->values[1] = pj_str("path");
+        }
 
         status = pjsip_regc_add_headers(acc->regc, &hdr_list);
         if (status != PJ_SUCCESS) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1897,19 +1897,19 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     /* Call hold type */
     acc->cfg.call_hold_type = cfg->call_hold_type;
 
+    /* Only forget a 439 when something determining the first hop, or what we
+     * advertise to it, actually changed: registrar URI, proxy, transport or
+     * the outbound settings. unreg_first is far broader -- credentials,
+     * custom headers, Contact parameters and the account ID all set it -- and
+     * offering outbound again to a hop already known to reject it would draw
+     * another 439, leaving the account unregistered where reg_retry_interval
+     * is 0.
+     */
+    if (first_hop_changed)
+        reset_outbound_rejection(acc);
+
     /* Unregister first */
     if (unreg_first) {
-        /* Only forget a 439 when something determining the first hop, or
-         * what we advertise to it, actually changed: registrar URI, proxy,
-         * transport or the outbound settings. unreg_first is far broader --
-         * credentials, custom headers, Contact parameters and the account ID
-         * all set it -- and retrying outbound against a hop already known to
-         * reject it would draw another 439, leaving the account unregistered
-         * again where reg_retry_interval is 0.
-         */
-        if (first_hop_changed)
-            reset_outbound_rejection(acc);
-
         if (acc->regc && !cfg->disable_reg_on_modify) {
             status = pjsua_acc_set_registration(acc->index, PJ_FALSE);
             if (status != PJ_SUCCESS) {

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -282,6 +282,21 @@ static void init_outbound_setting(pjsua_acc *acc)
     acc->rfc5626_status = OUTBOUND_WANTED;
 }
 
+/* Forget a 439 recorded against a first hop we may no longer be talking to.
+ *
+ * Clearing the flag alone would not re-enable outbound: the fallback left
+ * rfc5626_status at OUTBOUND_NA, and update_regc_contact() short-circuits on
+ * that, so the next Contact would be rebuilt without outbound anyway. Put the
+ * status back to UNKNOWN so it is decided afresh from the new path.
+ */
+static void reset_outbound_rejection(pjsua_acc *acc)
+{
+    if (acc->outbound_rejected && acc->rfc5626_status == OUTBOUND_NA)
+        acc->rfc5626_status = OUTBOUND_UNKNOWN;
+
+    acc->outbound_rejected = PJ_FALSE;
+}
+
 /*
  * Destroy account's registration and deinit.
  */
@@ -1776,12 +1791,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         if (acc->cfg.use_rfc5626 != cfg->use_rfc5626)
             acc->cfg.use_rfc5626 = cfg->use_rfc5626;
 
-        /* Outbound settings changed, so any previous 439 no longer
-         * describes what we would be sending. Try outbound again.
-         */
-        acc->outbound_rejected = PJ_FALSE;
-
-        if (pj_strcmp(&acc->cfg.rfc5626_instance_id, 
+        if (pj_strcmp(&acc->cfg.rfc5626_instance_id,
                       &cfg->rfc5626_instance_id)) 
         {
             pj_strdup_with_null(acc->pool, &acc->cfg.rfc5626_instance_id,
@@ -1883,6 +1893,13 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
     /* Unregister first */
     if (unreg_first) {
+        /* Something determining the first hop, or what we advertise to it,
+         * has changed -- registrar URI, proxy, transport or the outbound
+         * settings themselves. A 439 recorded against the old path says
+         * nothing about the new one.
+         */
+        reset_outbound_rejection(acc);
+
         if (acc->regc && !cfg->disable_reg_on_modify) {
             status = pjsua_acc_set_registration(acc->index, PJ_FALSE);
             if (status != PJ_SUCCESS) {
@@ -5432,7 +5449,7 @@ void pjsua_acc_on_tp_state_changed(pjsip_transport *tp,
             /* New transport means a possibly different first hop, so a
              * previous 439 no longer applies.
              */
-            acc->outbound_rejected = PJ_FALSE;
+            reset_outbound_rejection(acc);
 
             if (pjsua_var.acc[i].ip_change_op ==
                                             PJSUA_IP_CHANGE_OP_ACC_SHUTDOWN_TP)
@@ -5490,7 +5507,7 @@ pj_status_t pjsua_acc_update_contact_on_ip_change(pjsua_acc *acc)
     /* The IP change may have put us behind a different first hop, so give
      * SIP outbound another chance.
      */
-    acc->outbound_rejected = PJ_FALSE;
+    reset_outbound_rejection(acc);
 
     status = pjsua_acc_set_registration(acc->index, !need_unreg);
     if ((status != PJ_SUCCESS)

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3490,9 +3490,15 @@ static pj_status_t pjsua_regc_init(int acc_id)
         }
     }
 
-    /* If SIP outbound is used, add "Supported: outbound, path header" */
-    if (acc->rfc5626_status == OUTBOUND_WANTED ||
-        acc->rfc5626_status == OUTBOUND_ACTIVE)
+    /* If SIP outbound is used, add "Supported: outbound, path header".
+     * The outbound_rejected test is redundant while update_regc_contact()
+     * runs first and drives rfc5626_status to OUTBOUND_NA, but it keeps the
+     * option tag and the reg-id Contact param from ever disagreeing should
+     * that ordering change.
+     */
+    if ((acc->rfc5626_status == OUTBOUND_WANTED ||
+         acc->rfc5626_status == OUTBOUND_ACTIVE) &&
+        !acc->outbound_rejected)
     {
         pjsip_hdr hdr_list;
         pjsip_supported_hdr *hsup;

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -1245,6 +1245,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
     pj_str_t acc_proxy[PJSUA_ACC_MAX_PROXIES];
     pj_bool_t update_reg = PJ_FALSE;
     pj_bool_t unreg_first = PJ_FALSE;
+    pj_bool_t first_hop_changed = PJ_FALSE;
     pj_bool_t update_mwi = PJ_FALSE;
     pj_status_t status = PJ_SUCCESS;
     /* Server-affinity (#4964) snapshots: captured before config mutation
@@ -1427,6 +1428,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
+        first_hop_changed = PJ_TRUE;
     }
 
 
@@ -1572,6 +1574,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
+        first_hop_changed = PJ_TRUE;
     }
 
     /* Update keep-alive */
@@ -1640,6 +1643,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         acc->cfg.reg_use_proxy = cfg->reg_use_proxy;
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
+        first_hop_changed = PJ_TRUE;
     }
 
     /* Credential info */
@@ -1781,6 +1785,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         } 
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
+        first_hop_changed = PJ_TRUE;
     }
 
     /* SIP outbound setting */
@@ -1804,6 +1809,7 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         init_outbound_setting(acc);
         update_reg = PJ_TRUE;
         unreg_first = PJ_TRUE;
+        first_hop_changed = PJ_TRUE;
     }
 
     /* Video settings */
@@ -1893,12 +1899,16 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
 
     /* Unregister first */
     if (unreg_first) {
-        /* Something determining the first hop, or what we advertise to it,
-         * has changed -- registrar URI, proxy, transport or the outbound
-         * settings themselves. A 439 recorded against the old path says
-         * nothing about the new one.
+        /* Only forget a 439 when something determining the first hop, or
+         * what we advertise to it, actually changed: registrar URI, proxy,
+         * transport or the outbound settings. unreg_first is far broader --
+         * credentials, custom headers, Contact parameters and the account ID
+         * all set it -- and retrying outbound against a hop already known to
+         * reject it would draw another 439, leaving the account unregistered
+         * again where reg_retry_interval is 0.
          */
-        reset_outbound_rejection(acc);
+        if (first_hop_changed)
+            reset_outbound_rejection(acc);
 
         if (acc->regc && !cfg->disable_reg_on_modify) {
             status = pjsua_acc_set_registration(acc->index, PJ_FALSE);

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -536,6 +536,7 @@ static pj_status_t initialize_acc(unsigned acc_id)
     }
 
     acc->ip_change_op = PJSUA_IP_CHANGE_OP_NULL;
+    acc->outbound_rejected = PJ_FALSE;
 
     return PJ_SUCCESS;
 }
@@ -1775,6 +1776,11 @@ PJ_DEF(pj_status_t) pjsua_acc_modify( pjsua_acc_id acc_id,
         if (acc->cfg.use_rfc5626 != cfg->use_rfc5626)
             acc->cfg.use_rfc5626 = cfg->use_rfc5626;
 
+        /* Outbound settings changed, so any previous 439 no longer
+         * describes what we would be sending. Try outbound again.
+         */
+        acc->outbound_rejected = PJ_FALSE;
+
         if (pj_strcmp(&acc->cfg.rfc5626_instance_id, 
                       &cfg->rfc5626_instance_id)) 
         {
@@ -2107,6 +2113,10 @@ static void update_regc_contact(pjsua_acc *acc)
     const pj_str_t tls_param = pj_str(";transport=tls");
 
     if (!acc_cfg->use_rfc5626)
+        goto done;
+
+    /* The first hop answered 439 to outbound, so don't ask again. */
+    if (acc->outbound_rejected)
         goto done;
 
     /* Check if outbound has been requested and rejected */
@@ -2503,7 +2513,8 @@ static pj_bool_t acc_check_nat_addr(pjsua_acc *acc,
                                transport_param,
                                (int)acc->cfg.contact_uri_params.slen,
                                acc->cfg.contact_uri_params.ptr,
-                               (acc->cfg.use_rfc5626? ob: ""),
+                               ((acc->cfg.use_rfc5626 &&
+                                 !acc->outbound_rejected)? ob: ""),
                                (int)acc->cfg.contact_params.slen,
                                acc->cfg.contact_params.ptr);
         if (len < 1 || len >= PJSIP_MAX_URL_SIZE) {
@@ -3133,6 +3144,38 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
 
     /* Reaching this point means no contact rewrite, so reset the flag */
     acc->contact_rewritten = PJ_FALSE;
+
+    /* A 439 (PJSIP_SC_FIRST_HOP_LACKS_OUTBOUND_SUPPORT) means the first hop
+     * does not support SIP outbound (RFC 5626 section 6). Since use_rfc5626
+     * is enabled by default, resending the same REGISTER would only draw
+     * another 439 and the account would never register at all. Remember the
+     * rejection and re-register without outbound, as permitted by RFC 5626
+     * section 4.2.1.
+     *
+     * This needs its own flag rather than rfc5626_status: the failure path
+     * above has already called destroy_regc(), which resets rfc5626_status,
+     * and update_regc_contact() recomputes it from the Contact transport on
+     * every rebuild -- so a rejection recorded there cannot survive to the
+     * next registration. cfg.use_rfc5626 is deliberately left untouched, so
+     * the account's configured intent is preserved and outbound is tried
+     * again once the path may have changed (see the resets of this flag).
+     */
+    if (param->code == PJSIP_SC_FIRST_HOP_LACKS_OUTBOUND_SUPPORT &&
+        acc->cfg.use_rfc5626 && !acc->outbound_rejected)
+    {
+        PJ_LOG(3,(THIS_FILE, "Acc %d: first hop lacks outbound support, "
+                             "retrying registration without SIP outbound",
+                             acc->index));
+        acc->outbound_rejected = PJ_TRUE;
+
+        /* Note this is a no-op when reg_retry_interval is 0, i.e. the
+         * application has asked not to be retried on its behalf. The account
+         * is no longer stuck either way: the flag is set, so the
+         * application's own pjsua_acc_set_registration() now rebuilds the
+         * REGISTER without outbound and succeeds.
+         */
+        schedule_reregistration(acc);
+    }
 
     /* Check if we need to auto retry registration. Basically, registration
      * failure codes triggering auto-retry are those of temporal failures
@@ -4630,7 +4673,8 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uac_contact( pj_pool_t *pool,
                                      transport_param,
                                      (int)acc->cfg.contact_uri_params.slen,
                                      acc->cfg.contact_uri_params.ptr,
-                                     (acc->cfg.use_rfc5626? ob: ""),
+                                     ((acc->cfg.use_rfc5626 &&
+                                       !acc->outbound_rejected)? ob: ""),
                                      (int)acc->cfg.contact_params.slen,
                                      acc->cfg.contact_params.ptr);
     if (contact->slen < 1 || contact->slen >= (int)PJSIP_MAX_URL_SIZE)
@@ -5332,6 +5376,10 @@ void pjsua_acc_on_tp_state_changed(pjsip_transport *tp,
             if (acc->rfc5626_status == OUTBOUND_ACTIVE) {
                 acc->rfc5626_status = OUTBOUND_WANTED;
             }
+            /* New transport means a possibly different first hop, so a
+             * previous 439 no longer applies.
+             */
+            acc->outbound_rejected = PJ_FALSE;
 
             if (pjsua_var.acc[i].ip_change_op ==
                                             PJSUA_IP_CHANGE_OP_ACC_SHUTDOWN_TP)
@@ -5385,6 +5433,11 @@ pj_status_t pjsua_acc_update_contact_on_ip_change(pjsua_acc *acc)
 
     /* Prepare for contact rewrite */
     acc->contact_rewritten = PJ_FALSE;
+
+    /* The IP change may have put us behind a different first hop, so give
+     * SIP outbound another chance.
+     */
+    acc->outbound_rejected = PJ_FALSE;
 
     status = pjsua_acc_set_registration(acc->index, !need_unreg);
     if ((status != PJ_SUCCESS)

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -3164,17 +3164,30 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
         acc->cfg.use_rfc5626 && !acc->outbound_rejected)
     {
         PJ_LOG(3,(THIS_FILE, "Acc %d: first hop lacks outbound support, "
-                             "retrying registration without SIP outbound",
+                             "will re-register without SIP outbound",
                              acc->index));
         acc->outbound_rejected = PJ_TRUE;
 
-        /* Note this is a no-op when reg_retry_interval is 0, i.e. the
+        /* Recording the rejection is always right; driving a retry ourselves
+         * is not. An un-REGISTER also carries the outbound Contact params and
+         * can therefore be answered with 439, but retrying it as a REGISTER
+         * would bring an account the application asked to take offline back
+         * online. During an IP change the IP-change state machine owns
+         * registration, which is why the generic auto-retry below excludes
+         * that case too. The flag is set either way, so whoever registers
+         * next omits outbound.
+         *
+         * This is also a no-op when reg_retry_interval is 0, i.e. the
          * application has asked not to be retried on its behalf. The account
-         * is no longer stuck either way: the flag is set, so the
-         * application's own pjsua_acc_set_registration() now rebuilds the
-         * REGISTER without outbound and succeeds.
+         * is no longer stuck either way: the application's own
+         * pjsua_acc_set_registration() now rebuilds the REGISTER without
+         * outbound and succeeds.
          */
-        schedule_reregistration(acc);
+        if (!param->is_unreg &&
+            acc->ip_change_op != PJSUA_IP_CHANGE_OP_ACC_UPDATE_CONTACT)
+        {
+            schedule_reregistration(acc);
+        }
     }
 
     /* Check if we need to auto retry registration. Basically, registration
@@ -4618,6 +4631,14 @@ PJ_DEF(pj_status_t) pjsua_acc_create_uac_contact( pj_pool_t *pool,
     int secure;
     const char *beginquote, *endquote;
     char transport_param[32];
+    /* RFC 5626 section 2.1: in a Contact header field value the "ob" URI
+     * parameter indicates that the UA would like other requests in the same
+     * dialog to be routed over the same flow. This Contact is used for every
+     * outgoing UAC request of the account, not just REGISTER, so suppressing
+     * it after a 439 also drops it from dialog-forming requests -- which is
+     * the intent: a first hop that does not implement SIP outbound cannot
+     * honour the flow reuse "ob" asks for.
+     */
     const char *ob = ";ob";
 
     


### PR DESCRIPTION
Fixes #5146.

A 439 (`PJSIP_SC_FIRST_HOP_LACKS_OUTBOUND_SUPPORT`) response to REGISTER is handled nowhere: the account is left unregistered with no retry and no fallback, and every subsequent attempt — including a manual `pjsua_acc_set_registration()` — reproduces it. Handle it as RFC 5626 §4.2.1 permits, by re-registering without SIP outbound.

## Why this belongs in pjsua-lib rather than the application

**pjsua-lib turned the feature on.** `use_rfc5626` defaults to `PJ_TRUE`, so every TCP/TLS account emits `reg-id` plus the `outbound` option tag — exactly the combination §6 obliges a registrar to reject when the first hop is not outbound-aware. A library that enables a feature by default owns its failure mode.

**The degradation already exists here.** `update_rfc5626_status()` sets `OUTBOUND_NA` when a 2xx fails to confirm outbound support. "Stop asking when the path cannot do it" is established behaviour; 439 simply never reached it.

**The application-side workaround is poor.** Catch 439 in `on_reg_state`, then `pjsua_acc_modify()` with `use_rfc5626 = false`. That is an `unreg_first` field, so it tears down and re-establishes registration — not something to do mid-call. It also discards configured intent permanently: the application must then re-enable outbound itself on every network change, using signals it does not cleanly get. In-library the state is path-scoped and reset on transport/IP change, so a device that roams off a bad edge proxy regains outbound.

**And the symptom is hard to diagnose.** The status code is defined in `sip_msg.h`, given a phrase in `sip_msg.c`, and consumed nowhere; the field report is "registration fails forever with a status code nobody recognises".

## The change

A new internal `pj_bool_t outbound_rejected` on `struct pjsua_acc`, deliberately **not** cleared by `destroy_regc()`. `regc_cb()` sets it on a 439 and schedules a re-registration; the flag survives the teardown, so the rebuilt REGISTER omits outbound. `cfg.use_rfc5626` is left untouched, preserving configured intent.

`rfc5626_status` cannot carry this. `destroy_regc()` resets it and `pjsua_regc_init()` calls `destroy_regc()` itself, so a rejection recorded there is erased before it is read. Reading it *on entry* does not work either: `update_rfc5626_status()` drops it to `OUTBOUND_NA` on a 200 lacking `Require: outbound` — the normal reply from a registrar without outbound support — while the regc keeps sending the reg-id Contact it was initialised with. A 439 to any later refresh was then ignored. The trigger therefore mirrors the transport test `update_regc_contact()` itself uses, captured before `destroy_regc()` clears `acc->contact`.

The flag gates every site that emits outbound: `reg-id`/`+sip.instance` in `update_regc_contact()`, `;ob` in `pjsua_acc_create_uac_contact()` and in the `acc_check_nat_addr()` rebuild, and the option tag in `pjsua_regc_init()`.

**Only `outbound` is withdrawn, not `path`.** They share one `Supported` header but are independent capabilities, and the deployment that produces a 439 is one where an edge proxy inserts `Path` without an `;ob` parameter — it will keep inserting it on the retry. RFC 3327 §5.3 recommends a registrar reject a REGISTER carrying `Path` from a UA that does not advertise `path` with 420 (Bad Extension), which would trade a 439 for a 420 with no further retry. The retry emits `Supported: path` alone.

Recording the rejection and driving a retry are separated: the flag is always set, but `schedule_reregistration()` is skipped for an un-REGISTER (which carries the same params and can also draw a 439 — retrying it would re-register an account the application asked to take offline) and while an IP change is in progress, mirroring the exclusion the generic auto-retry block already makes.

The rejection describes a first hop, not an account, so `reset_outbound_rejection()` clears it wherever that hop may have changed: account init, `pjsua_acc_modify()`'s `unreg_first` branch (registrar URI, proxy, transport or outbound settings), transport change and IP change. It also lifts `rfc5626_status` out of `OUTBOUND_NA`, since `update_regc_contact()` short-circuits on that and clearing the flag alone would not actually re-enable outbound.

## Verification

No live 439-returning registrar was available, so three minimal registrars were written and each REGISTER inspected on the wire.

| Scenario | Result |
|---|---|
| TCP, 439 to any REGISTER advertising outbound | Retry drops `;ob`, `;reg-id`, `;+sip.instance` and the `outbound` tag, keeps `Supported: path`, accepted with 200 |
| UDP, 439 to everything | One REGISTER, no fallback — a UDP account never advertises outbound, so the 439 is non-conformant and ignored |
| TCP, 200 **without** `Require: outbound`, then 439 on the refresh | Fallback still fires and the account registers; this is what ruled out the `rfc5626_status` form, which left it unregistered |

The first REGISTER is byte-identical to unpatched behaviour: with no 439, `outbound_rejected` is always `PJ_FALSE` and every gate evaluates as before. All pjsip libraries rebuild clean under `-Wall`; `scripts-sipp/uas-auth` passes. `scripts-sipp/uas-register-ip-change` and `-port-only` fail identically with and without the patch — pre-existing, and both are already in `runall.py`'s `excluded_tests`.

## Not covered

No automated test. Reproducing a 439 needs a registrar that rejects outbound, and `tests/pjsua`'s SIPp harness is UDP-only (`mod_sipp.py` hardcodes the transport) while outbound applies only to TCP/TLS; `-m 1` also ends the scenario after one call, whereas the retry arrives on a new connection as a second call. Adding TCP support to the harness is a larger change to shared infrastructure than this fix warrants — happy to do it separately if wanted.

## Separate observation

`update_rfc5626_status()` sets `OUTBOUND_NA` and rewrites `acc->reg_contact`, but never calls `pjsip_regc_update_contact()`, so the regc keeps sending the reg-id Contact and the option tag while the account's own state says outbound is not in use. Not touched here. Happy to file it separately if you agree it is a bug.
