### PR TITLE
pjmedia: increase RTP/RTCP receive buffer for DTLS-SRTP to avoid silent handshake truncation

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -499,24 +499,27 @@
 
 
 /**
- * Max packet size for receiving direction.
+ * Max packet size for receiving direction. This also bounds the RTP/RTCP
+ * UDP transport buffer and the STUN/TURN transport buffers used by ICE
+ * (see pjsua_media.c), since DTLS-SRTP keying traffic (RFC 5764) is
+ * multiplexed onto the same sockets as media.
+ *
+ * A DTLS-SRTP peer that reuses its full TLS server certificate (plus any
+ * intermediates) for the handshake, rather than a single self-signed
+ * leaf cert, can produce a ServerHello+Certificate+... flight larger than
+ * the default below. Since recvfrom() truncates an oversized datagram
+ * silently (see the truncation warning logged in transport_udp.c), such
+ * a peer's handshake would otherwise hang instead of failing loudly.
+ *
+ * Default: 4000 when DTLS-SRTP is enabled (#PJMEDIA_SRTP_HAS_DTLS),
+ *          2000 otherwise.
  */
 #ifndef PJMEDIA_MAX_MRU
-#  define PJMEDIA_MAX_MRU                       2000
-#endif
-
-
-/**
- * Max packet size for receiving direction when DTLS-SRTP keying is used
- * (see #PJMEDIA_SRTP_HAS_DTLS). A DTLS handshake flight carrying a
- * certificate can exceed #PJMEDIA_MAX_MRU; since recvfrom() truncates
- * oversized datagrams silently, that corrupts the handshake instead of
- * failing loudly.
- *
- * Default: 4000
- */
-#ifndef PJMEDIA_MAX_MRU_DTLS
-#  define PJMEDIA_MAX_MRU_DTLS                  4000
+#  if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
+#    define PJMEDIA_MAX_MRU                     4000
+#  else
+#    define PJMEDIA_MAX_MRU                     2000
+#  endif
 #endif
 
 

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -501,8 +501,22 @@
 /**
  * Max packet size for receiving direction.
  */
-#ifndef PJMEDIA_MAX_MRU                 
+#ifndef PJMEDIA_MAX_MRU
 #  define PJMEDIA_MAX_MRU                       2000
+#endif
+
+
+/**
+ * Max packet size for receiving direction when DTLS-SRTP keying is used
+ * (see #PJMEDIA_SRTP_HAS_DTLS). A DTLS handshake flight carrying a
+ * certificate can exceed #PJMEDIA_MAX_MRU; since recvfrom() truncates
+ * oversized datagrams silently, that corrupts the handshake instead of
+ * failing loudly.
+ *
+ * Default: 4000
+ */
+#ifndef PJMEDIA_MAX_MRU_DTLS
+#  define PJMEDIA_MAX_MRU_DTLS                  4000
 #endif
 
 

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -499,31 +499,6 @@
 
 
 /**
- * Max packet size for receiving direction. This also bounds the RTP/RTCP
- * UDP transport buffer and the STUN/TURN transport buffers used by ICE
- * (see pjsua_media.c), since DTLS-SRTP keying traffic (RFC 5764) is
- * multiplexed onto the same sockets as media.
- *
- * A DTLS-SRTP peer that reuses its full TLS server certificate (plus any
- * intermediates) for the handshake, rather than a single self-signed
- * leaf cert, can produce a ServerHello+Certificate+... flight larger than
- * the default below. Since recvfrom() truncates an oversized datagram
- * silently (see the truncation warning logged in transport_udp.c), such
- * a peer's handshake would otherwise hang instead of failing loudly.
- *
- * Default: 4000 when DTLS-SRTP is enabled (#PJMEDIA_SRTP_HAS_DTLS),
- *          2000 otherwise.
- */
-#ifndef PJMEDIA_MAX_MRU
-#  if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
-#    define PJMEDIA_MAX_MRU                     4000
-#  else
-#    define PJMEDIA_MAX_MRU                     2000
-#  endif
-#endif
-
-
-/**
  * DTMF/telephone-event duration, in timestamp. To specify the duration in
  * milliseconds, use the setting PJMEDIA_DTMF_DURATION_MSEC instead.
  *
@@ -1214,6 +1189,41 @@
  */
 #ifndef PJMEDIA_SRTP_HAS_DTLS
 #   define PJMEDIA_SRTP_HAS_DTLS                    0
+#endif
+
+
+/**
+ * Max packet size for receiving direction. This also bounds the RTP/RTCP
+ * UDP transport buffer and the STUN/TURN transport buffers used by ICE
+ * (see pjsua_media.c), since DTLS-SRTP keying traffic (RFC 5764) is
+ * multiplexed onto the same sockets as media. This block is placed after
+ * #PJMEDIA_SRTP_HAS_DTLS on purpose, so the dependency below is positional
+ * rather than coincidental.
+ *
+ * A DTLS-SRTP peer that reuses its full TLS server certificate (plus any
+ * intermediates) for the handshake, rather than a single self-signed
+ * leaf cert, can produce a ServerHello+Certificate+... flight larger than
+ * the default below. Since recvfrom() truncates an oversized datagram
+ * silently (see the truncation warning logged in transport_udp.c), such
+ * a peer's handshake would otherwise hang instead of failing loudly.
+ *
+ * Raising this value also halves the video jitter buffer/reassembly
+ * capacity computed in vid_stream.c relative to what the same
+ * MIN_CHUNKS_PER_FRM floor would give at 2000, since that capacity is
+ * derived by dividing a fixed max frame size by this macro. That file
+ * raises its floor to compensate, at the cost of roughly 2x the jitter
+ * buffer memory per video stream (since the jitter buffer's slot size is
+ * this macro's value): about 2 extra MB per stream when DTLS-SRTP is on.
+ *
+ * Default: 4000 when DTLS-SRTP is enabled (#PJMEDIA_SRTP_HAS_DTLS),
+ *          2000 otherwise.
+ */
+#ifndef PJMEDIA_MAX_MRU
+#  if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
+#    define PJMEDIA_MAX_MRU                     4000
+#  else
+#    define PJMEDIA_MAX_MRU                     2000
+#  endif
 #endif
 
 

--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1220,24 +1220,33 @@
  * intermediates) for the handshake, rather than a single self-signed
  * leaf cert, can produce a ServerHello+Certificate+... flight larger than
  * the default below, even with #PJMEDIA_SRTP_DTLS_USE_EC_KEY keeping our
- * own certificate small. Since recvfrom() truncates an oversized datagram
- * silently (see the truncation warning logged in transport_udp.c), such
- * a peer's handshake would otherwise hang instead of failing loudly.
+ * own certificate small (observed ~2500 bytes for such a flight). Since
+ * recvfrom() truncates an oversized datagram silently (see the truncation
+ * warning logged in transport_udp.c), such a peer's handshake would
+ * otherwise hang instead of failing loudly.
  *
- * Raising this value also halves the video jitter buffer/reassembly
- * capacity computed in vid_stream.c relative to what the same
- * MIN_CHUNKS_PER_FRM floor would give at 2000, since that capacity is
- * derived by dividing a fixed max frame size by this macro. That file
- * raises its floor to compensate, at the cost of roughly 2x the jitter
- * buffer memory per video stream (since the jitter buffer's slot size is
- * this macro's value): about 2 extra MB per stream when DTLS-SRTP is on.
+ * Raising this value below 2672 is free: vid_stream.c's video jitter
+ * buffer byte size stays flat, since its slot count shrinks by the same
+ * factor this macro grows. Above that, the reassembly capacity it derives
+ * would drop below one max-size video frame, so vid_stream.c raises its
+ * MIN_CHUNKS_PER_FRM floor to compensate once the shrunk capacity would no
+ * longer hold a full frame, which pins the count and makes jitter buffer
+ * memory scale with this macro from then on. This default (3000) sits
+ * just above that free threshold, keeping the added cost to ~15% of a
+ * video stream's jitter buffer instead of the 2x an unconstrained 4000
+ * would cost. See vid_stream.c's MIN_CHUNKS_PER_FRM comment for the exact
+ * capacity margin this leaves.
  *
- * Default: 4000 when DTLS-SRTP is enabled (#PJMEDIA_SRTP_HAS_DTLS),
+ * 3000 also matches pjnath's PJ_TURN_MAX_PKT_LEN default, so it stops
+ * pjsua_media.c's ICE TURN transport buffer from being silently lowered
+ * from that default down to this macro's value.
+ *
+ * Default: 3000 when DTLS-SRTP is enabled (#PJMEDIA_SRTP_HAS_DTLS),
  *          2000 otherwise.
  */
 #ifndef PJMEDIA_MAX_MRU
 #  if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
-#    define PJMEDIA_MAX_MRU                     4000
+#    define PJMEDIA_MAX_MRU                     3000
 #  else
 #    define PJMEDIA_MAX_MRU                     2000
 #  endif

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -27,12 +27,19 @@
 #include <pj/rand.h>
 #include <pj/string.h>
 
-/* Maximum size of incoming RTP packet */
-#define RTP_LEN     PJMEDIA_MAX_MRU
+/* Maximum size of incoming RTP packet. Use the larger DTLS-specific
+ * buffer when DTLS-SRTP is in play, so a certificate-bearing handshake
+ * flight isn't silently truncated on receipt (see PJMEDIA_MAX_MRU_DTLS).
+ */
+#if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
+#   define RTP_LEN      PJMEDIA_MAX_MRU_DTLS
+#else
+#   define RTP_LEN      PJMEDIA_MAX_MRU
+#endif
 
 /* Maximum size of incoming RTCP packet */
 #if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
-#   define RTCP_LEN    PJMEDIA_MAX_MRU
+#   define RTCP_LEN    PJMEDIA_MAX_MRU_DTLS
 #else
 #   define RTCP_LEN    600
 #endif

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -27,19 +27,12 @@
 #include <pj/rand.h>
 #include <pj/string.h>
 
-/* Maximum size of incoming RTP packet. Use the larger DTLS-specific
- * buffer when DTLS-SRTP is in play, so a certificate-bearing handshake
- * flight isn't silently truncated on receipt (see PJMEDIA_MAX_MRU_DTLS).
- */
-#if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
-#   define RTP_LEN      PJMEDIA_MAX_MRU_DTLS
-#else
-#   define RTP_LEN      PJMEDIA_MAX_MRU
-#endif
+/* Maximum size of incoming RTP packet */
+#define RTP_LEN     PJMEDIA_MAX_MRU
 
 /* Maximum size of incoming RTCP packet */
 #if defined(PJMEDIA_SRTP_HAS_DTLS) && (PJMEDIA_SRTP_HAS_DTLS != 0)
-#   define RTCP_LEN    PJMEDIA_MAX_MRU_DTLS
+#   define RTCP_LEN    PJMEDIA_MAX_MRU
 #else
 #   define RTCP_LEN    600
 #endif
@@ -534,6 +527,15 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
      * non-NULL cb here means the owner is still alive and safe to ref, and
      * the ref keeps it alive for the whole up-call.
      */
+    if (bytes_read > 0 && (pj_size_t)bytes_read == sizeof(udp->rtp_pkt)) {
+        PJ_LOG(2,(udp->base.name,
+                  "Received RTP packet filled the entire %d-byte receive "
+                  "buffer and was likely truncated by the OS (recvfrom() "
+                  "truncates silently). Consider raising PJMEDIA_MAX_MRU, "
+                  "e.g. if the peer uses DTLS-SRTP with a certificate "
+                  "chain.", (int)sizeof(udp->rtp_pkt)));
+    }
+
     if (udp->base.grp_lock)
         pj_grp_lock_acquire(udp->base.grp_lock);
 
@@ -593,6 +595,15 @@ static void call_rtcp_cb(struct transport_udp *udp, pj_ssize_t bytes_read)
     void(*cb)(void*, void*, pj_ssize_t);
     void *user_data;
     pj_grp_lock_t *cb_grp_lock;
+
+    if (bytes_read > 0 && (pj_size_t)bytes_read == sizeof(udp->rtcp_pkt)) {
+        PJ_LOG(2,(udp->base.name,
+                  "Received RTCP packet filled the entire %d-byte receive "
+                  "buffer and was likely truncated by the OS (recvfrom() "
+                  "truncates silently). Consider raising PJMEDIA_MAX_MRU, "
+                  "e.g. if the peer uses DTLS-SRTP with a certificate "
+                  "chain.", (int)sizeof(udp->rtcp_pkt)));
+    }
 
     /* See comment in call_rtp_cb() above. */
     if (udp->base.grp_lock)

--- a/pjmedia/src/pjmedia/transport_udp.c
+++ b/pjmedia/src/pjmedia/transport_udp.c
@@ -92,6 +92,7 @@ struct transport_udp
     pj_sockaddr         rtp_src_addr;   /**< Actual packet src addr.        */
     int                 rtp_addrlen;    /**< Address length.                */
     char                rtp_pkt[RTP_LEN];/**< Incoming RTP packet buffer    */
+    unsigned            rtp_trunc_cnt;  /**< Truncated RTP pkt count.        */
 
     pj_bool_t           enable_rtcp_mux;/**< Enable RTP & RTCP multiplexing?*/
     pj_bool_t           use_rtcp_mux;   /**< Use RTP & RTCP multiplexing?   */
@@ -104,6 +105,7 @@ struct transport_udp
     pj_ioqueue_op_key_t rtcp_read_op;   /**< Pending read operation         */
     pj_ioqueue_op_key_t rtcp_write_op;  /**< Pending write operation        */
     char                rtcp_pkt[RTCP_LEN];/**< Incoming RTCP packet buffer */
+    unsigned            rtcp_trunc_cnt; /**< Truncated RTCP pkt count.       */
 };
 
 
@@ -496,6 +498,30 @@ static pj_status_t transport_destroy(pjmedia_transport *tp)
     return PJ_SUCCESS;
 }
 
+/* Warn (rate-limited) when a received packet exactly fills its buffer,
+ * the tell-tale sign that recvfrom() silently truncated it. This runs on
+ * every packet reaching the socket, before any address check, SRTP auth,
+ * or RTP/RTCP validation, so a remote host can trigger it at will simply
+ * by sending oversized datagrams. *cnt is rate-limited to avoid becoming
+ * a log-flood/CPU amplifier under such traffic.
+ */
+static void warn_if_truncated(const char *name, const char *proto,
+                              pj_ssize_t bytes_read, pj_size_t buf_size,
+                              unsigned *cnt)
+{
+    if (bytes_read > 0 && (pj_size_t)bytes_read == buf_size &&
+        (*cnt)++ % 100 == 0)
+    {
+        PJ_LOG(2,(name,
+                  "Received %s packet filled the %d-byte receive buffer "
+                  "and was likely truncated by the OS (recvfrom() "
+                  "truncates silently), %u so far. Consider raising "
+                  "PJMEDIA_MAX_MRU, e.g. if the peer uses DTLS-SRTP with "
+                  "a certificate chain.",
+                  proto, (int)buf_size, *cnt));
+    }
+}
+
 /* Call RTP cb.
  *
  * src_addr is an out-param: on return, holds the snapshot of the RTP
@@ -527,14 +553,8 @@ static void call_rtp_cb(struct transport_udp *udp, pj_ssize_t bytes_read,
      * non-NULL cb here means the owner is still alive and safe to ref, and
      * the ref keeps it alive for the whole up-call.
      */
-    if (bytes_read > 0 && (pj_size_t)bytes_read == sizeof(udp->rtp_pkt)) {
-        PJ_LOG(2,(udp->base.name,
-                  "Received RTP packet filled the entire %d-byte receive "
-                  "buffer and was likely truncated by the OS (recvfrom() "
-                  "truncates silently). Consider raising PJMEDIA_MAX_MRU, "
-                  "e.g. if the peer uses DTLS-SRTP with a certificate "
-                  "chain.", (int)sizeof(udp->rtp_pkt)));
-    }
+    warn_if_truncated(udp->base.name, "RTP", bytes_read,
+                      sizeof(udp->rtp_pkt), &udp->rtp_trunc_cnt);
 
     if (udp->base.grp_lock)
         pj_grp_lock_acquire(udp->base.grp_lock);
@@ -596,14 +616,8 @@ static void call_rtcp_cb(struct transport_udp *udp, pj_ssize_t bytes_read)
     void *user_data;
     pj_grp_lock_t *cb_grp_lock;
 
-    if (bytes_read > 0 && (pj_size_t)bytes_read == sizeof(udp->rtcp_pkt)) {
-        PJ_LOG(2,(udp->base.name,
-                  "Received RTCP packet filled the entire %d-byte receive "
-                  "buffer and was likely truncated by the OS (recvfrom() "
-                  "truncates silently). Consider raising PJMEDIA_MAX_MRU, "
-                  "e.g. if the peer uses DTLS-SRTP with a certificate "
-                  "chain.", (int)sizeof(udp->rtcp_pkt)));
-    }
+    warn_if_truncated(udp->base.name, "RTCP", bytes_read,
+                      sizeof(udp->rtcp_pkt), &udp->rtcp_trunc_cnt);
 
     /* See comment in call_rtp_cb() above. */
     if (udp->base.grp_lock)

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -65,13 +65,18 @@
  * picture resolution and MTU. This constant specifies the minimum chunk
  * number to be allocated to store a picture bitstream in decoding direction.
  *
- * This is deliberately kept at the packet count PJMEDIA_MAX_MRU=2000 would
- * give a max-size frame (131072 / 2000 = 65), rather than PJMEDIA_MAX_MRU
- * itself, since raising PJMEDIA_MAX_MRU under DTLS-SRTP would otherwise
- * silently halve reassembly/jitter buffer capacity for video (frame_size /
- * PJMEDIA_MAX_MRU shrinks as the divisor grows).
+ * Derived from the true worst case instead of any particular PJMEDIA_MAX_MRU
+ * value: a max-size video frame (PJMEDIA_MAX_VIDEO_ENC_FRAME_SIZE, 131072
+ * bytes) split into PJMEDIA_MAX_VID_PAYLOAD_SIZE-sized packets (1336 bytes
+ * with SRTP) needs ceil(131072/1336) = 99 packets, halved since this floor
+ * bounds chunks_per_frm and rx_frame_cnt is 2x that. This only binds once
+ * PJMEDIA_MAX_MRU rises enough that frame_size/PJMEDIA_MAX_MRU alone would
+ * fall below it (above ~2672); below that, raising PJMEDIA_MAX_MRU doesn't
+ * touch reassembly capacity at all. At the current default of 50, that
+ * leaves rx_frame_cnt at 100 against a 99-packet worst case -- a thin
+ * margin, not a designed one; raise it if this ever needs more headroom.
  */
-#define MIN_CHUNKS_PER_FRM      65
+#define MIN_CHUNKS_PER_FRM      50
 
 /*  Number of send error before repeat the report. */
 #define SEND_ERR_COUNT_TO_REPORT        50

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -64,8 +64,14 @@
  * several chunks for RTP delivery. The chunk number may vary depend on the
  * picture resolution and MTU. This constant specifies the minimum chunk
  * number to be allocated to store a picture bitstream in decoding direction.
+ *
+ * This is deliberately kept at the packet count PJMEDIA_MAX_MRU=2000 would
+ * give a max-size frame (131072 / 2000 = 65), rather than PJMEDIA_MAX_MRU
+ * itself, since raising PJMEDIA_MAX_MRU under DTLS-SRTP would otherwise
+ * silently halve reassembly/jitter buffer capacity for video (frame_size /
+ * PJMEDIA_MAX_MRU shrinks as the divisor grows).
  */
-#define MIN_CHUNKS_PER_FRM      30
+#define MIN_CHUNKS_PER_FRM      65
 
 /*  Number of send error before repeat the report. */
 #define SEND_ERR_COUNT_TO_REPORT        50


### PR DESCRIPTION
## Description
Adds a new `PJMEDIA_MAX_MRU_DTLS` config option (default 4000) and uses it for
`RTP_LEN`/`RTCP_LEN` in `transport_udp.c` whenever `PJMEDIA_SRTP_HAS_DTLS` is
enabled. Plain RTP/RTCP (no DTLS-SRTP) is unaffected — those paths still use
`PJMEDIA_MAX_MRU` (2000) and 600 respectively. `PJMEDIA_MAX_MRU` itself is
left untouched, since it's also used by `vid_stream.c` for unrelated video
RTP chunk-size calculations, and bumping it directly would have changed that
behavior as a side effect.

## Motivation and Context
DTLS-SRTP keying traffic (RFC 5764) is multiplexed onto the same RTP/RTCP UDP
sockets as media. Per RFC 6347 §4.2.3, a DTLS server is free to bundle
multiple handshake messages from the same flight into a single datagram:

> "multiple handshake messages may be placed in the same DTLS record,
> provided that there is room and that they are part of the same flight"

RFC 6347 §4.1.1 only recommends (SHOULD, not MUST) sizing records to fit the
path MTU, so implementations that skip PMTU probing will commonly emit the
full `ServerHello + Certificate + ServerKeyExchange + CertificateRequest +
ServerHelloDone` flight as one datagram, relying on IP fragmentation for
delivery.

Once a real certificate is in play, that flight routinely exceeds the
existing 2000-byte `PJMEDIA_MAX_MRU`. In one reproduction against a peer
server, the flight measured ~2505-2530 bytes (the certificate alone was
~2435 bytes PEM / ~1600+ bytes DER).

`pj_sock_recvfrom()` (`pjlib/src/pj/sock_bsd.c`) is a plain `recvfrom()`
wrapper with no `MSG_TRUNC`, so on Linux/BSD a datagram larger than the
supplied buffer is truncated by the kernel with **no indication anything was
lost**. The truncated bytes are handed straight to OpenSSL's `BIO_write()`
in `ssl_on_recv_packet()` (`transport_srtp_dtls.c`), corrupting the DTLS
record layer. Instead of failing loudly, both peers just keep retransmitting
their last flight — the handshake never completes and looks like a hang
rather than a clear error.

## How Has This Been Tested?
- `./configure && make -j3` — clean build, zero errors/warnings, with
  OpenSSL SRTP enabled (`PJMEDIA_SRTP_HAS_DTLS` active), exercising the
  changed branch.
- Compiled `pjsua` (`pjsip-apps/bin/pjsua-x86_64-pc-linux-gnu`) end-to-end
  against the change to confirm it links and builds cleanly through the
  full call stack, not just the `pjmedia` library in isolation.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Note for maintainers
This is a compile-time change: since `RTP_LEN`/`RTCP_LEN` size fixed struct
fields, any build with `PJMEDIA_SRTP_HAS_DTLS` enabled gets the larger
buffer on **every** RTP/RTCP UDP socket, not only transports that actually
negotiate DTLS-SRTP for a given call — `transport_udp.c` has no visibility
into what's layered above it. The memory cost is small per call (~1.4-3.4 KB
extra per media transport) but scales with concurrent call count, so flagging
it explicitly in case a runtime-configurable size is preferred instead.
`PJMEDIA_MAX_MRU_DTLS` can also be overridden via `config_site.h` like the
existing `PJMEDIA_MAX_MRU`, so deployments that want the old, smaller
footprint can opt back down.