### PR TITLE
pjsip: add pjsip_endpt_send_request2() returning the UAC transaction

### DIFF
--- a/pjsip/include/pjsip/sip_util.h
+++ b/pjsip/include/pjsip/sip_util.h
@@ -794,6 +794,54 @@ PJ_DECL(pj_status_t) pjsip_endpt_send_request( pjsip_endpoint *endpt,
                                                pjsip_endpt_send_callback cb);
 
 /**
+ * Variant of #pjsip_endpt_send_request() which can also return the
+ * transaction created to send the request. Application may use the
+ * transaction, for example, to terminate the request before any response
+ * is received, e.g. to stop the retransmissions of an out-of-dialog request
+ * such as OPTIONS. Note that terminating the transaction only abandons the
+ * request locally, nothing is sent to the network, as CANCEL is not
+ * applicable to non-INVITE requests (see RFC 3261 section 9.1).
+ *
+ * To terminate the transaction, application should use
+ * #pjsip_tsx_terminate_async() or #pjsip_tsx_terminate_async2(), which are
+ * safe to be called from any thread, including from within the callback
+ * \a cb itself. Terminating an already completed transaction is harmless.
+ *
+ * @param endpt     The endpoint instance.
+ * @param tdata     The transmit data to be sent.
+ * @param timeout   Optional timeout for final response to be received, or -1
+ *                  if the transaction should not have a timeout restriction.
+ *                  The value is in miliseconds. Note that this is not
+ *                  implemented yet, so application needs to use its own timer
+ *                  to handle timeout.
+ * @param token     Optional token to be associated with the transaction, and
+ *                  to be passed to the callback.
+ * @param cb        Optional callback to be called when the transaction has
+ *                  received a final response. The callback will be called with
+ *                  the previously registered token and the event that triggers
+ *                  the completion of the transaction.
+ * @param p_tsx     Optional pointer to receive the transaction which was
+ *                  created to send the request. If it is not NULL, on
+ *                  success it will be set to the transaction with its
+ *                  reference counter incremented, so application must
+ *                  release it using pj_grp_lock_dec_ref(tsx->grp_lock) once
+ *                  it no longer needs the transaction, e.g. after the
+ *                  callback \a cb is called. On failure, it will be set to
+ *                  NULL. Note that the callback \a cb may already be called
+ *                  before this function returns, so application must be
+ *                  ready for the transaction to be already completed by the
+ *                  time it inspects this argument.
+ *
+ * @return          PJ_SUCCESS, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsip_endpt_send_request2(pjsip_endpoint *endpt,
+                                               pjsip_tx_data *tdata,
+                                               pj_int32_t timeout,
+                                               void *token,
+                                               pjsip_endpt_send_callback cb,
+                                               pjsip_transaction **p_tsx);
+
+/**
  * @}
  */
 

--- a/pjsip/include/pjsip/sip_util.h
+++ b/pjsip/include/pjsip/sip_util.h
@@ -821,16 +821,17 @@ PJ_DECL(pj_status_t) pjsip_endpt_send_request( pjsip_endpoint *endpt,
  *                  the previously registered token and the event that triggers
  *                  the completion of the transaction.
  * @param p_tsx     Optional pointer to receive the transaction which was
- *                  created to send the request. If it is not NULL, on
- *                  success it will be set to the transaction with its
+ *                  created to send the request. On failure it will be set
+ *                  to NULL, on success to the transaction with its
  *                  reference counter incremented, so application must
  *                  release it using pj_grp_lock_dec_ref(tsx->grp_lock) once
- *                  it no longer needs the transaction, e.g. after the
- *                  callback \a cb is called. On failure, it will be set to
- *                  NULL. Note that the callback \a cb may already be called
- *                  before this function returns, so application must be
- *                  ready for the transaction to be already completed by the
- *                  time it inspects this argument.
+ *                  it no longer needs the transaction. The reference is
+ *                  handed over only after this function returns PJ_SUCCESS,
+ *                  so it must not be released from within the callback
+ *                  \a cb, which may be called before this function returns,
+ *                  i.e. the transaction may already be completed by the time
+ *                  application inspects this argument. The transaction is
+ *                  also available in the event given to the callback.
  *
  * @return          PJ_SUCCESS, or the appropriate error code.
  */

--- a/pjsip/include/pjsip/sip_util.h
+++ b/pjsip/include/pjsip/sip_util.h
@@ -807,6 +807,11 @@ PJ_DECL(pj_status_t) pjsip_endpt_send_request( pjsip_endpoint *endpt,
  * safe to be called from any thread, including from within the callback
  * \a cb itself. Terminating an already completed transaction is harmless.
  *
+ * Note that unlike the \a p_tsx output of #pjsip_endpt_respond(), which is
+ * returned without any reference added, the transaction returned by this
+ * function has its reference counter incremented, so application must
+ * release it once it no longer needs the transaction.
+ *
  * @param endpt     The endpoint instance.
  * @param tdata     The transmit data to be sent.
  * @param timeout   Optional timeout for final response to be received, or -1

--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -89,6 +89,17 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
                                                void *token,
                                                pjsip_endpt_send_callback cb)
 {
+    return pjsip_endpt_send_request2(endpt, tdata, timeout, token, cb, NULL);
+}
+
+
+PJ_DEF(pj_status_t) pjsip_endpt_send_request2( pjsip_endpoint *endpt,
+                                               pjsip_tx_data *tdata,
+                                               pj_int32_t timeout,
+                                               void *token,
+                                               pjsip_endpt_send_callback cb,
+                                               pjsip_transaction **p_tsx)
+{
     pjsip_transaction *tsx;
     struct tsx_data *tsx_data;
     pj_status_t status;
@@ -99,6 +110,8 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
     PJ_ASSERT_RETURN(mod_stateful_util.id != -1, PJ_EINVALIDOP);
 
     PJ_UNUSED_ARG(timeout);
+
+    if (p_tsx) *p_tsx = NULL;
 
     status = pjsip_tsx_create_uac(&mod_stateful_util, tdata, &tsx);
     if (status != PJ_SUCCESS) {
@@ -119,8 +132,24 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
      */
     pj_grp_lock_add_ref(tsx->grp_lock);
 
+    /* Return the transaction before sending the request, as the callback may
+     * already be called from another thread once the request is sent.
+     */
+    if (p_tsx) {
+        pj_grp_lock_add_ref(tsx->grp_lock);
+        *p_tsx = tsx;
+    }
+
     status = pjsip_tsx_send_msg(tsx, NULL);
     if (status != PJ_SUCCESS) {
+        /* Release the reference and reset the output before terminating the
+         * transaction, as terminating it may invoke the callback which may
+         * destroy the storage of the output argument.
+         */
+        if (p_tsx) {
+            *p_tsx = NULL;
+            pj_grp_lock_dec_ref(tsx->grp_lock);
+        }
         pjsip_tx_data_dec_ref(tdata);
         pjsip_tsx_terminate(tsx, tsx->status_code? tsx->status_code:
                             PJSIP_SC_SERVICE_UNAVAILABLE);

--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -132,24 +132,18 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request2( pjsip_endpoint *endpt,
      */
     pj_grp_lock_add_ref(tsx->grp_lock);
 
-    /* Return the transaction before sending the request, as the callback may
-     * already be called from another thread once the request is sent.
-     */
-    if (p_tsx) {
-        pj_grp_lock_add_ref(tsx->grp_lock);
-        *p_tsx = tsx;
-    }
-
     status = pjsip_tsx_send_msg(tsx, NULL);
-    if (status != PJ_SUCCESS) {
-        /* Release the reference and reset the output before terminating the
-         * transaction, as terminating it may invoke the callback which may
-         * destroy the storage of the output argument.
+    if (status == PJ_SUCCESS) {
+        /* Only hand over the transaction after a successful send, as the
+         * send may fail after the callback has been called. Our reference
+         * above keeps the transaction alive here, even when it has already
+         * been completed by the callback.
          */
         if (p_tsx) {
-            *p_tsx = NULL;
-            pj_grp_lock_dec_ref(tsx->grp_lock);
+            pj_grp_lock_add_ref(tsx->grp_lock);
+            *p_tsx = tsx;
         }
+    } else {
         pjsip_tx_data_dec_ref(tdata);
         pjsip_tsx_terminate(tsx, tsx->status_code? tsx->status_code:
                             PJSIP_SC_SERVICE_UNAVAILABLE);

--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -104,14 +104,17 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request2( pjsip_endpoint *endpt,
     struct tsx_data *tsx_data;
     pj_status_t status;
 
+    /* Reset the output first, so it is also reset when the checks below
+     * fail.
+     */
+    if (p_tsx) *p_tsx = NULL;
+
     PJ_ASSERT_RETURN(endpt && tdata && (timeout==-1 || timeout>0), PJ_EINVAL);
 
     /* Check that transaction layer module is registered to endpoint */
     PJ_ASSERT_RETURN(mod_stateful_util.id != -1, PJ_EINVALIDOP);
 
     PJ_UNUSED_ARG(timeout);
-
-    if (p_tsx) *p_tsx = NULL;
 
     status = pjsip_tsx_create_uac(&mod_stateful_util, tdata, &tsx);
     if (status != PJ_SUCCESS) {

--- a/pjsip/src/test/tsx_basic_test.c
+++ b/pjsip/src/test/tsx_basic_test.c
@@ -23,11 +23,23 @@
 
 #define THIS_FILE   "tsx_basic_test.c"
 
+struct send_request2_data
+{
+    pj_bool_t   cb_called;
+    int         status_code;
+};
+
 static struct tsx_basic_test_global_t
 {
     char TARGET_URI[PJSIP_MAX_URL_SIZE];
     char FROM_URI[PJSIP_MAX_URL_SIZE];
     pjsip_transport *tp;
+
+    /* Must outlive the test function, as the callback may still be called
+     * after the test returns, e.g. when the test fails to terminate the
+     * transaction.
+     */
+    struct send_request2_data sr;
 } g[MAX_TSX_TESTS];
 
 
@@ -159,6 +171,116 @@ static int double_terminate(unsigned tid)
     return PJ_SUCCESS;
 }
 
+static void send_request2_cb(void *token, pjsip_event *e)
+{
+    struct send_request2_data *sr = (struct send_request2_data*)token;
+
+    sr->cb_called = PJ_TRUE;
+    if (e->type == PJSIP_EVENT_TSX_STATE && e->body.tsx_state.tsx)
+        sr->status_code = e->body.tsx_state.tsx->status_code;
+}
+
+/* Test terminating a request sent using pjsip_endpt_send_request2(), e.g.
+ * to stop the retransmissions before any response is received.
+ */
+static int send_request2_test(unsigned tid)
+{
+    struct send_request2_data *sr = &g[tid].sr;
+    pj_str_t target, from, tsx_key;
+    pjsip_tx_data *tdata;
+    pjsip_transaction *tsx = NULL;
+    pjsip_tpselector tp_sel;
+    pj_bool_t prev_discard;
+    pj_status_t status;
+    int rc = 0;
+
+    PJ_LOG(3,(THIS_FILE, "  send request2 and terminate test"));
+
+    target = pj_str(g[tid].TARGET_URI);
+    from = pj_str(g[tid].FROM_URI);
+
+    /* Discard the outgoing request, so it will never be answered. */
+    pjsip_loop_set_discard(g[tid].tp, PJ_TRUE, &prev_discard);
+
+    status = pjsip_endpt_create_request(endpt, &pjsip_options_method, &target,
+                                        &from, &target, NULL, NULL, -1, NULL,
+                                        &tdata);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: unable to create request", status);
+        rc = -200;
+        goto on_return;
+    }
+
+    pj_bzero(&tp_sel, sizeof(tp_sel));
+    tp_sel.type = PJSIP_TPSELECTOR_TRANSPORT;
+    tp_sel.u.transport = g[tid].tp;
+    pjsip_tx_data_set_transport(tdata, &tp_sel);
+
+    pj_bzero(sr, sizeof(*sr));
+
+    status = pjsip_endpt_send_request2(endpt, tdata, -1, sr,
+                                       &send_request2_cb, &tsx);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: unable to send request", status);
+        rc = -210;
+        goto on_return;
+    }
+
+    if (tsx == NULL) {
+        PJ_LOG(3,(THIS_FILE, "   error: transaction is not returned"));
+        rc = -220;
+        goto on_return;
+    }
+
+    /* Save the key, to verify that the transaction is unregistered later. */
+    pj_strdup_with_null(tsx->pool, &tsx_key, &tsx->transaction_key);
+
+    /* Nothing should complete the transaction by itself. */
+    flush_events(100);
+    if (sr->cb_called) {
+        PJ_LOG(3,(THIS_FILE, "   error: transaction completed prematurely"));
+        rc = -230;
+        goto on_dec_ref;
+    }
+
+    status = pjsip_tsx_terminate_async(tsx, PJSIP_SC_REQUEST_TERMINATED);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: unable to terminate transaction", status);
+        rc = -240;
+        goto on_dec_ref;
+    }
+
+    flush_events(1000);
+
+    if (!sr->cb_called) {
+        PJ_LOG(3,(THIS_FILE, "   error: callback is not called"));
+        rc = -250;
+        goto on_dec_ref;
+    }
+
+    if (sr->status_code != PJSIP_SC_REQUEST_TERMINATED) {
+        PJ_LOG(3,(THIS_FILE, "   error: unexpected status code %d",
+                  sr->status_code));
+        rc = -260;
+        goto on_dec_ref;
+    }
+
+    /* The transaction must have been unregistered from the transaction
+     * layer, while our reference keeps the instance alive.
+     */
+    if (pjsip_tsx_layer_find_tsx2(&tsx_key, PJ_FALSE) != NULL) {
+        PJ_LOG(3,(THIS_FILE, "   error: transaction is still registered"));
+        rc = -270;
+    }
+
+on_dec_ref:
+    pj_grp_lock_dec_ref(tsx->grp_lock);
+
+on_return:
+    pjsip_loop_set_discard(g[tid].tp, prev_discard, NULL);
+    return rc;
+}
+
 int tsx_basic_test(unsigned tid)
 {
     struct tsx_test_param *param = &tsx_test[tid];
@@ -186,6 +308,13 @@ int tsx_basic_test(unsigned tid)
     status = double_terminate(tid);
     if (status != 0)
         goto on_return;
+
+    /* This test needs the loop transport to blackhole the request. */
+    if (g[tid].tp) {
+        status = send_request2_test(tid);
+        if (status != 0)
+            goto on_return;
+    }
 
     status = 0;
 


### PR DESCRIPTION
`pjsip_endpt_send_request()` does not return any handle to the transaction it creates, so an application has no way to abandon an out-of-dialog request that it no longer cares about.

The use case comes from a user sending an OPTIONS to every address resolved for an endpoint: once one target replies, the endpoint is already known to be reachable, but the requests to the non-responding targets keep being retransmitted until they time out. There is no way to stop them, as CANCEL is not applicable to non-INVITE requests (RFC 3261 section 9.1), so the request can only be abandoned locally, which requires the transaction. Replicating `pjsip_endpt_send_request()` in the application just to get the transaction from `pjsip_tsx_create_uac()` is not always practical.

- Add `pjsip_endpt_send_request2()`, which optionally returns the transaction created to send the request, using the same `pjsip_transaction **p_tsx` output convention as the existing `pjsip_endpt_respond()`. Unlike `pjsip_endpt_respond()`, which hands back the pointer without adding any reference, the transaction is returned with its reference counter incremented, so the application must release it using `pj_grp_lock_dec_ref(tsx->grp_lock)` once it no longer needs the transaction. That reference is what makes the handle safe to keep across the asynchronous completion, which is the point of the API, and the header documents the difference.
- No new API is needed for the termination itself, application can simply use the existing `pjsip_tsx_terminate_async()`, which is safe to be called from any thread, including from within the callback.
- `pjsip_endpt_send_request()` is now a thin wrapper of the new function, its behavior is unchanged.

Note that the transaction is handed over only *after* the request has been sent successfully. The reference the function holds across the send keeps the transaction alive until then, even when the completion callback has already run, e.g. on receiving a response or an asynchronous transport error from another thread.

This ordering matters because `pjsip_tsx_send_msg()` can invoke the callback and only *then* return an error, via the synchronous-send paths in `sip_transaction.c` that end with `if (status==PJ_SUCCESS && tsx->state == PJSIP_TSX_STATE_TERMINATED) status = tsx->transport_err;`. Setting the output before the send would let the application observe a reference in its callback that the failure path then releases, so an application releasing it there would release it twice. The callback does not need the argument in any case, as the event already carries the transaction.

On every failure path, including the argument checks, `*p_tsx` is set to NULL and no reference is handed out.

## Test plan

- New `send_request2_test()` in pjsip test `tsx_basic_test`: the loop transport is set to discard the outgoing packet so the request will never be answered, then an OPTIONS is sent using the new API and terminated using `pjsip_tsx_terminate_async()`. The test verifies that the transaction is returned, that it does not complete by itself, that the callback is then called with `PJSIP_SC_REQUEST_TERMINATED`, and that the transaction is unregistered from the transaction layer while the returned reference keeps the instance alive.
- `pjsip-test`: `tsx_basic_test` (loop, udp, tcp), `regc_test`, `auth_async_test`, `pjsua_auth_test`, `pjsua_call_test`, `dlg_core_test`, `inv_offer_answer_test` and `transport_loop_test` passed. `regc_test` and the pjsua tests cover the wrapped `pjsip_endpt_send_request()` path (`sip_reg.c`, `pjsua_im.c`, `pjsua_acc.c`).

Co-Authored-By Claude Code

