### PR TITLE
Fix PJSIP_REGISTER_CLIENT_ADD_XUID_PARAM having no effect

### DIFF
--- a/pjsip/src/pjsip/sip_config.c
+++ b/pjsip/src/pjsip/sip_config.c
@@ -53,7 +53,8 @@ pjsip_cfg_t pjsip_sip_cfg_var =
 
     /* Client registration client */
     {
-        PJSIP_REGISTER_CLIENT_CHECK_CONTACT
+        PJSIP_REGISTER_CLIENT_CHECK_CONTACT,
+        PJSIP_REGISTER_CLIENT_ADD_XUID_PARAM
     },
 
     /* TCP transport settings */


### PR DESCRIPTION
Fixes #5165.

`pjsip_cfg_t.regc` has two members, but the initialiser supplied one:

```c
    /* Client registration client */
    {
        PJSIP_REGISTER_CLIENT_CHECK_CONTACT
    },
```

`add_xuid_param` was therefore zero-initialised regardless of `PJSIP_REGISTER_CLIENT_ADD_XUID_PARAM`, and that macro was referenced nowhere except its own `#ifndef` default and the doc comment naming it as the default. Setting it in `config_site.h` did nothing; the only way to enable the feature was assigning `pjsip_cfg()->regc.add_xuid_param` at runtime.

`regc` was the only short block — `endpt` (13), `tsx` (5), `tcp` (1) and `tls` (1) all match their structs.

## Verified

With `PJSIP_REGISTER_CLIENT_ADD_XUID_PARAM` set to 1 in `config_site.h`, the REGISTER Contact now carries the parameter:

```
Contact: <sip:a@127.0.0.1:59723;transport=TCP;ob;x-uid=8148F456-D0EA-43FA-B7F4-314069E770FD>;reg-id=1;+sip.instance="<urn:uuid:...>"
```

The same build before this change produced no `x-uid` at all, which is how the issue was found.

Default builds are unaffected: with the macro unset the Contact carries no `x-uid`, and `scripts-sipp/uas-auth` passes. Clean build.
