### PR TITLE
pjsua2: remove recorder/player conference port only once on destroy

### DIFF
--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -612,6 +612,8 @@ AudioMediaPlayer::~AudioMediaPlayer()
             else if (port->info.signature == PJMEDIA_SIG_PORT_WAV_PLAYLIST)
                 pjmedia_wav_playlist_set_eof_cb2(port, NULL, NULL);
         }
+        /* Let pjsua_player_destroy() remove the conference port */
+        id = PJSUA_INVALID_ID;
         PJSUA2_CATCH_IGNORE( unregisterMediaPort() );
         pjsua_player_destroy(playerId);
     }
@@ -755,6 +757,8 @@ AudioMediaRecorder::AudioMediaRecorder()
 AudioMediaRecorder::~AudioMediaRecorder()
 {
     if (recorderId != PJSUA_INVALID_ID) {
+        /* Let pjsua_recorder_destroy() remove the conference port */
+        id = PJSUA_INVALID_ID;
         PJSUA2_CATCH_IGNORE( unregisterMediaPort() );
         pjsua_recorder_destroy(recorderId);
     }


### PR DESCRIPTION
Fixes #5153

## Problem

`AudioMediaRecorder::~AudioMediaRecorder()` requests removal of the same conference port twice:

1. `unregisterMediaPort()` → `pjsua_conf_remove_port(id)`
2. `pjsua_recorder_destroy(recorderId)` → `pjsua_conf_remove_port(slot)` on the same slot

Since #5057/#5064 correctly reject operations on ports already flagged for removal, the second request fails and logs:

```
Add port 1 (/tmp/rec_test_out.wav) queued
Destroying recorder 0..
Removing new port 1 (/tmp/rec_test_out.wav) synchronously
Removed port 1, port count=1
Remove port 1 failed: Invalid value or argument (PJ_EINVAL)
```

The first removal succeeds, so this is harmless but noisy on every recorder/player teardown.

`AudioMediaPlayer::~AudioMediaPlayer()` has the identical pattern.

## Fix

Clear the conference port id before calling `unregisterMediaPort()`, so it only performs the PJSUA2 registry/pool cleanup and leaves port removal to `pjsua_recorder_destroy()` / `pjsua_player_destroy()`.

This is the same approach already used elsewhere in `media.cpp` — `DevAudioMedia::~DevAudioMedia()` and `ExtraAudioDevice::close()` both set `id = PJSUA_INVALID_ID` before `unregisterMediaPort()`.

`Endpoint::mediaRemove()` matches by object pointer, not by id, so clearing the id first does not affect registry cleanup.

## Verification

Test program creating and destroying an `AudioMediaRecorder` and an `AudioMediaPlayer` (null audio device, ASan build).

Before:

```
=== destroying recorder ===
Removing new port 1 (/tmp/rec_test_out.wav) synchronously
Removed port 1, port count=1
Remove port 1 failed: Invalid value or argument (PJ_EINVAL)
=== destroying player ===
Removing new port 1 (input.16.wav) synchronously
Removed port 1, port count=1
Remove port 1 failed: Invalid value or argument (PJ_EINVAL)
```

After:

```
=== destroying recorder ===
Removing new port 1 (/tmp/rec_test_out.wav) synchronously
Removed port 1, port count=1
=== destroying player ===
Removing new port 1 (input.16.wav) synchronously
Removed port 1, port count=1
```

Ports are still removed exactly once, port count returns to 0 at shutdown, and no ASan reports. Builds clean with `-Wall`.

Co-Authored-By Claude Code