### PR TITLE
pjsip: add pjsip_endpt_send_request2()/pjsip_endpt_cancel_request()

### DIFF
--- a/pjsip/include/pjsip/sip_util.h
+++ b/pjsip/include/pjsip/sip_util.h
@@ -794,6 +794,102 @@ PJ_DECL(pj_status_t) pjsip_endpt_send_request( pjsip_endpoint *endpt,
                                                pjsip_endpt_send_callback cb);
 
 /**
+ * Suggested buffer size, in bytes, comfortably covering the key returned
+ * by #pjsip_endpt_send_request2() for any standard SIP method: 1 byte for
+ * the role character, 1 byte for the separator, up to 31 bytes for the
+ * method name, plus #PJSIP_MAX_BRANCH_LEN for the branch parameter. This
+ * is only a suggestion for sizing the caller's buffer -- the function
+ * itself bounds-checks against whatever capacity the caller actually
+ * supplies (see \a p_tsx_key below), it does not assume this size.
+ */
+#define PJSIP_TSX_KEY_MAX_LEN   (PJSIP_MAX_BRANCH_LEN + 32)
+
+/**
+ * Variant of #pjsip_endpt_send_request() that also returns the key of the
+ * transaction created to send the request. The application can save this
+ * key and use it later, at any time, to call #pjsip_endpt_cancel_request()
+ * to locally abandon the request (e.g. to stop retransmissions of an
+ * out-of-dialog request such as OPTIONS) before a response arrives.
+ *
+ * Unlike returning the transaction object itself, this key is a plain,
+ * inert value with no reference-counting or use-after-free hazard: the
+ * application does not need to add or release any reference. It only
+ * needs to keep the buffer backing \a p_tsx_key valid for as long as it
+ * may still want to call #pjsip_endpt_cancel_request() -- in practice,
+ * until its \a cb has been called for this transaction. Calling
+ * #pjsip_endpt_cancel_request() with a key whose transaction has already
+ * completed is safe and simply returns PJ_ENOTFOUND.
+ *
+ * @param endpt     The endpoint instance.
+ * @param tdata     The transmit data to be sent.
+ * @param timeout   Optional timeout for final response to be received, or -1
+ *                  if the transaction should not have a timeout restriction.
+ *                  The value is in miliseconds. Note that this is not
+ *                  implemented yet, so application needs to use its own timer
+ *                  to handle timeout.
+ * @param token     Optional token to be associated with the transaction, and
+ *                  to be passed to the callback.
+ * @param cb        Optional callback to be called when the transaction has
+ *                  received a final response. The callback will be called with
+ *                  the previously registered token and the event that triggers
+ *                  the completion of the transaction.
+ * @param p_tsx_key Optional, used as BOTH input and output. If not NULL,
+ *                  on input \a p_tsx_key->ptr MUST already point to a
+ *                  buffer owned/allocated by the caller (e.g. a field
+ *                  embedded in the caller's own session/call struct; see
+ *                  #PJSIP_TSX_KEY_MAX_LEN for a suggested size), and
+ *                  \a p_tsx_key->slen MUST be set to that buffer's actual
+ *                  capacity in bytes -- this function bounds-checks
+ *                  against that value, it does not assume any particular
+ *                  buffer size. On return, \a p_tsx_key->slen is
+ *                  overwritten with the actual key length on success, or
+ *                  set to 0 if no key could be produced (the send failed,
+ *                  or the supplied buffer was too small -- the latter is
+ *                  logged but does not fail the send itself). See
+ *                  ownership note above.
+ *
+ * @return          PJ_SUCCESS, or the appropriate error code.
+ */
+PJ_DECL(pj_status_t) pjsip_endpt_send_request2( pjsip_endpoint *endpt,
+                                                pjsip_tx_data *tdata,
+                                                pj_int32_t timeout,
+                                                void *token,
+                                                pjsip_endpt_send_callback cb,
+                                                pj_str_t *p_tsx_key);
+
+/**
+ * Locally abandon a request sent with #pjsip_endpt_send_request2(), using
+ * the transaction key it returned. This does NOT send anything on the
+ * wire (per RFC 3261 9.1, CANCEL does not apply to non-INVITE requests);
+ * it only stops the local transaction (retransmissions and the eventual
+ * completion callback) as soon as possible.
+ *
+ * This function is safe to call from anywhere, including from within the
+ * #pjsip_endpt_send_callback registered for the transaction: it uses
+ * #pjsip_tsx_terminate_async() internally, so it never synchronously
+ * re-enters the transaction's own state notification.
+ *
+ * If the transaction has already completed (e.g. a response already
+ * arrived) by the time this is called, this function simply returns
+ * PJ_ENOTFOUND; this is a normal, expected outcome, not an error to be
+ * treated specially.
+ *
+ * @param endpt     The endpoint instance.
+ * @param tsx_key   The transaction key, as returned by
+ *                  #pjsip_endpt_send_request2().
+ * @param code      The (final) status code to report for the abandoned
+ *                  transaction, e.g. PJSIP_SC_REQUEST_TERMINATED. Must be
+ *                  >= 200.
+ *
+ * @return          PJ_SUCCESS if the transaction was found and termination
+ *                  was scheduled, or PJ_ENOTFOUND if no matching
+ *                  transaction is currently active.
+ */
+PJ_DECL(pj_status_t) pjsip_endpt_cancel_request( pjsip_endpoint *endpt,
+                                                 const pj_str_t *tsx_key,
+                                                 int code);
+
+/**
  * @}
  */
 

--- a/pjsip/src/pjsip/sip_util_statefull.c
+++ b/pjsip/src/pjsip/sip_util_statefull.c
@@ -28,6 +28,8 @@
 #include <pj/pool.h>
 #include <pj/string.h>
 
+#define THIS_FILE   "sip_util_statefull.c"
+
 struct tsx_data
 {
     void *token;
@@ -83,22 +85,33 @@ static void mod_util_on_tsx_state(pjsip_transaction *tsx, pjsip_event *event)
 }
 
 
-PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
+PJ_DEF(pj_status_t) pjsip_endpt_send_request2( pjsip_endpoint *endpt,
                                                pjsip_tx_data *tdata,
                                                pj_int32_t timeout,
                                                void *token,
-                                               pjsip_endpt_send_callback cb)
+                                               pjsip_endpt_send_callback cb,
+                                               pj_str_t *p_tsx_key)
 {
     pjsip_transaction *tsx;
     struct tsx_data *tsx_data;
     pj_status_t status;
+    pj_size_t key_buf_cap;
 
     PJ_ASSERT_RETURN(endpt && tdata && (timeout==-1 || timeout>0), PJ_EINVAL);
+    PJ_ASSERT_RETURN(!p_tsx_key || (p_tsx_key->ptr && p_tsx_key->slen >= 0),
+                     PJ_EINVAL);
 
     /* Check that transaction layer module is registered to endpoint */
     PJ_ASSERT_RETURN(mod_stateful_util.id != -1, PJ_EINVALIDOP);
 
     PJ_UNUSED_ARG(timeout);
+
+    /* p_tsx_key->slen carries the caller-supplied buffer *capacity* on
+     * input; capture it now, before it gets overwritten below with the
+     * *actual* key length (or 0) on return.
+     */
+    key_buf_cap = p_tsx_key ? (pj_size_t) p_tsx_key->slen : 0;
+    if (p_tsx_key) p_tsx_key->slen = 0;
 
     status = pjsip_tsx_create_uac(&mod_stateful_util, tdata, &tsx);
     if (status != PJ_SUCCESS) {
@@ -124,11 +137,64 @@ PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
         pjsip_tx_data_dec_ref(tdata);
         pjsip_tsx_terminate(tsx, tsx->status_code? tsx->status_code:
                             PJSIP_SC_SERVICE_UNAVAILABLE);
+    } else if (p_tsx_key) {
+        /* Bounds-check against the capacity the caller actually gave us,
+         * not an assumed constant. Guard against overflow rather than
+         * silently truncate into a corrupt/unusable key.
+         */
+        if ((pj_size_t) tsx->transaction_key.slen <= key_buf_cap) {
+            pj_memcpy(p_tsx_key->ptr, tsx->transaction_key.ptr,
+                      tsx->transaction_key.slen);
+            p_tsx_key->slen = tsx->transaction_key.slen;
+        } else {
+            PJ_LOG(2,(THIS_FILE, "Transaction key (%d bytes) exceeds "
+                      "caller-provided buffer (%d bytes), unable to "
+                      "return key",
+                      (int)tsx->transaction_key.slen, (int)key_buf_cap));
+        }
     }
 
     pj_grp_lock_dec_ref(tsx->grp_lock);
 
     return status;
+}
+
+
+PJ_DEF(pj_status_t) pjsip_endpt_send_request(  pjsip_endpoint *endpt,
+                                               pjsip_tx_data *tdata,
+                                               pj_int32_t timeout,
+                                               void *token,
+                                               pjsip_endpt_send_callback cb)
+{
+    return pjsip_endpt_send_request2(endpt, tdata, timeout, token, cb, NULL);
+}
+
+
+/*
+ * Locally abandon a request sent with pjsip_endpt_send_request2().
+ */
+PJ_DEF(pj_status_t) pjsip_endpt_cancel_request( pjsip_endpoint *endpt,
+                                                const pj_str_t *tsx_key,
+                                                int code)
+{
+    pjsip_transaction *tsx;
+
+    PJ_ASSERT_RETURN(endpt && tsx_key && code >= 200, PJ_EINVAL);
+    PJ_UNUSED_ARG(endpt);
+
+    tsx = pjsip_tsx_layer_find_tsx2(tsx_key, PJ_TRUE);
+    if (!tsx)
+        return PJ_ENOTFOUND;
+
+    /* Use the async variant so this is safe to call from anywhere,
+     * including from within the pjsip_endpt_send_callback registered for
+     * this same transaction -- it never synchronously re-enters the
+     * transaction's own state notification.
+     */
+    pjsip_tsx_terminate_async(tsx, code);
+    pj_grp_lock_dec_ref(tsx->grp_lock);
+
+    return PJ_SUCCESS;
 }
 
 


### PR DESCRIPTION
## Summary

- Applications sending an out-of-dialog non-INVITE request (e.g. OPTIONS) via `pjsip_endpt_send_request()` had no way to locally abandon the request before a response arrives — the function returns no transaction handle, and per RFC 3261 §9.1 a wire-level CANCEL doesn't apply to non-INVITE requests anyway, so there was no supported mechanism at all.
- Adds `pjsip_endpt_send_request2()`, a variant of `pjsip_endpt_send_request()` that optionally returns the transaction's *key* (not the transaction object itself) into a caller-supplied buffer. The caller passes the buffer's actual capacity in via `p_tsx_key->slen`, and the function bounds-checks against that real value rather than assuming a fixed size — consistent with the existing `pjsip_uri_print()`/`pjsip_hdr_print_on()`/`pjsip_msg_print()` convention for output buffers in this codebase.
- Returning a key instead of the transaction pointer avoids any reference-counting or use-after-free hazard for the caller — the key is an inert value with no lifetime/ownership contract beyond "keep the buffer valid until your callback fires."
- Adds `pjsip_endpt_cancel_request(endpt, tsx_key, code)`, which looks the transaction up by that key (`pjsip_tsx_layer_find_tsx2()`) and terminates it via `pjsip_tsx_terminate_async()` (not the synchronous `pjsip_tsx_terminate()`), so it is safe to call from anywhere — including from within the transaction's own completion callback — without risking reentrant re-entry into the transaction's state-transition notification. If the transaction has already completed, it simply returns `PJ_ENOTFOUND`.
- `pjsip_endpt_send_request()` is now a thin wrapper delegating to `pjsip_endpt_send_request2()` with no key requested, so all existing callers are unaffected.
- Adds `PJSIP_TSX_KEY_MAX_LEN` as a suggested (not required/assumed) buffer size for callers who want a size that comfortably fits any standard SIP method's key.
