### PR TITLE
pjlib-util: fix stack buffer overflow reading pcap trailer

### DIFF
--- a/pjlib-util/src/pjlib-util/pcap.c
+++ b/pjlib-util/src/pjlib-util/pcap.c
@@ -203,6 +203,9 @@ static pj_status_t skip(pj_oshandle_t fd, pj_off_t bytes)
                 return status; \
         }
 
+/* Maximum record length accepted from file, as libpcap's MAXIMUM_SNAPLEN */
+#define MAX_REC_LEN     262144u
+
 /* Read UDP packet */
 PJ_DEF(pj_status_t) pj_pcap_read_udp(pj_pcap_file *file,
                                      pj_pcap_udp_hdr *udp_hdr,
@@ -268,6 +271,22 @@ PJ_DEF(pj_status_t) pj_pcap_read_udp_with_timestamp(
         }
 
         rec_incl = tmp.rec.incl_len;
+
+        /* Record length is unvalidated file data, check it before parsing.
+         * Too long is rejected rather than skipped, as seeking by such a
+         * length may overflow pj_off_t.
+         */
+        if (rec_incl > MAX_REC_LEN) {
+            TRACE_((file->obj_name, "Invalid record length %u", rec_incl));
+            return PJ_EINVAL;
+        }
+        if (rec_incl < sizeof(tmp.eth) + sizeof(tmp.ip)) {
+            TRACE_((file->obj_name, "Record length %u too short, skipping",
+                    rec_incl));
+            SKIP_PKT();
+            continue;
+        }
+
         if (ts) {
             /* If we add support for nanosecond pcap, this should be adapted accordingly */
             ts->u64 = 1000000000ull * tmp.rec.ts_sec + 1000ull * tmp.rec.ts_usec;
@@ -330,6 +349,12 @@ PJ_DEF(pj_status_t) pj_pcap_read_udp_with_timestamp(
         /* Read transport layer header */
         switch (tmp.ip.proto) {
         case PJ_PCAP_PROTO_TYPE_UDP:
+            /* Don't read past the record into the next one */
+            if (rec_incl - sz_read < sizeof(tmp.udp)) {
+                TRACE_((file->obj_name, "Truncated UDP header, skipping"));
+                SKIP_PKT();
+                continue;
+            }
             sz = sizeof(tmp.udp);
             status = read_file(file, &tmp.udp, &sz);
             if (status != PJ_SUCCESS) {
@@ -376,6 +401,12 @@ PJ_DEF(pj_status_t) pj_pcap_read_udp_with_timestamp(
                 continue;
             }
             sz = pj_ntohs(tmp.udp.len) - sizeof(tmp.udp);
+
+            /* Clamp to what the record actually holds, the UDP length may
+             * describe a packet that the capture truncated.
+             */
+            if (sz > (pj_ssize_t)(rec_incl - sz_read))
+                sz = (pj_ssize_t)(rec_incl - sz_read);
             break;
         default:
             TRACE_((file->obj_name, "Not UDP, skipping"));
@@ -406,20 +437,8 @@ PJ_DEF(pj_status_t) pj_pcap_read_udp_with_timestamp(
         /* Check that we've read all the packets */
         //PJ_ASSERT_RETURN(sz_read == rec_incl, PJ_EBUG);
 
-        /* Skip trailer, reading in chunks that fit tmp to avoid overflowing
-         * it when rec_incl exceeds the data already read.
-         */
-        while (sz_read < rec_incl) {
-            sz = rec_incl - sz_read;
-            if (sz > (pj_ssize_t)sizeof(tmp.eth))
-                sz = sizeof(tmp.eth);
-            status = read_file(file, &tmp.eth, &sz);
-            if (status != PJ_SUCCESS) {
-                TRACE_((file->obj_name, "Error reading trailer: %d", status));
-                return status;
-            }
-            sz_read += sz;
-        }
+        /* Skip trailer */
+        SKIP_PKT();
 
         return PJ_SUCCESS;
     }

--- a/pjlib-util/src/pjlib-util/pcap.c
+++ b/pjlib-util/src/pjlib-util/pcap.c
@@ -406,9 +406,13 @@ PJ_DEF(pj_status_t) pj_pcap_read_udp_with_timestamp(
         /* Check that we've read all the packets */
         //PJ_ASSERT_RETURN(sz_read == rec_incl, PJ_EBUG);
 
-        /* Skip trailer */
+        /* Skip trailer, reading in chunks that fit tmp to avoid overflowing
+         * it when rec_incl exceeds the data already read.
+         */
         while (sz_read < rec_incl) {
             sz = rec_incl - sz_read;
+            if (sz > (pj_ssize_t)sizeof(tmp.eth))
+                sz = sizeof(tmp.eth);
             status = read_file(file, &tmp.eth, &sz);
             if (status != PJ_SUCCESS) {
                 TRACE_((file->obj_name, "Error reading trailer: %d", status));


### PR DESCRIPTION
`pj_pcap_read_udp()` parses each record into a 20-byte stack union `tmp`, then consumes any trailing bytes by reading the whole remainder into `tmp.eth` (14 bytes) in a single `read_file()` call:

```c
while (sz_read < rec_incl) {
    sz = rec_incl - sz_read;
    status = read_file(file, &tmp.eth, &sz);   /* writes sz bytes into tmp */
    ...
}
```

`rec_incl` is the record's `incl_len`, taken from the file and otherwise unvalidated, so the read is unbounded and overflows the stack.

This is not limited to crafted files. Any capture whose records carry a trailer larger than the union, e.g. Ethernet padding, overflows it — a well-formed capture with a 60-byte trailer aborts under ASan with `WRITE of size 60`. That path appears not to have been exercised.

### Fix

Skip the trailer with a single seek, which is what the sibling `SKIP_PKT()` already does at the other five skip sites. The trailer is discarded either way, so the loop becomes `SKIP_PKT()`.

`rec_incl` is then sanity checked, since it drives every read in the function:

- reject `incl_len` beyond 262144 (libpcap's `MAXIMUM_SNAPLEN`). Rejected rather than skipped, as seeking by an unvalidated 32-bit length can overflow `pj_off_t` where file offsets are not 64-bit
- skip records too short to hold the Ethernet and IP headers, which the fixed-size reads would otherwise take from the following record, desyncing the stream. Same check before the UDP header
- clamp the payload to the bytes the record actually holds, as the UDP length field may describe a packet the capture truncated

### Reachability

`pj_pcap_read_udp()` is not used by any pjsip/pjmedia/pjnath runtime path — within pjproject it is only exercised by the `pcaputil` sample. The concern is an application (the sample, or third-party code) parsing a `.pcap` from an untrusted source, or a capture with large trailers.

### Testing

Seven crafted captures driven through `pj_pcap_read_udp()` under ASan and `-fstack-protector-all`: valid packet, legitimate trailer plus resync, oversize `incl_len`, `incl_len` 0xFFFFFFFF, short `incl_len` plus resync, UDP length beyond the record, and truncated UDP header.

- before: ASan stack-buffer-overflow, first triggered by the legitimate-trailer case
- after: all seven return the expected packets with the stream kept in sync, no ASan reports

`make` on pjlib-util is clean.

Co-Authored-By Claude Code
