### PR TITLE
tests: check return values flagged by Coverity

### DIFF
--- a/pjsip/src/test/dns_test.c
+++ b/pjsip/src/test/dns_test.c
@@ -584,8 +584,17 @@ int resolve_test(void)
     }
 
     nameserver = pj_str("192.168.0.106");
-    pj_dns_resolver_set_ns(resv, 1, &nameserver, &port);
-    pjsip_endpt_set_resolver(endpt, resv);
+    status = pj_dns_resolver_set_ns(resv, 1, &nameserver, &port);
+    if (status != PJ_SUCCESS) {
+        pjsip_endpt_release_pool(endpt, pool);
+        return -8;
+    }
+
+    status = pjsip_endpt_set_resolver(endpt, resv);
+    if (status != PJ_SUCCESS) {
+        pjsip_endpt_release_pool(endpt, pool);
+        return -9;
+    }
 
     add_dns_entries(resv);
 

--- a/pjsip/src/test/pjsua_call_test.c
+++ b/pjsip/src/test/pjsua_call_test.c
@@ -1349,6 +1349,11 @@ static int test_rtcp_mux_no_spurious_restart(void)
     if (rc != 0)
         goto on_return;
 
+    if (caller < 0 || callee < 0) {
+        rc = -1609;
+        goto on_return;
+    }
+
     created_a   = g_ctx.strm_created[caller];
     destroyed_a = g_ctx.strm_destroyed[caller];
     created_b   = g_ctx.strm_created[callee];
@@ -1450,6 +1455,11 @@ static int test_dir_narrowing_restarts_stream(void)
     rc = establish_self_call(&caller, &callee, -1700);
     if (rc != 0)
         goto on_return;
+
+    if (caller < 0 || callee < 0) {
+        rc = -1709;
+        goto on_return;
+    }
 
     /* Both legs are now running audio in ENCODING_DECODING. Arm the callee
      * leg and poke it with an ordinary no-op re-INVITE from the caller.

--- a/pjsip/src/test/tsx_basic_test.c
+++ b/pjsip/src/test/tsx_basic_test.c
@@ -262,7 +262,11 @@ static pj_status_t init_endpt()
         return rc;
     }
 
-    pj_dns_resolver_set_ns(resolver, 1, &ns, NULL);
+    rc = pj_dns_resolver_set_ns(resolver, 1, &ns, NULL);
+    if (rc != PJ_SUCCESS) {
+        app_perror("set nameserver", rc);
+        return rc;
+    }
 
     rc = pjsip_endpt_set_resolver(endpt, resolver);
     if (rc != PJ_SUCCESS) {


### PR DESCRIPTION
Fixes the two defects from the latest Coverity Scan reports, both in test code.

**CID 1685257 (CHECKED_RETURN), `pjsip/src/test/dns_test.c`** — `resolve_test()` ignored the `pj_dns_resolver_set_ns()` result. On failure the test would carry on with a resolver that has no nameserver, so the resolution assertions below would fail confusingly instead of reporting the setup failure. Check it, and the adjacent `pjsip_endpt_set_resolver()` as well. The same unchecked call in `tsx_basic_test.c` gets the same treatment, where `pjsip_endpt_set_resolver()` was already checked.

Note this call is not new code; the line number moved (564 to 587) when the file gained content above it, which is why Coverity reported it as a new defect.

**CID 1685268 (NEGATIVE_RETURNS), `pjsip/src/test/pjsua_call_test.c`** — a false positive, but worth silencing. `establish_self_call()` assigns `*p_caller`/`*p_callee` only on its success path and every failure exit returns non-zero without touching them, so the ids are valid where they index `g_ctx.strm_created[]`. Coverity cannot prove that through the out-params and assumes the `PJSUA_INVALID_ID` initializers. Guard the ids before using them as indices, in both tests that call `establish_self_call()`, since both index arrays with the result.

## Test plan

- Clean rebuild from scratch (`make clean`, `./configure`, `make -j3`): zero errors, only the known `PJ_TODO` unused-label warnings.
- `pjsip-test pjsua_call_test` passed (27.5s), covering both guarded call sites.
- `pjsip-test resolve_test tsx_basic_test` passed (4/4).

Co-Authored-By Claude Code