### PR TITLE
fix(pjmedia): use packets[0].timestamp instead of packets[i].timestamp

### DIFF
--- a/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
+++ b/pjmedia/src/pjmedia-codec/ffmpeg_vid_codecs.c
@@ -2061,7 +2061,7 @@ static pj_status_t ffmpeg_codec_decode( pjmedia_vid_codec *codec,
 
         whole_frm.buf = ff->dec_buf;
         whole_frm.size = whole_len;
-        whole_frm.timestamp = output->timestamp = packets[i].timestamp;
+        whole_frm.timestamp = output->timestamp = packets[0].timestamp;
         whole_frm.bit_info = 0;
 
         return ffmpeg_codec_decode_whole(codec, &whole_frm, out_size, output);


### PR DESCRIPTION
The pkt_count in each whole_frm is inconsistent. When using packets[i].timestamp, if the previous frame has a larger pkt_count than the current frame, it would incorrectly return the timestamp from the previous frame.

Use packets[0].timestamp to ensure we always get the timestamp of the first packet in the current frame.