### PR TITLE
pjsua: sync regc contact when outbound turns out unsupported

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2996,6 +2996,16 @@ static void update_rfc5626_status(pjsua_acc *acc, pjsip_rx_data *rdata)
 on_return:
     if (acc->rfc5626_status != OUTBOUND_ACTIVE) {
         acc->reg_contact = acc->contact;
+        /* The regc still carries the outbound-parameter Contact from the
+         * initial registration, so refresh REGISTERs keep advertising
+         * outbound even though we just learned the server does not
+         * support it. Sync the regc the same way the NAT rewrite paths
+         * do (see pjsip_regc_update_contact() call sites), so state and
+         * wire agree from the next refresh on.
+         */
+        if (acc->regc) {
+            pjsip_regc_update_contact(acc->regc, 1, &acc->reg_contact);
+        }
     }
     PJ_LOG(4,(THIS_FILE, "SIP outbound status for acc %d is %s",
                          acc->index, (acc->rfc5626_status==OUTBOUND_ACTIVE?


### PR DESCRIPTION
Ref #5159

## Problem

`update_rfc5626_status()` records `OUTBOUND_NA` on a 2xx that does not confirm outbound, and rewrites `acc->reg_contact` to the outbound-free contact — but it never tells the client registration. The regc keeps the Contact from the initial registration, so every refresh REGISTER keeps advertising outbound (`reg-id`, `+sip.instance`, `;ob`, `outbound` option-tag) while `acc->rfc5626_status` says `OUTBOUND_NA` and `acc->reg_contact` no longer carries those parameters. State and wire disagree.

The regular refresh path goes through the regc's own timer with the regc's stored contact; the contact-regeneration in `auto_rereg_timer_cb()` only runs on the auto-rereg retry path, so the divergence persists across refreshes.

## Fix

In `update_rfc5626_status()`, after rewriting `acc->reg_contact`, sync the regc with `pjsip_regc_update_contact()` — the same pattern already used by the NAT-bound-address rewrite paths (`acc_check_nat_addr()` and the IP-change recovery path). The next refresh then registers the outbound-free Contact, matching the recorded status.

## Validation

- `./configure && make dep && make` (Linux, pjsua/pjsua-lib included): builds clean, no warnings in the touched file.
- Code-path review: `pjsip_regc_update_contact()` updates the Contact used for the *next* REGISTER; the call site here mirrors the existing NAT-rewrite call sites. The regc is non-null on this path (registration just succeeded via it).
- Full SIPp-based scenario tests are not run in this environment (no SIPp); the change is confined to the same code region the existing contact-rewrite paths exercise.