### PR TITLE
tests/pjsua: add video call tests (100rel/PRACK, transfer, 3xx redirect)

### DIFF
--- a/tests/pjsua/scripts-call/570_video_call_prack_callee.py
+++ b/tests/pjsua/scripts-call/570_video_call_prack_callee.py
@@ -1,0 +1,54 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call where the callee requires 100rel: the callee answers with a
+# reliable 180, so the caller must PRACK it before the call is answered
+# with 200. Verifies PRACK works on a video call.
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.setup_video_devices(caller)
+    vid.setup_video_devices(callee)
+
+    caller.send("call new " + t.inst_params[0].uri)
+    caller.expect(const.STATE_CALLING)
+
+    # Callee answers with a reliable 180 (100rel); the caller PRACKs it.
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 180")
+    caller.expect("SIP/2.0 180")
+    callee.expect("PRACK sips?:")
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Now answer with 200; the video stream negotiates Active on both ends.
+    callee.send("call answer 200")
+    caller.expect(const.VID_MEDIA_ACTIVE)
+    callee.expect(const.VID_MEDIA_ACTIVE)
+    caller.expect(const.STATE_CONFIRMED)
+    callee.expect(const.STATE_CONFIRMED)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call 100rel/PRACK (callee requires)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS + " --use-100rel"),
+            InstanceParam("caller", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/580_video_call_prack_caller.py
+++ b/tests/pjsua/scripts-call/580_video_call_prack_caller.py
@@ -1,0 +1,55 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Video call where the caller requires 100rel: the callee therefore sends
+# a reliable 180 and the caller PRACKs it before the call is answered with
+# 200. Verifies PRACK works on a video call (caller-initiated 100rel).
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    vid.setup_video_devices(caller)
+    vid.setup_video_devices(callee)
+
+    caller.send("call new " + t.inst_params[0].uri)
+    caller.expect(const.STATE_CALLING)
+
+    # Callee answers with a reliable 180 (the caller required 100rel); the
+    # caller PRACKs it.
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 180")
+    caller.expect("SIP/2.0 180")
+    callee.expect("PRACK sips?:")
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Now answer with 200; the video stream negotiates Active on both ends.
+    callee.send("call answer 200")
+    caller.expect(const.VID_MEDIA_ACTIVE)
+    callee.expect(const.VID_MEDIA_ACTIVE)
+    caller.expect(const.STATE_CONFIRMED)
+    callee.expect(const.STATE_CONFIRMED)
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    vid.hangup_call(caller, callee)
+
+
+test_param = TestParam(
+        "Video call 100rel/PRACK (caller requires)",
+        [
+            InstanceParam("callee", vid.VIDEO_ARGS),
+            InstanceParam("caller", vid.VIDEO_ARGS + " --use-100rel")
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/590_video_call_transfer_unattended.py
+++ b/tests/pjsua/scripts-call/590_video_call_transfer_unattended.py
@@ -1,0 +1,64 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Unattended (blind) video call transfer, pjsua<->pjsua<->pjsua:
+#   A calls B; B transfers A to C via REFER (no Replaces); A places a new
+#   video call to C. Exercises both the transferor (B, sends REFER and
+#   receives transfer-progress NOTIFY) and the transferee (A, follows the
+#   REFER and calls C) roles in one flow.
+#
+# --max-calls is raised because the transferee briefly holds two calls
+# (the original to B and the new one to C) during the transfer.
+XFER_ARGS = vid.VIDEO_ARGS + " --max-calls=4"
+
+
+def test_func(t):
+    a = t.process[0]    # caller -> transferee (receives REFER, calls C)
+    b = t.process[1]    # callee  -> transferor (sends REFER)
+    c = t.process[2]    # transfer target
+
+    # A calls B (sets up video devices on A and B).
+    vid.make_video_call(a, b, t.inst_params[1].uri)
+
+    # Prepare C's headless video devices before it receives the call.
+    vid.setup_video_devices(c)
+
+    # B transfers A to C (unattended REFER with Refer-To: <C>).
+    b.send("call transfer " + t.inst_params[2].uri)
+
+    # A follows the REFER and places a new video call to C.
+    a.expect(const.STATE_CALLING)
+    c.expect(const.EVENT_INCOMING_CALL)
+    c.send("call answer 200")
+
+    # The transferred call (A<->C) has an active video stream on both ends.
+    a.expect(const.VID_MEDIA_ACTIVE)
+    c.expect(const.VID_MEDIA_ACTIVE)
+
+    # The transferor sees the transfer succeed (via NOTIFY) and its
+    # original call to A is torn down.
+    b.expect("call transferred successfully")
+    b.expect(const.STATE_DISCONNECTED)
+
+    a.sync_stdout()
+    c.sync_stdout()
+
+    # Tear down the resulting A<->C call.
+    vid.hangup_call(a, c)
+
+
+test_param = TestParam(
+        "Video call unattended transfer",
+        [
+            InstanceParam("A", XFER_ARGS),
+            InstanceParam("B", XFER_ARGS),
+            InstanceParam("C", XFER_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/590_video_call_transfer_unattended.py
+++ b/tests/pjsua/scripts-call/590_video_call_transfer_unattended.py
@@ -46,8 +46,11 @@ def test_func(t):
     a.sync_stdout()
     c.sync_stdout()
 
-    # Tear down the resulting A<->C call.
-    vid.hangup_call(a, c)
+    # Tear down from C, which holds exactly the one A<->C call: until A has
+    # processed B's BYE for the original A<->B leg it still has two calls,
+    # and (telnet-mode sync_stdout() being a no-op) hanging up A's current
+    # call could target the wrong one.
+    vid.hangup_call(c, a)
 
 
 test_param = TestParam(

--- a/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
+++ b/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
@@ -1,4 +1,5 @@
 #
+import socket
 import inc_vid as vid
 import inc_const as const
 import inc_util as util
@@ -15,13 +16,28 @@ from inc_cfg import *
 XFER_ARGS = vid.VIDEO_ARGS + " --max-calls=4"
 
 # The attended-transfer Refer-To is derived from the replaced dialog's
-# remote AOR (the peer's account id / From URI), which pjsua reports
-# without a port, NOT from its Contact. With no registrar in this loopback
-# test that portless AOR resolves to the default SIP port (5060), so the
-# transferee's INVITE-with-Replaces only reaches the replaced party if it
-# is listening there. A (process[0]) is that replaced party, so pin it to
-# 5060; B and C keep auto-assigned ports.
+# remote AOR (the peer's account id / From URI), which pjsua emits WITHOUT
+# a port -- even if the account --id carries one -- and NOT from its
+# Contact. With no registrar in this loopback test that portless AOR
+# resolves to the default SIP port (5060), so the transferee's
+# INVITE-with-Replaces only reaches the replaced party if it listens
+# there. A (process[0]) is that replaced party, so pin it to 5060; B and C
+# keep auto-assigned ports.
 SIP_PORT_DEFAULT = 5060
+
+
+# An explicitly supplied sip_port bypasses InstanceParam's free-port probe,
+# so 5060 being already in use would make the test fail at startup rather
+# than skip. Probe it here and skip the test if it isn't available.
+def _port_available(port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.bind(("0.0.0.0", port))
+        return True
+    except socket.error:
+        return False
+    finally:
+        s.close()
 
 
 def test_func(t):
@@ -87,5 +103,5 @@ test_param = TestParam(
         func=test_func
         )
 
-if not util.has_video(G_EXE):
+if not util.has_video(G_EXE) or not _port_available(SIP_PORT_DEFAULT):
     test_param.skip = True

--- a/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
+++ b/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
@@ -28,11 +28,14 @@ SIP_PORT_DEFAULT = 5060
 
 # An explicitly supplied sip_port bypasses InstanceParam's free-port probe,
 # so 5060 being already in use would make the test fail at startup rather
-# than skip. Probe it here and skip the test if it isn't available.
+# than skip. Probe it here and skip the test if it isn't available. The
+# probe binds the loopback interface only (the whole test runs over
+# 127.0.0.1) rather than 0.0.0.0, to avoid exposing a socket on all
+# interfaces.
 def _port_available(port):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.bind(("0.0.0.0", port))
+        s.bind(("127.0.0.1", port))
         return True
     except socket.error:
         return False

--- a/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
+++ b/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
@@ -1,0 +1,91 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Attended video call transfer, pjsua<->pjsua<->pjsua (REFER with Replaces):
+#   A calls B; B holds A and makes a consultation call to C; B then
+#   transfers A to C with a REFER whose Refer-To carries a Replaces header,
+#   so A's new INVITE replaces B's call leg to C. Exercises the attended
+#   transferor (B) and transferee (A) roles in one flow.
+#
+# --max-calls is raised because the transferor (B) holds two calls (A and
+# C) during the consultation.
+XFER_ARGS = vid.VIDEO_ARGS + " --max-calls=4"
+
+# The attended-transfer Refer-To is derived from the replaced dialog's
+# remote AOR (the peer's account id / From URI), which pjsua reports
+# without a port, NOT from its Contact. With no registrar in this loopback
+# test that portless AOR resolves to the default SIP port (5060), so the
+# transferee's INVITE-with-Replaces only reaches the replaced party if it
+# is listening there. A (process[0]) is that replaced party, so pin it to
+# 5060; B and C keep auto-assigned ports.
+SIP_PORT_DEFAULT = 5060
+
+
+def test_func(t):
+    a = t.process[0]    # caller -> transferee
+    b = t.process[1]    # callee  -> transferor
+    c = t.process[2]    # transfer target
+
+    # A calls B.
+    vid.make_video_call(a, b, t.inst_params[1].uri)
+
+    # B holds A.
+    b.send("call hold")
+    a.expect(const.VID_MEDIA_HOLD)
+    b.expect(const.VID_MEDIA_HOLD)
+    a.sync_stdout()
+    b.sync_stdout()
+
+    # B makes a consultation call to C.
+    vid.setup_video_devices(c)
+    b.send("call new " + t.inst_params[2].uri)
+    b.expect(const.STATE_CALLING)
+    c.expect(const.EVENT_INCOMING_CALL)
+    c.send("call answer 200")
+    b.expect(const.VID_MEDIA_ACTIVE)
+    c.expect(const.VID_MEDIA_ACTIVE)
+    b.expect(const.STATE_CONFIRMED)
+    c.expect(const.STATE_CONFIRMED)
+    b.sync_stdout()
+    c.sync_stdout()
+
+    # Attended-transfer using the consultation call (C, call 1) as the
+    # current call: 'call transfer_replaces 0' sends a REFER to C whose
+    # Refer-To carries a Replaces of the B<->A dialog (call 0), so C's new
+    # INVITE replaces B's leg to A -- leaving A and C connected. We refer C
+    # (not A) because the CLI's call-id choice list only offers calls
+    # enumerated before the current one, so with C current the only valid
+    # destination is call 0 = A.
+    b.send("call transfer_replaces 0")
+    c.expect("Call .* is being transferred")
+    b.expect("Subscription state .* ACCEPTED")
+    c.expect(const.STATE_CALLING)
+    a.expect("Call .* is being replaced")
+    b.expect("call transferred successfully")
+
+    # The resulting A<->C call has an active video stream on both ends.
+    a.expect(const.VID_MEDIA_ACTIVE)
+    c.expect(const.VID_MEDIA_ACTIVE)
+    b.expect(const.STATE_DISCONNECTED)
+
+    a.sync_stdout()
+    c.sync_stdout()
+
+    vid.hangup_call(a, c)
+
+
+test_param = TestParam(
+        "Video call attended transfer",
+        [
+            InstanceParam("A", XFER_ARGS, sip_port=SIP_PORT_DEFAULT),
+            InstanceParam("B", XFER_ARGS),
+            InstanceParam("C", XFER_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
+++ b/tests/pjsua/scripts-call/600_video_call_transfer_attended.py
@@ -21,17 +21,21 @@ XFER_ARGS = vid.VIDEO_ARGS + " --max-calls=4"
 # Contact. With no registrar in this loopback test that portless AOR
 # resolves to the default SIP port (5060), so the transferee's
 # INVITE-with-Replaces only reaches the replaced party if it listens
-# there. A (process[0]) is that replaced party, so pin it to 5060; B and C
-# keep auto-assigned ports.
+# there. A (process[0]) is that replaced party, so pin it to 5060.
+#
+# A is also given --bound-addr=127.0.0.1 so its transport binds the
+# loopback interface only (not 0.0.0.0): this keeps the derived AOR on
+# 127.0.0.1 and makes A's actual listening socket match the loopback
+# free-port probe below (and avoids binding all interfaces). B and C keep
+# auto-assigned ports.
 SIP_PORT_DEFAULT = 5060
+A_ARGS = XFER_ARGS + " --bound-addr=127.0.0.1"
 
 
 # An explicitly supplied sip_port bypasses InstanceParam's free-port probe,
 # so 5060 being already in use would make the test fail at startup rather
-# than skip. Probe it here and skip the test if it isn't available. The
-# probe binds the loopback interface only (the whole test runs over
-# 127.0.0.1) rather than 0.0.0.0, to avoid exposing a socket on all
-# interfaces.
+# than skip. Probe it (on the same loopback interface A binds) and skip the
+# test if it isn't available.
 def _port_available(port):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
@@ -99,7 +103,7 @@ def test_func(t):
 test_param = TestParam(
         "Video call attended transfer",
         [
-            InstanceParam("A", XFER_ARGS, sip_port=SIP_PORT_DEFAULT),
+            InstanceParam("A", A_ARGS, sip_port=SIP_PORT_DEFAULT),
             InstanceParam("B", XFER_ARGS),
             InstanceParam("C", XFER_ARGS)
         ],

--- a/tests/pjsua/scripts-call/610_video_call_transfer_norefersub.py
+++ b/tests/pjsua/scripts-call/610_video_call_transfer_norefersub.py
@@ -36,8 +36,11 @@ def test_func(t):
     a.sync_stdout()
     c.sync_stdout()
 
-    # Tear down: the original A<->B call and the new A<->C call.
-    vid.hangup_call(a, c)
+    # Tear down from C, which has exactly one call (A<->C): with
+    # norefersub A may briefly still hold the original A<->B call, so
+    # hanging up from A's (ambiguous) current call would be unreliable.
+    vid.hangup_call(c, a)
+    # Best-effort cleanup of any residual leg on B.
     b.send("call hangup all")
 
 

--- a/tests/pjsua/scripts-call/610_video_call_transfer_norefersub.py
+++ b/tests/pjsua/scripts-call/610_video_call_transfer_norefersub.py
@@ -23,8 +23,14 @@ def test_func(t):
     # B transfers A to C; its REFER suppresses the subscription.
     b.send("call transfer " + t.inst_params[2].uri)
 
-    # A receives the REFER carrying Refer-Sub: false, then follows it to C.
+    # A receives the REFER carrying Refer-Sub: false...
     a.expect("Refer-Sub: *false")
+    # ...and B, seeing the suppression, terminates its transfer event
+    # subscription instead of keeping it for NOTIFYs. Asserting this proves
+    # the no-subscription behaviour, not merely that the header was sent.
+    b.expect("Xfer subscription suppressed")
+
+    # A follows the REFER to C.
     a.expect(const.STATE_CALLING)
     c.expect(const.EVENT_INCOMING_CALL)
     c.send("call answer 200")

--- a/tests/pjsua/scripts-call/610_video_call_transfer_norefersub.py
+++ b/tests/pjsua/scripts-call/610_video_call_transfer_norefersub.py
@@ -1,0 +1,55 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Unattended video call transfer with norefersub (RFC 4488): the transferor
+# (B) is started with --norefersub, so its REFER carries "Refer-Sub: false"
+# and the transferee (A) does not create the implicit REFER subscription
+# (no NOTIFY traffic). The transfer itself still completes: A places a new
+# video call to C.
+XFER_ARGS = vid.VIDEO_ARGS + " --max-calls=4"
+
+
+def test_func(t):
+    a = t.process[0]    # caller -> transferee
+    b = t.process[1]    # callee  -> transferor (started with --norefersub)
+    c = t.process[2]    # transfer target
+
+    vid.make_video_call(a, b, t.inst_params[1].uri)
+    vid.setup_video_devices(c)
+
+    # B transfers A to C; its REFER suppresses the subscription.
+    b.send("call transfer " + t.inst_params[2].uri)
+
+    # A receives the REFER carrying Refer-Sub: false, then follows it to C.
+    a.expect("Refer-Sub: *false")
+    a.expect(const.STATE_CALLING)
+    c.expect(const.EVENT_INCOMING_CALL)
+    c.send("call answer 200")
+
+    # The transferred call (A<->C) has an active video stream on both ends.
+    a.expect(const.VID_MEDIA_ACTIVE)
+    c.expect(const.VID_MEDIA_ACTIVE)
+
+    a.sync_stdout()
+    c.sync_stdout()
+
+    # Tear down: the original A<->B call and the new A<->C call.
+    vid.hangup_call(a, c)
+    b.send("call hangup all")
+
+
+test_param = TestParam(
+        "Video call unattended transfer (norefersub)",
+        [
+            InstanceParam("A", XFER_ARGS),
+            InstanceParam("B", XFER_ARGS + " --norefersub"),
+            InstanceParam("C", XFER_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/620_video_call_redirect.py
+++ b/tests/pjsua/scripts-call/620_video_call_redirect.py
@@ -1,0 +1,59 @@
+#
+import inc_vid as vid
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# 3xx redirection of a video call, pjsua<->pjsua<->pjsua:
+#   A calls B; B answers 302 Moved Temporarily with a Contact of C; A
+#   (default redirect handling = ACCEPT_REPLACE) automatically re-sends the
+#   INVITE to C, which answers 200. Verifies pjsua follows a 3xx redirect
+#   on a video call. The 302 Contact is C's full URI (with port), so no
+#   default-port pinning is needed here.
+
+
+def test_func(t):
+    a = t.process[0]    # caller (follows the redirect)
+    b = t.process[1]    # first callee, redirects to C with 302
+    c = t.process[2]    # redirect target
+
+    # A and C exchange the media; B only sends a 302 and needs no devices.
+    vid.setup_video_devices(a)
+    vid.setup_video_devices(c)
+
+    # A calls B.
+    a.send("call new " + t.inst_params[1].uri)
+    a.expect(const.STATE_CALLING)
+
+    # B redirects the call to C with 302 Moved Temporarily (Contact: <C>).
+    b.expect(const.EVENT_INCOMING_CALL)
+    b.send("call answer 302 " + t.inst_params[2].uri)
+
+    # A follows the redirect (default ACCEPT_REPLACE) and re-INVITEs C.
+    c.expect(const.EVENT_INCOMING_CALL)
+    c.send("call answer 200")
+
+    # The redirected call (A<->C) has an active video stream on both ends.
+    a.expect(const.VID_MEDIA_ACTIVE)
+    c.expect(const.VID_MEDIA_ACTIVE)
+    a.expect(const.STATE_CONFIRMED)
+    c.expect(const.STATE_CONFIRMED)
+
+    a.sync_stdout()
+    c.sync_stdout()
+
+    vid.hangup_call(a, c)
+
+
+test_param = TestParam(
+        "Video call 3xx redirect",
+        [
+            InstanceParam("A", vid.VIDEO_ARGS),
+            InstanceParam("B", vid.VIDEO_ARGS),
+            InstanceParam("C", vid.VIDEO_ARGS)
+        ],
+        func=test_func
+        )
+
+if not util.has_video(G_EXE):
+    test_param.skip = True


### PR DESCRIPTION
## Summary

Extends the pjsua↔pjsua **video** call coverage (built on the `inc_vid` helpers from #5144) to more signalling scenarios: 100rel/PRACK, call transfer (unattended + attended + norefersub), and 3xx redirection. All run headless (colorbar capture / null renderer) and skip on non-video builds via `has_video()`.

## New tests (`tests/pjsua/scripts-call/`)

| Scenario | File | What it verifies |
|----------|------|------------------|
| **100rel/PRACK (callee requires)** | `570_video_call_prack_callee.py` | callee answers a reliable 180, caller PRACKs, then 200 → active video |
| **100rel/PRACK (caller requires)** | `580_video_call_prack_caller.py` | caller requires 100rel; same reliable-180 + PRACK flow |
| **Unattended transfer** | `590_video_call_transfer_unattended.py` | 3 instances; B blind-transfers A to C (REFER, no Replaces); A video-calls C. Covers transferor **and** transferee |
| **Attended transfer** | `600_video_call_transfer_attended.py` | 3 instances; B consults C then REFER-with-Replaces; A and C end up connected with video |
| **Transfer w/ norefersub** | `610_video_call_transfer_norefersub.py` | `--norefersub` → REFER carries `Refer-Sub: false` (no subscription) and the transfer still completes |
| **3xx redirect** | `620_video_call_redirect.py` | B answers `302` with C's Contact; A follows the redirect (default ACCEPT_REPLACE) to C and negotiates video |

Since all parties are pjsua, each transfer test exercises the transferor, transferee, and target together.

## Notes for reviewers

- Transfer tests raise `--max-calls` (a party briefly holds two calls).
- **Attended transfer addressing**: the attended Refer-To is derived from the replaced dialog's remote **AOR** (which pjsua reports without a port), not its Contact. With no registrar in this loopback test that AOR resolves to the default SIP port, so the replaced party (A) is pinned to `5060` to be reachable. It also refers the *consultation* call because the sample-app CLI's call-id choice list only offers calls enumerated before the current one.
- No harness/helper changes — only new test files, reusing `inc_vid` (`make_video_call`, `setup_video_devices`, `hangup_call`, `VIDEO_ARGS`) and `has_video()`.

## Testing

All six pass locally on macOS (H264 via VideoToolbox); PRACK, REFER/Replaces, `Refer-Sub: false`, and 302-follow were each confirmed against the SIP traces. Auto-discovered by `runall.py`; runs in the video-enabled CI job, skips elsewhere.

Depends on the helpers merged in #5144 / #5152.

Co-Authored-By Claude Code