### PR TITLE
ssl_sock_ossl: null-terminate server_name before SSL_set_tlsext_host_name()

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2812,9 +2812,24 @@ static void ssl_set_peer_name(pj_ssl_sock_t *ssock)
 #endif
         } else {
 #ifdef SSL_set_tlsext_host_name
-            /* Server name is null terminated already */
-            if (!SSL_set_tlsext_host_name(ossock->ossl_ssl,
-                                          ssock->param.server_name.ptr))
+            /* ssock->param.server_name is a pj_str_t (ptr+slen), NOT
+             * guaranteed null-terminated - it typically comes from
+             * tdata->dest_info.name, populated via plain pj_strdup()
+             * (sip_util.c), which does not append a '\0'.
+             * SSL_set_tlsext_host_name() is a macro over SSL_ctrl() that
+             * reads its argument as an ordinary strlen()-terminated C
+             * string, so passing server_name.ptr directly here can read
+             * past its pool allocation - confirmed live as a reliable
+             * SIGSEGV during the handshake when server_name is a
+             * hostname. Defensively copy+terminate into a local buffer
+             * first instead. */
+            char host_name[PJ_MAX_HOSTNAME];
+            pj_ssize_t len = PJ_MIN(ssock->param.server_name.slen,
+                                    (pj_ssize_t)sizeof(host_name) - 1);
+            pj_memcpy(host_name, ssock->param.server_name.ptr, len);
+            host_name[len] = '\0';
+
+            if (!SSL_set_tlsext_host_name(ossock->ossl_ssl, host_name))
             {
                 char err_str[PJ_ERR_MSG_SIZE];
 


### PR DESCRIPTION
## Bug

`ssl_set_peer_name()` in `pjlib/src/pj/ssl_sock_ossl.c` passes
`ssock->param.server_name.ptr` directly to `SSL_set_tlsext_host_name()`
(a macro over `SSL_ctrl()` that reads its argument as an ordinary
`strlen()`-terminated C string), under a comment claiming the `pj_str_t`
is "null terminated already". It generally isn't: this field is
typically populated from `tdata->dest_info.name` via plain `pj_strdup()`
(`sip_util.c`), which copies exactly `slen` bytes and does not append a
`\0`.

Reading past the end of that pool allocation is a reliable SIGSEGV
during the TLS handshake whenever the peer/server name is a hostname
(confirmed live via gdb: `asock_on_connect_complete` ->
`ssl_set_peer_name` -> crash inside OpenSSL's own string handling).
IP-literal server names happen to avoid this exact path (see the
surrounding `get_ip_addr_ver()` branch earlier in the function), which
is likely why this has gone unnoticed - any hostname-based SNI setup
(e.g. TLS/SIPS registration against a server addressed by hostname
rather than IP) hits it.

Reproduced on 2.14.1 and current `master` - the function is unchanged
across that range.

## Fix

Defensively copy `server_name` into a local, explicitly
null-terminated `char[PJ_MAX_HOSTNAME]` buffer before handing it to
`SSL_set_tlsext_host_name()`, instead of assuming the `pj_str_t`
already is null-terminated.

## Testing

Verified against a real hostname-based TLS/SIPS registration to a
production Asterisk server that previously crashed 100% of the time on
handshake; registration now succeeds and the process stays up.