### PR TITLE
Prevent transaction use-after-free on synchronous send failure in pjsip_endpt_send_request()

### DIFF
--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -114,8 +114,8 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
 
     tsx->mod_data[mod_stateful_util.id] = tsx_data;
 
-    /* Prevent the transaction to get deleted before we have chance to
-     * terminate it in case sending fails.
+    /* Prevent the transaction from being deleted before we have a chance
+     * to terminate it if sending fails.
      */
     pj_grp_lock_add_ref(tsx->grp_lock);
 
@@ -185,8 +185,8 @@ PJ_DEF(pj_status_t) pjsip_endpt_respond(  pjsip_endpoint *endpt,
         return status;
     }
 
-    /* Prevent the transaction to get deleted before we have chance to
-     * terminate it in case sending fails.
+    /* Prevent the transaction from being deleted before we have a chance
+     * to terminate it if sending fails.
      */
     pj_grp_lock_add_ref(tsx->grp_lock);
 

--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -23,6 +23,7 @@
 #include <pjsip/sip_event.h>
 #include <pjsip/sip_errno.h>
 #include <pj/assert.h>
+#include <pj/lock.h>
 #include <pj/log.h>
 #include <pj/pool.h>
 #include <pj/string.h>
@@ -113,12 +114,19 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
 
     tsx->mod_data[mod_stateful_util.id] = tsx_data;
 
+    /* Prevent the transaction to get deleted before we have chance to
+     * terminate it in case sending fails.
+     */
+    pj_grp_lock_add_ref(tsx->grp_lock);
+
     status = pjsip_tsx_send_msg(tsx, NULL);
     if (status != PJ_SUCCESS) {
         pjsip_tx_data_dec_ref(tdata);
         pjsip_tsx_terminate(tsx, tsx->status_code? tsx->status_code:
                             PJSIP_SC_SERVICE_UNAVAILABLE);
     }
+
+    pj_grp_lock_dec_ref(tsx->grp_lock);
 
     return status;
 }
@@ -177,6 +185,11 @@ PJ_DEF(pj_status_t) pjsip_endpt_respond(  pjsip_endpoint *endpt,
         return status;
     }
 
+    /* Prevent the transaction to get deleted before we have chance to
+     * terminate it in case sending fails.
+     */
+    pj_grp_lock_add_ref(tsx->grp_lock);
+
     /* Feed the request to the transaction. */
     pjsip_tsx_recv_msg(tsx, rdata);
 
@@ -189,6 +202,8 @@ PJ_DEF(pj_status_t) pjsip_endpt_respond(  pjsip_endpoint *endpt,
     } else if (p_tsx) {
         *p_tsx = tsx;
     }
+
+    pj_grp_lock_dec_ref(tsx->grp_lock);
 
     return status;
 }


### PR DESCRIPTION

## Problem

When `pjsip_tsx_send_msg()` fails synchronously inside `pjsip_endpt_send_request()`, the transaction may already be terminated and scheduled for destruction. The function holds no reference on the transaction group lock, so another thread can destroy the transaction before the subsequent `pjsip_tsx_terminate()` call runs. The result is a use-after-free: with assertions enabled it aborts, with NDEBUG it silently corrupts memory.

Observed in production (Android, pjsua2) as:

```
FATAL: Assert failed: pj_atomic_get(glock->ref_cnt) > 0   (pjlib/src/pj/lock.c, grp_lock_acquire)
  pjsip_tsx_terminate
  pjsip_endpt_send_request
  pjsip_regc_send
  pjsua_acc_set_registration
```

on two unrelated devices, both during re-registration storms on flaky networks (concurrent log lines: `Unable to send request, regc has another transaction pending`, `Unable to create/send REGISTER: Object is busy (PJSIP_EBUSY)`, TLS transports destroyed with "Network is unreachable", DNS answering "Refused").

## Details

The failure path in `pjsip_endpt_send_request()`:

```c
    status = pjsip_tsx_send_msg(tsx, NULL);
    if (status != PJ_SUCCESS) {
        pjsip_tx_data_dec_ref(tdata);
        pjsip_tsx_terminate(tsx, ...);
    }
```

The interleaving:

1. Caller thread: `pjsip_tsx_create_uac()` creates the transaction; group lock ref count is 1 (the transaction's self reference). The caller holds no reference of its own.
2. Caller thread: inside `pjsip_tsx_send_msg()`, the send fails synchronously. This is not exotic: `sip_resolve.c` invokes the DNS callback synchronously when the answer is served from the cache (including negative answers such as "Refused"), and a TCP/TLS connect can fail synchronously with ENETUNREACH during a network change. `tsx_send_msg` / `send_msg_callback` then self-terminate the transaction: `tsx_set_state(TERMINATED, PJSIP_EVENT_TRANSPORT_ERROR, ...)` schedules the zero-length timeout timer that will destroy it.
3. Worker thread: the timer fires immediately: `tsx_on_state_terminated` -> `tsx_set_state(DESTROYED)` -> `tsx_shutdown()` drops the transaction's self reference, the timer poll drops the timer reference, the group lock ref count reaches zero, `grp_lock_destroy` runs `tsx_on_destroy` and releases the transaction pool. The group lock memory is gone.
4. Caller thread: `pjsip_tsx_terminate(tsx, ...)` -> `pj_grp_lock_acquire(tsx->grp_lock)` on freed memory -> `pj_assert(pj_atomic_get(glock->ref_cnt) > 0)`.

Every other caller that keeps a transaction pointer across an unlocked window takes a group lock reference first (e.g. `find_tsx()` in `sip_transaction.c`: "Prevent the transaction to get deleted before we have chance to lock it"). `pjsip_endpt_send_request()` is the exception, and `pjsip_endpt_respond()` has the same pattern on the UAS side.

The fix takes a group lock reference before `pjsip_tsx_send_msg()` and releases it after the error handling, in both functions. `pjsip_tsx_terminate()` is already idempotent for transactions that reached TERMINATED (#1756), so terminating an alive-but-terminated transaction is safe; the reference only guarantees it is still alive.

The `pjsip_tsx_terminate()` call here was added by 8839ffa21 (#4781) to destroy the transaction when sending fails; the terminate itself is needed, it just runs without holding a reference. The closed #4793/#4796 show the same assertion text with an unrelated cause (the since-reverted #4759 lock chaining).

## Testing

- The synchronous-failure path itself is already covered by the existing `regc_test` "immediate error" case (REGISTER to `sip:unresolved-host-xyy`), which goes through `pjsip_regc_send` -> `pjsip_endpt_send_request` -> synchronous resolution failure -> `pjsip_tsx_terminate`. It passes with the patch.
- The race window itself closes only with a second thread running the timer heap between two statements of `pjsip_endpt_send_request()`; it is not deterministically reproducible from the public API without fault-injection hooks, hence no new test. The analysis above pins every step to the code.
- `make pjsip-test` full suite passes on macOS arm64.
- Clean builds on macOS arm64 and Linux gcc 13.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
