### PR TITLE
pjsua: fix stack buffer overflow when saving settings with long contact params (follow-up to #5163)

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1966,6 +1966,7 @@ pj_status_t load_config(int argc,
 static void write_account_settings(int acc_index, pj_str_t *result)
 {
     unsigned i;
+    int len;
     char line[128];
     pjsua_acc_config *acc_cfg = &app_config.acc_cfg[acc_index];
 
@@ -2022,17 +2023,30 @@ static void write_account_settings(int acc_index, pj_str_t *result)
      * truncated without swallowing it and merging the next option.
      */
     if (acc_cfg->reg_contact_params.slen) {
-        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-params %.*s",
-                        (int)acc_cfg->reg_contact_params.slen,
-                        acc_cfg->reg_contact_params.ptr);
+        len = pj_ansi_snprintf(line, sizeof(line), "--reg-contact-params %.*s",
+                              (int)acc_cfg->reg_contact_params.slen,
+                              acc_cfg->reg_contact_params.ptr);
+        if (len >= (int)sizeof(line) || len < 0) {
+            PJ_LOG(2,(THIS_FILE, "Warning: acc %d --reg-contact-params "
+                                 "truncated when saving settings",
+                                 acc_index));
+        }
+        PJ_CHECK_TRUNC_STR(len, line, sizeof(line));
         pj_strcat2(result, line);
         pj_strcat2(result, "\n");
     }
 
     if (acc_cfg->reg_contact_uri_params.slen) {
-        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-uri-params %.*s",
-                        (int)acc_cfg->reg_contact_uri_params.slen,
-                        acc_cfg->reg_contact_uri_params.ptr);
+        len = pj_ansi_snprintf(line, sizeof(line),
+                              "--reg-contact-uri-params %.*s",
+                              (int)acc_cfg->reg_contact_uri_params.slen,
+                              acc_cfg->reg_contact_uri_params.ptr);
+        if (len >= (int)sizeof(line) || len < 0) {
+            PJ_LOG(2,(THIS_FILE, "Warning: acc %d --reg-contact-uri-params "
+                                 "truncated when saving settings",
+                                 acc_index));
+        }
+        PJ_CHECK_TRUNC_STR(len, line, sizeof(line));
         pj_strcat2(result, line);
         pj_strcat2(result, "\n");
     }

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -2018,18 +2018,22 @@ static void write_account_settings(int acc_index, pj_str_t *result)
         pj_strcat2(result, line);
     }
 
-    /* Appended directly: line[] is shorter than the config reader's buffer
-     * and would truncate a long value such as a push token.
+    /* Newline appended separately so that a value too long for line[] is
+     * truncated without swallowing it and merging the next option.
      */
     if (acc_cfg->reg_contact_params.slen) {
-        pj_strcat2(result, "--reg-contact-params ");
-        pj_strcat(result, &acc_cfg->reg_contact_params);
+        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-params %.*s",
+                        (int)acc_cfg->reg_contact_params.slen,
+                        acc_cfg->reg_contact_params.ptr);
+        pj_strcat2(result, line);
         pj_strcat2(result, "\n");
     }
 
     if (acc_cfg->reg_contact_uri_params.slen) {
-        pj_strcat2(result, "--reg-contact-uri-params ");
-        pj_strcat(result, &acc_cfg->reg_contact_uri_params);
+        pj_ansi_snprintf(line, sizeof(line), "--reg-contact-uri-params %.*s",
+                        (int)acc_cfg->reg_contact_uri_params.slen,
+                        acc_cfg->reg_contact_uri_params.ptr);
+        pj_strcat2(result, line);
         pj_strcat2(result, "\n");
     }
 


### PR DESCRIPTION
Follow-up to #5163, which was merged before this correction landed. Root cause tracked in #5196.

#5163 appends the account's `pj_str_t` values directly:

```c
        pj_strcat2(result, "--reg-contact-params ");
        pj_strcat(result, &acc_cfg->reg_contact_params);
```

`pj_strcat()` performs no capacity check, `write_settings()` ignores its `max`, and all four callers pass `char settings[2000]` — so a long value writes past the caller's frame when settings are saved. My fault: I changed it to that form during review of #5163 without checking the destination.

## Changes

Bounded `pj_ansi_snprintf` as the surrounding fields use, plus:

- **Newline appended separately.** Truncating through `line[128]` also drops the trailing `\n`, so the next option lands on the same physical line and the file reloads as one merged token:
  ```
  --reg-contact-params ;pn-prid=PtYg...kv--reg-contact-uri-params ;pn-provider=apns
  ```
- **Truncation marked and reported** — `PJ_CHECK_TRUNC_STR()` plus a warning naming the account and option, since for these two options truncation is the expected case and the result otherwise looks like a valid config.

## Verified

163-character token, current master: no crash, line bounded at 127 and terminated with `..`, the warning emitted, the following option intact on its own line, file reads back through `--config-file` without error.

## Not covered

Long values are still truncated. Refusing and reporting instead needs `write_settings()` to honour `max` — #5196. The merged-line flaw affects the neighbouring fields too; left for that work rather than widening this fix.
