### PR TITLE
pjmedia: fix NULL fn ptr call race in port get_frame()/put_frame()

### DIFF
--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -105,6 +105,11 @@ PJ_DEF(pj_status_t) pjmedia_port_get_frame( pjmedia_port *port,
      * locking to stop the streaming while other threads (e.g. conf bridge
      * clock) may still be polling this port, so a plain check-then-call
      * could re-read it as NULL and call through it.
+     *
+     * Formally still a data race, but aligned pointer loads/stores do
+     * not tear on supported platforms, so the snapshot is either the old
+     * value or NULL, never garbage. Atomics or a lock here would cost a
+     * barrier on every media frame for a shutdown-only hazard.
      */
     get_frame = *(port_frame_op volatile *)&port->get_frame;
 

--- a/pjmedia/src/pjmedia/port.c
+++ b/pjmedia/src/pjmedia/port.c
@@ -87,16 +87,29 @@ PJ_DEF(pjmedia_clock_src *) pjmedia_port_get_clock_src( pjmedia_port *port,
         return NULL;
 }
 
+/* Snapshot type for get_frame()/put_frame() pointers, see below. */
+typedef pj_status_t (*port_frame_op)(pjmedia_port *this_port,
+                                     pjmedia_frame *frame);
+
 /**
  * Get a frame from the port (and subsequent downstream ports).
  */
 PJ_DEF(pj_status_t) pjmedia_port_get_frame( pjmedia_port *port,
                                             pjmedia_frame *frame )
 {
+    port_frame_op get_frame;
+
     PJ_ASSERT_RETURN(port && frame, PJ_EINVAL);
 
-    if (port->get_frame)
-        return port->get_frame(port, frame);
+    /* Read the pointer exactly once. Stream destroy clears it without
+     * locking to stop the streaming while other threads (e.g. conf bridge
+     * clock) may still be polling this port, so a plain check-then-call
+     * could re-read it as NULL and call through it.
+     */
+    get_frame = *(port_frame_op volatile *)&port->get_frame;
+
+    if (get_frame)
+        return (*get_frame)(port, frame);
     else {
         frame->type = PJMEDIA_FRAME_TYPE_NONE;
         return PJ_EINVALIDOP;
@@ -110,10 +123,15 @@ PJ_DEF(pj_status_t) pjmedia_port_get_frame( pjmedia_port *port,
 PJ_DEF(pj_status_t) pjmedia_port_put_frame( pjmedia_port *port,
                                             pjmedia_frame *frame )
 {
+    port_frame_op put_frame;
+
     PJ_ASSERT_RETURN(port && frame, PJ_EINVAL);
 
-    if (port->put_frame)
-        return port->put_frame(port, frame);
+    /* See the comment in pjmedia_port_get_frame() above. */
+    put_frame = *(port_frame_op volatile *)&port->put_frame;
+
+    if (put_frame)
+        return (*put_frame)(port, frame);
     else
         return PJ_EINVALIDOP;
 }

--- a/pjsip/src/test/pjsua_stress.c
+++ b/pjsip/src/test/pjsua_stress.c
@@ -962,6 +962,22 @@ static void *crash_fault_pc(void *uctx)
 #endif
 }
 
+/* Best-effort call site of a call through a NULL function pointer. With
+ * PC==0 the unwinder cannot step past the signal frame, so the backtrace
+ * never shows the caller; but the 'call' pushed the return address at SP
+ * (x86_64), or left it in LR (aarch64). */
+static void *crash_null_call_site(void *uctx)
+{
+#if defined(PJSUA_STRESS_HAS_FAULT_PC) && defined(__x86_64__)
+    return *(void**)((ucontext_t*)uctx)->uc_mcontext.gregs[REG_RSP];
+#elif defined(PJSUA_STRESS_HAS_FAULT_PC) && defined(__aarch64__)
+    return (void*)((ucontext_t*)uctx)->uc_mcontext.regs[30];
+#else
+    (void)uctx;
+    return NULL;
+#endif
+}
+
 /* Async-signal-safe handler: dumps a native backtrace, then re-raises
  * the signal with the default disposition so the process still dies
  * with the original status (e.g. 134 for SIGABRT). The build links
@@ -970,6 +986,7 @@ static void crash_signal_handler(int sig, siginfo_t *info, void *uctx)
 {
     static const char header[] = "\n=== pjsua_stress backtrace ===\n";
     static const char pchdr[] = "faulting frame:\n";
+    static const char nullhdr[] = "NULL fn ptr called from:\n";
     void *frames[64];
     void *pc;
     int n;
@@ -984,6 +1001,14 @@ static void crash_signal_handler(int sig, siginfo_t *info, void *uctx)
     if (pc) {
         (void)!write(STDERR_FILENO, pchdr, sizeof(pchdr) - 1);
         backtrace_symbols_fd(&pc, 1, STDERR_FILENO);
+    } else if (sig == SIGSEGV) {
+        /* PC==0: a call through a NULL function pointer. Dump the return
+         * address so the call site still lands in the log. */
+        pc = crash_null_call_site(uctx);
+        if (pc) {
+            (void)!write(STDERR_FILENO, nullhdr, sizeof(nullhdr) - 1);
+            backtrace_symbols_fd(&pc, 1, STDERR_FILENO);
+        }
     }
 
     n = backtrace(frames, (int)(sizeof(frames) / sizeof(frames[0])));


### PR DESCRIPTION
Fixes the intermittent `stress / asan` / `stress / tsan` CI crash (SIGSEGV, exit 139) where the backtrace shows only the signal-delivery frames and no crash site, e.g. run 31672829636 (PR #5185) and run 31571932318 (master).

### Root cause

The crash is a call through a NULL function pointer (fault PC = 0, which is also why the backtrace cannot unwind past the signal frame):

1. On hangup/re-INVITE, pjsua queues the conference bridge port removal and then immediately calls `pjmedia_stream_destroy()`, whose first act is to clear `port.get_frame`/`port.put_frame` ("stop the streaming") without locking. Same pattern in `pjmedia_vid_stream_destroy()`.
2. The conf bridge still holds a grp_lock reference on the port until the queued REMOVE op executes, so the clock thread keeps polling the port through `pjmedia_port_get_frame()`.
3. That wrapper read the pointer twice — `if (port->get_frame) return port->get_frame(port, frame);` — so with the unoptimized sanitizer build the second read can observe NULL and jump through it.

This never shows as an ASan report (the port memory is still alive, no use-after-free), and TSan does not report it because `tests/sanitizers/tsan.supp` suppresses `race:*`.

### Fix

- `pjmedia/src/pjmedia/port.c`: snapshot the function pointer with a single volatile read before checking and calling it, in both `pjmedia_port_get_frame()` and `pjmedia_port_put_frame()`. Late calls during destroy remain no-ops, as intended.
- `pjsip/src/test/pjsua_stress.c`: when the fault PC is NULL, the crash handler now dumps the return address (stack top on x86_64, LR on aarch64) under a "NULL fn ptr called from:" header, so a future NULL-fn-ptr crash still resolves to its call site via the workflow's addr2line step.

Note on why not atomics/grp_lock: strictly (C11 §5.1.2.4) the snapshot is still a data race — volatile does not make the concurrent plain write well-defined, and TSan will keep flagging it (covered by the existing `race:*` suppression). In practice aligned pointer loads/stores are atomic on all supported platforms, so the reader sees the old value or NULL, never a torn pointer; atomics or a lock here would put a barrier on every media frame for a shutdown-only hazard.

### Validation

- A race harness (4 threads hammering `pjmedia_port_get_frame()` while another toggles the pointer, `-O0` + ASan) reproduces the exact CI signature on the unpatched build — `SEGV on unknown address 0x000000000000 (pc 0x000000000000 ...)` — within a second, and survives 20 s with the fix.
- Full `pjsua-stress -n 256 -v 16 -t 8 --duration 360` under ASan with the patched library runs to completion.
- `make -j3` passes with no warnings.

Co-Authored-By Claude Code