### PR TITLE
pjmedia: send unconditional start-of-stream keep-alive for text streams

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1460,6 +1460,12 @@
  *
  * Setting this to 0 will disable it.
  *
+ * Note that text streams always use this setting (along with
+ * PJMEDIA_STREAM_START_KA_INTERVAL_MSEC) for NAT hole punching at stream
+ * start, regardless of PJMEDIA_STREAM_ENABLE_KA, unless ICE is active.
+ * When PJMEDIA_STREAM_ENABLE_KA is enabled, the runtime keep-alive settings
+ * of the stream take precedence.
+ *
  * Default : 2
  */
 #ifndef PJMEDIA_STREAM_START_KA_CNT

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1460,11 +1460,13 @@
  *
  * Setting this to 0 will disable it.
  *
- * Note that text streams always use this setting (along with
- * PJMEDIA_STREAM_START_KA_INTERVAL_MSEC) for NAT hole punching at stream
- * start, regardless of PJMEDIA_STREAM_ENABLE_KA, unless ICE is active.
- * When PJMEDIA_STREAM_ENABLE_KA is enabled, the runtime keep-alive settings
- * of the stream take precedence.
+ * Note that text streams also send this start-of-stream keep-alive burst
+ * (using this setting and PJMEDIA_STREAM_START_KA_INTERVAL_MSEC) when
+ * PJMEDIA_STREAM_ENABLE_KA is disabled, as they have no other way to punch
+ * a NAT hole before the first text is typed. When PJMEDIA_STREAM_ENABLE_KA
+ * is enabled, the stream's runtime use_ka and ka_cfg settings apply
+ * instead. In both cases the burst is skipped when ICE is active, and the
+ * count is capped at 10 and the interval floored at 500 ms.
  *
  * Default : 2
  */

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -477,11 +477,11 @@ PJ_DEF(pj_status_t) pjmedia_txt_stream_start(pjmedia_txt_stream *stream)
     pj_status_t status;
 
     pjmedia_stream_common_start(c_strm);
-    if (!c_strm->enc->paused || !c_strm->dec->paused) {
-        status = pjmedia_clock_start(stream->clock);
-    } else {
-        status = pjmedia_clock_stop(stream->clock);
-    }
+
+    /* Run the clock even for inactive direction, RTCP and start-of-stream
+     * keep-alives are still needed (RFC 3264 5.1, RFC 6263 1).
+     */
+    status = pjmedia_clock_start(stream->clock);
 
     return status;
 }

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -100,10 +100,10 @@ typedef struct pjmedia_txt_stream {
     pj_timestamp rtcp_last_tx;   /**< Last RTCP tx time.     */
     pj_timestamp tx_last_ts;     /**< Timestamp of last tx.  */
 
-    unsigned start_ka_cnt;         /**< Remaining start-of-stream
+    unsigned start_ka_left;        /**< Remaining start-of-stream
                                         keep-alives to send.      */
-    unsigned start_ka_interval;    /**< Start keep-alive interval
-                                        in msec.                  */
+    unsigned start_ka_msec;        /**< Effective start keep-alive
+                                        interval, in msec.        */
     pj_timestamp start_ka_last_tx; /**< Last start keep-alive tx. */
     red_buf tx_buf[NUM_BUFFERS]; /**< Tx buffer.         */
     int tx_nred;                 /**< Num of redundant data. */
@@ -124,28 +124,28 @@ static void clock_cb(const pj_timestamp *ts, void *user_data);
  * Set up the start-of-stream keep-alive burst, see check_start_ka().
  * Must be called after the transport is attached.
  */
-static void init_start_ka(pjmedia_txt_stream *stream,
-                          const pjmedia_txt_stream_info *info)
+static void init_start_ka(pjmedia_txt_stream *stream)
 {
     pjmedia_stream_common *c_strm = &stream->base;
     pjmedia_transport_info tpinfo;
     pjmedia_ice_transport_info *ice_info;
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
-    stream->start_ka_cnt = info->use_ka ? info->ka_cfg.start_count : 0;
-    stream->start_ka_interval = info->ka_cfg.start_interval;
+    /* Take the runtime settings, already set from info->ka_cfg above. */
+    stream->start_ka_left = c_strm->use_ka ? c_strm->start_ka_count : 0;
+    stream->start_ka_msec = c_strm->start_ka_interval;
 #else
-    PJ_UNUSED_ARG(info);
-    stream->start_ka_cnt = PJMEDIA_STREAM_START_KA_CNT;
-    stream->start_ka_interval = PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
+    /* No runtime settings in this build, they are compiled out. */
+    stream->start_ka_left = PJMEDIA_STREAM_START_KA_CNT;
+    stream->start_ka_msec = PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
 #endif
 
-    if (stream->start_ka_cnt > START_KA_MAX_CNT)
-        stream->start_ka_cnt = START_KA_MAX_CNT;
-    if (stream->start_ka_interval < START_KA_MIN_INTERVAL_MSEC)
-        stream->start_ka_interval = START_KA_MIN_INTERVAL_MSEC;
+    if (stream->start_ka_left > START_KA_MAX_CNT)
+        stream->start_ka_left = START_KA_MAX_CNT;
+    if (stream->start_ka_msec < START_KA_MIN_INTERVAL_MSEC)
+        stream->start_ka_msec = START_KA_MIN_INTERVAL_MSEC;
 
-    if (stream->start_ka_cnt == 0)
+    if (stream->start_ka_left == 0)
         return;
 
     /* ICE connectivity checks already create the NAT bindings. */
@@ -156,7 +156,7 @@ static void init_start_ka(pjmedia_txt_stream *stream,
                    pjmedia_transport_info_get_spc_info(
                        &tpinfo, PJMEDIA_TRANSPORT_TYPE_ICE);
         if (ice_info && ice_info->active)
-            stream->start_ka_cnt = 0;
+            stream->start_ka_left = 0;
     }
 }
 
@@ -450,7 +450,7 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
         pjmedia_stream_common_send_rtcp_sdes(c_strm);
     }
 
-    init_start_ka(stream, info);
+    init_start_ka(stream);
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
     /* NAT hole punching by sending KA packet via RTP transport. */
@@ -1040,7 +1040,7 @@ static void check_tx_rtcp(pjmedia_txt_stream *stream)
 /*
  * check_start_ka()
  * Punch NAT holes at stream start by sending a few empty RTP packets (plus
- * RTCP) spaced start_ka_interval apart, so the bindings exist before any
+ * RTCP) spaced start_ka_msec apart, so the bindings exist before any
  * text is typed and survive a lost packet. Kept out of send_text_locked()
  * so it doesn't disturb the first-packet (BOM) logic there.
  */
@@ -1054,13 +1054,13 @@ static void check_start_ka(pjmedia_txt_stream *stream)
     pj_timestamp now;
     pj_status_t status;
 
-    if (stream->start_ka_cnt == 0)
+    if (stream->start_ka_left == 0)
         return;
 
     pj_get_timestamp(&now);
     if (stream->start_ka_last_tx.u64 != 0 &&
         pj_elapsed_msec(&stream->start_ka_last_tx, &now) <
-            stream->start_ka_interval)
+            stream->start_ka_msec)
     {
         return;
     }
@@ -1083,10 +1083,14 @@ static void check_start_ka(pjmedia_txt_stream *stream)
     if (status != PJ_SUCCESS)
         return;
 
-    send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled, PJ_FALSE, PJ_FALSE,
-              PJ_FALSE, PJ_FALSE, PJ_FALSE);
+    status = send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled, PJ_FALSE,
+                       PJ_FALSE, PJ_FALSE, PJ_FALSE, PJ_FALSE);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(4, (c_strm->port.info.name.ptr, status,
+                      "Error sending start keep-alive RTCP"));
+    }
 
-    stream->start_ka_cnt--;
+    stream->start_ka_left--;
 }
 
 /* Clock callback */

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -91,6 +91,9 @@ typedef struct pjmedia_txt_stream {
     pjmedia_clock *clock; /**< Clock.                 */
     unsigned buf_time;    /**< Buffering time.        */
     pj_bool_t is_idle;    /**< Is idle?               */
+    unsigned start_ka_left; /**< Remaining number of automatic
+                                 start-of-stream keep-alives to
+                                 send (for NAT hole punching).  */
 
     pj_timestamp rtcp_last_tx;   /**< Last RTCP tx time.     */
     pj_timestamp tx_last_ts;     /**< Timestamp of last tx.  */
@@ -241,6 +244,13 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
     c_strm->rtcp_fb_nack.pid = -1;
     stream->rx_last_seq = -1;
     stream->is_idle = PJ_TRUE;
+
+    /* Unconditionally (regardless of PJMEDIA_STREAM_ENABLE_KA) send a
+     * short burst of empty packets right after stream start, to help with
+     * NAT hole punching even if the user hasn't typed anything yet. This
+     * reuses the existing start-keep-alive count/interval settings.
+     */
+    stream->start_ka_left = PJMEDIA_STREAM_START_KA_CNT;
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
     c_strm->use_ka = info->use_ka;
@@ -823,11 +833,26 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
             rtp_ts_len = 1;
     }
 
-    /* Keep-alive check */
+    /* Keep-alive check.
+     * The very first packet is always sent, even if empty, so that an
+     * initial RTP packet goes out immediately at stream start to help
+     * with NAT hole punching. On top of that, up to
+     * PJMEDIA_STREAM_START_KA_CNT more empty packets are sent, spaced
+     * PJMEDIA_STREAM_START_KA_INTERVAL_MSEC apart, so the hole punch
+     * survives losing any single packet. Once that budget is spent,
+     * fall back to the normal 10-second idle keep-alive.
+     */
     if (stream->is_idle && stream->tx_buf[0].length == 0) {
-        if (!is_first_packet &&
-            pj_elapsed_msec(&stream->tx_last_ts, &now) >= 10000) {
+        unsigned idle_msec = pj_elapsed_msec(&stream->tx_last_ts, &now);
+        pj_bool_t start_burst =
+            stream->start_ka_left > 0 &&
+            idle_msec >= PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
+
+        if (is_first_packet || start_burst || idle_msec >= 10000)
+        {
             is_keepalive = PJ_TRUE;
+            if (stream->start_ka_left > 0)
+                stream->start_ka_left--;
         } else {
             return PJ_SUCCESS; /* Clean return */
         }
@@ -933,6 +958,13 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
                 pjmedia_transport_send_rtp(c_strm->transport, tx_pkt, tx_size);
             pj_mutex_lock(c_strm->jb_mutex);
         }
+
+        /* Record time of this transmission so that is_first_packet,
+         * the keep-alive gate above, and the RTP timestamp calculation
+         * are based on the actual last-send time instead of always
+         * comparing against a zeroed timestamp.
+         */
+        stream->tx_last_ts = now;
 
         /* Prepare second pass if needed */
         pass++;

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -450,13 +450,15 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
         pjmedia_stream_common_send_rtcp_sdes(c_strm);
     }
 
+    init_start_ka(stream, info);
+
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
     /* NAT hole punching by sending KA packet via RTP transport. */
-    if (c_strm->use_ka)
+    if (c_strm->use_ka) {
         send_keep_alive_packet(c_strm);
+        pj_get_timestamp(&stream->start_ka_last_tx);
+    }
 #endif
-
-    init_start_ka(stream, info);
 
     /* Success! */
     *p_stream = stream;

--- a/pjmedia/src/pjmedia/txt_stream.c
+++ b/pjmedia/src/pjmedia/txt_stream.c
@@ -31,6 +31,7 @@
 #include <pjmedia/rtp.h>
 #include <pjmedia/sdp_neg.h>
 #include <pjmedia/transport.h>
+#include <pjmedia/transport_ice.h>
 #include <pjmedia/txt_stream.h>
 
 #define THIS_FILE "txt_stream.c"
@@ -77,6 +78,10 @@
 /* Maximum size of a single text frame in bytes */
 #define MAX_TEXT_FRAME_SIZE PJMEDIA_MAX_MTU
 
+/* Sanity bounds for the start-of-stream keep-alive settings. */
+#define START_KA_MAX_CNT 10
+#define START_KA_MIN_INTERVAL_MSEC 500
+
 /* Buffer to store redundancy and primary data. */
 typedef struct red_buf {
     unsigned timestamp;
@@ -91,12 +96,15 @@ typedef struct pjmedia_txt_stream {
     pjmedia_clock *clock; /**< Clock.                 */
     unsigned buf_time;    /**< Buffering time.        */
     pj_bool_t is_idle;    /**< Is idle?               */
-    unsigned start_ka_left; /**< Remaining number of automatic
-                                 start-of-stream keep-alives to
-                                 send (for NAT hole punching).  */
 
     pj_timestamp rtcp_last_tx;   /**< Last RTCP tx time.     */
     pj_timestamp tx_last_ts;     /**< Timestamp of last tx.  */
+
+    unsigned start_ka_cnt;         /**< Remaining start-of-stream
+                                        keep-alives to send.      */
+    unsigned start_ka_interval;    /**< Start keep-alive interval
+                                        in msec.                  */
+    pj_timestamp start_ka_last_tx; /**< Last start keep-alive tx. */
     red_buf tx_buf[NUM_BUFFERS]; /**< Tx buffer.         */
     int tx_nred;                 /**< Num of redundant data. */
 
@@ -111,6 +119,46 @@ typedef struct pjmedia_txt_stream {
 static void clock_cb(const pj_timestamp *ts, void *user_data);
 
 #include "stream_imp_common.c"
+
+/*
+ * Set up the start-of-stream keep-alive burst, see check_start_ka().
+ * Must be called after the transport is attached.
+ */
+static void init_start_ka(pjmedia_txt_stream *stream,
+                          const pjmedia_txt_stream_info *info)
+{
+    pjmedia_stream_common *c_strm = &stream->base;
+    pjmedia_transport_info tpinfo;
+    pjmedia_ice_transport_info *ice_info;
+
+#if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
+    stream->start_ka_cnt = info->use_ka ? info->ka_cfg.start_count : 0;
+    stream->start_ka_interval = info->ka_cfg.start_interval;
+#else
+    PJ_UNUSED_ARG(info);
+    stream->start_ka_cnt = PJMEDIA_STREAM_START_KA_CNT;
+    stream->start_ka_interval = PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
+#endif
+
+    if (stream->start_ka_cnt > START_KA_MAX_CNT)
+        stream->start_ka_cnt = START_KA_MAX_CNT;
+    if (stream->start_ka_interval < START_KA_MIN_INTERVAL_MSEC)
+        stream->start_ka_interval = START_KA_MIN_INTERVAL_MSEC;
+
+    if (stream->start_ka_cnt == 0)
+        return;
+
+    /* ICE connectivity checks already create the NAT bindings. */
+    pjmedia_transport_info_init(&tpinfo);
+    if (pjmedia_transport_get_info(c_strm->transport, &tpinfo) == PJ_SUCCESS)
+    {
+        ice_info = (pjmedia_ice_transport_info *)
+                   pjmedia_transport_info_get_spc_info(
+                       &tpinfo, PJMEDIA_TRANSPORT_TYPE_ICE);
+        if (ice_info && ice_info->active)
+            stream->start_ka_cnt = 0;
+    }
+}
 
 static void on_stream_destroy(void *arg)
 {
@@ -244,13 +292,6 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
     c_strm->rtcp_fb_nack.pid = -1;
     stream->rx_last_seq = -1;
     stream->is_idle = PJ_TRUE;
-
-    /* Unconditionally (regardless of PJMEDIA_STREAM_ENABLE_KA) send a
-     * short burst of empty packets right after stream start, to help with
-     * NAT hole punching even if the user hasn't typed anything yet. This
-     * reuses the existing start-keep-alive count/interval settings.
-     */
-    stream->start_ka_left = PJMEDIA_STREAM_START_KA_CNT;
 
 #if defined(PJMEDIA_STREAM_ENABLE_KA) && PJMEDIA_STREAM_ENABLE_KA != 0
     c_strm->use_ka = info->use_ka;
@@ -414,6 +455,8 @@ pjmedia_txt_stream_create(pjmedia_endpt *endpt, pj_pool_t *pool,
     if (c_strm->use_ka)
         send_keep_alive_packet(c_strm);
 #endif
+
+    init_start_ka(stream, info);
 
     /* Success! */
     *p_stream = stream;
@@ -833,26 +876,11 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
             rtp_ts_len = 1;
     }
 
-    /* Keep-alive check.
-     * The very first packet is always sent, even if empty, so that an
-     * initial RTP packet goes out immediately at stream start to help
-     * with NAT hole punching. On top of that, up to
-     * PJMEDIA_STREAM_START_KA_CNT more empty packets are sent, spaced
-     * PJMEDIA_STREAM_START_KA_INTERVAL_MSEC apart, so the hole punch
-     * survives losing any single packet. Once that budget is spent,
-     * fall back to the normal 10-second idle keep-alive.
-     */
+    /* Keep-alive check */
     if (stream->is_idle && stream->tx_buf[0].length == 0) {
-        unsigned idle_msec = pj_elapsed_msec(&stream->tx_last_ts, &now);
-        pj_bool_t start_burst =
-            stream->start_ka_left > 0 &&
-            idle_msec >= PJMEDIA_STREAM_START_KA_INTERVAL_MSEC;
-
-        if (is_first_packet || start_burst || idle_msec >= 10000)
-        {
+        if (!is_first_packet &&
+            pj_elapsed_msec(&stream->tx_last_ts, &now) >= 10000) {
             is_keepalive = PJ_TRUE;
-            if (stream->start_ka_left > 0)
-                stream->start_ka_left--;
         } else {
             return PJ_SUCCESS; /* Clean return */
         }
@@ -959,13 +987,6 @@ static pj_status_t send_text_locked(pjmedia_txt_stream *stream,
             pj_mutex_lock(c_strm->jb_mutex);
         }
 
-        /* Record time of this transmission so that is_first_packet,
-         * the keep-alive gate above, and the RTP timestamp calculation
-         * are based on the actual last-send time instead of always
-         * comparing against a zeroed timestamp.
-         */
-        stream->tx_last_ts = now;
-
         /* Prepare second pass if needed */
         pass++;
         if (pass == 1 && has_deferred_char) {
@@ -1014,6 +1035,58 @@ static void check_tx_rtcp(pjmedia_txt_stream *stream)
     }
 }
 
+/*
+ * check_start_ka()
+ * Punch NAT holes at stream start by sending a few empty RTP packets (plus
+ * RTCP) spaced start_ka_interval apart, so the bindings exist before any
+ * text is typed and survive a lost packet. Kept out of send_text_locked()
+ * so it doesn't disturb the first-packet (BOM) logic there.
+ */
+static void check_start_ka(pjmedia_txt_stream *stream)
+{
+    pjmedia_stream_common *c_strm = &stream->base;
+    pjmedia_channel *channel = c_strm->enc;
+    pjmedia_rtp_hdr hdr;
+    const void *rtphdr;
+    int hdrlen;
+    pj_timestamp now;
+    pj_status_t status;
+
+    if (stream->start_ka_cnt == 0)
+        return;
+
+    pj_get_timestamp(&now);
+    if (stream->start_ka_last_tx.u64 != 0 &&
+        pj_elapsed_msec(&stream->start_ka_last_tx, &now) <
+            stream->start_ka_interval)
+    {
+        return;
+    }
+    stream->start_ka_last_tx = now;
+
+    /* The RTP session is shared with send_text_locked(). */
+    pj_mutex_lock(c_strm->jb_mutex);
+    status = pjmedia_rtp_encode_rtp(&channel->rtp, channel->pt, 0, 1, 0,
+                                    &rtphdr, &hdrlen);
+    if (status == PJ_SUCCESS)
+        pj_memcpy(&hdr, rtphdr, sizeof(hdr));
+    pj_mutex_unlock(c_strm->jb_mutex);
+    if (status != PJ_SUCCESS)
+        return;
+
+    TRC_((c_strm->port.info.name.ptr, "Sending start keep-alive"));
+
+    /* On failure (e.g. SRTP keys not ready yet), retry at next interval. */
+    status = pjmedia_transport_send_rtp(c_strm->transport, &hdr, sizeof(hdr));
+    if (status != PJ_SUCCESS)
+        return;
+
+    send_rtcp(c_strm, !c_strm->rtcp_sdes_bye_disabled, PJ_FALSE, PJ_FALSE,
+              PJ_FALSE, PJ_FALSE, PJ_FALSE);
+
+    stream->start_ka_cnt--;
+}
+
 /* Clock callback */
 static void clock_cb(const pj_timestamp *ts, void *user_data)
 {
@@ -1036,6 +1109,8 @@ static void clock_cb(const pj_timestamp *ts, void *user_data)
 
     /* Check if now is the time to transmit RTCP SR/RR report. */
     check_tx_rtcp(stream);
+
+    check_start_ka(stream);
 }
 
 PJ_DEF(pj_status_t)


### PR DESCRIPTION
An idle text stream never emits an RTP packet until the user types, since `send_text_locked()` returns early on the idle check. Unlike audio, which punches a NAT hole via its initial VAD-suspended frames, a text stream behind NAT therefore has no RTP binding at call setup and cannot receive the peer's text until it has sent some itself.

This adds a start-of-stream keep-alive burst for text streams, driven from the stream clock alongside the periodic RTCP check:

- Sends a few empty T140 RTP packets (plus RTCP) spaced `PJMEDIA_STREAM_START_KA_INTERVAL_MSEC` apart, up to `PJMEDIA_STREAM_START_KA_CNT`, so the hole punch survives a lost packet.
- Runs regardless of `PJMEDIA_STREAM_ENABLE_KA` and of media direction (including `inactive`); when `PJMEDIA_STREAM_ENABLE_KA` is enabled, the stream's runtime `use_ka`/`ka_cfg` apply instead.
- Skipped when ICE is active, as connectivity checks already create the bindings.
- Kept out of `send_text_locked()` so the first-packet (BOM) logic is untouched.
