### PR TITLE
pjsua: smart media update doesn't consider text streams

### DIFF
--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -183,6 +183,7 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
     pj_pool_t *own_pool = NULL;
     char *p;
     unsigned buf_size;
+    unsigned i;
     pj_status_t status;
     pjmedia_transport_attach_param att_param;
     pjmedia_clock_param cparam;
@@ -209,6 +210,19 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
                              &info->loc_rtcp_fb);
     pjmedia_rtcp_fb_info_dup(pool, &c_strm->si->rem_rtcp_fb,
                              &info->rem_rtcp_fb);
+
+    for (i = 0; i < stream->si.enc_fmtp.cnt; ++i) {
+        pj_strdup(pool, &stream->si.enc_fmtp.param[i].name,
+                  &info->enc_fmtp.param[i].name);
+        pj_strdup(pool, &stream->si.enc_fmtp.param[i].val,
+                  &info->enc_fmtp.param[i].val);
+    }
+    for (i = 0; i < stream->si.dec_fmtp.cnt; ++i) {
+        pj_strdup(pool, &stream->si.dec_fmtp.param[i].name,
+                  &info->dec_fmtp.param[i].name);
+        pj_strdup(pool, &stream->si.dec_fmtp.param[i].val,
+                  &info->dec_fmtp.param[i].val);
+    }
 
     /* Init stream/port name */
     name.ptr = (char *) pj_pool_alloc(pool, M);

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4190,7 +4190,6 @@ static pj_bool_t is_media_changed(const pjsua_call *call,
             return PJ_TRUE;
         }
     }
-
     else {
         /* Just return PJ_TRUE for other media type */
         return PJ_TRUE;

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4131,6 +4131,66 @@ static pj_bool_t is_media_changed(const pjsua_call *call,
 
 #endif
 
+    else if (call_med->type == PJMEDIA_TYPE_TEXT) {
+        pjmedia_txt_stream_info the_old_si;
+        const pjmedia_txt_stream_info *old_si = NULL;
+        const pjmedia_txt_stream_info *new_si = &new_si_->info.txt;
+        const pjmedia_codec_info *old_ci = NULL;
+        const pjmedia_codec_info *new_ci = &new_si->fmt;
+
+        /* Compare media direction */
+        if (call_med->dir != new_si->dir)
+            return PJ_TRUE;
+
+        /* Get current active stream info */
+        if (call_med->strm.t.stream) {
+            pjmedia_txt_stream_get_info(call_med->strm.t.stream, &the_old_si);
+            old_si = &the_old_si;
+            old_ci = &old_si->fmt;
+        } else {
+            /* The stream is inactive. */
+            return (new_si->dir != PJMEDIA_DIR_NONE);
+        }
+
+        if (old_si->rtcp_mux != new_si->rtcp_mux)
+            return PJ_TRUE;
+
+        /* Compare remote RTP address. If ICE is running, change in default
+         * address can happen after negotiation, this can be handled
+         * internally by ICE and does not need to cause media restart.
+         */
+        if (!is_ice_running(call_med->tp) &&
+            pj_sockaddr_cmp(&old_si->rem_addr, &new_si->rem_addr))
+        {
+            return PJ_TRUE;
+        }
+
+        /* Compare codec info */
+        if (pj_stricmp(&old_ci->encoding_name, &new_ci->encoding_name) ||
+            old_ci->clock_rate != new_ci->clock_rate ||
+            old_si->rx_pt != new_si->rx_pt ||
+            old_si->tx_pt != new_si->tx_pt)
+        {
+            return PJ_TRUE;
+        }
+
+        /* Compare redundancy (RFC 2198) settings */
+        if (old_si->rx_red_pt != new_si->rx_red_pt ||
+            old_si->tx_red_pt != new_si->tx_red_pt ||
+            old_si->rx_red_level != new_si->rx_red_level ||
+            old_si->tx_red_level != new_si->tx_red_level)
+        {
+            return PJ_TRUE;
+        }
+
+        /* Compare SDP fmtp for both directions */
+        if (!match_codec_fmtp(&old_si->dec_fmtp, &new_si->dec_fmtp) ||
+            !match_codec_fmtp(&old_si->enc_fmtp, &new_si->enc_fmtp))
+        {
+            return PJ_TRUE;
+        }
+    }
+
     else {
         /* Just return PJ_TRUE for other media type */
         return PJ_TRUE;

--- a/pjsip/src/pjsua-lib/pjsua_txt.c
+++ b/pjsip/src/pjsua-lib/pjsua_txt.c
@@ -214,18 +214,18 @@ pj_status_t pjsua_txt_channel_update(pjsua_call_media *call_med,
             (*pjsua_var.ua_cfg.cb.on_stream_precreate)(call->index, &prm);
 
             /* Copy back only the fields which are allowed to be changed. */
-            si->jb_init = prm.stream_info.info.aud.jb_init;
-            si->jb_min_pre = prm.stream_info.info.aud.jb_min_pre;
-            si->jb_max_pre = prm.stream_info.info.aud.jb_max_pre;
-            si->jb_max = prm.stream_info.info.aud.jb_max;
-            si->jb_discard_algo = prm.stream_info.info.aud.jb_discard_algo;
+            si->jb_init = prm.stream_info.info.txt.jb_init;
+            si->jb_min_pre = prm.stream_info.info.txt.jb_min_pre;
+            si->jb_max_pre = prm.stream_info.info.txt.jb_max_pre;
+            si->jb_max = prm.stream_info.info.txt.jb_max;
+            si->jb_discard_algo = prm.stream_info.info.txt.jb_discard_algo;
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && (PJMEDIA_STREAM_ENABLE_KA != 0)
-            si->use_ka = prm.stream_info.info.aud.use_ka;
+            si->use_ka = prm.stream_info.info.txt.use_ka;
 
-            si->ka_cfg = prm.stream_info.info.aud.ka_cfg;
+            si->ka_cfg = prm.stream_info.info.txt.ka_cfg;
 #endif
             si->rtcp_sdes_bye_disabled =
-                prm.stream_info.info.aud.rtcp_sdes_bye_disabled;
+                prm.stream_info.info.txt.rtcp_sdes_bye_disabled;
         }
 
         /* Create session based on session info. */


### PR DESCRIPTION
While testing with realtime text streams I noticed that text streams would always be recreated on re-INVITE.
The function [is_media_changed()](https://github.com/pjsip/pjproject/blob/1ef88fabfd78093ee62d16348f7128062f0b2d79/pjsip/src/pjsua-lib/pjsua_media.c#L3969) simply didn't check for text streams.
The new branch is similar to the audio branch except that it doesn't check codec params
but does check the redundancy parameters.

_**NOTE:**_ The commit 003bd3d was created by Claude.

Without this change, the recreation can be observed with the stock pjsua app:

**terminal 1 — answering side**
  `./pjsua --null-audio --text --local-port=6080 --auto-answer=200 --log-level=4`
  
  **### terminal 2 — calling side**
  `./pjsua --null-audio --text --local-port=6082 --log-level=4`

In terminal 2 press m, enter sip:127.0.0.1:6080, wait for the call to come up (audio + text), then press v to send a re-INVITE.

In the logs:
```
pjsua_txt.c  Stopping text stream..
tstrm…  Stream destroying
```
and with this fix:
```
Call N: stream #1 (text) unchanged.
```
