### PR TITLE
swig: catch C++ exceptions in the Java binding instead of aborting the JVM

### DIFF
--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -14,6 +14,43 @@ using namespace std;
 using namespace pj;
 %}
 
+#ifdef SWIGJAVA
+// Keep C++ exceptions from crossing the JNI boundary, which aborts the process
+// (there is no C++ unwind handler in the intervening JVM frames). Exceptions
+// from methods that are not declared PJSUA2_THROW, including constructors,
+// become a Java RuntimeException; a Java exception thrown inside a director
+// callback is logged and cleared instead of unwinding into pjsip C code.
+%exception {
+  try {
+    $action
+  } catch (Swig::DirectorException &e) {
+    e.throwException(jenv);
+    return $null;
+  } catch (pj::Error &e) {
+    jclass excep = jenv->FindClass("java/lang/RuntimeException");
+    if (excep)
+      jenv->ThrowNew(excep, e.info(true).c_str());
+    return $null;
+  } catch (std::exception &e) {
+    jclass excep = jenv->FindClass("java/lang/RuntimeException");
+    if (excep)
+      jenv->ThrowNew(excep, e.what());
+    return $null;
+  } catch (...) {
+    jclass excep = jenv->FindClass("java/lang/RuntimeException");
+    if (excep)
+      jenv->ThrowNew(excep, "Unknown C++ exception");
+    return $null;
+  }
+}
+%feature("director:except") {
+  if (jenv->ExceptionCheck()) {
+    jenv->ExceptionDescribe();
+    jenv->ExceptionClear();
+  }
+}
+#endif
+
 //
 // STL stuff.
 //

--- a/pjsip-apps/src/swig/pjsua2.i
+++ b/pjsip-apps/src/swig/pjsua2.i
@@ -15,11 +15,21 @@ using namespace pj;
 %}
 
 #ifdef SWIGJAVA
+%{
+static void pjsua2_throw_java_runtime(JNIEnv *jenv, const char *msg)
+{
+  jclass excep = jenv->FindClass("java/lang/RuntimeException");
+  if (excep)
+    jenv->ThrowNew(excep, msg);
+}
+%}
 // Keep C++ exceptions from crossing the JNI boundary, which aborts the process
 // (there is no C++ unwind handler in the intervening JVM frames). Exceptions
 // from methods that are not declared PJSUA2_THROW, including constructors,
 // become a Java RuntimeException; a Java exception thrown inside a director
 // callback is logged and cleared instead of unwinding into pjsip C code.
+// Placed before the STL %template instantiations below so the handler also
+// wraps their generated wrappers (e.g. std::vector::at() out-of-range).
 %exception {
   try {
     $action
@@ -27,19 +37,13 @@ using namespace pj;
     e.throwException(jenv);
     return $null;
   } catch (pj::Error &e) {
-    jclass excep = jenv->FindClass("java/lang/RuntimeException");
-    if (excep)
-      jenv->ThrowNew(excep, e.info(true).c_str());
+    pjsua2_throw_java_runtime(jenv, e.info(true).c_str());
     return $null;
   } catch (std::exception &e) {
-    jclass excep = jenv->FindClass("java/lang/RuntimeException");
-    if (excep)
-      jenv->ThrowNew(excep, e.what());
+    pjsua2_throw_java_runtime(jenv, e.what());
     return $null;
   } catch (...) {
-    jclass excep = jenv->FindClass("java/lang/RuntimeException");
-    if (excep)
-      jenv->ThrowNew(excep, "Unknown C++ exception");
+    pjsua2_throw_java_runtime(jenv, "Unknown C++ exception");
     return $null;
   }
 }


### PR DESCRIPTION
A pjsua2 method or constructor that is not declared `PJSUA2_THROW(Error)` but throws a
C++ exception aborts the whole JVM instead of raising a catchable Java exception.

## Problem

`PJSUA2_THROW(x)` expands to `throw(x)` only under `#ifdef SWIG` (config.hpp), and the
Java `%typemap(throws) pj::Error` fires only for methods carrying that specification. Any
pjsua2 method or **constructor** without it that throws — e.g. the `Endpoint`
constructor, which raises `PJ_EEXISTS` on double construction (endpoint.cpp:666) — gets
no wrapper try/catch. The C++ exception unwinds across the JNI boundary, finds no C++
handler in the JVM frames, and `std::terminate()` aborts the process (`SIGABRT`). This is
uncatchable and unrecoverable from Java.

Only the `PJSUA2_THROW`-annotated functions are protected today (about 320 of the ~3000
generated JNI wrappers); every constructor and the rest are not. The Python target has a
`%feature("director:except")` safety net (pjsua2.i, `#ifdef SWIGPYTHON`); the Java target
has neither that nor a global `%exception`.

The uncaught-exception abort at the JNI boundary looks like:

```
first Endpoint created
libc++abi: terminating due to uncaught exception of type pj::Error   (exit 134)
```

## Details

The change adds, inside `#ifdef SWIGJAVA` only, a global `%exception` that translates a
C++ exception escaping any wrapper into a Java `RuntimeException`, and a
`%feature("director:except")` that clears (after logging) a Java exception thrown inside
a director callback instead of letting it unwind into pjsip C code.

It composes cleanly with the existing `throws` typemap. For a `PJSUA2_THROW`-declared
method the generated wrapper nests the typemap's catch **inside** `$action`, so it still
fires first and is unchanged; the new outer handler is never reached for those:

```c
/* Endpoint_libCreate (declared) — unchanged behavior */
try {                                   // new outer %exception
  try {                                 // existing throws typemap
    (arg1)->libCreate();
  } catch(pj::Error &_e) {              // -> java.lang.Exception (checked), as before
    ...; return ;
  }
} catch (Swig::DirectorException &e){ ... }
  catch (pj::Error &e){ ... }           // never reached for declared methods
```

```c
/* new_Endpoint (undeclared ctor) — previously unprotected */
try {
  result = (pj::Endpoint *)new SwigDirector_Endpoint(jenv);
} catch (pj::Error &e) {
  ... ThrowNew(RuntimeException, e.info(true)); return 0;   // was: unwind -> abort
}
```

Declared methods keep their `throws java.lang.Exception` signature; the new net on
undeclared methods raises an **unchecked** `RuntimeException`, so no existing Java
signature changes and no caller must be updated. All non-Java targets are unaffected
(the whole block is under `#ifdef SWIGJAVA`).

## Design notes

The `director:except` behavior is a deliberate choice; happy to adjust to your preference.

- This mirrors the existing Python handler: describe + clear
  + continue (Python does `PyErr_Print` with `Py_Exit(1)` commented out). Only three
  director callbacks are non-void — `Endpoint::onCredAuth` (`pj_status_t`),
  `Call::onCallRedirected` (`pjsip_redirect_op`), `FindBuddyMatch::match` (`bool`). For
  those, a throwing override makes the JNI upcall return 0: `PJSIP_REDIRECT_REJECT` for
  the redirect (the C++ default is `STOP`, so it tries the next target instead of
  stopping), `false` for the match (no match), and `PJ_SUCCESS` for `onCredAuth` — the
  last sends an empty digest, so authentication fails rather than the library recomputing
  it. All are contained, never a crash. If you prefer, `onCredAuth` could special-case
  `PJ_ENOTSUP` (library computes the digest) on a throwing override, at the cost of
  diverging from strict Python parity. `%catches(Swig::DirectorException)`
  is not sufficient here, since most pjsua2 callbacks fire from pjsip's own C threads with
  no Java frame to catch at.

## Testing

`cd pjsip-apps/src/swig && make java` builds cleanly (SWIG 4.3.1, g++, JDK 21): wrapper
generation, JNI library, and `javac` of the package and samples all succeed.

The generated wrapper shows the fix: `new_Endpoint` now has the try/catch, while the
declared `Endpoint_libCreate` keeps its inner `pj::Error -> java.lang.Exception` typemap
unchanged (the new outer handler nests around it).
