### PR TITLE
tests/fuzz: avoid real DNS resolution in fuzz-sip

### DIFF
--- a/tests/fuzz/fuzz-sip.c
+++ b/tests/fuzz/fuzz-sip.c
@@ -52,6 +52,39 @@ static void on_tsx_state(pjsip_transaction *tsx, pjsip_event *event)
     PJ_UNUSED_ARG(event);
 }
 
+/* Stub resolver.
+ *
+ * Message content can direct a response to an arbitrary host name (e.g. via
+ * the Via "maddr" parameter, see RFC 3261 section 18.2.2), which would make
+ * the endpoint perform a real DNS lookup with getaddrinfo(). Blocking network
+ * I/O is not allowed in the fuzzing environment, so resolve every target to
+ * the loopback address on the loop transport instead.
+ */
+static void fuzz_resolve(pjsip_resolver_t *resolver, pj_pool_t *pool,
+                         const pjsip_host_info *target, void *token,
+                         pjsip_resolver_callback *cb)
+{
+    pjsip_server_addresses svr_addr;
+    pj_uint16_t port;
+
+    PJ_UNUSED_ARG(resolver);
+    PJ_UNUSED_ARG(pool);
+
+    port = (pj_uint16_t)(target->addr.port? target->addr.port : 5060);
+
+    pj_bzero(&svr_addr, sizeof(svr_addr));
+    svr_addr.count = 1;
+    svr_addr.entry[0].name = target->addr.host;
+    svr_addr.entry[0].type = PJSIP_TRANSPORT_LOOP_DGRAM;
+    pj_sockaddr_in_init(&svr_addr.entry[0].addr.ipv4, NULL, port);
+    svr_addr.entry[0].addr.ipv4.sin_addr.s_addr = pj_htonl(0x7F000001);
+    svr_addr.entry[0].addr_len = sizeof(pj_sockaddr_in);
+
+    (*cb)(PJ_SUCCESS, token, &svr_addr);
+}
+
+static pjsip_ext_resolver fuzz_ext_resolver = { &fuzz_resolve };
+
 /* Standard header types to test */
 static const pjsip_hdr_e hdr_types[] = {
     PJSIP_H_AUTHORIZATION,
@@ -382,6 +415,13 @@ LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
         if (pjsip_tsx_layer_init_module(endpt) != PJ_SUCCESS ||
             pjsip_loop_start(endpt, NULL) != PJ_SUCCESS) {
+            free(DataFx);
+            return 0;
+        }
+
+        if (pjsip_endpt_set_ext_resolver(endpt, &fuzz_ext_resolver)
+            != PJ_SUCCESS)
+        {
             free(DataFx);
             return 0;
         }


### PR DESCRIPTION
## Problem

OSS-Fuzz reports an `ABRT` in `fuzz-sip` (testcase `clusterfuzz-testcase-fuzz-sip-5223125951512576`):

```
#2  send_dg resolv/res_send.c:1111
...
#14 getaddrinfo nss/getaddrinfo.c:2391
#16 pj_getaddrinfo pjlib/src/pj/addr_resolv_sock.c:422
#17 pjsip_resolve pjsip/src/pjsip/sip_resolve.c:346
#18 pjsip_endpt_send_response pjsip/src/pjsip/sip_util.c:1915
#19 pjsip_endpt_respond_stateless pjsip/src/pjsip/sip_util.c:2006
#20 mod_ua_on_rx_request pjsip/src/pjsip/sip_ua_layer.c:671
#21 pjsip_endpt_process_rx_data pjsip/src/pjsip/sip_endpoint.c:961
#22 LLVMFuzzerTestOneInput tests/fuzz/fuzz-sip.c:494
```

This is not a memory safety issue — the harness is performing real DNS over the network, and the fuzzing sandbox kills the process on the `send()` inside the libc resolver.

Chain of events:

1. `do_test_transaction_layer()` stamps a To-tag onto every request, so almost any request input reaches `mod_ua_on_rx_request()`, finds no dialog set, and answers 481 statelessly.
2. The testcase carries `Via: SIP/2.0/UDP pc33.atlata.com;maddr=9fxZZZZ4.0`. Per RFC 3261 section 18.2.2, `pjsip_get_response_addr()` takes the maddr branch, which leaves `res_addr->transport` NULL and uses the maddr value as the destination host — bypassing the loopback `received`/`rport` values the harness sets up.
3. With no transport, `pjsip_endpt_send_response()` calls `pjsip_endpt_resolve()`. The harness never configures a DNS resolver, so `pjsip_resolve()` falls back to a synchronous `pj_getaddrinfo()` on the fuzzer-controlled name.

## Fix

Install a stub external resolver via `pjsip_endpt_set_ext_resolver()` that maps every target to `127.0.0.1` on the loop transport. This closes all resolve callers (response send, request send, `send_raw`), not just the maddr case, and keeps response-send coverage intact since the loop transport is still used.

## Verification

- Builds clean with the harness's `-Wall -Werror`.
- With `getaddrinfo()` interposed in a standalone driver: the testcase caused one `getaddrinfo("9fxZZZZ4.0")` call before the change, and zero after. Clean exit.
- All 15 inputs from `fuzz-sip_seed_corpus.zip`: no crash, no `getaddrinfo` call.

Co-Authored-By Claude Code