### PR TITLE
tests/pjsua: add audio call tests (RTCP, RTCP XR, 3xx redirect)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -117,7 +117,13 @@ jobs:
     - name: install dependencies
       run: sudo apt-get update && sudo apt-get install -y swig sip-tester libopencore-amrnb-dev libopencore-amrwb-dev libvo-amrwbenc-dev
     - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+      # Enable RTCP XR so scripts-call/415_call_rtcp_xr.py runs instead of
+      # skipping (it skips unless PJMEDIA_HAS_RTCP_XR is compiled in; the
+      # test then activates XR per-call via pjsua's --rtcp-xr option).
+      run: |
+        cd pjlib/include/pj
+        cp config_site_test.h config_site.h
+        echo "#define PJMEDIA_HAS_RTCP_XR 1" >> config_site.h
     - name: configure
       run: CFLAGS="-g -fPIC -fsanitize=address" CXXFLAGS="-g -fPIC -fsanitize=address" LDFLAGS="-rdynamic -fsanitize=address" ./configure --enable-libwebrtc-aec3
     - name: make

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -151,7 +151,13 @@ jobs:
         unzip -o visqol.zip -d tests/pjsua/tools
         chmod +x tests/pjsua/tools/visqol
     - name: config site
-      run: cd pjlib/include/pj && cp config_site_test.h config_site.h
+      # Enable RTCP XR so scripts-call/415_call_rtcp_xr.py runs instead of
+      # skipping (it skips unless PJMEDIA_HAS_RTCP_XR is compiled in; the
+      # test then activates XR per-call via pjsua's --rtcp-xr option).
+      run: |
+        cd pjlib/include/pj
+        cp config_site_test.h config_site.h
+        echo "#define PJMEDIA_HAS_RTCP_XR 1" >> config_site.h
     - name: configure
       run: CFLAGS="-g $(pkg-config --cflags openssl) $(pkg-config --cflags opencore-amrnb) $(pkg-config --cflags opencore-amrwb) $(pkg-config --cflags vo-amrwbenc) -fPIC" LDFLAGS="$(pkg-config --libs-only-L openssl) $(pkg-config --libs-only-L opencore-amrnb) $(pkg-config --libs-only-L opencore-amrwb) $(pkg-config --libs-only-L vo-amrwbenc)" CXXFLAGS="-g -fPIC" ./configure
     - name: make

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -1968,6 +1968,7 @@ static pj_status_t app_init(void)
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
             acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
+            acc_cfg.enable_rtcp_xr = app_config.enable_rtcp_xr;
             pjsua_acc_modify(aid, &acc_cfg);
         }
 
@@ -2014,6 +2015,7 @@ static pj_status_t app_init(void)
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
             acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
+            acc_cfg.enable_rtcp_xr = app_config.enable_rtcp_xr;
             // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
             pjsua_acc_modify(aid, &acc_cfg);
         }
@@ -2051,6 +2053,7 @@ static pj_status_t app_init(void)
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
             acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
+            acc_cfg.enable_rtcp_xr = app_config.enable_rtcp_xr;
             pjsua_acc_modify(aid, &acc_cfg);
         }
 
@@ -2083,6 +2086,7 @@ static pj_status_t app_init(void)
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
             acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
+            acc_cfg.enable_rtcp_xr = app_config.enable_rtcp_xr;
             // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
             pjsua_acc_modify(aid, &acc_cfg);
         }
@@ -2124,6 +2128,7 @@ static pj_status_t app_init(void)
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
             acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
+            acc_cfg.enable_rtcp_xr = app_config.enable_rtcp_xr;
             pjsua_acc_modify(acc_id, &acc_cfg);
         }
 
@@ -2155,6 +2160,7 @@ static pj_status_t app_init(void)
             acc_cfg.txt_red_level = app_config.txt_red_level;
             acc_cfg.rtp_cfg = app_config.rtp_cfg;
             acc_cfg.enable_rtcp_mux = app_config.enable_rtcp_mux;
+            acc_cfg.enable_rtcp_xr = app_config.enable_rtcp_xr;
             // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
             pjsua_acc_modify(aid, &acc_cfg);
         }

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -86,6 +86,7 @@ typedef struct pjsua_app_config
     pjsua_transport_config  udp_cfg;
     pjsua_transport_config  rtp_cfg;
     pj_bool_t               enable_rtcp_mux;
+    pj_bool_t               enable_rtcp_xr;
     pjsip_redirect_op       redir_op;
     int                     srtp_keying;
 

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1844,7 +1844,11 @@ static void default_config()
     pjsua_transport_config_default(&cfg->rtp_cfg);
     cfg->rtp_cfg.port = 4000;
     cfg->enable_rtcp_mux = PJ_FALSE;
-    cfg->enable_rtcp_xr = PJ_FALSE;
+    /* Match pjsua_acc_config_default()'s macro-derived default so that
+     * applying this app-level fallback to transport-created local accounts
+     * doesn't override RTCP XR on builds that enable it by default. The
+     * --rtcp-xr option force-enables it regardless. */
+    cfg->enable_rtcp_xr = (PJMEDIA_HAS_RTCP_XR && PJMEDIA_STREAM_ENABLE_XR);
     cfg->redir_op = PJSIP_REDIRECT_ACCEPT_REPLACE;
     cfg->duration = PJSUA_APP_NO_LIMIT_DURATION;
     cfg->wav_id = PJSUA_INVALID_ID;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -221,8 +221,8 @@ static void usage(void)
     puts  ("  --turn-user         TURN username");
     puts  ("  --turn-passwd       TURN password");
     puts  ("  --rtcp-mux          Enable RTP & RTCP multiplexing (default: no)");
-    puts  ("  --rtcp-xr           Enable RTCP XR, extended reports (default: no,");
-    puts  ("                      requires PJMEDIA_HAS_RTCP_XR build option)");
+    puts  ("  --rtcp-xr           Enable RTCP XR, extended reports");
+    puts  ("                      (requires PJMEDIA_HAS_RTCP_XR build option)");
 #if defined(PJMEDIA_HAS_SRTP) && (PJMEDIA_HAS_SRTP != 0)
     puts  ("  --srtp-keying       SRTP keying method for outgoing SDP offer.");
     puts  ("                      0=SDES (default), 1=DTLS");
@@ -710,6 +710,12 @@ static pj_status_t parse_args(int argc, char *argv[],
             if (pj_log_get_level() < 3)
                 pj_log_set_level(3);
             pj_dump_config();
+            /* pj_dump_config() lives in pjlib and cannot report pjmedia
+             * build flags. Emit the ones the test suite probes for here so
+             * detection works regardless of static vs. shared linking
+             * (inc_util.has_rtcp_xr). */
+            PJ_LOG(3, (THIS_FILE, "PJMEDIA_HAS_RTCP_XR : %d",
+                       PJMEDIA_HAS_RTCP_XR));
             return PJ_EINVAL;
 
         case OPT_NULL_AUDIO:

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -221,6 +221,8 @@ static void usage(void)
     puts  ("  --turn-user         TURN username");
     puts  ("  --turn-passwd       TURN password");
     puts  ("  --rtcp-mux          Enable RTP & RTCP multiplexing (default: no)");
+    puts  ("  --rtcp-xr           Enable RTCP XR, extended reports (default: no,");
+    puts  ("                      requires PJMEDIA_HAS_RTCP_XR build option)");
 #if defined(PJMEDIA_HAS_SRTP) && (PJMEDIA_HAS_SRTP != 0)
     puts  ("  --srtp-keying       SRTP keying method for outgoing SDP offer.");
     puts  ("                      0=SDES (default), 1=DTLS");
@@ -409,7 +411,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_TURN_TLS_CA_FILE, OPT_TURN_TLS_CERT_FILE, 
            OPT_TURN_TLS_NEG_TIMEOUT, OPT_TURN_TLS_CIPHER,
            OPT_TURN_TLS_PRIV_FILE, OPT_TURN_TLS_PASSWORD,
-           OPT_RTCP_MUX, OPT_SRTP_KEYING,
+           OPT_RTCP_MUX, OPT_RTCP_XR, OPT_SRTP_KEYING,
            OPT_PLAY_FILE, OPT_PLAY_TONE, OPT_RTP_PORT, OPT_ADD_CODEC,
            OPT_ILBC_MODE, OPT_REC_FILE, OPT_AUTO_REC,
            OPT_COMPLEXITY, OPT_QUALITY, OPT_PTIME, OPT_NO_VAD,
@@ -526,6 +528,7 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "turn-user",  1, 0, OPT_TURN_USER},
         { "turn-passwd",1, 0, OPT_TURN_PASSWD},
         { "rtcp-mux",   0, 0, OPT_RTCP_MUX},
+        { "rtcp-xr",    0, 0, OPT_RTCP_XR},
 
 #if defined(PJMEDIA_HAS_SRTP) && (PJMEDIA_HAS_SRTP != 0)
         { "use-srtp",   1, 0, OPT_USE_SRTP},
@@ -1264,6 +1267,11 @@ static pj_status_t parse_args(int argc, char *argv[],
             cfg->enable_rtcp_mux = PJ_TRUE;
             break;
 
+        case OPT_RTCP_XR:
+            cur_acc->enable_rtcp_xr = PJ_TRUE;
+            cfg->enable_rtcp_xr = PJ_TRUE;
+            break;
+
 #if defined(PJMEDIA_HAS_SRTP) && (PJMEDIA_HAS_SRTP != 0)
         case OPT_USE_SRTP:
             app_config.cfg.use_srtp = my_atoi(pj_optarg);
@@ -1836,6 +1844,7 @@ static void default_config()
     pjsua_transport_config_default(&cfg->rtp_cfg);
     cfg->rtp_cfg.port = 4000;
     cfg->enable_rtcp_mux = PJ_FALSE;
+    cfg->enable_rtcp_xr = PJ_FALSE;
     cfg->redir_op = PJSIP_REDIRECT_ACCEPT_REPLACE;
     cfg->duration = PJSUA_APP_NO_LIMIT_DURATION;
     cfg->wav_id = PJSUA_INVALID_ID;
@@ -2173,6 +2182,9 @@ static void write_account_settings(int acc_index, pj_str_t *result)
 
     if (acc_cfg->enable_rtcp_mux)
         pj_strcat2(result, "--rtcp-mux\n");
+
+    if (acc_cfg->enable_rtcp_xr)
+        pj_strcat2(result, "--rtcp-xr\n");
 }
 
 /*
@@ -2249,6 +2261,9 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
      * write_account_settings(), so emit it here from the global flag. */
     if (config->acc_cnt == 0 && config->enable_rtcp_mux) {
         pj_strcat2(&cfg, "--rtcp-mux\n");
+    }
+    if (config->acc_cnt == 0 && config->enable_rtcp_xr) {
+        pj_strcat2(&cfg, "--rtcp-xr\n");
     }
 
     /* Message Composition Indication */

--- a/tests/pjsua/inc_util.py
+++ b/tests/pjsua/inc_util.py
@@ -21,10 +21,10 @@ def has_rtcp_xr(exe):
    open (returns True) so a genuinely XR-enabled build still runs.
 
    Note this only detects the build-time capability. XR must also be
-   enabled per stream at run-time (PJMEDIA_STREAM_ENABLE_XR, which pjsua
-   uses as the default for pjsua_media_config.enable_rtcp_xr); an XR build
-   normally sets both together. The test itself surfaces a clear error if
-   XR was compiled in but not enabled at run-time.
+   enabled per stream at run-time via pjsua_acc_config.enable_rtcp_xr,
+   whose default pjsua_acc_config_default() derives from the
+   PJMEDIA_STREAM_ENABLE_XR build setting; the 415 test enables it
+   explicitly with pjsua's --rtcp-xr option regardless of that default.
    """
    try:
       with open(exe.strip(), "rb") as f:

--- a/tests/pjsua/inc_util.py
+++ b/tests/pjsua/inc_util.py
@@ -6,19 +6,14 @@ def has_rtcp_xr(exe):
    """Return True if the pjsua build under test was compiled with RTCP XR
    (extended reports) support, i.e. PJMEDIA_HAS_RTCP_XR != 0.
 
-   RTCP XR is a compile-time option, off by default and -- unlike
-   PJ_HAS_SSL_SOCK -- not reported by pj_dump_config(), so "--version"
-   can't tell us. Instead we detect it structurally: the call-quality dump
-   prints an "Extended reports:" section, and that string literal is only
-   compiled into the binary when PJMEDIA_HAS_RTCP_XR is enabled. So scan
-   the pjsua executable for the marker.
-
-   'exe' is the executable path (inc_cfg.G_EXE). For a static build (the
-   default, and every CI build) the pjsua_dump.c object is linked into the
-   binary, so the marker -- if present -- is in the exe. A shared build
-   (--enable-shared) keeps it in libpjsua instead; there the scan won't
-   find it and the XR test is skipped rather than run. A read error fails
-   open (returns True) so a genuinely XR-enabled build still runs.
+   RTCP XR is a compile-time option, off by default. pj_dump_config()
+   (pjlib) can't report a pjmedia flag, so the pjsua app prints
+   "PJMEDIA_HAS_RTCP_XR : 0|1" in its "--version" output (alongside
+   pj_dump_config's own lines). We run "<exe> --version" and parse it --
+   the same approach as has_ssl_sock() below. Querying the running binary
+   works regardless of static vs. shared linking (the value is compiled
+   into the app itself), unlike scanning the executable for a string that
+   a shared build would keep in libpjsua.
 
    Note this only detects the build-time capability. XR must also be
    enabled per stream at run-time via pjsua_acc_config.enable_rtcp_xr,
@@ -27,10 +22,20 @@ def has_rtcp_xr(exe):
    explicitly with pjsua's --rtcp-xr option regardless of that default.
    """
    try:
-      with open(exe.strip(), "rb") as f:
-         return b"Extended reports:" in f.read()
-   except OSError:
-      return True
+      out = subprocess.check_output(exe + " --version", shell=True,
+                                     stderr=subprocess.STDOUT,
+                                     universal_newlines=True, timeout=10)
+   except (OSError, subprocess.CalledProcessError,
+           subprocess.TimeoutExpired) as e:
+      out = getattr(e, "output", "") or ""
+
+   m = re.search(r'PJMEDIA_HAS_RTCP_XR\s*:\s*(\d+)', out)
+   if m:
+      return m.group(1) != "0"
+   # No flag line (e.g. a pjsua too old to print it, or the probe couldn't
+   # run): RTCP XR is off in almost every build, so skip rather than run
+   # test 415 and have it fail spuriously on a build that lacks XR.
+   return False
 
 def has_ssl_sock(exe):
    """Return True if the pjsua build under test was configured with SSL

--- a/tests/pjsua/inc_util.py
+++ b/tests/pjsua/inc_util.py
@@ -2,6 +2,36 @@ import re
 import subprocess
 import sys
 
+def has_rtcp_xr(exe):
+   """Return True if the pjsua build under test was compiled with RTCP XR
+   (extended reports) support, i.e. PJMEDIA_HAS_RTCP_XR != 0.
+
+   RTCP XR is a compile-time option, off by default and -- unlike
+   PJ_HAS_SSL_SOCK -- not reported by pj_dump_config(), so "--version"
+   can't tell us. Instead we detect it structurally: the call-quality dump
+   prints an "Extended reports:" section, and that string literal is only
+   compiled into the binary when PJMEDIA_HAS_RTCP_XR is enabled. So scan
+   the pjsua executable for the marker.
+
+   'exe' is the executable path (inc_cfg.G_EXE). For a static build (the
+   default, and every CI build) the pjsua_dump.c object is linked into the
+   binary, so the marker -- if present -- is in the exe. A shared build
+   (--enable-shared) keeps it in libpjsua instead; there the scan won't
+   find it and the XR test is skipped rather than run. A read error fails
+   open (returns True) so a genuinely XR-enabled build still runs.
+
+   Note this only detects the build-time capability. XR must also be
+   enabled per stream at run-time (PJMEDIA_STREAM_ENABLE_XR, which pjsua
+   uses as the default for pjsua_media_config.enable_rtcp_xr); an XR build
+   normally sets both together. The test itself surfaces a clear error if
+   XR was compiled in but not enabled at run-time.
+   """
+   try:
+      with open(exe.strip(), "rb") as f:
+         return b"Extended reports:" in f.read()
+   except OSError:
+      return True
+
 def has_ssl_sock(exe):
    """Return True if the pjsua build under test was configured with SSL
    socket (TLS transport) support, i.e. PJ_HAS_SSL_SOCK is not 0.

--- a/tests/pjsua/scripts-call/410_call_rtcp.py
+++ b/tests/pjsua/scripts-call/410_call_rtcp.py
@@ -1,0 +1,70 @@
+#
+import time
+import inc_const as const
+from inc_cfg import *
+
+# Audio call RTCP support: once the call is up, the peer must send RTCP
+# reports for the audio stream. We verify this via the call-quality dump:
+# the audio stream's TX statistics' "last update" shows a time "ago" (not
+# "never") once an RTCP report from the peer has been received for that
+# stream.
+#
+# The default RTCP interval is ~5s (and jittered), so how soon the first
+# report arrives can vary on a loaded runner. Poll the dump with a bounded,
+# generous budget rather than assuming a fixed delay.
+POLL_ATTEMPTS = 15
+POLL_INTERVAL = 2
+
+
+def rtcp_received(ua):
+    ua.send("call dump_q")
+    ua.expect(r"#[0-9]+ audio")
+    line = ua.expect(r"TX .*last update:.*(ago|never)")
+    return "ago" in line
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    caller.send("call new " + t.inst_params[0].uri)
+    caller.expect(const.STATE_CALLING)
+
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 200")
+
+    caller.expect(const.MEDIA_ACTIVE)
+    callee.expect(const.MEDIA_ACTIVE)
+    caller.expect(const.STATE_CONFIRMED)
+    callee.expect(const.STATE_CONFIRMED)
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Poll until the caller has received the peer's RTCP for the audio
+    # stream (or fail if it never arrives within the budget).
+    got_rtcp = False
+    for attempt in range(POLL_ATTEMPTS):
+        if rtcp_received(caller):
+            got_rtcp = True
+            break
+        time.sleep(POLL_INTERVAL)
+    if not got_rtcp:
+        raise TestError("no RTCP received for the audio stream")
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    caller.send("call hangup")
+    callee.expect("BYE sips?:")
+    caller.expect(const.STATE_DISCONNECTED)
+    callee.expect(const.STATE_DISCONNECTED)
+
+
+test_param = TestParam(
+        "Audio call RTCP",
+        [
+            InstanceParam("callee", "--null-audio --max-calls=1 --no-tcp"),
+            InstanceParam("caller", "--null-audio --max-calls=1 --no-tcp")
+        ],
+        func=test_func
+        )

--- a/tests/pjsua/scripts-call/415_call_rtcp_xr.py
+++ b/tests/pjsua/scripts-call/415_call_rtcp_xr.py
@@ -1,0 +1,81 @@
+#
+import time
+import inc_const as const
+import inc_util as util
+from inc_cfg import *
+
+# Audio call RTCP XR (RFC 3611, extended reports) support: once the call
+# is up, pjsua exchanges RTCP XR blocks in addition to plain RTCP. We
+# verify this via the call-quality dump: an "Extended reports:" section
+# (with a Statistics Summary / VoIP metrics) is printed for the audio
+# stream only when RTCP XR is enabled and running on that stream.
+#
+# RTCP XR is a build option (PJMEDIA_HAS_RTCP_XR) that is off by default,
+# so this test skips unless the binary was compiled with it (see
+# util.has_rtcp_xr). Like plain RTCP, the reports are sent on the ~5s
+# (jittered) RTCP interval, so poll with a bounded, generous budget.
+POLL_ATTEMPTS = 15
+POLL_INTERVAL = 2
+
+
+def xr_reported(ua):
+    ua.send("call dump_q")
+    ua.expect(r"#[0-9]+ audio")
+    # The XR "Extended reports:" section follows the RX/TX stats within the
+    # same audio-stream block; it is printed only when RTCP XR is enabled
+    # on the stream. Absence just means "not yet / not enabled" -- don't
+    # raise, let the caller keep polling.
+    line = ua.expect(r"Extended reports:", raise_on_error=False, timeout=3)
+    return line is not None
+
+
+def test_func(t):
+    callee = t.process[0]
+    caller = t.process[1]
+
+    caller.send("call new " + t.inst_params[0].uri)
+    caller.expect(const.STATE_CALLING)
+
+    callee.expect(const.EVENT_INCOMING_CALL)
+    callee.send("call answer 200")
+
+    caller.expect(const.MEDIA_ACTIVE)
+    callee.expect(const.MEDIA_ACTIVE)
+    caller.expect(const.STATE_CONFIRMED)
+    callee.expect(const.STATE_CONFIRMED)
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    # Poll until the caller's quality dump shows the RTCP XR section for
+    # the audio stream.
+    got_xr = False
+    for attempt in range(POLL_ATTEMPTS):
+        if xr_reported(caller):
+            got_xr = True
+            break
+        time.sleep(POLL_INTERVAL)
+    if not got_xr:
+        raise TestError("no RTCP XR extended reports for the audio stream "
+                        "(RTCP XR compiled in but not enabled at run-time? "
+                        "see PJMEDIA_STREAM_ENABLE_XR)")
+
+    caller.sync_stdout()
+    callee.sync_stdout()
+
+    caller.send("call hangup")
+    callee.expect("BYE sips?:")
+    caller.expect(const.STATE_DISCONNECTED)
+    callee.expect(const.STATE_DISCONNECTED)
+
+
+test_param = TestParam(
+        "Audio call RTCP XR",
+        [
+            InstanceParam("callee", "--null-audio --max-calls=1 --no-tcp --rtcp-xr"),
+            InstanceParam("caller", "--null-audio --max-calls=1 --no-tcp --rtcp-xr")
+        ],
+        func=test_func
+        )
+
+if not util.has_rtcp_xr(G_EXE):
+    test_param.skip = True

--- a/tests/pjsua/scripts-call/415_call_rtcp_xr.py
+++ b/tests/pjsua/scripts-call/415_call_rtcp_xr.py
@@ -21,12 +21,18 @@ POLL_INTERVAL = 2
 def xr_reported(ua):
     ua.send("call dump_q")
     ua.expect(r"#[0-9]+ audio")
-    # The XR "Extended reports:" section follows the RX/TX stats within the
-    # same audio-stream block; it is printed only when RTCP XR is enabled
-    # on the stream. Absence just means "not yet / not enabled" -- don't
-    # raise, let the caller keep polling.
-    line = ua.expect(r"Extended reports:", raise_on_error=False, timeout=3)
-    return line is not None
+    # Two conditions must hold, in order, within the same audio-stream
+    # block. (1) The "Extended reports:" section is present -- printed only
+    # when RTCP XR is enabled on the stream. (2) The XR summary's "TX last
+    # update" shows a time "ago" (not "never"): the heading alone appears
+    # as soon as XR is enabled locally, so requiring the TX update proves a
+    # peer XR report was actually received, i.e. the XR exchange works.
+    # Absence of either just means "not yet" -- don't raise, keep polling.
+    if ua.expect(r"Extended reports:", raise_on_error=False, timeout=3) is None:
+        return False
+    line = ua.expect(r"TX last update: .*(ago|never)",
+                     raise_on_error=False, timeout=3)
+    return line is not None and "ago" in line
 
 
 def test_func(t):
@@ -46,7 +52,7 @@ def test_func(t):
     caller.sync_stdout()
     callee.sync_stdout()
 
-    # Poll until the caller's quality dump shows the RTCP XR section for
+    # Poll until the caller's quality dump shows a received XR report for
     # the audio stream.
     got_xr = False
     for attempt in range(POLL_ATTEMPTS):
@@ -55,7 +61,7 @@ def test_func(t):
             break
         time.sleep(POLL_INTERVAL)
     if not got_xr:
-        raise TestError("no RTCP XR extended reports for the audio stream "
+        raise TestError("no RTCP XR report received for the audio stream "
                         "(RTCP XR compiled in but not enabled at run-time? "
                         "see PJMEDIA_STREAM_ENABLE_XR)")
 

--- a/tests/pjsua/scripts-call/420_call_redirect.py
+++ b/tests/pjsua/scripts-call/420_call_redirect.py
@@ -1,0 +1,53 @@
+#
+import inc_const as const
+from inc_cfg import *
+
+# 3xx redirection of an audio call, pjsua<->pjsua<->pjsua:
+#   A calls B; B answers 302 Moved Temporarily with a Contact of C; A
+#   (default redirect handling = ACCEPT_REPLACE) automatically re-sends the
+#   INVITE to C, which answers 200. Verifies pjsua follows a 3xx redirect
+#   on an audio call. The 302 Contact is C's full URI (with port), so no
+#   default-port pinning is needed here.
+
+
+def test_func(t):
+    a = t.process[0]    # caller (follows the redirect)
+    b = t.process[1]    # first callee, redirects to C with 302
+    c = t.process[2]    # redirect target
+
+    # A calls B.
+    a.send("call new " + t.inst_params[1].uri)
+    a.expect(const.STATE_CALLING)
+
+    # B redirects the call to C with 302 Moved Temporarily (Contact: <C>).
+    b.expect(const.EVENT_INCOMING_CALL)
+    b.send("call answer 302 " + t.inst_params[2].uri)
+
+    # A follows the redirect (default ACCEPT_REPLACE) and re-INVITEs C.
+    c.expect(const.EVENT_INCOMING_CALL)
+    c.send("call answer 200")
+
+    # The redirected call (A<->C) has an active audio stream on both ends.
+    a.expect(const.MEDIA_ACTIVE)
+    c.expect(const.MEDIA_ACTIVE)
+    a.expect(const.STATE_CONFIRMED)
+    c.expect(const.STATE_CONFIRMED)
+
+    a.sync_stdout()
+    c.sync_stdout()
+
+    a.send("call hangup")
+    c.expect("BYE sips?:")
+    a.expect(const.STATE_DISCONNECTED)
+    c.expect(const.STATE_DISCONNECTED)
+
+
+test_param = TestParam(
+        "Audio call 3xx redirect",
+        [
+            InstanceParam("A", "--null-audio --max-calls=1 --no-tcp"),
+            InstanceParam("B", "--null-audio --max-calls=1 --no-tcp"),
+            InstanceParam("C", "--null-audio --max-calls=1 --no-tcp")
+        ],
+        func=test_func
+        )


### PR DESCRIPTION
## Summary

Extends the pjsua↔pjsua **audio** call coverage with three signalling/media scenarios, complementing the **video** equivalents merged in #5155 / #5157. All run headless (`--null-audio`) and are auto-discovered by `runall.py` (`mod_call.py`).

## New tests (`tests/pjsua/scripts-call/`)

| Scenario | File | What it verifies |
|----------|------|------------------|
| **RTCP** | `410_call_rtcp.py` | After one RTCP interval, `call dump_q` shows the audio stream's TX stats with a `last update ... ago` (not `never`) — i.e. an RTCP report from the peer was received for the audio media |
| **RTCP XR** | `415_call_rtcp_xr.py` | The `Extended reports:` (RFC 3611 VoIP-metrics) section appears in `call dump_q` for the audio stream — i.e. RTCP XR was negotiated (`a=rtcp-xr`) and is running |
| **3xx redirect** | `420_call_redirect.py` | B answers `302` with C's Contact; A follows the redirect (default `ACCEPT_REPLACE`) to C and negotiates audio. 3 instances, so transferor/target are covered together |

## pjsua sample-app change: `--rtcp-xr`

RTCP XR could not be exercised from the stock pjsua app — `pjsua_acc_config_default()` zero-inits `enable_rtcp_xr` and never inherits the media-config default, and there was no CLI knob (this is likely why #5157 covered RTCP but not RTCP XR). This PR adds a `--rtcp-xr` option that mirrors `--rtcp-mux` exactly (help, enum, long-option, parser, default reset, applied to local accounts, config-file serialization) and enables RTCP XR on the account. `415` uses it.

## CI

RTCP XR is a build option (`PJMEDIA_HAS_RTCP_XR`, off by default), so `415` skips unless the binary was compiled with it — detected by a new `inc_util.has_rtcp_xr()` that scans the executable for the `"Extended reports:"` marker (XR isn't reported by `pj_dump_config()`/`--version`). To make `415` actually execute, this PR enables `PJMEDIA_HAS_RTCP_XR` in two existing `make pjsua-test` jobs — **Default / pjsua** (Linux) and **Default / pjsua-test** (Mac) — by appending the define to `config_site.h`. Other jobs keep the default (no XR), where `415` continues to skip.

## Notes for reviewers

- **RTCP / RTCP XR**: reports are sent on the ~5s (jittered) RTCP interval, so both tests poll `dump_q` with a bounded, generous budget rather than a fixed sleep.
- No harness changes beyond the `has_rtcp_xr()` helper; no source files added, so no Makefile/vcxproj/CMake updates needed.

## Testing

On macOS: `410` and `420` pass on a default build; `415` skips. Rebuilt with `PJMEDIA_HAS_RTCP_XR=1`, `415` passes (`a=rtcp-xr` negotiated, `Extended reports:` shown). `make -j3` clean.

Co-Authored-By Claude Code