### PR TITLE
sip_msg: auto-add 'lr' param instead of asserting when 'hide' is set without it

### DIFF
--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -1800,8 +1800,18 @@ static int pjsip_routing_hdr_print( pjsip_routing_hdr *hdr,
             const pj_str_t st_hide = {"hide", 4};
 
             if (pj_stricmp(&p->name, &st_hide) == 0) {
-                /* Check if param 'hide' is specified without 'lr'. */
-                pj_assert(sip_uri->lr_param != 0);
+                /* By design, the proprietary 'hide' param is always paired
+                 * with 'lr' when PJSIP generates the route itself. However,
+                 * this URI may come from external/malformed input, so
+                 * rather than asserting (which is a no-op in release builds
+                 * and could be used as a DoS vector), just auto-add the
+                 * missing 'lr' and log it.
+                 */
+                if (sip_uri->lr_param == 0) {
+                    PJ_LOG(4, ("sip_msg", "Route/Record-Route URI has 'hide' "
+                                          "param without 'lr', adding 'lr'"));
+                    sip_uri->lr_param = 1;
+                }
                 return 0;
             }
             p = p->next;

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -1801,16 +1801,16 @@ static int pjsip_routing_hdr_print( pjsip_routing_hdr *hdr,
 
             if (pj_stricmp(&p->name, &st_hide) == 0) {
                 /* By design, the proprietary 'hide' param is always paired
-                 * with 'lr' when PJSIP generates the route itself. However,
-                 * this URI may come from external/malformed input, so
-                 * rather than asserting (which is a no-op in release builds
-                 * and could be used as a DoS vector), just auto-add the
-                 * missing 'lr' and log it.
+                 * with 'lr' when PJSIP generates the route itself. This URI
+                 * may come from external/malformed input though, so rather
+                 * than asserting (a no-op in release builds, and reachable
+                 * with external input), just log it. This header is
+                 * suppressed either way; pjsip_process_route_set() is
+                 * where 'hide' without 'lr' actually gets normalized.
                  */
                 if (sip_uri->lr_param == 0) {
-                    PJ_LOG(4, ("sip_msg", "Route/Record-Route URI has 'hide' "
-                                          "param without 'lr', adding 'lr'"));
-                    sip_uri->lr_param = 1;
+                    PJ_LOG(5, ("sip_msg", "Route/Record-Route URI has 'hide' "
+                                          "param without 'lr'"));
                 }
                 return 0;
             }

--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -989,6 +989,26 @@ PJ_DEF(pj_status_t) pjsip_process_route_set(pjsip_tx_data *tdata,
             const pjsip_sip_uri *url = (const pjsip_sip_uri*)
                 pjsip_uri_get_uri((const void*)topmost_route_uri);
             has_lr_param = url->lr_param;
+
+            /* By design, PJSIP's proprietary 'hide' param is always
+             * paired with 'lr'. This URI may come from external/
+             * malformed input though, so don't rely on that invariant:
+             * treat 'hide' as implying 'lr' here too, otherwise a
+             * hidden route would incorrectly be treated as a strict
+             * route (Request-URI rewritten to a URI that was meant to
+             * stay hidden).
+             */
+            if (!has_lr_param) {
+                const pj_str_t st_hide = {"hide", 4};
+                const pjsip_param *prm = url->other_param.next;
+
+                for (; prm != &url->other_param; prm = prm->next) {
+                    if (pj_stricmp(&prm->name, &st_hide) == 0) {
+                        has_lr_param = PJ_TRUE;
+                        break;
+                    }
+                }
+            }
         } else {
             has_lr_param = 0;
         }

--- a/pjsip/src/test/msg_test.c
+++ b/pjsip/src/test/msg_test.c
@@ -2245,96 +2245,115 @@ static pj_status_t malformed_hdr_test(void)
  */
 static int route_hide_lr_test(void)
 {
-    pj_pool_t *pool;
-    pjsip_tx_data *tdata;
-    pjsip_hdr *hdr;
-    char hdr_line[] = "<sip:proxy.example.com;hide>\r\n";
-    pj_str_t hname = { "Route", 5 };
-    pj_str_t target, from, to, contact;
-    pjsip_host_info dest_info;
-    char printed[512];
-    char uri_buf[128];
-    int parsed_len = 0, len;
-    pj_status_t status;
+    static const struct {
+        const char *desc;
+        const char *route_uri;
+    } cases[] = {
+        { "'hide' without 'lr' (malformed/external input)",
+          "<sip:proxy.example.com;hide>" },
+        { "'hide' with 'lr' (well-formed)",
+          "<sip:proxy.example.com;hide;lr>" },
+    };
+    unsigned i;
 
-    PJ_LOG(3,(THIS_FILE, "  testing Route with 'hide' param but no 'lr'.."));
+    PJ_LOG(3,(THIS_FILE, "  testing Route with 'hide' param.."));
 
-    pool = pjsip_endpt_create_pool(endpt, NULL, POOL_SIZE, POOL_SIZE);
+    for (i = 0; i < PJ_ARRAY_SIZE(cases); ++i) {
+        pjsip_tx_data *tdata;
+        pjsip_hdr *hdr;
+        char hdr_line[64];
+        pj_str_t hname = { "Route", 5 };
+        pj_str_t target, from, to, contact, result;
+        pjsip_host_info dest_info;
+        char printed[512];
+        char uri_buf[128];
+        int parsed_len = 0, len;
+        pj_status_t status;
 
-    target = pj_str("sip:user@example.com");
-    from = pj_str("sip:alice@example.com");
-    to = pj_str("sip:bob@example.com");
-    contact = pj_str("sip:alice@1.2.3.4");
+        PJ_LOG(3,(THIS_FILE, "    case: %s", cases[i].desc));
 
-    status = pjsip_endpt_create_request(endpt, &pjsip_invite_method, &target,
-                                        &from, &to, &contact, NULL, -1,
-                                        NULL, &tdata);
-    if (status != PJ_SUCCESS) {
-        PJ_LOG(3,(THIS_FILE, "    error: failed to create request"));
-        pjsip_endpt_release_pool(endpt, pool);
-        return -800;
-    }
+        pj_ansi_snprintf(hdr_line, sizeof(hdr_line), "%s\r\n",
+                         cases[i].route_uri);
 
-    hdr = (pjsip_hdr*) pjsip_parse_hdr(tdata->pool, &hname, hdr_line,
-                                       pj_ansi_strlen(hdr_line), &parsed_len);
-    if (!hdr) {
-        PJ_LOG(3,(THIS_FILE, "    error: failed to parse Route header"));
+        target = pj_str("sip:user@example.com");
+        from = pj_str("sip:alice@example.com");
+        to = pj_str("sip:bob@example.com");
+        contact = pj_str("sip:alice@1.2.3.4");
+
+        status = pjsip_endpt_create_request(endpt, &pjsip_invite_method,
+                                            &target, &from, &to, &contact,
+                                            NULL, -1, NULL, &tdata);
+        if (status != PJ_SUCCESS) {
+            PJ_LOG(3,(THIS_FILE, "      error: failed to create request"));
+            return -800;
+        }
+
+        hdr = (pjsip_hdr*) pjsip_parse_hdr(tdata->pool, &hname, hdr_line,
+                                           pj_ansi_strlen(hdr_line),
+                                           &parsed_len);
+        if (!hdr) {
+            PJ_LOG(3,(THIS_FILE, "      error: failed to parse Route "
+                                  "header"));
+            pjsip_tx_data_dec_ref(tdata);
+            return -810;
+        }
+        pjsip_msg_add_hdr(tdata->msg, hdr);
+
+        /* Process the route set first, exactly as happens in real usage
+         * (routing decisions are made before the message is ever printed
+         * for transmission). This must not silently rely on any
+         * print-time side effect.
+         */
+        status = pjsip_process_route_set(tdata, &dest_info);
+        if (status != PJ_SUCCESS) {
+            PJ_LOG(3,(THIS_FILE,
+                      "      error: pjsip_process_route_set() failed"));
+            pjsip_tx_data_dec_ref(tdata);
+            return -820;
+        }
+
+        /* Route header must be kept -- 'hide' implies 'lr', so this is
+         * never treated as a strict route.
+         */
+        if (pjsip_msg_find_hdr(tdata->msg, PJSIP_H_ROUTE, NULL) == NULL) {
+            PJ_LOG(3,(THIS_FILE, "      error: Route header was erased "
+                                  "even though 'hide' implies 'lr'"));
+            pjsip_tx_data_dec_ref(tdata);
+            return -830;
+        }
+
+        /* Request-URI must be left untouched -- a strict route would
+         * have rewritten it to the (deliberately hidden) route URI.
+         * Compare with the exact printed length, not just a prefix, so
+         * a truncated/garbled URI can't slip through.
+         */
+        len = pjsip_uri_print(PJSIP_URI_IN_REQ_URI,
+                              tdata->msg->line.req.uri,
+                              uri_buf, sizeof(uri_buf));
+        result.ptr = uri_buf;
+        result.slen = (len < 0? 0: len);
+        if (len < 0 || pj_strcmp2(&result, "sip:user@example.com") != 0) {
+            PJ_LOG(3,(THIS_FILE, "      error: Request-URI was rewritten "
+                                  "to the hidden route URI"));
+            pjsip_tx_data_dec_ref(tdata);
+            return -840;
+        }
+
+        /* Printing (as would happen at transmission time) must not
+         * crash -- this was the original bug report -- and a 'hide'
+         * route must always be fully suppressed, i.e. print 0 bytes.
+         */
+        len = pjsip_hdr_print_on(hdr, printed, sizeof(printed)-1);
+        if (len != 0) {
+            PJ_LOG(3,(THIS_FILE, "      error: 'hide' route was not "
+                                  "fully suppressed from print (len=%d)",
+                                  len));
+            pjsip_tx_data_dec_ref(tdata);
+            return -850;
+        }
+
         pjsip_tx_data_dec_ref(tdata);
-        pjsip_endpt_release_pool(endpt, pool);
-        return -810;
     }
-    pjsip_msg_add_hdr(tdata->msg, hdr);
-
-    /* Process the route set first, exactly as happens in real usage
-     * (routing decisions are made before the message is ever printed
-     * for transmission). This must not silently rely on any print-time
-     * side effect.
-     */
-    status = pjsip_process_route_set(tdata, &dest_info);
-    if (status != PJ_SUCCESS) {
-        PJ_LOG(3,(THIS_FILE, "    error: pjsip_process_route_set() failed"));
-        pjsip_tx_data_dec_ref(tdata);
-        pjsip_endpt_release_pool(endpt, pool);
-        return -820;
-    }
-
-    /* Route header must be kept -- only a strict route (no 'lr') gets
-     * erased from the message.
-     */
-    if (pjsip_msg_find_hdr(tdata->msg, PJSIP_H_ROUTE, NULL) == NULL) {
-        PJ_LOG(3,(THIS_FILE, "    error: Route header was erased even "
-                              "though 'hide' implies 'lr'"));
-        pjsip_tx_data_dec_ref(tdata);
-        pjsip_endpt_release_pool(endpt, pool);
-        return -830;
-    }
-
-    /* Request-URI must be left untouched -- a strict route would have
-     * rewritten it to the (deliberately hidden) route URI.
-     */
-    len = pjsip_uri_print(PJSIP_URI_IN_REQ_URI, tdata->msg->line.req.uri,
-                          uri_buf, sizeof(uri_buf));
-    if (len < 0 || pj_ansi_strncmp(uri_buf, "sip:user@example.com", len)!=0) {
-        PJ_LOG(3,(THIS_FILE, "    error: Request-URI was rewritten to the "
-                              "hidden route URI"));
-        pjsip_tx_data_dec_ref(tdata);
-        pjsip_endpt_release_pool(endpt, pool);
-        return -840;
-    }
-
-    /* Printing (as would happen at transmission time) must not crash --
-     * this was the original bug report.
-     */
-    len = pjsip_hdr_print_on(hdr, printed, sizeof(printed)-1);
-    if (len < 0) {
-        PJ_LOG(3,(THIS_FILE, "    error: failed to print Route header"));
-        pjsip_tx_data_dec_ref(tdata);
-        pjsip_endpt_release_pool(endpt, pool);
-        return -850;
-    }
-
-    pjsip_tx_data_dec_ref(tdata);
-    pjsip_endpt_release_pool(endpt, pool);
 
     return PJ_SUCCESS;
 }

--- a/pjsip/src/test/msg_test.c
+++ b/pjsip/src/test/msg_test.c
@@ -2231,6 +2231,115 @@ static pj_status_t malformed_hdr_test(void)
 }
 
 
+/*
+ * Regression test for PJSIP #4991: a Route header with the proprietary
+ * 'hide' param but without 'lr' -- which by design should never happen,
+ * but can be triggered by external/malformed input (e.g. a received
+ * "Route: <sip:host;hide>") -- used to crash the process via pj_assert()
+ * in pjsip_routing_hdr_print().
+ *
+ * This verifies both that printing no longer crashes, and that
+ * pjsip_process_route_set() treats 'hide' as implying 'lr' (i.e. as a
+ * loose route: Request-URI left alone, Route header kept), instead of
+ * mistakenly treating the hidden route as a strict route.
+ */
+static int route_hide_lr_test(void)
+{
+    pj_pool_t *pool;
+    pjsip_tx_data *tdata;
+    pjsip_hdr *hdr;
+    char hdr_line[] = "<sip:proxy.example.com;hide>\r\n";
+    pj_str_t hname = { "Route", 5 };
+    pj_str_t target, from, to, contact;
+    pjsip_host_info dest_info;
+    char printed[512];
+    char uri_buf[128];
+    int parsed_len = 0, len;
+    pj_status_t status;
+
+    PJ_LOG(3,(THIS_FILE, "  testing Route with 'hide' param but no 'lr'.."));
+
+    pool = pjsip_endpt_create_pool(endpt, NULL, POOL_SIZE, POOL_SIZE);
+
+    target = pj_str("sip:user@example.com");
+    from = pj_str("sip:alice@example.com");
+    to = pj_str("sip:bob@example.com");
+    contact = pj_str("sip:alice@1.2.3.4");
+
+    status = pjsip_endpt_create_request(endpt, &pjsip_invite_method, &target,
+                                        &from, &to, &contact, NULL, -1,
+                                        NULL, &tdata);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(3,(THIS_FILE, "    error: failed to create request"));
+        pjsip_endpt_release_pool(endpt, pool);
+        return -800;
+    }
+
+    hdr = (pjsip_hdr*) pjsip_parse_hdr(tdata->pool, &hname, hdr_line,
+                                       pj_ansi_strlen(hdr_line), &parsed_len);
+    if (!hdr) {
+        PJ_LOG(3,(THIS_FILE, "    error: failed to parse Route header"));
+        pjsip_tx_data_dec_ref(tdata);
+        pjsip_endpt_release_pool(endpt, pool);
+        return -810;
+    }
+    pjsip_msg_add_hdr(tdata->msg, hdr);
+
+    /* Process the route set first, exactly as happens in real usage
+     * (routing decisions are made before the message is ever printed
+     * for transmission). This must not silently rely on any print-time
+     * side effect.
+     */
+    status = pjsip_process_route_set(tdata, &dest_info);
+    if (status != PJ_SUCCESS) {
+        PJ_LOG(3,(THIS_FILE, "    error: pjsip_process_route_set() failed"));
+        pjsip_tx_data_dec_ref(tdata);
+        pjsip_endpt_release_pool(endpt, pool);
+        return -820;
+    }
+
+    /* Route header must be kept -- only a strict route (no 'lr') gets
+     * erased from the message.
+     */
+    if (pjsip_msg_find_hdr(tdata->msg, PJSIP_H_ROUTE, NULL) == NULL) {
+        PJ_LOG(3,(THIS_FILE, "    error: Route header was erased even "
+                              "though 'hide' implies 'lr'"));
+        pjsip_tx_data_dec_ref(tdata);
+        pjsip_endpt_release_pool(endpt, pool);
+        return -830;
+    }
+
+    /* Request-URI must be left untouched -- a strict route would have
+     * rewritten it to the (deliberately hidden) route URI.
+     */
+    len = pjsip_uri_print(PJSIP_URI_IN_REQ_URI, tdata->msg->line.req.uri,
+                          uri_buf, sizeof(uri_buf));
+    if (len < 0 || pj_ansi_strncmp(uri_buf, "sip:user@example.com", len)!=0) {
+        PJ_LOG(3,(THIS_FILE, "    error: Request-URI was rewritten to the "
+                              "hidden route URI"));
+        pjsip_tx_data_dec_ref(tdata);
+        pjsip_endpt_release_pool(endpt, pool);
+        return -840;
+    }
+
+    /* Printing (as would happen at transmission time) must not crash --
+     * this was the original bug report.
+     */
+    len = pjsip_hdr_print_on(hdr, printed, sizeof(printed)-1);
+    if (len < 0) {
+        PJ_LOG(3,(THIS_FILE, "    error: failed to print Route header"));
+        pjsip_tx_data_dec_ref(tdata);
+        pjsip_endpt_release_pool(endpt, pool);
+        return -850;
+    }
+
+    pjsip_tx_data_dec_ref(tdata);
+    pjsip_endpt_release_pool(endpt, pool);
+
+    return PJ_SUCCESS;
+}
+
+
 /*****************************************************************************/
 
 int msg_test(void)
@@ -2254,6 +2363,10 @@ int msg_test(void)
         return status;
 
     status = malformed_hdr_test();
+    if (status != PJ_SUCCESS)
+        return status;
+
+    status = route_hide_lr_test();
     if (status != PJ_SUCCESS)
         return status;
 


### PR DESCRIPTION
## Description

`pjsip_routing_hdr_print()` in `sip_msg.c` asserted that a Route/Record-Route URI's proprietary `hide` param is always paired with `lr`:

```c
if (pj_stricmp(&p->name, &st_hide) == 0) {
    /* Check if param 'hide' is specified without 'lr'. */
    pj_assert(sip_uri->lr_param != 0);
    return 0;
}
```

Since `hide` can appear in an externally supplied/malformed Route header (e.g. `Route: <sip:host;hide>`), this assertion is reachable with external input. `pj_assert()` aborts the process in debug builds, and is a no-op in release builds (i.e. provides no real protection there either).

This follows up on #4991, which fixed the crash by simply deleting the assertion. Per [review feedback on that PR](https://github.com/pjsip/pjproject/pull/4991#issuecomment-4539562352), rather than dropping the check, this PR normalizes `'hide'` to imply `'lr'`.

**Where the normalization actually belongs.** An earlier revision of this PR did the normalization inside `pjsip_routing_hdr_print()` itself. [Review feedback here](https://github.com/pjsip/pjproject/pull/5185#pullrequestreview-4923772118) pointed out that's ineffective: the very next statement suppresses the header (`return 0`), so mutating `lr_param` there changes nothing on the wire. Worse, by the time a message is ever printed, `pjsip_process_route_set()` has already run and, for a route without `lr`, already erased it as a strict route — rewriting the Request-URI to the very URI `hide` was meant to keep off the wire. A print function mutating the message is also worth avoiding on its own, since messages get printed more than once (re-encode after `pjsip_tx_data_invalidate_msg()`, retransmissions, auth retries).

The fix now lives in `pjsip_process_route_set()` (`sip_util.c`), where `has_lr_param` is computed and is the only place the value is actually acted upon:

```c
has_lr_param = url->lr_param;

if (!has_lr_param) {
    const pj_str_t st_hide = {"hide", 4};
    const pjsip_param *prm = url->other_param.next;

    for (; prm != &url->other_param; prm = prm->next) {
        if (pj_stricmp(&prm->name, &st_hide) == 0) {
            has_lr_param = PJ_TRUE;
            break;
        }
    }
}
```

`sip_msg.c` no longer mutates the URI; it just logs the anomaly (at level 5, since this is reachable from a remote-supplied route set and doesn't dedupe — each message has its own URI object):

```c
if (pj_stricmp(&p->name, &st_hide) == 0) {
    if (sip_uri->lr_param == 0) {
        PJ_LOG(5, ("sip_msg", "Route/Record-Route URI has 'hide' "
                              "param without 'lr'"));
    }
    return 0;
}
```

Behavior is unchanged for well-formed input (`hide` + `lr`). For malformed input (`hide` without `lr`): no crash, the route is still suppressed from the wire, and — the actual behavioral fix — it's now correctly treated as a loose route (Request-URI left alone, Route header kept) instead of a strict route.

`sip_util_proxy.c:191`, the other reader of `lr_param`, was also reviewed but left untouched since that whole code path is `#if 0`.

## Motivation and Context

Fixes the DoS vector described in #4991 (crash via `Route: <sip:host;hide>`), and — per review on this PR — fixes the actual routing-decision bug rather than a print-time side effect that never took effect.

## How Has This Been Tested?

- Full `pjsip` build completes with zero errors/warnings.
- Added `route_hide_lr_test()` to `pjsip/src/test/msg_test.c` (real CI coverage; `INCLUDE_MSG_TEST` only excludes Apple+ASan, so this runs under normal CI). It builds a request via `pjsip_endpt_create_request()`, adds a parsed `Route: <sip:proxy.example.com;hide>` header, calls `pjsip_process_route_set()` first (matching real message-flow order: routing decisions happen before transmission-time printing), and checks:
  - the Route header is kept (not erased as a strict route),
  - the Request-URI is left untouched (not rewritten to the hidden route),
  - printing the header afterwards doesn't crash.
- Verified locally (temporarily flipping the `APPLE_ASAN` test guard off) that the test actually catches both failure modes:
  - reverting to the original `pj_assert()` aborts the process on this test input,
  - reverting just the `sip_util.c` fix (keeping only the old print-function mutation) makes the test fail with "Request-URI was rewritten to the hidden route URI",
  - with both fixes in place, the test passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the CODING STYLE of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] All new and existing tests passed.
