### PR TITLE
pjsua: fix unused variable warning when SIPREC is disabled

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -1739,7 +1739,9 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
     pj_str_t st_reason = pj_str("");
     int ret_st_code = 0;
     pj_status_t status;
+#if PJSUA_HAS_SIPREC
     pjsip_siprec_verify_setting siprec_setting;
+#endif
 
     /* Don't want to handle anything but INVITE */
     if (msg->line.req.method.id != PJSIP_INVITE_METHOD)


### PR DESCRIPTION
Fixes #5171.

`siprec_setting` is declared unconditionally in `pjsua_call_on_incoming()`, but every use of it is inside `#if PJSUA_HAS_SIPREC`, which defaults to 0. Default builds therefore warn:

```
pjsua_call.c:1742:33: warning: unused variable 'siprec_setting' [-Wunused-variable]
```

Guard the declaration with the same condition as its uses. Removing it would break builds with SIPREC enabled, where it is needed — hence the `#if` rather than a deletion.

## Verified

Both configurations, since the point of the guard is that only one of them was broken:

- `PJSUA_HAS_SIPREC` at its default (0): warning gone, `pjsip` builds clean.
- `PJSUA_HAS_SIPREC` set to 1 in `config_site.h`: full rebuild compiles clean, `libpjsua` links. The only warning left is the pre-existing `pjsua2_demo.cpp:515: 'main' should not be 'extern "C"'`, which is unrelated.

Introduced by dee7dae22 (#5128).
