### PR TITLE
resolver: reject new queries once destroy has started

### DIFF
--- a/pjlib-util/include/pjlib-util/resolver.h
+++ b/pjlib-util/include/pjlib-util/resolver.h
@@ -407,11 +407,14 @@ PJ_DECL(pj_status_t) pj_dns_resolver_destroy(pj_dns_resolver *resolver,
  *                  and which will be given back in the callback.
  * @param p_query   Optional pointer to receive the query object, if one
  *                  was started. If this pointer is specified, a NULL will
- *                  be returned if response cache is available immediately.
+ *                  be returned if response cache is available immediately,
+ *                  or if the query is rejected because the resolver is
+ *                  being destroyed.
  *
- * @return          PJ_SUCCESS if either an asynchronous query has been 
+ * @return          PJ_SUCCESS if either an asynchronous query has been
  *                  started successfully or response cache is available and
- *                  the user callback has been called.
+ *                  the user callback has been called; PJ_EGONE if the
+ *                  resolver is being destroyed.
  */
 PJ_DECL(pj_status_t) pj_dns_resolver_start_query(pj_dns_resolver *resolver,
                                                  const pj_str_t *name,

--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -71,6 +71,9 @@ static pj_sem_t *sem;
 static pj_dns_settings set;
 static volatile pj_bool_t destroy_done;
 static volatile pj_bool_t cb_after_destroy;
+static pj_dns_resolver *start_during_destroy_res;
+static pj_status_t start_during_destroy_status;
+static pj_dns_async_query *start_during_destroy_query;
 
 #define MAX_LABEL   32
 
@@ -1119,6 +1122,91 @@ static int dns_destroy_pending_test(void)
 }
 
 
+/* Callback for the start-during-destroy test: starts a new query from
+ * inside the PJ_ECANCELLED notification delivered by
+ * pj_dns_resolver_destroy(), the way the SRV resolver's fallback does.
+ */
+static void dns_callback_start_during_destroy(void *user_data,
+                                              pj_status_t status,
+                                              pj_dns_parsed_packet *resp)
+{
+    pj_str_t name = pj_str("name_restart");
+
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(resp);
+
+    if (status != PJ_ECANCELLED)
+        return;
+
+    /* Seed the out-pointer with a dummy, as the SRV resolver does, to
+     * verify that a rejected start still writes it.
+     */
+    start_during_destroy_query = (pj_dns_async_query*)0x1;
+    start_during_destroy_status =
+        pj_dns_resolver_start_query(start_during_destroy_res, &name,
+                                    PJ_DNS_TYPE_A, 0,
+                                    &dns_callback_destroy, NULL,
+                                    &start_during_destroy_query);
+}
+
+
+/* Start a query from inside destroy's cancel notification: the resolver
+ * must reject it with PJ_EGONE, write the out-pointer, and leave no timer
+ * armed past the teardown.
+ */
+static int dns_start_during_destroy_test(void)
+{
+    pj_str_t name = pj_str("name_sdd");
+    pj_str_t nameservers[2];
+    pj_uint16_t ports[2];
+
+    PJ_LOG(3,(THIS_FILE, "  start query during destroy test"));
+
+    destroy_done = PJ_FALSE;
+    cb_after_destroy = PJ_FALSE;
+    start_during_destroy_status = PJ_SUCCESS;
+    start_during_destroy_query = NULL;
+
+    /* Servers ignore the query so it stays pending. */
+    g_server[0].action = ACTION_IGNORE;
+    g_server[1].action = ACTION_IGNORE;
+
+    nameservers[0] = nameservers[1] = pj_str("127.0.0.1");
+    ports[0] = g_server[0].port;
+    ports[1] = g_server[1].port;
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_create(mem, NULL, 0, timer_heap, ioqueue,
+                                           &start_during_destroy_res),
+                    NULL, return -720);
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_ns(start_during_destroy_res, 2,
+                                           nameservers, ports),
+                    NULL, return -725);
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        start_during_destroy_res, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_start_during_destroy, NULL, NULL),
+                    NULL, return -730);
+
+    destroy_done = PJ_TRUE;
+    pj_dns_resolver_destroy(start_during_destroy_res, PJ_TRUE);
+
+    /* The cancel notification must have run and its re-entrant start must
+     * have been rejected with the out-pointer cleared.
+     */
+    PJ_TEST_EQ(start_during_destroy_status, PJ_EGONE, NULL, return -740);
+    PJ_TEST_TRUE(start_during_destroy_query == NULL, NULL, return -745);
+
+    /* Wait past the retransmit delay: a timer armed by the rejected start
+     * would fire here.
+     */
+    pj_thread_sleep((unsigned)(set.qretr_delay * 2));
+
+    PJ_TEST_EQ(cb_after_destroy, PJ_FALSE, NULL, return -750);
+
+    return 0;
+}
+
+
 /* DNS test */
 static int dns_test(void)
 {
@@ -2017,6 +2105,11 @@ int resolver_test(void)
 
     PJ_LOG(3,(THIS_FILE, "dns_destroy_pending_test"));
     rc = dns_destroy_pending_test();
+    if (rc != 0)
+        goto on_error;
+
+    PJ_LOG(3,(THIS_FILE, "dns_start_during_destroy_test"));
+    rc = dns_start_during_destroy_test();
     if (rc != 0)
         goto on_error;
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -218,6 +218,11 @@ struct pj_dns_resolver
 
     /* Query entries free list */
     struct query_head    query_free_nodes;
+
+    /* Set once pj_dns_resolver_destroy() has started, to reject new queries
+     * and cache updates that would otherwise miss the teardown.
+     */
+    pj_bool_t            shutting_down;
 };
 
 
@@ -492,6 +497,7 @@ PJ_DEF(pj_status_t) pj_dns_resolver_destroy( pj_dns_resolver *resolver,
     pj_list_init(&cancel_list);
 
     pj_grp_lock_acquire(resolver->grp_lock);
+    resolver->shutting_down = PJ_TRUE;
     it = pj_hash_first(resolver->hquerybyid, &it_buf);
     while (it) {
         q = (pj_dns_async_query *)pj_hash_this(resolver->hquerybyid, it);
@@ -939,6 +945,17 @@ PJ_DEF(pj_status_t) pj_dns_resolver_start_query( pj_dns_resolver *resolver,
 
     /* Start working with the resolver */
     pj_grp_lock_acquire(resolver->grp_lock);
+
+    /* Reject new queries once destroy has started: a query started after
+     * destroy collected the pending queries would arm a timer that survives
+     * the teardown.
+     */
+    if (resolver->shutting_down) {
+        if (p_query)
+            *p_query = NULL;
+        pj_grp_lock_release(resolver->grp_lock);
+        return PJ_EGONE;
+    }
 
     /* Get current time. */
     pj_gettimeofday(&now);
@@ -1833,8 +1850,11 @@ static void on_read_complete(pj_ioqueue_key_t *key,
     /* Workaround for deadlock problem in #1108 */
     pj_grp_lock_acquire(resolver->grp_lock);
 
-    /* Truncated responses MUST NOT be saved (cached). */
-    if (PJ_DNS_GET_TC(dns_pkt->hdr.flags) == 0) {
+    /* Truncated responses MUST NOT be saved (cached). Skip caching as well
+     * once destroy has started: destroy sweeps the cache, so a late entry
+     * would never be freed.
+     */
+    if (PJ_DNS_GET_TC(dns_pkt->hdr.flags) == 0 && !resolver->shutting_down) {
         /* Save/update response cache. */
         update_res_cache(resolver, &q->key, status, PJ_TRUE, dns_pkt);
     }


### PR DESCRIPTION
A DNS query started while `pj_dns_resolver_destroy()` is already running slips past the
teardown, leaving a retransmit timer armed in a heap the teardown destroys, or firing
later against the closed socket.

Follow-up to #5167 (second of the two remaining items @nanangizz asked to track separately).

## Problem

`pj_dns_resolver_destroy()` collects the pending queries and cancels their timers under
the group lock (#5167). A `pj_dns_resolver_start_query()` that acquires the lock after
that snapshot creates a query the snapshot never saw: its retransmit timer is armed in a
timer heap the teardown below is about to destroy (`own_timer`), or fires later against
the closed socket. The query also lands in hash tables destroy has already swept.

The common vector is a second thread: a resolution in flight (`srv_resolver.c`'s
fallback, `sip_resolve.c`) calls `start_query()` on a worker thread while another thread
destroys the resolver — pjsip itself tears it down this way (`sip_resolve.c` destroys
with `notify=FALSE`). With `destroy(notify=TRUE)` no second thread is even needed:
`sip_resolve.c` always sets the `PJ_DNS_SRV_FALLBACK_*` flags, and on an unsuccessful
SRV status — including the `PJ_ECANCELLED` delivered by destroy itself —
`srv_resolver.c`'s `dns_callback` falls back to starting new A/AAAA queries; destroy
invokes the callbacks after releasing the lock, so those `start_query()` calls run in
the middle of destroy, on the destroying thread.

## Details

The resolver now sets a `shutting_down` flag as the first statement of destroy's locked
snapshot, and `start_query()` checks it right after acquiring the group lock:

```c
if (resolver->shutting_down) {
    if (p_query)
        *p_query = NULL;
    pj_grp_lock_release(resolver->grp_lock);
    return PJ_EGONE;
}
```

Since both sides run under the group lock, every query either starts before the snapshot
(and is cancelled by it) or is rejected; no ordering arms a timer the teardown misses.

Writing `*p_query = NULL` is required: `srv_resolver.c` seeds `srv->q_aaaa` with a dummy
pointer and relies on `start_query()` overwriting it, and its completion logic
(`srv_completed = (srv->q_aaaa == NULL)`) would otherwise wait forever once a rejected
AAAA start follows an already-started A query. Both in-tree
callers (`srv_resolver.c`, `sip_resolve.c`) already handle a synchronous failure status
generically, so the new return introduces no leak or double report. `PJ_EGONE` follows
the existing convention for rejecting work on an object being destroyed
(`turn_sock.c`, `sip_reg.c`, `sip_inv.c`).

`on_read_complete()` gets the same check where it re-acquires the lock to update the
response cache: a response that came in while destroy is running must not allocate a new
cache entry, since destroy sweeps the cache and a late entry would never be freed.

Left out as pre-existing and separate: destroy's cache sweep does not honor
`cache->ref_cnt` against a concurrent cache-hit callback in `start_query()`, and
`pj_dns_resolver_add_entry()` / `pj_dns_resolver_handle_events()` are not gated by the
new flag.

## Testing

Adds `dns_start_during_destroy_test`, which starts a query from inside destroy's
`PJ_ECANCELLED` notification (the SRV-fallback pattern), seeds the out-pointer with a
dummy the way the SRV resolver does, and asserts the start is rejected with `PJ_EGONE`,
the out-pointer is cleared, and no timer fires past the teardown. It fails on stock
master (`start_query()` returns `PJ_SUCCESS` and arms the stray timer) and passes with
this change. `pjlib-util-test resolver_test` passes on macOS (arm64) and Linux (gcc 13),
0 failed, including this test and `dns_destroy_pending_test` from #5167.
