### PR TITLE
pjlib-util: bound HTTP client response body size

### DIFF
--- a/pjlib-util/include/pjlib-util/config.h
+++ b/pjlib-util/include/pjlib-util/config.h
@@ -306,6 +306,21 @@
 #   define PJ_HTTP_DEFAULT_TIMEOUT         (60000)
 #endif
 
+/**
+ * Maximum size (in bytes) of an HTTP response body that the HTTP client will
+ * buffer internally. A response advertising a larger Content-Length is
+ * rejected before its body is allocated, and a response without Content-Length
+ * is aborted once the received body grows past this limit. This bounds memory
+ * usage against a malicious or malfunctioning server. Applications that stream
+ * the body themselves via the on_data_read() callback are not subject to this
+ * limit. Set to 0 to disable the check (not recommended).
+ *
+ * Default: 8 MB
+ */
+#ifndef PJ_HTTP_MAX_CONTENT_LENGTH
+#   define PJ_HTTP_MAX_CONTENT_LENGTH      (8 * 1024 * 1024)
+#endif
+
 /* **************************************************************************
  * CLI configuration
  */

--- a/pjlib-util/src/pjlib-util-test/http_client.c
+++ b/pjlib-util/src/pjlib-util-test/http_client.c
@@ -59,6 +59,7 @@ static pj_size_t send_size = 0;
 static pj_status_t sstatus;
 static pj_sockaddr_in addr;
 static int counter = 0;
+static pj_status_t g_comp_status;
 
 static int server_thread(void *p)
 {
@@ -201,6 +202,8 @@ static void on_complete(pj_http_req *hreq, pj_status_t status,
                         const pj_http_resp *resp)
 {
     PJ_UNUSED_ARG(hreq);
+
+    g_comp_status = status;
 
     if (status == PJ_ECANCELLED) {
         PJ_LOG(5, (THIS_FILE, "Request cancelled"));
@@ -923,10 +926,114 @@ int http_client_test_delete()
     return PJ_SUCCESS;
 }
 
+/*
+ * GET request against a server that advertises an oversized Content-Length.
+ * The client must reject the response (PJ_ETOOBIG) instead of allocating a
+ * buffer of the attacker-declared size.
+ */
+int http_client_test_maxlen()
+{
+    pj_str_t url;
+    pj_http_req_callback hcb;
+    pj_http_req_param param;
+    char urlbuf[80];
+
+    pj_bzero(&hcb, sizeof(hcb));
+    hcb.on_complete = &on_complete;
+    hcb.on_response = &on_response;
+
+    /* Create pool, timer, and ioqueue */
+    pool = pj_pool_create(mem, NULL, 8192, 4096, NULL);
+    if (pj_timer_heap_create(pool, 16, &timer_heap))
+        return -71;
+    if (pj_ioqueue_create(pool, 16, &ioqueue))
+        return -72;
+
+#ifdef USE_LOCAL_SERVER
+    thread_quit = PJ_FALSE;
+    g_server.action = ACTION_REPLY;
+    g_server.send_content_length = PJ_TRUE;
+    /* Advertise a body larger than the client's internal buffering limit. */
+    g_server.data_size = (unsigned)PJ_HTTP_MAX_CONTENT_LENGTH + 1024;
+    g_server.buf_size = 1024;
+
+    sstatus = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0,
+                             &g_server.sock);
+    if (sstatus != PJ_SUCCESS)
+        return -41;
+
+    pj_sockaddr_in_init(&addr, NULL, 0);
+
+    sstatus = pj_sock_bind(g_server.sock, &addr, sizeof(addr));
+    if (sstatus != PJ_SUCCESS)
+        return -43;
+
+    {
+        pj_sockaddr_in addr2;
+        int addr_len = sizeof(addr2);
+        sstatus = pj_sock_getsockname(g_server.sock, &addr2, &addr_len);
+        if (sstatus != PJ_SUCCESS)
+            return -44;
+        g_server.port = pj_sockaddr_in_get_port(&addr2);
+        pj_ansi_snprintf(urlbuf, sizeof(urlbuf),
+                         "http://127.0.0.1:%d/big",
+                         g_server.port);
+        url = pj_str(urlbuf);
+    }
+
+    sstatus = pj_sock_listen(g_server.sock, 8);
+    if (sstatus != PJ_SUCCESS)
+        return -45;
+
+    sstatus = pj_thread_create(pool, NULL, &server_thread, &g_server,
+                               0, 0, &g_server.thread);
+    if (sstatus != PJ_SUCCESS)
+        return -47;
+#else
+    pj_cstr(&url, "http://127.0.0.1:280/big");
+#endif
+
+    g_comp_status = PJ_SUCCESS;
+    pj_http_req_param_default(&param);
+    if (pj_http_req_create(pool, &url, timer_heap, ioqueue,
+                           &param, &hcb, &http_req))
+        return -73;
+
+    if (pj_http_req_start(http_req))
+        return -75;
+
+    while (pj_http_req_is_running(http_req)) {
+        pj_time_val delay = {0, 50};
+        pj_ioqueue_poll(ioqueue, &delay);
+        pj_timer_heap_poll(timer_heap, NULL);
+    }
+
+#ifdef USE_LOCAL_SERVER
+    thread_quit = PJ_TRUE;
+    pj_thread_join(g_server.thread);
+    pj_sock_close(g_server.sock);
+#endif
+
+    pj_http_req_destroy(http_req);
+    pj_ioqueue_destroy(ioqueue);
+    pj_timer_heap_destroy(timer_heap);
+    pj_pool_release(pool);
+
+#ifdef USE_LOCAL_SERVER
+    /* The oversized response must have been rejected. */
+    if (g_comp_status != PJ_ETOOBIG) {
+        PJ_LOG(3, (THIS_FILE, "  expected PJ_ETOOBIG, got %d", g_comp_status));
+        return -77;
+    }
+#endif
+
+    return PJ_SUCCESS;
+}
+
 int http_client_test()
 {
     int rc;
-    
+
     PJ_LOG(3, (THIS_FILE, "..Testing URL parsing"));
     rc = parse_url_test();
     if (rc)
@@ -954,6 +1061,11 @@ int http_client_test()
 
     PJ_LOG(3, (THIS_FILE, "..Testing DELETE request"));
     rc = http_client_test_delete();
+    if (rc)
+        return rc;
+
+    PJ_LOG(3, (THIS_FILE, "..Testing oversized Content-Length rejection"));
+    rc = http_client_test_maxlen();
     if (rc)
         return rc;
 

--- a/pjlib-util/src/pjlib-util/http_client.c
+++ b/pjlib-util/src/pjlib-util/http_client.c
@@ -420,15 +420,32 @@ static pj_bool_t http_on_data_read(pj_activesock_t *asock,
         if (size > 0)
             (*hreq->cb.on_data_read)(hreq, data, size);
     } else {
+#if PJ_HTTP_MAX_CONTENT_LENGTH
+        /* Bound the amount of response body buffered internally. Reject a
+         * response whose declared Content-Length is too large before
+         * allocating anything, and abort an unknown-length response once the
+         * received body grows past the limit. This prevents a malicious or
+         * malfunctioning server from forcing a huge allocation.
+         */
+        if (hreq->response.content_length > PJ_HTTP_MAX_CONTENT_LENGTH ||
+            hreq->tcp_state.current_read_size + size >
+            PJ_HTTP_MAX_CONTENT_LENGTH)
+        {
+            hreq->error = PJ_ETOOBIG;
+            pj_http_req_cancel(hreq, PJ_TRUE);
+            return PJ_FALSE;
+        }
+#endif
+
         if (hreq->response.size == 0) {
             /* If we know the content length, allocate the data based
-             * on that, otherwise we'll use initial buffer size and grow 
+             * on that, otherwise we'll use initial buffer size and grow
              * it later if necessary.
              */
-            hreq->response.size = (hreq->response.content_length == -1 ? 
-                                   INITIAL_DATA_BUF_SIZE : 
+            hreq->response.size = (hreq->response.content_length == -1 ?
+                                   INITIAL_DATA_BUF_SIZE :
                                    hreq->response.content_length);
-            hreq->response.data = pj_pool_alloc(hreq->pool, 
+            hreq->response.data = pj_pool_alloc(hreq->pool,
                                                 hreq->response.size);
         }
 
@@ -716,8 +733,18 @@ static pj_status_t http_response_parse(pj_pool_t *pool,
         if (!pj_stricmp(&response->headers.header[i].name,
                         &STR_CONTENT_LENGTH))
         {
-            response->content_length = 
+            unsigned long clen =
                 pj_strtoul(&response->headers.header[i].value);
+
+            /* Treat a value that does not fit in the (signed) content_length
+             * field as unspecified, so it cannot wrap to a negative value and
+             * later be used as a huge allocation size.
+             */
+            if (clen > PJ_MAXINT32) {
+                response->content_length = -1;
+            } else {
+                response->content_length = (pj_int32_t)clen;
+            }
             /* If content length is zero, make sure that it is because the
              * header value is really zero and not due to parsing error.
              */

--- a/pjlib-util/src/pjlib-util/http_client.c
+++ b/pjlib-util/src/pjlib-util/http_client.c
@@ -707,7 +707,8 @@ static pj_status_t http_response_parse(pj_pool_t *pool,
         response->status_code = (pj_uint16_t)pj_strtoul(&s);
         pj_scan_advance_n(&scanner, 1, PJ_FALSE);
         pj_scan_get_until_ch(&scanner, '\n', &response->reason);
-        if (response->reason.ptr[response->reason.slen-1] == '\r')
+        if (response->reason.slen > 0 &&
+            response->reason.ptr[response->reason.slen-1] == '\r')
             response->reason.slen--;
     }
     PJ_CATCH_ANY {
@@ -781,7 +782,7 @@ static pj_status_t http_headers_parse(char *hdata, pj_size_t size,
             if (*scanner.curptr == ':') {
                 pj_scan_advance_n(&scanner, 1, PJ_TRUE);
                 pj_scan_get_until_ch(&scanner, '\n', &s2);
-                if (s2.ptr[s2.slen-1] == '\r')
+                if (s2.slen > 0 && s2.ptr[s2.slen-1] == '\r')
                     s2.slen--;
                 status = pj_http_headers_add_elmt(headers, &s, &s2);
                 if (status != PJ_SUCCESS)


### PR DESCRIPTION
## Summary

Two response-parsing hardening fixes in the HTTP client (`pjlib-util/src/pjlib-util/http_client.c`).

### 1. Bound the response body size (main fix)

The client sized its response buffer directly from the server-supplied `Content-Length`:

- **Untrusted pre-allocation.** A server advertising a huge `Content-Length` (up to ~2 GB, the max of the signed 32-bit `content_length` field) forced a matching `pj_pool_alloc()` on the first body byte — a cheap memory-exhaustion DoS.
- **Integer wrap.** `pj_strtoul()` returns `unsigned long`; a `Content-Length` exceeding `INT32_MAX` wrapped to a negative `content_length`, then used (via `pj_size_t`) as an enormous allocation size.

Fix:
- New config `PJ_HTTP_MAX_CONTENT_LENGTH` (default **8 MB**). A response advertising a larger `Content-Length` is rejected with `PJ_ETOOBIG` **before its body is allocated**; an unknown-length response is aborted once the buffered body grows past the limit. Streaming via `on_data_read()` is unaffected. Set to `0` to disable.
- Clamp a `Content-Length` that does not fit the signed field to *unspecified* (`-1`), killing the negative wrap.
- `PJ_ETOOBIG` matches the existing convention (already used for an oversized response header).

Added `http_client_test_maxlen()`: a mock server advertises `Content-Length` above the limit; the client must complete with `PJ_ETOOBIG`.

### 2. Avoid a 1-byte under-read on empty reason/header value

The status-line and header parsers checked `ptr[slen-1]` for a trailing `\r` without ensuring `slen > 0`. An empty reason phrase (`HTTP/1.0 200 \n`) or empty header value (`X-Foo:\n`) made `slen` 0, reading `ptr[-1]` — one byte before the buffer. Both checks are now guarded with `slen > 0`.

## Reachability

The `pj_http_req` API is used in-tree only by the `httpdemo` sample, so these are hardening fixes rather than core-stack vulnerabilities — hence a public PR.

## Validation

- `make -j3` clean, no new warnings.
- `pjlib-util-test http_client_test` — OK (includes the new oversized-Content-Length case).

## Notes for large legitimate downloads

Responses larger than `PJ_HTTP_MAX_CONTENT_LENGTH` that must be fully buffered should either raise the limit or use the `on_data_read()` streaming callback, which is unaffected by this bound.