### PR TITLE
Fix race when txdata is reused while a send is still in progress

### DIFF
--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1481,12 +1481,42 @@ typedef void (*pjsip_tp_send_callback)(void *token, pjsip_tx_data *tdata,
  *                  indicates immediate failure, and in this case the 
  *                  callback will not be called.
  */
-PJ_DECL(pj_status_t) pjsip_transport_send( pjsip_transport *tr, 
+PJ_DECL(pj_status_t) pjsip_transport_send( pjsip_transport *tr,
                                            pjsip_tx_data *tdata,
                                            const pj_sockaddr_t *addr,
                                            int addr_len,
                                            void *token,
                                            pjsip_tp_send_callback cb);
+
+
+/**
+ * Variant of #pjsip_transport_send() which also reports the number of bytes
+ * sent when the message is sent immediately.
+ *
+ * Callers must use this instead of inspecting the transmit data buffer after
+ * the send, since the message may already be answered by the peer, and the
+ * transmit data invalidated and reused by another thread, before this
+ * function returns.
+ *
+ * @param tr        The SIP transport to be used.
+ * @param tdata     Transmit data buffer containing SIP message.
+ * @param addr      Destination address.
+ * @param addr_len  Length of destination address.
+ * @param token     Arbitrary token to be returned back to callback.
+ * @param cb        Optional callback to be called to notify caller about
+ *                  the completion status of the pending send operation.
+ * @param sent      Optional pointer to receive the number of bytes sent.
+ *                  It is only set when this function returns PJ_SUCCESS.
+ *
+ * @return          See #pjsip_transport_send().
+ */
+PJ_DECL(pj_status_t) pjsip_transport_send2(pjsip_transport *tr,
+                                           pjsip_tx_data *tdata,
+                                           const pj_sockaddr_t *addr,
+                                           int addr_len,
+                                           void *token,
+                                           pjsip_tp_send_callback cb,
+                                           pj_ssize_t *sent);
 
 
 /**

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1463,7 +1463,13 @@ typedef void (*pjsip_tp_send_callback)(void *token, pjsip_tx_data *tdata,
 /**
  * This is a low-level function to send a SIP message using the specified
  * transport to the specified destination.
- * 
+ *
+ * Once this function returns, the message is already on the wire, so the peer
+ * may have answered it and the application may have reused the transmit data
+ * for the next request from another thread. No field of the transmit data may
+ * be assumed to be stable afterwards, in particular its buffer, which is why
+ * #pjsip_transport_send2() exists to report the number of bytes sent.
+ *
  * @param tr        The SIP transport to be used.
  * @param tdata     Transmit data buffer containing SIP message.
  * @param addr      Destination address.

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2150,6 +2150,7 @@ static void send_msg_callback( pjsip_send_state *send_state,
 {
     pjsip_transaction *tsx = (pjsip_transaction*) send_state->token;
     pjsip_tx_data *tdata = send_state->tdata;
+    pj_bool_t tdata_is_ours;
 
     /* Check if transaction has cancelled itself from this transmit
      * notification (https://github.com/pjsip/pjproject/issues/1033).
@@ -2177,19 +2178,30 @@ static void send_msg_callback( pjsip_send_state *send_state,
     /* Decrease pending send counter */
     pj_grp_lock_dec_ref(tsx->grp_lock);
 
-    /* Reset. Only release the tdata if it is still ours, it may already have
-     * been taken over by another transaction, e.g. reused for an
-     * authentication retry (see #5176).
+    /* The tdata may already have been taken over by another transaction,
+     * e.g. reused for an authentication retry (see #5176). If so, it is
+     * neither ours to release nor to inspect or send again, since the other
+     * transaction may be updating it concurrently.
      */
-    if (tdata->mod_data[mod_tsx_layer.mod.id] == tsx)
+    tdata_is_ours = (tdata->mod_data[mod_tsx_layer.mod.id] == tsx);
+
+    /* Reset */
+    if (tdata_is_ours)
         tdata->mod_data[mod_tsx_layer.mod.id] = NULL;
+    else
+        *cont = PJ_FALSE;
     tsx->pending_tx = NULL;
 
     if (sent > 0) {
         /* Successfully sent! */
         pj_assert(send_state->cur_transport != NULL);
 
-        if (tsx->transport != send_state->cur_transport) {
+        /* Adopt the transport and remote address only from a tdata which is
+         * still ours, the dest_info of a tdata taken over by another
+         * transaction may be updated concurrently. Leaving them untouched
+         * makes our next transmission resolve the destination again.
+         */
+        if (tdata_is_ours && tsx->transport != send_state->cur_transport) {
             /* Update transport. */
             tsx_update_transport(tsx, send_state->cur_transport);
 
@@ -2208,8 +2220,13 @@ static void send_msg_callback( pjsip_send_state *send_state,
         /* Clear pending transport flag. */
         tsx->transport_flag &= ~(TSX_HAS_PENDING_TRANSPORT);
 
-        /* Mark that we have resolved the addresses. */
-        tsx->transport_flag |= TSX_HAS_RESOLVED_SERVER;
+        /* Mark that we have resolved the addresses. Not when the tdata is no
+         * longer ours, since we then have no transport to go with it, and a
+         * UAC without transport but with resolved server is terminated by
+         * tsx_send_msg().
+         */
+        if (tdata_is_ours)
+            tsx->transport_flag |= TSX_HAS_RESOLVED_SERVER;
 
         /* Pending destroy? */
         if (tsx->transport_flag & TSX_HAS_PENDING_DESTROY) {
@@ -2342,7 +2359,9 @@ static void send_msg_callback( pjsip_send_state *send_state,
                 unlock_timer(tsx);
             }
 
-            /* Put again pending tdata */
+            /* Put again pending tdata. The tdata is still ours here, a tdata
+             * taken over by another transaction has cleared *cont above.
+             */
             tdata->mod_data[mod_tsx_layer.mod.id] = tsx;
             tsx->pending_tx = tdata;
 

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2177,8 +2177,12 @@ static void send_msg_callback( pjsip_send_state *send_state,
     /* Decrease pending send counter */
     pj_grp_lock_dec_ref(tsx->grp_lock);
 
-    /* Reset */
-    tdata->mod_data[mod_tsx_layer.mod.id] = NULL;
+    /* Reset. Only release the tdata if it is still ours, it may already have
+     * been taken over by another transaction, e.g. reused for an
+     * authentication retry (see #5176).
+     */
+    if (tdata->mod_data[mod_tsx_layer.mod.id] == tsx)
+        tdata->mod_data[mod_tsx_layer.mod.id] = NULL;
     tsx->pending_tx = NULL;
 
     if (sent > 0) {

--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -2178,10 +2178,12 @@ static void send_msg_callback( pjsip_send_state *send_state,
     /* Decrease pending send counter */
     pj_grp_lock_dec_ref(tsx->grp_lock);
 
-    /* The tdata may already have been taken over by another transaction,
-     * e.g. reused for an authentication retry (see #5176). If so, it is
-     * neither ours to release nor to inspect or send again, since the other
-     * transaction may be updating it concurrently.
+    /* The tdata may already have been taken over by another transaction, e.g.
+     * reused for an authentication retry (see #5176). If so, it is neither
+     * ours to release nor to inspect or send again. The takeover is done
+     * under the other transaction's group lock, so this only narrows the
+     * window in general, but it is exact for the authentication retry, which
+     * takes over from within our own state callback, i.e. under this lock.
      */
     tdata_is_ours = (tdata->mod_data[mod_tsx_layer.mod.id] == tsx);
 
@@ -2291,8 +2293,11 @@ static void send_msg_callback( pjsip_send_state *send_state,
             /* Clear pending transport flag. */
             tsx->transport_flag &= ~(TSX_HAS_PENDING_TRANSPORT);
 
-            /* Mark that we have resolved the addresses. */
-            tsx->transport_flag |= TSX_HAS_RESOLVED_SERVER;
+            /* Mark that we have resolved the addresses, see the same
+             * assignment in the success branch above.
+             */
+            if (tdata_is_ours)
+                tsx->transport_flag |= TSX_HAS_RESOLVED_SERVER;
 
             /* Server resolution error is now mapped to 502 instead of 503,
              * since with 503 normally client should try again.

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -967,13 +967,26 @@ static pj_status_t mod_on_tx_msg(pjsip_tx_data *tdata)
 /*
  * Send a SIP message using the specified transport.
  */
-PJ_DEF(pj_status_t) pjsip_transport_send(  pjsip_transport *tr, 
+PJ_DEF(pj_status_t) pjsip_transport_send(  pjsip_transport *tr,
                                            pjsip_tx_data *tdata,
                                            const pj_sockaddr_t *addr,
                                            int addr_len,
                                            void *token,
                                            pjsip_tp_send_callback cb)
 {
+    return pjsip_transport_send2(tr, tdata, addr, addr_len, token, cb, NULL);
+}
+
+
+PJ_DEF(pj_status_t) pjsip_transport_send2( pjsip_transport *tr,
+                                           pjsip_tx_data *tdata,
+                                           const pj_sockaddr_t *addr,
+                                           int addr_len,
+                                           void *token,
+                                           pjsip_tp_send_callback cb,
+                                           pj_ssize_t *sent)
+{
+    pj_ssize_t msg_size;
     pj_status_t status;
 
     PJ_ASSERT_RETURN(tr && tdata && addr, PJ_EINVAL);
@@ -1024,8 +1037,14 @@ PJ_DEF(pj_status_t) pjsip_transport_send(  pjsip_transport *tr,
     /* Mark as pending. */
     tdata->is_pending = 1;
 
+    /* Remember the message size while the buffer is still ours. Once the
+     * message is on the wire, the peer may already answer it and another
+     * thread may invalidate and reuse this tdata (see #5176).
+     */
+    msg_size = tdata->buf.cur - tdata->buf.start;
+
     /* Send to transport. */
-    status = (*tr->send_msg)(tr, tdata,  addr, addr_len, (void*)tdata, 
+    status = (*tr->send_msg)(tr, tdata,  addr, addr_len, (void*)tdata,
                              &transport_send_callback);
 
     if (status != PJ_EPENDING) {
@@ -1033,6 +1052,9 @@ PJ_DEF(pj_status_t) pjsip_transport_send(  pjsip_transport *tr,
 
         /* Print log on successful sending */
         if (status == PJ_SUCCESS) {
+            if (sent)
+                *sent = msg_size;
+
             PJ_LOG(5,(tr->obj_name,
                       "%s sent successfully", pjsip_tx_data_get_info(tdata)));
         }

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1318,6 +1318,9 @@ static void stateless_send_transport_cb( void *token,
                                         &stateless_send_transport_cb,
                                         &sent);
         if (status == PJ_SUCCESS) {
+            /* A sent message is never empty, don't derive this from tdata. */
+            pj_assert(sent > 0);
+
             /* Recursively call this function. */
             stateless_send_transport_cb( stateless_data, tdata, sent );
             return;
@@ -1914,6 +1917,9 @@ static void send_response_resolver_cb( pj_status_t status, void *token,
                                     &send_response_transport_cb,
                                     &sent);
     if (status == PJ_SUCCESS) {
+        /* A sent message is never empty, don't derive this from tdata. */
+        pj_assert(sent > 0);
+
         send_response_transport_cb(send_state, send_state->tdata, sent);
 
     } else if (status == PJ_EPENDING) {
@@ -1957,6 +1963,9 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_response( pjsip_endpoint *endpt,
                                         &send_response_transport_cb,
                                         &sent );
         if (status == PJ_SUCCESS) {
+            /* A sent message is never empty, don't derive this from tdata. */
+            pj_assert(sent > 0);
+
             send_response_transport_cb(send_state, tdata, sent);
             return PJ_SUCCESS;
         } else if (status == PJ_EPENDING) {

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1310,15 +1310,15 @@ static void stateless_send_transport_cb( void *token,
         pjsip_tx_data_invalidate_msg(tdata);
 
         /* Send message using this transport. */
-        status = pjsip_transport_send( stateless_data->cur_transport,
-                                       tdata,
-                                       cur_addr,
-                                       cur_addr_len,
-                                       stateless_data,
-                                       &stateless_send_transport_cb);
+        status = pjsip_transport_send2( stateless_data->cur_transport,
+                                        tdata,
+                                        cur_addr,
+                                        cur_addr_len,
+                                        stateless_data,
+                                        &stateless_send_transport_cb,
+                                        &sent);
         if (status == PJ_SUCCESS) {
             /* Recursively call this function. */
-            sent = tdata->buf.cur - tdata->buf.start;
             stateless_send_transport_cb( stateless_data, tdata, sent );
             return;
         } else if (status == PJ_EPENDING) {
@@ -1866,6 +1866,7 @@ static void send_response_resolver_cb( pj_status_t status, void *token,
                                        const pjsip_server_addresses *addr )
 {
     pjsip_send_state *send_state = (pjsip_send_state*) token;
+    pj_ssize_t sent;
     unsigned i;
 
     if (status != PJ_SUCCESS) {
@@ -1905,15 +1906,14 @@ static void send_response_resolver_cb( pj_status_t status, void *token,
     }
 
     /* Send response using the transoprt. */
-    status = pjsip_transport_send( send_state->cur_transport, 
-                                   send_state->tdata,
-                                   &addr->entry[0].addr,
-                                   addr->entry[0].addr_len,
-                                   send_state,
-                                   &send_response_transport_cb);
+    status = pjsip_transport_send2( send_state->cur_transport,
+                                    send_state->tdata,
+                                    &addr->entry[0].addr,
+                                    addr->entry[0].addr_len,
+                                    send_state,
+                                    &send_response_transport_cb,
+                                    &sent);
     if (status == PJ_SUCCESS) {
-        pj_ssize_t sent = send_state->tdata->buf.cur - 
-                          send_state->tdata->buf.start;
         send_response_transport_cb(send_state, send_state->tdata, sent);
 
     } else if (status == PJ_EPENDING) {
@@ -1936,6 +1936,7 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_response( pjsip_endpoint *endpt,
      * based on Section 18.2.2 of RFC 3261.
      */
     pjsip_send_state *send_state;
+    pj_ssize_t sent;
     pj_status_t status;
 
     /* Create structure to keep the sending state. */
@@ -1949,13 +1950,13 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_response( pjsip_endpoint *endpt,
         send_state->cur_transport = res_addr->transport;
         pjsip_transport_add_ref(send_state->cur_transport);
 
-        status = pjsip_transport_send( send_state->cur_transport, tdata, 
-                                       &res_addr->addr,
-                                       res_addr->addr_len,
-                                       send_state,
-                                       &send_response_transport_cb );
+        status = pjsip_transport_send2( send_state->cur_transport, tdata,
+                                        &res_addr->addr,
+                                        res_addr->addr_len,
+                                        send_state,
+                                        &send_response_transport_cb,
+                                        &sent );
         if (status == PJ_SUCCESS) {
-            pj_ssize_t sent = tdata->buf.cur - tdata->buf.start;
             send_response_transport_cb(send_state, tdata, sent);
             return PJ_SUCCESS;
         } else if (status == PJ_EPENDING) {


### PR DESCRIPTION
Fixes #5176.

## Root cause

By the time `pjsip_transport_send()` returns, the message has already left the socket, so the peer's response can already be in flight. With more than one worker thread, the response can be processed — and the txdata reused — before the sending thread executes its next statement.

The INVITE 401/407 retry path does exactly that: `pjsip_auth_clt_reinit_req()` deliberately reuses the same `pjsip_tx_data` and calls `pjsip_tx_data_invalidate_msg()` on it, which resets `buf.cur` to `buf.start`.

`stateless_send_transport_cb()` then computed the number of bytes sent *after* the send:

```c
status = pjsip_transport_send(...);
if (status == PJ_SUCCESS) {
    sent = tdata->buf.cur - tdata->buf.start;   /* may already be 0 */
    stateless_send_transport_cb(stateless_data, tdata, sent);
```

reading zero and hitting `pj_assert(sent != 0)` in `send_msg_callback()` (`sip_transaction.c`). This matches the reported core dump: the old serialized text still present in the buffer but with zero valid length, no use-after-free, and the new transaction stuck in `CALLING` with `transport_flag == 0` because its `tsx_send_msg()` had hit the `tdata->is_pending` guard.

Note that the check suggested in the issue (`tdata->mod_data[...] != tsx`) would not have prevented the assertion, since the zero length is computed in `sip_util.c` before `send_msg_callback()` inspects `mod_data`.

## Changes

- **`pjsip_transport_send2()`** (new): same as `pjsip_transport_send()` plus an optional `pj_ssize_t *sent` out-param. The size is captured from the buffer before the txdata is handed to the transport, i.e. while it is still exclusively ours. `pjsip_transport_send()` becomes a thin wrapper, so existing callers are unaffected.
- **`sip_util.c`**: the three places that derived the byte count from `tdata->buf` after a synchronous send now take it from the out-param — `stateless_send_transport_cb()`, `send_response_resolver_cb()` and `pjsip_endpt_send_response()`.
- **`sip_transaction.c`**: `send_msg_callback()` only clears `tdata->mod_data[mod_tsx_layer.mod.id]` when it still points at this transaction. Previously a late callback could wipe the marker belonging to the transaction which had taken over the txdata; that transaction's own send callback would then bail out early, leaking a group lock reference (transaction never destroyed) and skipping its retransmission scheduling.

## Testing

`pjsip-test` built with ASan, all passing:

- `txdata_test`, `tsx_basic_test`, `tsx_uac_test`, `tsx_uas_test`, `tsx_destroy_test`, `transport_loop_test`, `transport_udp_test`, `transport_tcp_test`, `resolve_test` — 15 tests, 0 failed
- `auth_async_test`, `pjsua_auth_test`, `regc_test`, `dlg_core_test`, `inv_offer_answer_test` — 6 tests, 0 failed

## Not addressed here

The same race can still make the retried INVITE hit the `tdata->is_pending` guard in `tsx_send_msg()` and be skipped (logged as "message is pending"). Timer A recovers it on UDP; on a reliable transport it would stall until timer B. That guard is deliberate (#1665) and addressing it properly needs send queueing, so it is left for a separate change.

Co-Authored-By Claude Code