### PR TITLE
pjmedia: use EC P-256 key for DTLS-SRTP self-signed certificate

### DIFF
--- a/pjmedia/include/pjmedia/config.h
+++ b/pjmedia/include/pjmedia/config.h
@@ -1201,6 +1201,22 @@
 
 
 /**
+ * Use EC key on the P-256 curve for the DTLS-SRTP self-signed certificate,
+ * which is the key type commonly used by DTLS-SRTP peers and the one required
+ * by RFC 8827 for WebRTC. It also makes the certificate, and hence the
+ * handshake, significantly smaller than RSA.
+ *
+ * Disable this to use RSA 2048 bit key instead, e.g: for interoperability
+ * with peers that do not support ECDSA cipher suites.
+ *
+ * Default value: 1 (enabled)
+ */
+#ifndef PJMEDIA_SRTP_DTLS_USE_EC_KEY
+#   define PJMEDIA_SRTP_DTLS_USE_EC_KEY             1
+#endif
+
+
+/**
  * Set OpenSSL ciphers for DTLS-SRTP.
  *
  * Default value: "DEFAULT"

--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -27,7 +27,9 @@
  * Include OpenSSL headers
  */
 #include <openssl/bn.h>
+#include <openssl/ec.h>
 #include <openssl/err.h>
+#include <openssl/obj_mac.h>
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 
@@ -414,30 +416,89 @@ static pj_status_t ssl_get_fingerprint(X509 *cert, pj_bool_t is_sha256,
     return PJ_SUCCESS;
 }
 
+/* Generate private key for the self-signed cert */
+static pj_status_t ssl_generate_key(EVP_PKEY **p_priv_key)
+{
+    EVP_PKEY *priv_key = NULL;
+
+#if PJMEDIA_SRTP_DTLS_USE_EC_KEY
+
+    EC_KEY *ec_key;
+
+    ec_key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+    if (!ec_key) return PJ_EUNKNOWN;
+
+    /* Refer to the curve by name, as some peers reject certificate with
+     * explicit curve parameters.
+     */
+    EC_KEY_set_asn1_flag(ec_key, OPENSSL_EC_NAMED_CURVE);
+
+    if (!EC_KEY_generate_key(ec_key))
+        goto on_error;
+
+    priv_key = EVP_PKEY_new();
+    if (!priv_key)
+        goto on_error;
+
+    if (!EVP_PKEY_assign_EC_KEY(priv_key, ec_key))
+        goto on_error;
+
+    *p_priv_key = priv_key;
+    return PJ_SUCCESS;
+
+on_error:
+    EC_KEY_free(ec_key);
+    if (priv_key) EVP_PKEY_free(priv_key);
+    return PJ_EUNKNOWN;
+
+#else
+
+    BIGNUM *bne = NULL;
+    RSA *rsa_key = NULL;
+
+    bne = BN_new();
+    if (!bne) return PJ_EUNKNOWN;
+    if (!BN_set_word(bne, RSA_F4))
+        goto on_error;
+
+    rsa_key = RSA_new();
+    if (!rsa_key)
+        goto on_error;
+
+    if (!RSA_generate_key_ex(rsa_key, 2048, bne, NULL))
+        goto on_error;
+
+    priv_key = EVP_PKEY_new();
+    if (!priv_key)
+        goto on_error;
+
+    if (!EVP_PKEY_assign_RSA(priv_key, rsa_key))
+        goto on_error;
+
+    BN_free(bne);
+
+    *p_priv_key = priv_key;
+    return PJ_SUCCESS;
+
+on_error:
+    BN_free(bne);
+    if (rsa_key) RSA_free(rsa_key);
+    if (priv_key) EVP_PKEY_free(priv_key);
+    return PJ_EUNKNOWN;
+
+#endif
+}
+
 /* Generate self-signed cert */
 static pj_status_t ssl_generate_cert(X509 **p_cert, EVP_PKEY **p_priv_key)
 {
-    BIGNUM *bne = NULL;
-    RSA *rsa_key = NULL;
     X509_NAME *cert_name = NULL;
     X509 *cert = NULL;
     EVP_PKEY *priv_key = NULL;
 
-    /* Create big number */
-    bne = BN_new();
-    if (!bne) goto on_error;
-    if (!BN_set_word(bne, RSA_F4)) goto on_error;
-
-    /* Generate RSA key */
-    rsa_key = RSA_new();
-    if (!rsa_key) goto on_error;
-    if (!RSA_generate_key_ex(rsa_key, 2048, bne, NULL)) goto on_error;
-
     /* Create private key */
-    priv_key = EVP_PKEY_new();
-    if (!priv_key) goto on_error;
-    if (!EVP_PKEY_assign_RSA(priv_key, rsa_key)) goto on_error;
-    rsa_key = NULL;
+    if (ssl_generate_key(&priv_key) != PJ_SUCCESS)
+        return PJ_EUNKNOWN;
 
     /* Create certificate */
     cert = X509_new();
@@ -469,16 +530,11 @@ static pj_status_t ssl_generate_cert(X509 **p_cert, EVP_PKEY **p_priv_key)
     /* Sign with the private key */
     if (!X509_sign(cert, priv_key, EVP_sha256())) goto on_error;
 
-    /* Free big number */
-    BN_free(bne);
-
     *p_cert = cert;
     *p_priv_key = priv_key;
     return PJ_SUCCESS;
 
 on_error:
-    if (bne) BN_free(bne);
-    if (rsa_key && !priv_key) RSA_free(rsa_key);
     if (priv_key) EVP_PKEY_free(priv_key);
     if (cert) X509_free(cert);
     return PJ_EUNKNOWN;


### PR DESCRIPTION
- The DTLS-SRTP certificate we generate is self-signed and authenticated by its fingerprint in the SDP, not by PKI, so the key type is purely a local choice. The RSA 2048 bit key dates back to the initial DTLS-SRTP implementation (edcedb569) with no interop rationale recorded.
- Switch it to an EC key on the P-256 curve, which is what peers commonly present, and which RFC 8827 requires for WebRTC: *"All implementations MUST support DTLS 1.2 with the TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 cipher suite and the P-256 curve"*. RSA cipher suites carry no such requirement.
- Measured with OpenSSL 3.0.13 on the exact certificate this code builds: certificate DER **694 to 297 bytes**, and the one time key generation in `dtls_init()` **~145ms to ~0.07ms**. The ServerKeyExchange signature also shrinks, from 256 bytes with RSA 2048 to about 72 with ECDSA P-256. A smaller flight is welcome given how easily an oversized one gets silently truncated on receive (see #5190).
- The curve is encoded by name (`OPENSSL_EC_NAMED_CURVE`), as some peers reject certificates carrying explicit curve parameters.
- `EC_KEY_new_by_curve_name()` is used rather than the `EVP_PKEY_CTX` form, since it behaves the same across the OpenSSL versions supported here and matches existing usage in `pjlib/src/pj/ssl_sock_ossl.c`.

**Behavior change and escape hatch.** A peer that cannot negotiate an ECDSA cipher suite would now fail the handshake outright rather than degrade. Compliant WebRTC peers cannot be in that set, but legacy SIP equipment conceivably could, and so could a deployment that has narrowed `PJMEDIA_SRTP_DTLS_OSSL_CIPHERS` to an RSA only list. `PJMEDIA_SRTP_DTLS_USE_EC_KEY` is therefore added, enabled by default, so such deployments can restore the previous RSA key from `config_site.h` without patching. Worth a release note regardless.

Key generation moves into its own function so the certificate code stays free of the conditional. The error path also no longer leaks the key on the (unreachable in practice) `EVP_PKEY_assign_*` failure.

## Test plan

With `PJMEDIA_SRTP_HAS_DTLS 1`, both branches of the new option were built and exercised:

| | build | `160_srtp_dtls` | `320_ice_dtls_srtp` |
|---|---|---|---|
| `PJMEDIA_SRTP_DTLS_USE_EC_KEY 1` (default) | clean, no new warnings | passed | passed |
| `PJMEDIA_SRTP_DTLS_USE_EC_KEY 0` (RSA) | clean, no new warnings | passed | passed |

Both tests complete a real DTLS-SRTP handshake between two pjsua instances, so the generated certificate is exercised end to end in each configuration.

Co-Authored-By Claude Code