### PR TITLE
pjmedia: validate bundle-only media as active media

### DIFF
--- a/pjmedia/include/pjmedia/sdp.h
+++ b/pjmedia/include/pjmedia/sdp.h
@@ -783,7 +783,10 @@ PJ_DECL(pj_status_t) pjmedia_sdp_validate(const pjmedia_sdp_session *sdp);
  *
  * @param sdp       The SDP session descriptor to validate.
  * @param strict    Flag whether the check should be strict, i.e: allow
- *                  media without connection line when port is zero.
+ *                  media without connection line when port is zero. Note
+ *                  that this relaxation, along with the format and rtpmap
+ *                  checks, is not applied to bundle-only media, as such
+ *                  media is not disabled despite having zero port.
  *
  * @return          PJ_SUCCESS on success.
  */

--- a/pjmedia/src/pjmedia/sdp.c
+++ b/pjmedia/src/pjmedia/sdp.c
@@ -18,6 +18,7 @@
  */
 #include <pjmedia/sdp.h>
 #include <pjmedia/errno.h>
+#include "sdp_internal.h"
 #include <pjlib-util/scanner.h>
 #include <pj/array.h>
 #include <pj/except.h>
@@ -1660,6 +1661,79 @@ static pj_status_t validate_sdp_conn(const pjmedia_sdp_conn *c)
 }
 
 
+/* Return PJ_TRUE if a session level group attribute lists the supplied MID
+ * in a BUNDLE group.
+ */
+static pj_bool_t bundle_group_contains_mid(const pjmedia_sdp_session *sdp,
+                                           const pj_str_t *mid)
+{
+    unsigned i;
+
+    for (i = 0; i < sdp->attr_count; ++i) {
+        const pjmedia_sdp_attr *attr = sdp->attr[i];
+        const char *pos, *end;
+        unsigned token_index = 0;
+        pj_bool_t is_bundle = PJ_FALSE;
+
+        if (pj_stricmp2(&attr->name, "group") != 0)
+            continue;
+
+        if (attr->value.ptr == NULL || attr->value.slen == 0)
+            continue;
+
+        pos = attr->value.ptr;
+        end = attr->value.ptr + attr->value.slen;
+        while (pos < end) {
+            const char *token_start;
+            pj_str_t token;
+
+            while (pos < end && (*pos == ' ' || *pos == '\t'))
+                ++pos;
+            if (pos == end)
+                break;
+
+            token_start = pos;
+            while (pos < end && *pos != ' ' && *pos != '\t')
+                ++pos;
+
+            token.ptr = (char *)token_start;
+            token.slen = pos - token_start;
+
+            if (token_index++ == 0) {
+                is_bundle = (pj_stricmp2(&token, "BUNDLE") == 0);
+                if (!is_bundle)
+                    break;
+                continue;
+            }
+
+            if (is_bundle && pj_strcmp(&token, mid) == 0)
+                return PJ_TRUE;
+        }
+    }
+
+    return PJ_FALSE;
+}
+
+
+pj_bool_t pjmedia_sdp_media_is_bundle_only(const pjmedia_sdp_session *sdp,
+                                           const pjmedia_sdp_media *media)
+{
+    const pjmedia_sdp_attr *mid;
+
+    if (media->desc.port != 0 ||
+        !pjmedia_sdp_media_find_attr2(media, "bundle-only", NULL))
+    {
+        return PJ_FALSE;
+    }
+
+    mid = pjmedia_sdp_media_find_attr2(media, "mid", NULL);
+    if (!mid)
+        return PJ_FALSE;
+
+    return bundle_group_contains_mid(sdp, &mid->value);
+}
+
+
 /* Validate SDP session descriptor. */
 PJ_DEF(pj_status_t) pjmedia_sdp_validate(const pjmedia_sdp_session *sdp)
 {
@@ -1700,12 +1774,20 @@ PJ_DEF(pj_status_t) pjmedia_sdp_validate2(const pjmedia_sdp_session *sdp,
     /* Validate each media. */
     for (i=0; i<sdp->media_count; ++i) {
         const pjmedia_sdp_media *m = sdp->media[i];
+        pj_bool_t is_active;
         unsigned j;
 
         /* Validate the m= line. */
         CHECK( m->desc.media.slen != 0, PJMEDIA_SDP_EINMEDIA);
         CHECK( m->desc.transport.slen != 0, PJMEDIA_SDP_EINMEDIA);
-        CHECK( m->desc.fmt_count != 0 || m->desc.port==0, PJMEDIA_SDP_ENOFMT);
+
+        /* Zero port media is disabled, so the checks below are relaxed for
+         * it, except for bundle-only media which is still usable (RFC 9143).
+         */
+        is_active = (m->desc.port != 0) ||
+                    pjmedia_sdp_media_is_bundle_only(sdp, m);
+
+        CHECK( m->desc.fmt_count != 0 || !is_active, PJMEDIA_SDP_ENOFMT);
 
         /* If media level connection info is present, validate it. */
         if (m->conn) {
@@ -1719,7 +1801,7 @@ PJ_DEF(pj_status_t) pjmedia_sdp_validate2(const pjmedia_sdp_session *sdp,
          */
         if (m->conn == NULL) {
             if (sdp->conn == NULL)
-                if (strict || m->desc.port != 0)
+                if (strict || is_active)
                     return PJMEDIA_SDP_EMISSINGCONN;
         }
 
@@ -1737,10 +1819,10 @@ PJ_DEF(pj_status_t) pjmedia_sdp_validate2(const pjmedia_sdp_session *sdp,
                  */
                 CHECK( status == PJ_SUCCESS && pt <= 127, PJMEDIA_SDP_EINPT);
 
-                /* If port is not zero, then for each dynamic payload type, an
+                /* If media is active, then for each dynamic payload type, an
                  * rtpmap attribute must be specified.
                  */
-                if (m->desc.port != 0 && pt >= 96) {
+                if (is_active && pt >= 96) {
                     const pjmedia_sdp_attr *a;
 
                     a = pjmedia_sdp_media_find_attr(m, &STR_RTPMAP, 

--- a/pjmedia/src/pjmedia/sdp_internal.h
+++ b/pjmedia/src/pjmedia/sdp_internal.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
+ * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+#ifndef __PJMEDIA_SDP_INTERNAL_H__
+#define __PJMEDIA_SDP_INTERNAL_H__
+
+/* Private API shared by the SDP modules, not for application use. */
+
+#include <pjmedia/sdp.h>
+
+/* Return PJ_TRUE if the media is a bundle-only media as defined by RFC 9143,
+ * i.e. it has zero port, an a=bundle-only attribute, and a MID listed in a
+ * session level group:BUNDLE attribute. Unlike other zero port media, such
+ * media is not disabled, hence it must be validated and negotiated as if it
+ * had a non-zero port.
+ */
+pj_bool_t pjmedia_sdp_media_is_bundle_only(const pjmedia_sdp_session *sdp,
+                                           const pjmedia_sdp_media *media);
+
+#endif  /* __PJMEDIA_SDP_INTERNAL_H__ */

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -22,6 +22,7 @@
 #include <pjmedia/stream_common.h>
 #include <pjmedia/vid_codec.h>
 #include <pjmedia/errno.h>
+#include "sdp_internal.h"
 #include <pj/assert.h>
 #include <pj/pool.h>
 #include <pj/string.h>
@@ -1273,84 +1274,6 @@ static void apply_answer_symmetric_pt(pj_pool_t *pool,
 }
 
 
-/* Return PJ_TRUE if a session-level group attribute contains the supplied MID
- * in a BUNDLE group.
- */
-static pj_bool_t bundle_group_contains_mid(const pjmedia_sdp_session *sdp,
-                                           const pj_str_t *mid)
-{
-    unsigned i;
-
-    for (i = 0; i < sdp->attr_count; ++i) {
-        const pjmedia_sdp_attr *attr = sdp->attr[i];
-        const char *pos, *end;
-        unsigned token_index = 0;
-        pj_bool_t is_bundle = PJ_FALSE;
-
-        if (pj_stricmp2(&attr->name, "group") != 0)
-            continue;
-
-        if (attr->value.ptr == NULL || attr->value.slen == 0)
-            continue;
-
-        pos = attr->value.ptr;
-        end = attr->value.ptr + attr->value.slen;
-        while (pos < end) {
-            const char *token_start;
-            pj_str_t token;
-
-            while (pos < end && (*pos == ' ' || *pos == '\t'))
-                ++pos;
-            if (pos == end)
-                break;
-
-            token_start = pos;
-            while (pos < end && *pos != ' ' && *pos != '\t')
-                ++pos;
-
-            token.ptr = (char *)token_start;
-            token.slen = pos - token_start;
-
-            if (token_index++ == 0) {
-                is_bundle = (pj_stricmp2(&token, "BUNDLE") == 0);
-                if (!is_bundle)
-                    break;
-                continue;
-            }
-
-            if (is_bundle && pj_strcmp(&token, mid) == 0)
-                return PJ_TRUE;
-        }
-    }
-
-    return PJ_FALSE;
-}
-
-
-/* RFC 9143 allows a bundled m= section in an offer to use port zero when
- * a=bundle-only is present.  The exception only applies when the section has
- * a MID and that MID is actually listed in a session-level group:BUNDLE
- * attribute.
- */
-static pj_bool_t is_bundle_only_offer(const pjmedia_sdp_session *sdp,
-                                      const pjmedia_sdp_media *media)
-{
-    const pjmedia_sdp_attr *mid;
-
-    if (media->desc.port != 0 ||
-        !pjmedia_sdp_media_find_attr2(media, "bundle-only", NULL))
-    {
-        return PJ_FALSE;
-    }
-
-    mid = pjmedia_sdp_media_find_attr2(media, "mid", NULL);
-    if (!mid)
-        return PJ_FALSE;
-
-    return bundle_group_contains_mid(sdp, &mid->value);
-}
-
-
 /* Try to match offer with answer. */
 static pj_status_t match_offer(pj_pool_t *pool,
                                pj_bool_t prefer_remote_codec_order,
@@ -1832,7 +1755,7 @@ static pj_status_t create_answer( pj_pool_t *pool,
         unsigned j;
 
         om = offer->media[i];
-        bundle_only = is_bundle_only_offer(offer, om);
+        bundle_only = pjmedia_sdp_media_is_bundle_only(offer, om);
 
         om_tp = pjmedia_sdp_transport_get_proto(&om->desc.transport);
         PJMEDIA_TP_PROTO_TRIM_FLAG(om_tp, PJMEDIA_TP_PROFILE_RTCP_FB);

--- a/pjmedia/src/test/sdp_neg_test.c
+++ b/pjmedia/src/test/sdp_neg_test.c
@@ -1822,6 +1822,94 @@ static int sdp_neg_bundle_only_test(pj_pool_t *pool)
     return 0;
 }
 
+
+/* A bundle-only media is not disabled, so it must be validated as any
+ * active media, i.e. it must have format and rtpmap for dynamic payload
+ * type. Otherwise the offer must be rejected, instead of being negotiated
+ * as if it was validated.
+ */
+static int sdp_neg_bundle_only_invalid_test(pj_pool_t *pool)
+{
+    /* Bundle-only media without rtpmap for its dynamic payload type. */
+    static char no_rtpmap_str[] =
+        "v=0\r\n"
+        "o=- 0 0 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0 1\r\n"
+        "m=audio 4000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 0 RTP/AVP 96\r\n"
+        "a=mid:1\r\n"
+        "a=bundle-only\r\n";
+
+    /* Bundle-only media without any format. */
+    static char no_fmt_str[] =
+        "v=0\r\n"
+        "o=- 0 0 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0 1\r\n"
+        "m=audio 4000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 0 RTP/AVP\r\n"
+        "a=mid:1\r\n"
+        "a=bundle-only\r\n";
+
+    static char local_str[] =
+        "v=0\r\n"
+        "o=- 1 1 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0 1\r\n"
+        "m=audio 5000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 5002 RTP/AVP 96\r\n"
+        "a=mid:1\r\n"
+        "a=rtpmap:96 VP8/90000\r\n";
+
+    struct {
+        char        *sdp;
+        unsigned     len;
+        pj_status_t  exp_status;
+    } offers[] = {
+        { no_rtpmap_str, sizeof(no_rtpmap_str)-1, PJMEDIA_SDP_EMISSINGRTPMAP },
+        { no_fmt_str,    sizeof(no_fmt_str)-1,    PJMEDIA_SDP_ENOFMT }
+    };
+    pjmedia_sdp_session *offer, *local;
+    pjmedia_sdp_neg *neg;
+    pj_status_t status;
+    unsigned i;
+    char b1[sizeof(no_rtpmap_str) > sizeof(no_fmt_str) ?
+            sizeof(no_rtpmap_str) : sizeof(no_fmt_str)];
+    char b2[sizeof(local_str)];
+
+    pj_memcpy(b2, local_str, sizeof(local_str));
+    if (pjmedia_sdp_parse(pool, b2, pj_ansi_strlen(b2), &local) != PJ_SUCCESS)
+        return -3060;
+
+    for (i=0; i<PJ_ARRAY_SIZE(offers); ++i) {
+        pj_memcpy(b1, offers[i].sdp, offers[i].len + 1);
+
+        if (pjmedia_sdp_parse(pool, b1, offers[i].len, &offer) != PJ_SUCCESS)
+            return -3070 - i*10;
+
+        status = pjmedia_sdp_validate2(offer, PJ_FALSE);
+        if (status != offers[i].exp_status)
+            return -3072 - i*10;
+
+        status = pjmedia_sdp_neg_create_w_remote_offer(pool, local, offer,
+                                                       &neg);
+        if (status != offers[i].exp_status)
+            return -3074 - i*10;
+    }
+
+    return 0;
+}
+
 int sdp_neg_test()
 {
     unsigned i;
@@ -1868,6 +1956,10 @@ int sdp_neg_test()
 
         PJ_LOG(3,(THIS_FILE, "  sdp_neg_bundle_only_test"));
         status = sdp_neg_bundle_only_test(pool);
+        if (status == 0) {
+            PJ_LOG(3,(THIS_FILE, "  sdp_neg_bundle_only_invalid_test"));
+            status = sdp_neg_bundle_only_invalid_test(pool);
+        }
         pj_pool_release(pool);
 
         if (status != 0)

--- a/pjmedia/src/test/sdp_neg_test.c
+++ b/pjmedia/src/test/sdp_neg_test.c
@@ -1910,6 +1910,111 @@ static int sdp_neg_bundle_only_invalid_test(pj_pool_t *pool)
     return 0;
 }
 
+
+/* A zero port media having a=bundle-only is not a bundle-only media when
+ * its MID is missing or is not listed in the session level BUNDLE group,
+ * so it is just an ordinary disabled media, i.e. the validation relaxations
+ * still apply and it is simply rejected in the answer.
+ */
+static int sdp_neg_bundle_only_relaxed_test(pj_pool_t *pool)
+{
+    /* Zero port media with a=bundle-only, but without a=mid. */
+    static char no_mid_str[] =
+        "v=0\r\n"
+        "o=- 0 0 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0\r\n"
+        "m=audio 4000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 0 RTP/AVP 96\r\n"
+        "a=bundle-only\r\n";
+
+    /* Zero port media with a=bundle-only and a=mid, but the MID is not
+     * listed in the session level BUNDLE group.
+     */
+    static char no_group_str[] =
+        "v=0\r\n"
+        "o=- 0 0 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0\r\n"
+        "m=audio 4000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 0 RTP/AVP 96\r\n"
+        "a=mid:1\r\n"
+        "a=bundle-only\r\n";
+
+    static char local_str[] =
+        "v=0\r\n"
+        "o=- 1 1 IN IP4 127.0.0.1\r\n"
+        "s=-\r\n"
+        "c=IN IP4 127.0.0.1\r\n"
+        "t=0 0\r\n"
+        "a=group:BUNDLE 0 1\r\n"
+        "m=audio 5000 RTP/AVP 0\r\n"
+        "a=mid:0\r\n"
+        "m=video 5002 RTP/AVP 96\r\n"
+        "a=mid:1\r\n"
+        "a=rtpmap:96 VP8/90000\r\n";
+
+    struct {
+        char        *sdp;
+        unsigned     len;
+    } offers[] = {
+        { no_mid_str,   sizeof(no_mid_str)-1 },
+        { no_group_str, sizeof(no_group_str)-1 }
+    };
+    pjmedia_sdp_session *offer, *local;
+    pjmedia_sdp_neg *neg;
+    const pjmedia_sdp_session *active_local;
+    pj_status_t status;
+    unsigned i;
+    char *b1;
+    char b2[sizeof(local_str)];
+
+    pj_memcpy(b2, local_str, sizeof(local_str));
+    if (pjmedia_sdp_parse(pool, b2, pj_ansi_strlen(b2), &local) != PJ_SUCCESS)
+        return -3080;
+
+    for (i=0; i<PJ_ARRAY_SIZE(offers); ++i) {
+        b1 = (char*)pj_pool_alloc(pool, offers[i].len + 1);
+        pj_memcpy(b1, offers[i].sdp, offers[i].len + 1);
+
+        if (pjmedia_sdp_parse(pool, b1, offers[i].len, &offer) != PJ_SUCCESS)
+            return -3090 - i*10;
+
+        /* The media is not bundle-only, so the missing rtpmap for its
+         * dynamic payload type must still be tolerated.
+         */
+        status = pjmedia_sdp_validate2(offer, PJ_FALSE);
+        if (status != PJ_SUCCESS)
+            return -3092 - i*10;
+
+        status = pjmedia_sdp_neg_create_w_remote_offer(pool, local, offer,
+                                                       &neg);
+        if (status != PJ_SUCCESS)
+            return -3094 - i*10;
+
+        status = pjmedia_sdp_neg_negotiate(pool, neg, 0);
+        if (status != PJ_SUCCESS)
+            return -3096 - i*10;
+
+        pjmedia_sdp_neg_get_active_local(neg, &active_local);
+
+        /* The media must be rejected as any other disabled media. */
+        if (active_local->media_count != 2 ||
+            active_local->media[1]->desc.port != 0)
+        {
+            return -3098 - i*10;
+        }
+    }
+
+    return 0;
+}
+
 int sdp_neg_test()
 {
     unsigned i;
@@ -1959,6 +2064,10 @@ int sdp_neg_test()
         if (status == 0) {
             PJ_LOG(3,(THIS_FILE, "  sdp_neg_bundle_only_invalid_test"));
             status = sdp_neg_bundle_only_invalid_test(pool);
+        }
+        if (status == 0) {
+            PJ_LOG(3,(THIS_FILE, "  sdp_neg_bundle_only_relaxed_test"));
+            status = sdp_neg_bundle_only_relaxed_test(pool);
         }
         pj_pool_release(pool);
 


### PR DESCRIPTION
- A bundle-only media (RFC 9143) has zero port but is not disabled, it is negotiated as any active media since #5067. However, SDP validation still relaxes the format, connection info, and rtpmap checks for any zero port media.
- Consequently, an offer containing a bundle-only media without rtpmap for its dynamic payload type passes the validation and then hits the assertion in `match_offer()`, i.e. "Bug! Offer should have been validated".
- Now `pjmedia_sdp_validate2()` validates bundle-only media as if it had non-zero port, so such offer is rejected with `PJMEDIA_SDP_EMISSINGRTPMAP` or `PJMEDIA_SDP_ENOFMT`, instead of being negotiated as if it was validated.
- The bundle-only check is moved from sdp_neg.c to sdp.c and shared via a new private header, so nothing bundle related is published.

Note that in non-assert build, the offer was not negotiated either, `match_offer()` simply returned an error and the media got rejected in the answer, so there is no memory safety issue.

Credits to OSS-Fuzz and libFuzzer for finding this bug via the fuzz-sdp target.

## Test plan

- New `sdp_neg_bundle_only_invalid_test()` in pjmedia sdp_neg test, covering bundle-only media without rtpmap and without format.
- Verified that the assertion is reproducible before the fix and gone after it.
- `pjmedia-test sdp_neg_test` passed.

Co-Authored-By Claude Code
