### PR TITLE
pjsua: add --reg-contact-params and --reg-contact-uri-params

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -2018,20 +2018,19 @@ static void write_account_settings(int acc_index, pj_str_t *result)
         pj_strcat2(result, line);
     }
 
-    /* REGISTER-only Contact header parameters */
+    /* Appended directly: line[] is shorter than the config reader's buffer
+     * and would truncate a long value such as a push token.
+     */
     if (acc_cfg->reg_contact_params.slen) {
-        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-params %.*s\n",
-                        (int)acc_cfg->reg_contact_params.slen,
-                        acc_cfg->reg_contact_params.ptr);
-        pj_strcat2(result, line);
+        pj_strcat2(result, "--reg-contact-params ");
+        pj_strcat(result, &acc_cfg->reg_contact_params);
+        pj_strcat2(result, "\n");
     }
 
-    /* REGISTER-only Contact URI parameters */
     if (acc_cfg->reg_contact_uri_params.slen) {
-        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-uri-params %.*s\n",
-                        (int)acc_cfg->reg_contact_uri_params.slen,
-                        acc_cfg->reg_contact_uri_params.ptr);
-        pj_strcat2(result, line);
+        pj_strcat2(result, "--reg-contact-uri-params ");
+        pj_strcat(result, &acc_cfg->reg_contact_uri_params);
+        pj_strcat2(result, "\n");
     }
 
     /*  */

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -67,6 +67,10 @@ static void usage(void)
     puts  ("  --contact=url       Optionally override the Contact information");
     puts  ("  --contact-params=S  Append the specified parameters S in Contact header");
     puts  ("  --contact-uri-params=S  Append the specified parameters S in Contact URI");
+    puts  ("  --reg-contact-params=S  Append the specified parameters S in Contact");
+    puts  ("                      header of REGISTER requests only");
+    puts  ("  --reg-contact-uri-params=S  Append the specified parameters S in");
+    puts  ("                      Contact URI of REGISTER requests only");
     puts  ("  --proxy=url         Optional URL of proxy server to visit");
     puts  ("                      May be specified multiple times");
     printf("  --reg-timeout=SEC   Optional registration interval (default %d)\n",
@@ -398,6 +402,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_LOCAL_PORT, OPT_IP_ADDR, OPT_PROXY, OPT_OUTBOUND_PROXY,
            OPT_REGISTRAR, OPT_REG_TIMEOUT, OPT_PUBLISH, OPT_ID, OPT_CONTACT,
            OPT_BOUND_ADDR, OPT_CONTACT_PARAMS, OPT_CONTACT_URI_PARAMS,
+           OPT_REG_CONTACT_PARAMS, OPT_REG_CONTACT_URI_PARAMS,
            OPT_100REL, OPT_USE_IMS, OPT_REALM, OPT_USERNAME, OPT_PASSWORD, OPT_AKA_OP, OPT_AKA_AMF,
            OPT_REG_RETRY_INTERVAL, OPT_REG_USE_PROXY,
            OPT_MWI, OPT_NAMESERVER, OPT_STUN_SRV, OPT_UPNP, OPT_OUTB_RID,
@@ -477,6 +482,8 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "contact",    1, 0, OPT_CONTACT},
         { "contact-params",1,0, OPT_CONTACT_PARAMS},
         { "contact-uri-params",1,0, OPT_CONTACT_URI_PARAMS},
+        { "reg-contact-params",1,0, OPT_REG_CONTACT_PARAMS},
+        { "reg-contact-uri-params",1,0, OPT_REG_CONTACT_URI_PARAMS},
         { "auto-update-nat",    1, 0, OPT_AUTO_UPDATE_NAT},
         { "disable-stun",0,0, OPT_DISABLE_STUN},
         { "use-compact-form",   0, 0, OPT_USE_COMPACT_FORM},
@@ -928,6 +935,14 @@ static pj_status_t parse_args(int argc, char *argv[],
 
         case OPT_CONTACT_URI_PARAMS:
             cur_acc->contact_uri_params = pj_str(pj_optarg);
+            break;
+
+        case OPT_REG_CONTACT_PARAMS:
+            cur_acc->reg_contact_params = pj_str(pj_optarg);
+            break;
+
+        case OPT_REG_CONTACT_URI_PARAMS:
+            cur_acc->reg_contact_uri_params = pj_str(pj_optarg);
             break;
 
         case OPT_AUTO_UPDATE_NAT:   /* OPT_AUTO_UPDATE_NAT */
@@ -2000,6 +2015,22 @@ static void write_account_settings(int acc_index, pj_str_t *result)
         pj_ansi_snprintf(line, sizeof(line), "--contact-uri-params %.*s\n",
                         (int)acc_cfg->contact_uri_params.slen,
                         acc_cfg->contact_uri_params.ptr);
+        pj_strcat2(result, line);
+    }
+
+    /* REGISTER-only Contact header parameters */
+    if (acc_cfg->reg_contact_params.slen) {
+        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-params %.*s\n",
+                        (int)acc_cfg->reg_contact_params.slen,
+                        acc_cfg->reg_contact_params.ptr);
+        pj_strcat2(result, line);
+    }
+
+    /* REGISTER-only Contact URI parameters */
+    if (acc_cfg->reg_contact_uri_params.slen) {
+        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-uri-params %.*s\n",
+                        (int)acc_cfg->reg_contact_uri_params.slen,
+                        acc_cfg->reg_contact_uri_params.ptr);
         pj_strcat2(result, line);
     }
 


### PR DESCRIPTION
Fixes #5162.

`pjsua_acc_config.reg_contact_params` and `reg_contact_uri_params` — the Contact parameters that apply to REGISTER only — had no command-line equivalent. `--contact-params` / `--contact-uri-params` are the dialog Contact and go on every request, so they are not a substitute.

It matters most for RFC 8599 push registration, where the push parameters belong on the REGISTER Contact and nowhere else: the sample app could not demonstrate, exercise or reproduce anything involving them.

Not a hypothetical gap. While working on #5159 I proposed a change that would have dropped these parameters from every re-registration. Review caught it, but the correction could only be argued from the source, because there was no way to put such a parameter on a REGISTER from the CLI. With these options it is one command:

```
--reg-contact-params ";pn-prid=TOKEN123" --reg-contact-uri-params ";pn-provider=apns"
```

```
Contact: <sip:a@host:port;transport=TCP;ob;pn-provider=apns>
         ;reg-id=1;+sip.instance="<urn:uuid:...>";pn-prid=TOKEN123
```

URI parameter inside the angle brackets, header parameter after, and on REGISTER only — the dialog Contact is unaffected. Verified on the wire.

Wired like the existing pair: usage text, option enum, long option, argument handling, and `write_settings()`.

## On saving settings

`write_settings()` formats each field through `line[128]`, so a long value is truncated when settings are saved. I do not fix that here: the function ignores its `max` argument and the callers pass a fixed `char settings[2000]`, so bypassing `line[]` to preserve long values overflows the caller's stack buffer — I tried it, and review caught it. The config reader also caps lines at 200 bytes, so a very long token could not round-trip even if it were written in full.

What this does do is append the newline separately, so a truncated value cannot swallow the line terminator and run the next option onto the same line. The other fields in that function share the original flaw and are left alone.
