### PR TITLE
Keep TCP/TLS transport factory registered when listener restart fails

### DIFF
--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1843,18 +1843,26 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_lis_start(pjsip_tpfactory *factory,
                                   pjsip_endpt_get_ioqueue(listener->endpt),
                                   &listener_cb, listener,
                                   &listener->asock);
+    if (status != PJ_SUCCESS)
+        goto on_error;
 
     /* Start pending accept() operations */
     status = pj_activesock_start_accept(listener->asock,
                                         listener->factory.pool);
+    if (status != PJ_SUCCESS)
+        goto on_error;
 
     update_transport_info(listener);
 
-    return status;
+    return PJ_SUCCESS;
 
 on_error:
-    if (listener->asock == NULL && sock != PJ_INVALID_SOCKET)
+    if (listener->asock) {
+        pj_activesock_close(listener->asock);
+        listener->asock = NULL;
+    } else if (sock != PJ_INVALID_SOCKET) {
         pj_sock_close(sock);
+    }
 
     return status;
 }

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1883,23 +1883,20 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_restart(pjsip_tpfactory *factory,
        return PJ_SUCCESS;
     }
 
-    lis_close(listener);
+    /* Close the listener socket only; keep the factory registered so it
+     * stays usable for outgoing transports if the restart below fails.
+     */
+    pj_activesock_close(listener->asock);
+    listener->asock = NULL;
 
     status = pjsip_tcp_transport_lis_start(factory, local, a_name);
-    if (status != PJ_SUCCESS) { 
+    if (status != PJ_SUCCESS) {
         tcp_perror(listener->factory.obj_name,
                    "Unable to start listener after closing it", status);
 
-        return status;
-    }
-
-    status = pjsip_tpmgr_register_tpfactory(listener->tpmgr,
-                                            &listener->factory);
-    if (status != PJ_SUCCESS) {
-        tcp_perror(listener->factory.obj_name,
-                   "Unable to register the transport listener", status);
-    } else {
-        listener->is_registered = PJ_TRUE;
+        /* Update the published address anyway (client only) */
+        update_factory_addr(listener, a_name);
+        update_transport_info(listener);
     }
 
     return status;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -546,13 +546,16 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
                             &newsock_param);
 
     if (status == PJ_SUCCESS || status == PJ_EPENDING) {
-        pj_ssl_sock_info info;  
+        pj_ssl_sock_info info;
 
         /* Retrieve the bound address */
         status = pj_ssl_sock_get_info(listener->ssock, &info);
         if (status == PJ_SUCCESS)
             pj_sockaddr_cp(listener_addr, (pj_sockaddr_t*)&info.local_addr);
 
+    } else {
+        /* Don't let update_factory_addr() below overwrite the error */
+        return status;
     }
     status = update_factory_addr(listener, a_name);
     if (status != PJ_SUCCESS)
@@ -833,7 +836,11 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
        return PJ_SUCCESS;
     }
 
-    lis_close(listener);
+    /* Close the listener socket only; keep the factory registered so it
+     * stays usable for outgoing transports if the restart below fails.
+     */
+    pj_ssl_sock_close(listener->ssock);
+    listener->ssock = NULL;
 
     /* Update TLS settings if provided */
     if (opt) {
@@ -899,23 +906,14 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
     }
 
     status = pjsip_tls_transport_lis_start(factory, local, a_name);
-    if (status != PJ_SUCCESS) { 
-        tls_perror(listener->factory.obj_name, 
-                   "Unable to start listener after closing it", status, NULL);
-
-        return status;
-    }
-    
-    status = pjsip_tpmgr_register_tpfactory(listener->tpmgr,
-                                            &listener->factory);
     if (status != PJ_SUCCESS) {
         tls_perror(listener->factory.obj_name,
-                    "Unable to register the transport listener", status, NULL);
+                   "Unable to start listener after closing it", status, NULL);
 
-        listener->is_registered = PJ_FALSE;     
-    } else {
-        listener->is_registered = PJ_TRUE;      
-    }    
+        /* Update the published address anyway (client only) */
+        update_factory_addr(listener, a_name);
+        update_transport_info(listener);
+    }
 
     return status;
 }

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -529,8 +529,11 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
     if (listener->cert) {
         status = pj_ssl_sock_set_certificate(listener->ssock, 
                                        listener->factory.pool, listener->cert);
-        if (status != PJ_SUCCESS)
+        if (status != PJ_SUCCESS) {
+            pj_ssl_sock_close(listener->ssock);
+            listener->ssock = NULL;
             return status;
+        }
     }
 
     /* Start accepting incoming connections. Note that some TLS/SSL
@@ -554,7 +557,11 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
             pj_sockaddr_cp(listener_addr, (pj_sockaddr_t*)&info.local_addr);
 
     } else {
-        /* Don't let update_factory_addr() below overwrite the error */
+        /* Close the failed listener and report the error (don't let
+         * update_factory_addr() below overwrite it).
+         */
+        pj_ssl_sock_close(listener->ssock);
+        listener->ssock = NULL;
         return status;
     }
     status = update_factory_addr(listener, a_name);

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -147,6 +147,90 @@ static pj_status_t multi_listener_test(pjsip_tpfactory *factory[],
     return PJ_SUCCESS;
 }
 
+/*
+ * Test that a failed listener restart does not unregister the factory
+ * from the transport manager: occupy a port with a plain listening
+ * socket, restart the listener to that port (the bind fails with
+ * "address in use"), then verify that the factory is still usable
+ * for creating outgoing transports.
+ */
+static int restart_failure_test(void)
+{
+    pjsip_tpfactory *tpfactory = NULL;
+    pjsip_transport *tcp = NULL;
+    pj_sock_t blocker = PJ_INVALID_SOCKET;
+    pj_sockaddr_in blocker_addr;
+    pj_sockaddr restart_addr;
+    pj_sockaddr_in rem_addr;
+    pj_str_t localhost = pj_str("127.0.0.1");
+    pjsip_tpselector tp_sel;
+    int addr_len = sizeof(blocker_addr);
+    pj_status_t status;
+    int ret = 0;
+
+    /* Start TCP listener on arbitrary port. */
+    status = pjsip_tcp_transport_start(endpt, NULL, 1, &tpfactory);
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to start TCP transport", status);
+        return -110;
+    }
+
+    /* Occupy a port with a plain listening socket. */
+    status = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0, &blocker);
+    if (status != PJ_SUCCESS) {
+        ret = -111;
+        goto on_return;
+    }
+    pj_sockaddr_in_init(&blocker_addr, &localhost, 0);
+    status = pj_sock_bind(blocker, &blocker_addr, sizeof(blocker_addr));
+    if (status == PJ_SUCCESS)
+        status = pj_sock_getsockname(blocker, &blocker_addr, &addr_len);
+    if (status == PJ_SUCCESS)
+        status = pj_sock_listen(blocker, 5);
+    if (status != PJ_SUCCESS) {
+        ret = -112;
+        goto on_return;
+    }
+
+    /* Restart the listener to the occupied port, this must fail. */
+    pj_sockaddr_init(pj_AF_INET(), &restart_addr, &localhost,
+                     pj_ntohs(blocker_addr.sin_port));
+    status = pjsip_tcp_transport_restart(tpfactory, &restart_addr, NULL);
+    if (status == PJ_SUCCESS) {
+        PJ_LOG(3,(THIS_FILE, "   restart to an occupied port unexpectedly "
+                             "succeeded, skipping"));
+        goto on_return;
+    }
+
+    /* The factory must still be registered to the transport manager and
+     * usable for outgoing transports; connect to the blocker socket.
+     */
+    pj_bzero(&tp_sel, sizeof(tp_sel));
+    tp_sel.type = PJSIP_TPSELECTOR_LISTENER;
+    tp_sel.u.listener = tpfactory;
+    pj_sockaddr_in_init(&rem_addr, &localhost,
+                        pj_ntohs(blocker_addr.sin_port));
+    status = pjsip_endpt_acquire_transport(endpt, PJSIP_TRANSPORT_TCP,
+                                           &rem_addr, sizeof(rem_addr),
+                                           &tp_sel, &tcp);
+    if (status != PJ_SUCCESS || tcp == NULL) {
+        app_perror("   Error: factory unusable after failed restart", status);
+        ret = -113;
+        goto on_return;
+    }
+
+    pjsip_transport_dec_ref(tcp);
+    pjsip_transport_destroy(tcp);
+
+on_return:
+    if (blocker != PJ_INVALID_SOCKET)
+        pj_sock_close(blocker);
+    if (tpfactory)
+        (*tpfactory->destroy)(tpfactory);
+    flush_events(500);
+    return ret;
+}
+
 int transport_tcp_test(void)
 {
     enum { SEND_RECV_LOOP = 8 };
@@ -163,6 +247,10 @@ int transport_tcp_test(void)
     unsigned i;
     unsigned num_listener = NUM_LISTENER;
     unsigned num_tp = NUM_TP;
+
+    status = restart_failure_test();
+    if (status != 0)
+        return status;
 
     status = multi_listener_test(tpfactory, num_listener, tcp, &num_tp);
     if (status != PJ_SUCCESS)

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -222,6 +222,30 @@ static int restart_failure_test(void)
     pjsip_transport_dec_ref(tcp);
     pjsip_transport_destroy(tcp);
 
+    /* The listener can be started again once the port is free. */
+    pj_sock_close(blocker);
+    blocker = PJ_INVALID_SOCKET;
+    status = pjsip_tcp_transport_lis_start(tpfactory, &restart_addr, NULL);
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to start listener after failed restart",
+                   status);
+        ret = -114;
+        goto on_return;
+    }
+
+    /* Verify the listener really accepts connections. */
+    status = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0, &blocker);
+    if (status == PJ_SUCCESS) {
+        pj_sockaddr_in_init(&rem_addr, &localhost,
+                            (pj_uint16_t)tpfactory->addr_name.port);
+        status = pj_sock_connect(blocker, &rem_addr, sizeof(rem_addr));
+    }
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: restarted listener does not accept", status);
+        ret = -115;
+        goto on_return;
+    }
+
 on_return:
     if (blocker != PJ_INVALID_SOCKET)
         pj_sock_close(blocker);


### PR DESCRIPTION

## Problem

After an IP change, restarting a TCP or TLS listener can fail, typically with "Address already in use" while sockets of the old transports are still lingering. When this happens, the transport factory is left permanently unregistered from the transport manager, and the automatic restart retry reports success without restoring it.

From that point on everything that needs the factory fails with PJ_ENOTFOUND until the application restarts the library: creating outgoing transports, resolving the local address for Via/Contact, and any account bound to the transport via `transport_id`, for both REGISTER and INVITE.

## Log

Android device, pjsua2, network change while the app is running:

```
15:27:17.193           pjsua_core.c  IP change shutting down transports..
15:27:17.197             tcptp:7476  Unable to start listener after closing it: [code=120098]: Address already in use
15:27:17.198           pjsua_core.c  Listener tcp 192.168.1.6:7476 restart: Address already in use
15:27:17.198           pjsua_core.c  Retry listener tcp 192.168.1.6:7476 restart in 10 ms
15:27:17.210             tcptp:7476  TCP restart requested while no listener created, update the published address only
15:27:17.213           pjsua_core.c  Listener tcp 192.168.1.6:7476 restart: Success
```

UDP hit the same transient error and recovered on its retry; TCP reported success but the factory was gone. Any account bound to this transport is dead from here on:

```
15:31:01.053            pjsua_acc.c  .Acc 1: setting registration..
15:31:01.057        sip_transport.c  ...Specified factory for creating transport is not found
15:31:01.058              sip_reg.c  ..Error sending request: Not found (PJ_ENOTFOUND)
15:31:01.058            pjsua_acc.c  .....SIP registration failed, status=503 (Not found (PJ_ENOTFOUND))
```

Outgoing INVITEs fail the same way. Accounts on UDP keep working, which makes the failure look account-specific.

## Details

`pjsip_tcp_transport_restart()` and `pjsip_tls_transport_restart2()` call `lis_close()`, which unregisters the factory from the transport manager, before starting the new listener. If `lis_start()` fails, the function returns with the factory unregistered and nothing ever registers it back. The subsequent retry takes the "restart requested while no listener created, update the published address only" branch and returns PJ_SUCCESS, masking the failure.

The fix makes restart close only the listener socket and keep the factory registered the whole time. Factory registration belongs to the factory lifecycle (`pjsip_tcp_transport_start3()` / `lis_destroy()`), and a registered factory without a listener socket is already a supported state (`PJSIP_TCP_TRANSPORT_DONT_CREATE_LISTENER`, "client only"). This also mirrors UDP restart, which keeps the transport registered while its socket is replaced. On listener start failure the published address is still updated and the error is returned to the caller; the factory remains usable for outgoing transports. A side effect is that the transient window during a successful restart, in which the factory was missing from the transport manager, is gone as well.

The patch also fixes the TLS half of the same scenario: `pjsip_tls_transport_lis_start()` overwrote the `pj_ssl_sock_start_accept2()` error with the `update_factory_addr()` status, so a failed TLS re-bind reported PJ_SUCCESS and logged "SIP TLS listener is ready for incoming connections" while no listener existed. The error is now returned and the half-open socket is closed, so the factory is left genuinely client-only (the same cleanup applies to TCP and to the certificate-load path). Note this also makes `pjsip_tls_transport_start2()` fail on an occupied port instead of silently creating a transport with a dead listener, consistent with TCP.

A regression test is added: occupy a port with a plain listening socket, restart the TCP listener onto it (the bind fails), then verify the factory is still usable for creating an outgoing transport via an explicit transport selector. On current master the test fails with PJ_ENOTFOUND; with the patch it passes.

Known limitation, unchanged from the existing "no listener" behavior: the listener itself is not resurrected after a failed re-bind. The factory continues in client-only mode, same as with `PJSIP_*_TRANSPORT_DONT_CREATE_LISTENER`; accepting incoming connections again requires re-creating the transport or calling `pjsip_tcp_transport_lis_start()`.

## History

Both defects date back to fdce1c4b1 (#2041, pjsip 2.7), which introduced the restart API with the unregister-then-return sequence and, in the same refactoring, lost the `pj_ssl_sock_start_accept2()` status check when extracting `pjsip_tls_transport_lis_start()`. Until 2.15 a restart retry could still recover the TCP factory, because the second `lis_start()` attempted a real re-bind. a974061441 (#3873) added the "no listener, update the published address only" branch, which made the loss unrecoverable and masked as success.

## Testing

- New regression test in `transport_tcp_test`: fails on master, passes with the patch.
- `make pjsip-test`: full suite passes on macOS arm64.
- Clean builds on macOS arm64 and Linux gcc 13 (aarch64), no new warnings.

