### PR TITLE
pjmedia: make VoiceProcessingIO other-audio ducking configurable on Apple platforms

### DIFF
--- a/pjlib/include/pj/config_site_sample.h
+++ b/pjlib/include/pj/config_site_sample.h
@@ -322,6 +322,11 @@
     /* The CoreAudio backend has built-in echo canceller! */
     #define PJMEDIA_HAS_SPEEX_AEC    0
 
+    /* Duck other audio based on voice activity, instead of for the whole
+     * call (requires iOS 17).
+     */
+    #define PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING 1
+
     /* Disable some codecs */
     #define PJMEDIA_HAS_L16_CODEC               0
     //#define PJMEDIA_HAS_G722_CODEC            0

--- a/pjmedia/include/pjmedia-audiodev/config.h
+++ b/pjmedia/include/pjmedia-audiodev/config.h
@@ -137,6 +137,43 @@ PJ_BEGIN_DECL
 #endif
 
 
+/**
+ * Specify whether the coreaudio backend should enable advanced ducking of
+ * other (i.e. non-voice) audio while the VoiceProcessingIO audio unit is in
+ * use, i.e. while echo cancellation is enabled. Advanced ducking follows the
+ * voice activity of the chat participants, so other audio is only attenuated
+ * while somebody is talking, instead of being attenuated for the whole call.
+ *
+ * Requires macOS 14 or iOS 17, it is ignored on older versions.
+ *
+ * Default: 0 (no, i.e. the fixed ducking applied by the system). Enabled in
+ * config_site_sample.h for iOS.
+ */
+#ifndef PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING
+#   define PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING 0
+#endif
+
+
+/**
+ * Specify how much the coreaudio backend should duck other (i.e. non-voice)
+ * audio while the VoiceProcessingIO audio unit is in use, i.e. while echo
+ * cancellation is enabled. Valid values are the AUVoiceIOOtherAudioDuckingLevel
+ * constants: kAUVoiceIOOtherAudioDuckingLevelDefault (0),
+ * kAUVoiceIOOtherAudioDuckingLevelMin (10),
+ * kAUVoiceIOOtherAudioDuckingLevelMid (20), or
+ * kAUVoiceIOOtherAudioDuckingLevelMax (30). This setting is independent of
+ * PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING.
+ *
+ * Requires macOS 14 or iOS 17, it is ignored on older versions.
+ *
+ * Default: 0 (kAUVoiceIOOtherAudioDuckingLevelDefault, the level Apple applies
+ * for a typical voice chat)
+ */
+#ifndef PJMEDIA_AUDIO_DEV_COREAUDIO_DUCKING_LEVEL
+#   define PJMEDIA_AUDIO_DEV_COREAUDIO_DUCKING_LEVEL 0
+#endif
+
+
  /**
   * This setting controls whether WMME support should be included.
   */

--- a/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
+++ b/pjmedia/src/pjmedia-audiodev/coreaudio_dev.m
@@ -1346,6 +1346,46 @@ static pj_status_t create_audio_resample(struct coreaudio_stream     *strm,
 }
 #endif
 
+#if (TARGET_OS_IPHONE && !TARGET_OS_TV && !TARGET_OS_WATCH && \
+     defined(__IPHONE_17_0)) || \
+    (TARGET_OS_OSX && defined(__MAC_14_0))
+/* Internal: configure how the VoiceProcessingIO unit ducks other audio */
+static void set_other_audio_ducking(AudioUnit io_unit)
+    API_AVAILABLE(macos(14.0), ios(17.0))
+{
+    AUVoiceIOOtherAudioDuckingConfiguration ducking;
+    Boolean writable = false;
+    OSStatus ostatus;
+
+    ostatus = AudioUnitGetPropertyInfo(io_unit,
+                  kAUVoiceIOProperty_OtherAudioDuckingConfiguration,
+                  kAudioUnitScope_Global, 0, NULL, &writable);
+    if (ostatus != noErr || !writable) {
+        PJ_LOG(4, (THIS_FILE, "Warning: other audio ducking is not "
+                              "configurable, error: %d", (int)ostatus));
+        return;
+    }
+
+    ducking.mEnableAdvancedDucking =
+        PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING;
+    ducking.mDuckingLevel = (AUVoiceIOOtherAudioDuckingLevel)
+        PJMEDIA_AUDIO_DEV_COREAUDIO_DUCKING_LEVEL;
+
+    ostatus = AudioUnitSetProperty(io_unit,
+                  kAUVoiceIOProperty_OtherAudioDuckingConfiguration,
+                  kAudioUnitScope_Global, 0, &ducking, sizeof(ducking));
+    if (ostatus != noErr) {
+        PJ_LOG(4, (THIS_FILE, "Warning: cannot set other audio ducking "
+                              "configuration, error: %d", (int)ostatus));
+        return;
+    }
+
+    PJ_LOG(4, (THIS_FILE, "Other audio ducking: advanced=%d, level=%d",
+               (int)ducking.mEnableAdvancedDucking,
+               (int)ducking.mDuckingLevel));
+}
+#endif
+
 /* Internal: create audio unit for recorder/playback device */
 static pj_status_t create_audio_unit(AudioComponent io_comp,
                                      AudioDeviceID dev_id,
@@ -1364,6 +1404,15 @@ static pj_status_t create_audio_unit(AudioComponent io_comp,
     if (ostatus != noErr) {
         return PJMEDIA_AUDIODEV_ERRNO_FROM_COREAUDIO(ostatus);
     }
+
+#if (TARGET_OS_IPHONE && !TARGET_OS_TV && !TARGET_OS_WATCH && \
+     defined(__IPHONE_17_0)) || \
+    (TARGET_OS_OSX && defined(__MAC_14_0))
+    if (strm->param.ec_enabled) {
+        if (@available(macOS 14.0, iOS 17.0, *))
+            set_other_audio_ducking(*io_unit);
+    }
+#endif
 
     /* Set audio unit's properties for capture device */
     if (dir & PJMEDIA_DIR_CAPTURE) {


### PR DESCRIPTION
Fixes #5177

### Motivation

The coreaudio backend opens the VoiceProcessingIO (VPIO) audio unit whenever echo cancellation
is enabled. VPIO ducks "other audio" — every audio stream on the system that is not the voice
chat — to improve the intelligibility of the call.

With the system defaults that duck is **fixed and held for the entire call**. A user listening
to music who accepts a call has that music attenuated from answer to hangup, even during the
long stretches when nobody is talking.

macOS 14 / iOS 17 added `kAUVoiceIOProperty_OtherAudioDuckingConfiguration`, which exposes two
independent controls over that behaviour:

- `mEnableAdvancedDucking` — the *style* of ducking. When enabled, the duck follows the voice
  activity of the local and remote chat participants: more ducking while someone is talking,
  less when nobody is. Apple compares it to FaceTime SharePlay, where media volume comes back
  up between utterances.
- `mDuckingLevel` — the *amount* of ducking: `Default`, `Min`, `Mid`, `Max`.

pjproject currently sets neither, so it gets Apple's implicit default: advanced ducking off,
level `Default`.

### Change

`create_audio_unit()` sets the property right after the audio unit is instantiated, only when
EC is enabled (i.e. only when the unit actually is VPIO). Gating follows the existing in-tree
style for macOS 14 / iOS 17 API in `pjmedia/src/pjmedia-videodev/darwin_dev.m`: an SDK check
(`__IPHONE_17_0` / `__MAC_14_0`) plus a runtime `if (@available(macOS 14.0, iOS 17.0, *))`.

The property is queried with `AudioUnitGetPropertyInfo` first and skipped unless it is present
and writable. Every failure path logs a `PJ_LOG(4, …)` warning and returns — configuring the
duck must never be able to break audio.

Two `config.h` macros, `#ifndef`-guarded so they can be overridden from `config_site.h`:

| Macro | Default | Effect |
|---|---|---|
| `PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING` | `1` | Enable voice-activity-driven ducking |
| `PJMEDIA_AUDIO_DEV_COREAUDIO_DUCKING_LEVEL` | `0` (`kAUVoiceIOOtherAudioDuckingLevelDefault`) | Ducking depth |

No new `pjmedia_aud_dev_cap`: this has no independent runtime axis — it is a refinement of
existing EC/VPIO behaviour, not something an application would toggle per call through
`pjmedia_aud_stream_set_cap()` — and adding one would push `PJMEDIA_AUD_DEV_CAP_MAX` past its
current `16384`.

### Why these defaults

**Advanced ducking on.** The complaint this addresses is precisely "other audio is attenuated
for the whole call". Following voice activity fixes exactly that, and it is the part of the
change that is unambiguously better for any VoIP application.

**Depth left at Apple's default.** Ducking depth is a much more opinionated axis, and real
deployments differ: a dispatch or contact-centre application may want a deep duck for
intelligibility, a consumer softphone a light one. Apple describes `Default` as the tuned value
for a typical voice chat, and it is the level pjproject already gets today. A library should
not pick a side there, so it is exposed as its own macro and left where it is. Keeping the
depth unchanged also holds the behavioural delta to one clearly-motivated axis.

### Three things worth flagging

**1. This changes existing behaviour.** Anyone building against a macOS 14+ / iOS 17+ SDK with
EC enabled gets voice-activity-driven ducking instead of a constant duck. Setting
`PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING` to `0` restores the previous behaviour exactly:
with both macros at `0` the property is set to `{advanced off, level Default}`, which
`AudioUnitProperties.h` documents as identical to never setting the property at all — "If not
set, the default ducking configuration is to disable advanced ducking, with a ducking level set
to `kAUVoiceIOOtherAudioDuckingLevelDefault`." Happy to flip the default to opt-in (`0`) if you
would rather ship this as strictly additive.

**2. `mDuckingLevel` is meaningful whether or not advanced ducking is on.** I checked rather
than assumed. WWDC23 session 10235 states the struct "provides controls of two independent
aspects of ducking — the style of ducking, that is `mEnableAdvancedDucking`, and the amount of
ducking, that is `mDuckingLevel`", and that "the two controls can be used independently".
That is why they are two macros and not one enum.

**3. Platform scope.** `kAUVoiceIOProperty_OtherAudioDuckingConfiguration` is declared
`API_AVAILABLE(ios(17.0), macos(14.0)) API_UNAVAILABLE(watchos, tvos)`. That covers every
platform this backend targets — macOS, iOS, and Mac Catalyst, which inherits the iOS
availability — and I verified Catalyst compiles. It does **not** cover tvOS or watchOS, where
the symbol is declared but unavailable and would fail to compile. The guard I used matches the
file's convention that `TARGET_OS_IPHONE` means iOS, which is true for pjproject today (there
is no tvOS or watchOS build support anywhere in the tree). If you would rather harden it
against a future port, `&& !TARGET_OS_TV && !TARGET_OS_WATCH` on the `TARGET_OS_IPHONE` arm is
the one-line change — say the word and I will add it.

### Validation

- `make` in `pjmedia/build` on `aarch64-apple-darwin` — clean, zero warnings, and the new code
  is confirmed present in the built `coreaudio_dev.o`.
- `coreaudio_dev.m` compiles clean (`-Wall -Wextra`, no output) for: macOS at the host
  deployment target and at `-mmacosx-version-min=10.15`; iOS `arm64` at deployment targets 15.0
  and 12.0 — i.e. both the compiled-in and the runtime-`@available`-false paths; Mac Catalyst
  `arm64`; with `PJMEDIA_AUDIO_DEV_COREAUDIO_ADVANCED_DUCKING=0`; with
  `PJMEDIA_AUDIO_DEV_COREAUDIO_DUCKING_LEVEL=kAUVoiceIOOtherAudioDuckingLevelMin` (confirming
  the macro accepts the Apple constants by name from `config_site.h`); and with
  `PJMEDIA_AUDIO_DEV_HAS_COREAUDIO=0`.
- Non-Apple platforms are unaffected: the two new macros are referenced only in
  `coreaudio_dev.m`, and `config.h` gains only integer literals, so it still compiles with no
  Apple headers in scope (verified by compiling `audiodev.c` against it).
- **Not verified: the listening test.** I have not played music, placed a call with EC enabled,
  and confirmed by ear that the music is no longer flattened for the call's duration and that
  echo cancellation still works. That check is human-only and has not been done.

