### PR TITLE
resolver: capture and clear the query callback under the group lock in the timeout and read-complete paths

### DIFF
--- a/pjlib-util/include/pjlib-util/resolver.h
+++ b/pjlib-util/include/pjlib-util/resolver.h
@@ -429,7 +429,9 @@ PJ_DECL(pj_status_t) pj_dns_resolver_start_query(pj_dns_resolver *resolver,
  *
  * @param query     The pending asynchronous query to be cancelled.
  * @param notify    If non-zero, the callback will be called with failure
- *                  status to notify that the query has been cancelled.
+ *                  status to notify that the query has been cancelled,
+ *                  unless the query has already completed and its callback
+ *                  has already been invoked.
  *
  * @return          PJ_SUCCESS on success, or the appropriate error code,
  */

--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -76,6 +76,16 @@ static pj_status_t start_during_destroy_status;
 static pj_dns_async_query *start_during_destroy_query;
 static int cancel_in_cb_count;
 static pj_dns_async_query *cancel_in_cb_query;
+static pj_bool_t cancel_in_cb_cancelled;
+static int cancel_in_tocb_count;
+static pj_dns_async_query *cancel_in_tocb_query;
+static pj_bool_t cancel_in_tocb_cancelled;
+static pj_status_t cancel_in_tocb_status;
+static int cancel_child_parent_count;
+static int cancel_child_child_count;
+static pj_dns_async_query *cancel_child_query;
+static pj_bool_t cancel_child_cancelled;
+static pj_status_t cancel_child_status;
 
 #define MAX_LABEL   32
 
@@ -1227,6 +1237,7 @@ static void dns_callback_cancel_in_cb(void *user_data,
     if (cancel_in_cb_count == 1 && cancel_in_cb_query) {
         pj_dns_async_query *q = cancel_in_cb_query;
         cancel_in_cb_query = NULL;
+        cancel_in_cb_cancelled = PJ_TRUE;
         pj_dns_resolver_cancel_query(q, PJ_TRUE);
     }
 
@@ -1246,6 +1257,7 @@ static int dns_cancel_in_callback_test(void)
 
     cancel_in_cb_count = 0;
     cancel_in_cb_query = NULL;
+    cancel_in_cb_cancelled = PJ_FALSE;
 
     /* Servers answer so the query completes and the callback fires. */
     g_server[0].action = PJ_DNS_RCODE_NXDOMAIN;
@@ -1254,14 +1266,204 @@ static int dns_cancel_in_callback_test(void)
     PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
                         resolver, &name, PJ_DNS_TYPE_A, 0,
                         &dns_callback_cancel_in_cb, NULL, &cancel_in_cb_query),
-                    NULL, return -600);
+                    NULL, return -670);
 
     pj_sem_wait(sem);
 
-    /* Give any erroneous second (PJ_ECANCELLED) delivery time to arrive. */
-    pj_thread_sleep(1000);
+    /* Guard against a vacuous pass: the assertions below only pin the
+     * behavior if the cancel actually ran inside the callback.
+     */
+    PJ_TEST_EQ(cancel_in_cb_cancelled, PJ_TRUE, NULL, return -672);
+    PJ_TEST_EQ(cancel_in_cb_count, 1, NULL, return -674);
 
-    PJ_TEST_EQ(cancel_in_cb_count, 1, NULL, return -610);
+    return 0;
+}
+
+
+/* Same as dns_callback_cancel_in_cb, but for the timeout variant below. */
+static void dns_callback_cancel_in_tocb(void *user_data,
+                                        pj_status_t status,
+                                        pj_dns_parsed_packet *resp)
+{
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(resp);
+
+    cancel_in_tocb_count++;
+
+    if (cancel_in_tocb_count == 1) {
+        cancel_in_tocb_status = status;
+        if (cancel_in_tocb_query) {
+            pj_dns_async_query *q = cancel_in_tocb_query;
+            cancel_in_tocb_query = NULL;
+            cancel_in_tocb_cancelled = PJ_TRUE;
+            pj_dns_resolver_cancel_query(q, PJ_TRUE);
+        }
+    }
+
+    pj_sem_post(sem);
+}
+
+
+/* Same as dns_cancel_in_callback_test, but through the timeout path: the
+ * servers do not respond, so the callback is delivered by on_timeout()
+ * rather than on_read_complete(). Uses a dedicated resolver with short
+ * retransmission settings to keep the timeout fast.
+ */
+static int dns_cancel_in_timeout_callback_test(void)
+{
+    pj_str_t name = pj_str("name_cancel_in_tocb");
+    pj_str_t nameservers[2];
+    pj_uint16_t ports[2];
+    pj_dns_settings lset;
+    pj_dns_resolver *res;
+
+    PJ_LOG(3,(THIS_FILE, "  cancel query from within its timeout callback test"));
+
+    cancel_in_tocb_count = 0;
+    cancel_in_tocb_query = NULL;
+    cancel_in_tocb_cancelled = PJ_FALSE;
+    cancel_in_tocb_status = PJ_SUCCESS;
+
+    /* Servers ignore the query so it times out. */
+    g_server[0].action = ACTION_IGNORE;
+    g_server[1].action = ACTION_IGNORE;
+
+    nameservers[0] = nameservers[1] = pj_str("127.0.0.1");
+    ports[0] = g_server[0].port;
+    ports[1] = g_server[1].port;
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_create(mem, NULL, 0, timer_heap, ioqueue,
+                                           &res),
+                    NULL, return -650);
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_ns(res, 2, nameservers, ports),
+                    NULL, return -651);
+
+    pj_dns_resolver_get_settings(res, &lset);
+    lset.qretr_delay = 200;
+    lset.qretr_count = 1;
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_settings(res, &lset),
+                    NULL, return -652);
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        res, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_cancel_in_tocb, NULL,
+                        &cancel_in_tocb_query),
+                    NULL, return -653);
+
+    pj_sem_wait(sem);
+
+    PJ_TEST_EQ(cancel_in_tocb_status, PJ_ETIMEDOUT, NULL, return -654);
+    PJ_TEST_EQ(cancel_in_tocb_cancelled, PJ_TRUE, NULL, return -655);
+    PJ_TEST_EQ(cancel_in_tocb_count, 1, NULL, return -656);
+
+    pj_dns_resolver_destroy(res, PJ_FALSE);
+
+    return 0;
+}
+
+
+static void dns_callback_cancel_child_parent(void *user_data,
+                                             pj_status_t status,
+                                             pj_dns_parsed_packet *resp)
+{
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(status);
+    PJ_UNUSED_ARG(resp);
+
+    cancel_child_parent_count++;
+
+    pj_sem_post(sem);
+}
+
+/* Callback of the coalesced child query; cancels its own query on the first
+ * delivery, like dns_callback_cancel_in_cb.
+ */
+static void dns_callback_cancel_child(void *user_data,
+                                      pj_status_t status,
+                                      pj_dns_parsed_packet *resp)
+{
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(resp);
+
+    cancel_child_child_count++;
+
+    if (cancel_child_child_count == 1) {
+        cancel_child_status = status;
+        if (cancel_child_query) {
+            pj_dns_async_query *q = cancel_child_query;
+            cancel_child_query = NULL;
+            cancel_child_cancelled = PJ_TRUE;
+            pj_dns_resolver_cancel_query(q, PJ_TRUE);
+        }
+    }
+
+    pj_sem_post(sem);
+}
+
+
+/* Same again, but cancelling a coalesced CHILD query from inside its own
+ * callback, to cover the child (ccb) capture loop. The servers ignore the
+ * query, so the parent stays pending in the resolver's hash tables until
+ * its timeout fires; the second start_query() below is therefore guaranteed
+ * to join it as a child, and both callbacks are delivered by the same
+ * on_timeout() pass.
+ */
+static int dns_cancel_child_in_callback_test(void)
+{
+    pj_str_t name = pj_str("name_cancel_child_tocb");
+    pj_str_t nameservers[2];
+    pj_uint16_t ports[2];
+    pj_dns_settings lset;
+    pj_dns_resolver *res;
+
+    PJ_LOG(3,(THIS_FILE, "  cancel child query from within its callback test"));
+
+    cancel_child_parent_count = 0;
+    cancel_child_child_count = 0;
+    cancel_child_query = NULL;
+    cancel_child_cancelled = PJ_FALSE;
+    cancel_child_status = PJ_SUCCESS;
+
+    /* Servers ignore the query so it times out. */
+    g_server[0].action = ACTION_IGNORE;
+    g_server[1].action = ACTION_IGNORE;
+
+    nameservers[0] = nameservers[1] = pj_str("127.0.0.1");
+    ports[0] = g_server[0].port;
+    ports[1] = g_server[1].port;
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_create(mem, NULL, 0, timer_heap, ioqueue,
+                                           &res),
+                    NULL, return -660);
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_ns(res, 2, nameservers, ports),
+                    NULL, return -661);
+
+    pj_dns_resolver_get_settings(res, &lset);
+    lset.qretr_delay = 200;
+    lset.qretr_count = 1;
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_settings(res, &lset),
+                    NULL, return -662);
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        res, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_cancel_child_parent, NULL, NULL),
+                    NULL, return -663);
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        res, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_cancel_child, NULL,
+                        &cancel_child_query),
+                    NULL, return -664);
+
+    /* One delivery for the parent, one for the child. */
+    pj_sem_wait(sem);
+    pj_sem_wait(sem);
+
+    PJ_TEST_EQ(cancel_child_status, PJ_ETIMEDOUT, NULL, return -665);
+    PJ_TEST_EQ(cancel_child_cancelled, PJ_TRUE, NULL, return -666);
+    PJ_TEST_EQ(cancel_child_child_count, 1, NULL, return -667);
+    PJ_TEST_EQ(cancel_child_parent_count, 1, NULL, return -668);
+
+    pj_dns_resolver_destroy(res, PJ_FALSE);
 
     return 0;
 }
@@ -2150,6 +2352,16 @@ int resolver_test(void)
 
     PJ_LOG(3,(THIS_FILE, "dns_cancel_in_callback_test"));
     rc = dns_cancel_in_callback_test();
+    if (rc != 0)
+        goto on_error;
+
+    PJ_LOG(3,(THIS_FILE, "dns_cancel_in_timeout_callback_test"));
+    rc = dns_cancel_in_timeout_callback_test();
+    if (rc != 0)
+        goto on_error;
+
+    PJ_LOG(3,(THIS_FILE, "dns_cancel_child_in_callback_test"));
+    rc = dns_cancel_child_in_callback_test();
     if (rc != 0)
         goto on_error;
 

--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -74,6 +74,8 @@ static volatile pj_bool_t cb_after_destroy;
 static pj_dns_resolver *start_during_destroy_res;
 static pj_status_t start_during_destroy_status;
 static pj_dns_async_query *start_during_destroy_query;
+static int cancel_in_cb_count;
+static pj_dns_async_query *cancel_in_cb_query;
 
 #define MAX_LABEL   32
 
@@ -1207,6 +1209,64 @@ static int dns_start_during_destroy_test(void)
 }
 
 
+/* Callback for the cancel-in-callback test: on the first delivery it cancels
+ * its own query with notify=PJ_TRUE. Before the callback is captured and
+ * cleared under the group lock, the query still held a live cb, so cancel
+ * delivered a second (PJ_ECANCELLED) callback for the same query.
+ */
+static void dns_callback_cancel_in_cb(void *user_data,
+                                      pj_status_t status,
+                                      pj_dns_parsed_packet *resp)
+{
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(status);
+    PJ_UNUSED_ARG(resp);
+
+    cancel_in_cb_count++;
+
+    if (cancel_in_cb_count == 1 && cancel_in_cb_query) {
+        pj_dns_async_query *q = cancel_in_cb_query;
+        cancel_in_cb_query = NULL;
+        pj_dns_resolver_cancel_query(q, PJ_TRUE);
+    }
+
+    pj_sem_post(sem);
+}
+
+
+/* Cancelling a query from inside its own completion callback must not deliver
+ * the callback a second time (the cb is captured and cleared under the lock
+ * before it is invoked). Asserts the callback runs exactly once.
+ */
+static int dns_cancel_in_callback_test(void)
+{
+    pj_str_t name = pj_str("name_cancel_in_cb");
+
+    PJ_LOG(3,(THIS_FILE, "  cancel query from within its callback test"));
+
+    cancel_in_cb_count = 0;
+    cancel_in_cb_query = NULL;
+
+    /* Servers answer so the query completes and the callback fires. */
+    g_server[0].action = PJ_DNS_RCODE_NXDOMAIN;
+    g_server[1].action = PJ_DNS_RCODE_NXDOMAIN;
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        resolver, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_cancel_in_cb, NULL, &cancel_in_cb_query),
+                    NULL, return -600);
+
+    pj_sem_wait(sem);
+
+    /* Give any erroneous second (PJ_ECANCELLED) delivery time to arrive. */
+    pj_thread_sleep(1000);
+
+    PJ_TEST_EQ(cancel_in_cb_count, 1, NULL, return -610);
+
+    return 0;
+}
+
+
 /* DNS test */
 static int dns_test(void)
 {
@@ -2085,6 +2145,11 @@ int resolver_test(void)
 
     PJ_LOG(3,(THIS_FILE, "dns_test"));
     rc = dns_test();
+    if (rc != 0)
+        goto on_error;
+
+    PJ_LOG(3,(THIS_FILE, "dns_cancel_in_callback_test"));
+    rc = dns_cancel_in_callback_test();
     if (rc != 0)
         goto on_error;
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -1680,16 +1680,11 @@ static void on_timeout( pj_timer_heap_t *timer_heap,
     pj_hash_set(NULL, resolver->hquerybyid, &q->id, sizeof(q->id), 0, NULL);
     pj_hash_set(NULL, resolver->hquerybyres, &q->key, sizeof(q->key), 0, NULL);
 
-    /* Workaround for deadlock problem in #1565 (similar to #1108) */
-    pj_grp_lock_release(resolver->grp_lock);
-
-    /* Capture and clear each callback under the lock, but invoke it after
-     * releasing, so it neither runs under the lock nor races a concurrent
-     * cancel into a duplicate call.
-     */
-    pj_grp_lock_acquire(resolver->grp_lock);
+    /* Capture and clear the callback under the lock; invoke it unlocked. */
     cb = q->cb;
     q->cb = NULL;
+
+    /* Workaround for deadlock problem in #1565 (similar to #1108) */
     pj_grp_lock_release(resolver->grp_lock);
 
     if (cb)
@@ -1699,14 +1694,15 @@ static void on_timeout( pj_timer_heap_t *timer_heap,
     cq = q->child_head.next;
     while (cq != (void*)&q->child_head) {
         pj_dns_async_query *next = cq->next;
+        pj_dns_callback *ccb;
 
         pj_grp_lock_acquire(resolver->grp_lock);
-        cb = cq->cb;
+        ccb = cq->cb;
         cq->cb = NULL;
         pj_grp_lock_release(resolver->grp_lock);
 
-        if (cb)
-            (*cb)(cq->user_data, PJ_ETIMEDOUT, NULL);
+        if (ccb)
+            (*ccb)(cq->user_data, PJ_ETIMEDOUT, NULL);
 
         cq = next;
     }
@@ -1844,19 +1840,14 @@ static void on_read_complete(pj_ioqueue_key_t *key,
     pj_hash_set(NULL, resolver->hquerybyid, &q->id, sizeof(q->id), 0, NULL);
     pj_hash_set(NULL, resolver->hquerybyres, &q->key, sizeof(q->key), 0, NULL);
 
-    /* Workaround for deadlock problem in #1108 */
-    pj_grp_lock_release(resolver->grp_lock);
-
     /* Notify applications first, to allow application to modify the
-     * record before it is saved to the hash table.
-     *
-     * Capture and clear each callback under the lock, but invoke it after
-     * releasing, so it neither runs under the lock nor races a concurrent
-     * cancel into a duplicate call.
+     * record before it is saved to the hash table. Capture and clear
+     * the callback under the lock; invoke it unlocked.
      */
-    pj_grp_lock_acquire(resolver->grp_lock);
     cb = q->cb;
     q->cb = NULL;
+
+    /* Workaround for deadlock problem in #1108 */
     pj_grp_lock_release(resolver->grp_lock);
 
     if (cb)
@@ -1869,14 +1860,15 @@ static void on_read_complete(pj_ioqueue_key_t *key,
         child_q = q->child_head.next;
         while (child_q != (pj_dns_async_query*)&q->child_head) {
             pj_dns_async_query *next = child_q->next;
+            pj_dns_callback *ccb;
 
             pj_grp_lock_acquire(resolver->grp_lock);
-            cb = child_q->cb;
+            ccb = child_q->cb;
             child_q->cb = NULL;
             pj_grp_lock_release(resolver->grp_lock);
 
-            if (cb)
-                (*cb)(child_q->user_data, status, dns_pkt);
+            if (ccb)
+                (*ccb)(child_q->user_data, status, dns_pkt);
 
             child_q = next;
         }

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -1638,6 +1638,7 @@ static void on_timeout( pj_timer_heap_t *timer_heap,
 {
     pj_dns_resolver *resolver;
     pj_dns_async_query *q, *cq;
+    pj_dns_callback *cb;
     pj_status_t status;
 
     PJ_UNUSED_ARG(timer_heap);
@@ -1682,16 +1683,32 @@ static void on_timeout( pj_timer_heap_t *timer_heap,
     /* Workaround for deadlock problem in #1565 (similar to #1108) */
     pj_grp_lock_release(resolver->grp_lock);
 
-    /* Call application callback, if any. */
-    if (q->cb)
-        (*q->cb)(q->user_data, PJ_ETIMEDOUT, NULL);
+    /* Capture and clear each callback under the lock, but invoke it after
+     * releasing, so it neither runs under the lock nor races a concurrent
+     * cancel into a duplicate call.
+     */
+    pj_grp_lock_acquire(resolver->grp_lock);
+    cb = q->cb;
+    q->cb = NULL;
+    pj_grp_lock_release(resolver->grp_lock);
+
+    if (cb)
+        (*cb)(q->user_data, PJ_ETIMEDOUT, NULL);
 
     /* Call application callback for child queries. */
     cq = q->child_head.next;
     while (cq != (void*)&q->child_head) {
-        if (cq->cb)
-            (*cq->cb)(cq->user_data, PJ_ETIMEDOUT, NULL);
-        cq = cq->next;
+        pj_dns_async_query *next = cq->next;
+
+        pj_grp_lock_acquire(resolver->grp_lock);
+        cb = cq->cb;
+        cq->cb = NULL;
+        pj_grp_lock_release(resolver->grp_lock);
+
+        if (cb)
+            (*cb)(cq->user_data, PJ_ETIMEDOUT, NULL);
+
+        cq = next;
     }
 
     /* Workaround for deadlock problem in #1565 (similar to #1108) */
@@ -1725,6 +1742,7 @@ static void on_read_complete(pj_ioqueue_key_t *key,
     pj_pool_t *pool = NULL;
     pj_dns_parsed_packet *dns_pkt;
     pj_dns_async_query *q;
+    pj_dns_callback *cb;
     char addr[PJ_INET6_ADDRSTRLEN];
     pj_sockaddr *src_addr;
     int *src_addr_len;
@@ -1829,11 +1847,20 @@ static void on_read_complete(pj_ioqueue_key_t *key,
     /* Workaround for deadlock problem in #1108 */
     pj_grp_lock_release(resolver->grp_lock);
 
-    /* Notify applications first, to allow application to modify the 
+    /* Notify applications first, to allow application to modify the
      * record before it is saved to the hash table.
+     *
+     * Capture and clear each callback under the lock, but invoke it after
+     * releasing, so it neither runs under the lock nor races a concurrent
+     * cancel into a duplicate call.
      */
-    if (q->cb)
-        (*q->cb)(q->user_data, status, dns_pkt);
+    pj_grp_lock_acquire(resolver->grp_lock);
+    cb = q->cb;
+    q->cb = NULL;
+    pj_grp_lock_release(resolver->grp_lock);
+
+    if (cb)
+        (*cb)(q->user_data, status, dns_pkt);
 
     /* If query has subqueries, notify subqueries's application callback */
     if (!pj_list_empty(&q->child_head)) {
@@ -1841,9 +1868,17 @@ static void on_read_complete(pj_ioqueue_key_t *key,
 
         child_q = q->child_head.next;
         while (child_q != (pj_dns_async_query*)&q->child_head) {
-            if (child_q->cb)
-                (*child_q->cb)(child_q->user_data, status, dns_pkt);
-            child_q = child_q->next;
+            pj_dns_async_query *next = child_q->next;
+
+            pj_grp_lock_acquire(resolver->grp_lock);
+            cb = child_q->cb;
+            child_q->cb = NULL;
+            pj_grp_lock_release(resolver->grp_lock);
+
+            if (cb)
+                (*cb)(child_q->user_data, status, dns_pkt);
+
+            child_q = next;
         }
     }
 


### PR DESCRIPTION
A DNS query callback can be invoked twice or called through a NULL pointer when
`pj_dns_resolver_cancel_query()` runs on another thread concurrently with the delivery
of that query's response or timeout.

Follow-up to #5167 (the two remaining call sites @nanangizz asked to track separately).

## Problem

`pj_dns_resolver_cancel_query()` captures and clears `query->cb` under the group lock
before invoking it. `on_timeout()` and `on_read_complete()` do the opposite: to avoid
the #1108/#1565 deadlock they release the group lock first, then read and invoke `q->cb`
(and each child `cq->cb`) with no lock held:

```c
/* on_read_complete(), before */
pj_grp_lock_release(resolver->grp_lock);
...
if (q->cb)
    (*q->cb)(q->user_data, status, dns_pkt);
```

A `cancel_query()` running on any other thread — an application thread holding the query
handle, or a second worker — races that unlocked read:

- it clears `q->cb` between the `if (q->cb)` check and the `(*q->cb)` deref, turning the
  call into a jump through a NULL pointer, or
- the notify path never clears `q->cb`, so the callback fires here and again from
  `cancel_query(notify=TRUE)` for the same query (double delivery, cf. #1809).

#5167 fixed this class for `pj_dns_resolver_destroy()`; `on_timeout()` and
`on_read_complete()` are the remaining call sites.

## Details

Both paths now mirror the #5167 destroy path: capture and clear each callback under the
group lock, then invoke the saved pointer after releasing it, for the parent query and
each child (`cancel_query()` already does the capture-and-clear half under the lock):

```c
/* on_read_complete(), after */
pj_grp_lock_acquire(resolver->grp_lock);
cb = q->cb;
q->cb = NULL;
pj_grp_lock_release(resolver->grp_lock);

if (cb)
    (*cb)(q->user_data, status, dns_pkt);
```

The child loop reads `next = child_q->next` before the release window; child nodes live
on the parent's `child_head` only (they are never in `hquerybyid`/`hquerybyres`), and the
parent was already removed from both hashes under the lock before the notify loops, so no
other thread can recycle the query or its children while the callbacks run. The
callback-before-cache ordering in `on_read_complete()` (notify first, then
`update_res_cache()`) is unchanged. No callback is invoked while holding the lock, so the
#1108/#1565 deadlock avoidance is preserved.

This also fixes a user-visible re-entrancy case on a single thread: because the callback pointer was previously read but not cleared before being invoked, an application that cancels a query (with `notify`) from inside that query's own completion callback received a second, `PJ_ECANCELLED`, delivery. This applies to child queries too, since a child is handed to the application as a query handle. Capturing and clearing the callback under the lock before invoking makes each query's callback fire exactly once.

This relies on the `if (notify && cb)` guard `cancel_query()` gained in #5167: once the
timeout/read-complete paths clear `q->cb`, a losing `cancel_query(notify=TRUE)` must skip
the now-NULL pointer.

## Testing

`pjlib-util-test resolver_test` passes on macOS (arm64) and Linux (gcc 13,
aarch64-unknown-linux-gnu), 0 failed, including under an ASan build. Three new deterministic tests pin the exactly-once contract, all red on master and green here, no thread interleaving: `dns_cancel_in_callback_test` (cancel from inside the completion callback, response path), `dns_cancel_in_timeout_callback_test` (same through `on_timeout()`, servers ignore the query), and `dns_cancel_child_in_callback_test` (a coalesced child cancels itself from its callback, covering the per-child capture loop). Each test also asserts its cancel actually ran, so a vacuous pass fails at the guard. The race is a few instructions wide; it was
reproduced deterministically on stock master by widening the window (a `pj_thread_sleep`
between the `if (q->cb)` check and the deref) and driving
`pj_dns_resolver_cancel_query()` from another thread, which faults through a NULL
callback. With this change the pointer is captured and cleared under the lock before
that window exists, so the cancel either runs first (delivery here is skipped) or reads
NULL and skips.


