### PR TITLE
Cancel pending query timers in pj_dns_resolver_destroy()

### DIFF
--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -69,8 +69,8 @@ static pj_ioqueue_t *ioqueue;
 static pj_thread_t *poll_thread;
 static pj_sem_t *sem;
 static pj_dns_settings set;
-static pj_bool_t destroy_done;
-static pj_bool_t cb_after_destroy;
+static volatile pj_bool_t destroy_done;
+static volatile pj_bool_t cb_after_destroy;
 
 #define MAX_LABEL   32
 

--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -69,6 +69,8 @@ static pj_ioqueue_t *ioqueue;
 static pj_thread_t *poll_thread;
 static pj_sem_t *sem;
 static pj_dns_settings set;
+static pj_bool_t destroy_done;
+static pj_bool_t cb_after_destroy;
 
 #define MAX_LABEL   32
 
@@ -1048,6 +1050,75 @@ static void dns_callback_1b(void *user_data,
 
 
 
+/* Callback for the destroy-with-pending-query test: flags any invocation
+ * that happens after the resolver has been destroyed.
+ */
+static void dns_callback_destroy(void *user_data,
+                                 pj_status_t status,
+                                 pj_dns_parsed_packet *resp)
+{
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(status);
+    PJ_UNUSED_ARG(resp);
+
+    if (destroy_done)
+        cb_after_destroy = PJ_TRUE;
+}
+
+
+/* Destroy the resolver while a query is still pending and the timer heap is
+ * being polled by another thread. The query's retransmit timer must be
+ * cancelled by pj_dns_resolver_destroy(); otherwise it fires after the
+ * socket is closed and sends on a NULL udp_key (assert/abort), or, with
+ * asserts disabled, invokes the callback after a destroy(notify=PJ_FALSE).
+ */
+static int dns_destroy_pending_test(void)
+{
+    pj_str_t name = pj_str("name_destroy");
+    pj_str_t nameservers[2];
+    pj_uint16_t ports[2];
+    pj_dns_resolver *res;
+
+    PJ_LOG(3,(THIS_FILE, "  destroy with pending query test"));
+
+    destroy_done = PJ_FALSE;
+    cb_after_destroy = PJ_FALSE;
+
+    /* Servers ignore the query so it stays pending and keeps retransmitting. */
+    g_server[0].action = ACTION_IGNORE;
+    g_server[1].action = ACTION_IGNORE;
+
+    /* Use a dedicated resolver over the shared, polled timer heap and
+     * ioqueue, so destroying it does not disturb the test harness.
+     */
+    nameservers[0] = nameservers[1] = pj_str("127.0.0.1");
+    ports[0] = g_server[0].port;
+    ports[1] = g_server[1].port;
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_create(mem, NULL, 0, timer_heap, ioqueue,
+                                           &res),
+                    NULL, return -500);
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_ns(res, 2, nameservers, ports),
+                    NULL, return -505);
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        res, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_destroy, NULL, NULL),
+                    NULL, return -510);
+
+    /* Destroy while the poll thread is still running. */
+    destroy_done = PJ_TRUE;
+    pj_dns_resolver_destroy(res, PJ_FALSE);
+
+    /* Wait past the retransmit delay: a surviving timer would fire here. */
+    pj_thread_sleep((unsigned)(set.qretr_delay * 2));
+
+    PJ_TEST_EQ(cb_after_destroy, PJ_FALSE, NULL, return -520);
+
+    return 0;
+}
+
+
 /* DNS test */
 static int dns_test(void)
 {
@@ -1941,6 +2012,11 @@ int resolver_test(void)
 
     PJ_LOG(3,(THIS_FILE, "srv_resolver_many_test"));
     rc = srv_resolver_many_test();
+    if (rc != 0)
+        goto on_error;
+
+    PJ_LOG(3,(THIS_FILE, "dns_destroy_pending_test"));
+    rc = dns_destroy_pending_test();
     if (rc != 0)
         goto on_error;
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -516,26 +516,37 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
     }
     pj_grp_lock_release(resolver->grp_lock);
 
-    /* Notify outside the lock. Clear each callback before invoking it so a
-     * re-entrant pj_dns_resolver_cancel_query() cannot fire it a second time.
+    /* Capture and clear each callback under the lock, but invoke it after
+     * releasing, so it neither runs under the lock nor races a concurrent
+     * cancel into a duplicate call.
      */
     q = cancel_list.next;
     while (q != (pj_dns_async_query*)&cancel_list) {
         pj_dns_async_query *next_q = q->next;
         pj_dns_async_query *cq;
-        pj_dns_callback *cb = q->cb;
+        pj_dns_callback *cb;
 
+        pj_grp_lock_acquire(resolver->grp_lock);
+        cb = q->cb;
         q->cb = NULL;
+        pj_grp_lock_release(resolver->grp_lock);
+
         if (notify && cb)
             (*cb)(q->user_data, PJ_ECANCELLED, NULL);
 
         cq = q->child_head.next;
         while (cq != (pj_dns_async_query*)&q->child_head) {
             pj_dns_async_query *next_cq = cq->next;
-            pj_dns_callback *ccb = cq->cb;
+            pj_dns_callback *ccb;
+
+            pj_grp_lock_acquire(resolver->grp_lock);
+            ccb = cq->cb;
             cq->cb = NULL;
+            pj_grp_lock_release(resolver->grp_lock);
+
             if (notify && ccb)
                 (*ccb)(cq->user_data, PJ_ECANCELLED, NULL);
+
             cq = next_cq;
         }
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -473,8 +473,8 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
                                              pj_bool_t notify)
 {
     pj_hash_iterator_t it_buf, *it;
-    pj_dns_async_query **qlist = NULL;
-    unsigned i, qcount = 0;
+    struct query_head cancel_list;
+    pj_dns_async_query *q;
     PJ_ASSERT_RETURN(resolver, PJ_EINVAL);
 
     /*
@@ -485,19 +485,16 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
      * lock -- would otherwise fire after the socket is closed below and
      * retransmit on a NULL udp_key. Removing the query from the hash tables
      * makes an already-dispatched on_timeout() exit at its recheck instead.
-     * The queries are collected and notified after the lock is released, to
-     * avoid the lock inversion that on_timeout() also guards against (#1565).
+     * The dequeued queries are moved to a local list and notified after the
+     * lock is released, to avoid the lock inversion that on_timeout() also
+     * guards against (#1565).
      */
+    pj_list_init(&cancel_list);
+
     pj_grp_lock_acquire(resolver->grp_lock);
-    qcount = pj_hash_count(resolver->hquerybyid);
-    if (qcount)
-        qlist = (pj_dns_async_query**)
-                pj_pool_calloc(resolver->pool, qcount, sizeof(qlist[0]));
-    i = 0;
     it = pj_hash_first(resolver->hquerybyid, &it_buf);
     while (it) {
-        pj_dns_async_query *q = (pj_dns_async_query *)
-                                pj_hash_this(resolver->hquerybyid, it);
+        q = (pj_dns_async_query *)pj_hash_this(resolver->hquerybyid, it);
 
         if (q->timer_entry.id == 1)
             pj_timer_heap_cancel_if_active(resolver->timer,
@@ -508,28 +505,41 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
         pj_hash_set(NULL, resolver->hquerybyid, &q->id, sizeof(q->id),
                     0, NULL);
 
-        if (qlist)
-            qlist[i++] = q;
+        /* A pending parent query is on no list, so its list links are free
+         * to move it onto the local cancel list. The queries are not returned
+         * to query_free_nodes here; the whole pool is released once the
+         * resolver's group lock reference count reaches zero.
+         */
+        pj_list_push_back(&cancel_list, q);
 
         it = pj_hash_first(resolver->hquerybyid, &it_buf);
     }
     pj_grp_lock_release(resolver->grp_lock);
 
-    if (notify && qlist) {
-        for (i = 0; i < qcount; ++i) {
-            pj_dns_async_query *q = qlist[i];
-            pj_dns_async_query *cq;
+    /* Notify outside the lock. Clear each callback before invoking it so a
+     * re-entrant pj_dns_resolver_cancel_query() cannot fire it a second time.
+     */
+    q = cancel_list.next;
+    while (q != (pj_dns_async_query*)&cancel_list) {
+        pj_dns_async_query *next_q = q->next;
+        pj_dns_async_query *cq;
+        pj_dns_callback *cb = q->cb;
 
-            if (q->cb)
-                (*q->cb)(q->user_data, PJ_ECANCELLED, NULL);
+        q->cb = NULL;
+        if (notify && cb)
+            (*cb)(q->user_data, PJ_ECANCELLED, NULL);
 
-            cq = q->child_head.next;
-            while (cq != (pj_dns_async_query*)&q->child_head) {
-                if (cq->cb)
-                    (*cq->cb)(cq->user_data, PJ_ECANCELLED, NULL);
-                cq = cq->next;
-            }
+        cq = q->child_head.next;
+        while (cq != (pj_dns_async_query*)&q->child_head) {
+            pj_dns_async_query *next_cq = cq->next;
+            pj_dns_callback *ccb = cq->cb;
+            cq->cb = NULL;
+            if (notify && ccb)
+                (*ccb)(cq->user_data, PJ_ECANCELLED, NULL);
+            cq = next_cq;
         }
+
+        q = next_q;
     }
 
     /* Destroy cached entries */
@@ -1075,7 +1085,7 @@ PJ_DEF(pj_status_t) pj_dns_resolver_cancel_query(pj_dns_async_query *query,
     cb = query->cb;
     query->cb = NULL;
 
-    if (notify)
+    if (notify && cb)
         (*cb)(query->user_data, PJ_ECANCELLED, NULL);
 
     pj_grp_lock_release(query->resolver->grp_lock);

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -475,27 +475,38 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
     pj_hash_iterator_t it_buf, *it;
     PJ_ASSERT_RETURN(resolver, PJ_EINVAL);
 
-    if (notify) {
-        /*
-         * Notify pending queries if requested.
-         */
-        it = pj_hash_first(resolver->hquerybyid, &it_buf);
-        while (it) {
-            pj_dns_async_query *q = (pj_dns_async_query *)
-                                    pj_hash_this(resolver->hquerybyid, it);
-            pj_dns_async_query *cq;
-            if (q->cb)
-                (*q->cb)(q->user_data, PJ_ECANCELLED, NULL);
+    /*
+     * Cancel the retransmission timer of any pending query. This must be
+     * done regardless of the notify flag: the timer lives in the (possibly
+     * shared) timer heap, so leaving it armed lets it fire after the socket
+     * is closed here, sending on a NULL udp_key. Notify the queries only if
+     * requested.
+     */
+    pj_grp_lock_acquire(resolver->grp_lock);
+    it = pj_hash_first(resolver->hquerybyid, &it_buf);
+    while (it) {
+        pj_dns_async_query *q = (pj_dns_async_query *)
+                                pj_hash_this(resolver->hquerybyid, it);
+        pj_dns_async_query *cq;
 
-            cq = q->child_head.next;
-            while (cq != (pj_dns_async_query*)&q->child_head) {
-                if (cq->cb)
-                    (*cq->cb)(cq->user_data, PJ_ECANCELLED, NULL);
-                cq = cq->next;
-            }
-            it = pj_hash_next(resolver->hquerybyid, it);
+        if (q->timer_entry.id == 1)
+            pj_timer_heap_cancel_if_active(resolver->timer,
+                                           &q->timer_entry, 0);
+
+        if (notify && q->cb)
+            (*q->cb)(q->user_data, PJ_ECANCELLED, NULL);
+        q->cb = NULL;
+
+        cq = q->child_head.next;
+        while (cq != (pj_dns_async_query*)&q->child_head) {
+            if (notify && cq->cb)
+                (*cq->cb)(cq->user_data, PJ_ECANCELLED, NULL);
+            cq->cb = NULL;
+            cq = cq->next;
         }
+        it = pj_hash_next(resolver->hquerybyid, it);
     }
+    pj_grp_lock_release(resolver->grp_lock);
 
     /* Destroy cached entries */
     it = pj_hash_first(resolver->hrescache, &it_buf);

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -473,40 +473,64 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
                                              pj_bool_t notify)
 {
     pj_hash_iterator_t it_buf, *it;
+    pj_dns_async_query **qlist = NULL;
+    unsigned i, qcount = 0;
     PJ_ASSERT_RETURN(resolver, PJ_EINVAL);
 
     /*
-     * Cancel the retransmission timer of any pending query. This must be
-     * done regardless of the notify flag: the timer lives in the (possibly
-     * shared) timer heap, so leaving it armed lets it fire after the socket
-     * is closed here, sending on a NULL udp_key. Notify the queries only if
-     * requested.
+     * Cancel and dequeue every pending query. This must be done regardless
+     * of the notify flag: a query's retransmit timer lives in the (possibly
+     * shared) timer heap, so a timer that is still armed -- or one that has
+     * already been dispatched and is blocked in on_timeout() on the group
+     * lock -- would otherwise fire after the socket is closed below and
+     * retransmit on a NULL udp_key. Removing the query from the hash tables
+     * makes an already-dispatched on_timeout() exit at its recheck instead.
+     * The queries are collected and notified after the lock is released, to
+     * avoid the lock inversion that on_timeout() also guards against (#1565).
      */
     pj_grp_lock_acquire(resolver->grp_lock);
+    qcount = pj_hash_count(resolver->hquerybyid);
+    if (qcount)
+        qlist = (pj_dns_async_query**)
+                pj_pool_calloc(resolver->pool, qcount, sizeof(qlist[0]));
+    i = 0;
     it = pj_hash_first(resolver->hquerybyid, &it_buf);
     while (it) {
         pj_dns_async_query *q = (pj_dns_async_query *)
                                 pj_hash_this(resolver->hquerybyid, it);
-        pj_dns_async_query *cq;
 
         if (q->timer_entry.id == 1)
             pj_timer_heap_cancel_if_active(resolver->timer,
                                            &q->timer_entry, 0);
 
-        if (notify && q->cb)
-            (*q->cb)(q->user_data, PJ_ECANCELLED, NULL);
-        q->cb = NULL;
+        pj_hash_set(NULL, resolver->hquerybyres, &q->key, sizeof(q->key),
+                    0, NULL);
+        pj_hash_set(NULL, resolver->hquerybyid, &q->id, sizeof(q->id),
+                    0, NULL);
 
-        cq = q->child_head.next;
-        while (cq != (pj_dns_async_query*)&q->child_head) {
-            if (notify && cq->cb)
-                (*cq->cb)(cq->user_data, PJ_ECANCELLED, NULL);
-            cq->cb = NULL;
-            cq = cq->next;
-        }
-        it = pj_hash_next(resolver->hquerybyid, it);
+        if (qlist)
+            qlist[i++] = q;
+
+        it = pj_hash_first(resolver->hquerybyid, &it_buf);
     }
     pj_grp_lock_release(resolver->grp_lock);
+
+    if (notify && qlist) {
+        for (i = 0; i < qcount; ++i) {
+            pj_dns_async_query *q = qlist[i];
+            pj_dns_async_query *cq;
+
+            if (q->cb)
+                (*q->cb)(q->user_data, PJ_ECANCELLED, NULL);
+
+            cq = q->child_head.next;
+            while (cq != (pj_dns_async_query*)&q->child_head) {
+                if (cq->cb)
+                    (*cq->cb)(cq->user_data, PJ_ECANCELLED, NULL);
+                cq = cq->next;
+            }
+        }
+    }
 
     /* Destroy cached entries */
     it = pj_hash_first(resolver->hrescache, &it_buf);


### PR DESCRIPTION

## Problem

`pj_dns_resolver_destroy()` closes the resolver socket but does not cancel the retransmission timers of queries that are still pending. When the resolver uses a shared (application-provided) timer heap, a pending query's timer fires after the resolver is destroyed, runs `on_timeout()` -> `transmit_query()` -> `pj_ioqueue_sendto(resolver->udp_key, ...)` with `udp_key` already NULLed by `close_sock()`, and aborts on `PJ_ASSERT_RETURN(key && op_key && data && length, ...)` in `pj_ioqueue_sendto()`. With assertions disabled it degrades to a different contract violation: the send fails, `on_timeout()` falls through to the timeout branch and invokes the query callback even when destroy was called with `notify == PJ_FALSE`.

Observed in production (Android) as an abort in `pj_ioqueue_sendto` reached from `transmit_query`/`on_timeout` on a worker thread, when the DNS resolver was destroyed and recreated on a network change while a REGISTER-triggered resolution was in flight.

## Details

`pj_dns_resolver_destroy()` iterates `hquerybyid` only in the `notify` branch, and only to invoke callbacks; it never cancels the per-query timer, never clears `q->cb`, and never removes hash entries. The retransmit timer is armed by `transmit_query()` for the whole life of a pending query (cancelled only on response or final timeout), so "pending query" implies "armed timer".

The timer lives in the resolver's timer heap. If that heap is the application's own — the normal pjsip case, `pjsip_endpt` passes `endpt->timer_heap` to `pj_dns_resolver_create()` — nothing stops it from firing after destroy. This is not limited to application misuse: the public `pjsip_endpt_set_ext_resolver()` tears down the DNS resolver via `pj_dns_resolver_destroy(res, PJ_FALSE)` at runtime while endpoint worker threads keep polling that timer heap.

The scheduled timer holds a group-lock reference (`pj_timer_heap_schedule_w_grp_lock`), so the resolver memory stays alive until the timer fires — hence a deterministic assert rather than a use-after-free.

The fix iterates the pending queries regardless of the `notify` flag. Under the group lock it cancels each query's retransmit timer (via `pj_timer_heap_cancel_if_active`, as `pj_dns_resolver_cancel_query()` does) and removes the query from both hash tables, then moves it to a local list. Removing it from `hquerybyid` is what makes an already-dispatched `on_timeout()` — one popped from the timer heap and blocked on the group lock — exit at its own `hquerybyid` recheck instead of retransmitting on the closed socket.

Each callback is captured and cleared while holding the group lock, then invoked after releasing it: capturing under the lock keeps a concurrent or re-entrant `pj_dns_resolver_cancel_query()` from delivering it twice, and invoking after release avoids the lock inversion `on_timeout()` guards against (#1565). `pj_dns_resolver_cancel_query()` gains a matching NULL check so the cleared callback is a no-op there rather than a null dereference.

The header documents `notify` as "all pending asynchronous queries will be cancelled and its callback will be called", so cancelling the queries is the contracted behaviour, not just an app convenience — the old code invoked the callbacks but never actually cancelled the timers or dequeued the queries, so the crash occurred regardless of the `notify` value.

## Testing

- New `dns_destroy_pending_test` in `resolver_test.c`: starts a query against non-responding servers so it stays pending, then destroys the resolver while the timer heap is polled by another thread. On current master it aborts in `pj_ioqueue_sendto`; with the fix it passes and no callback is invoked after a `notify == PJ_FALSE` destroy.
- `make pjlib-util-test` full suite passes on macOS arm64 and Linux (gcc 13).

## Prior art

The same class of resolver timer/callback-lifetime bug has been fixed before, in #1809 (double callback) and #2024 (uncancelled timer in the query transmit path); this closes the remaining destroy path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

