### PR TITLE
pjlib-util: limit JSON parser nesting depth and bound writer indent

### DIFF
--- a/pjlib-util/include/pjlib-util/config.h
+++ b/pjlib-util/include/pjlib-util/config.h
@@ -422,6 +422,17 @@
 #endif
 
 /**
+ * Maximum JSON nesting depth accepted by pj_json_parse(), to bound the
+ * parser's recursion and prevent stack exhaustion from deeply nested arrays
+ * or objects. Parsing fails beyond this depth.
+ *
+ * Default: 256
+ */
+#ifndef PJ_JSON_MAX_NESTING
+#   define PJ_JSON_MAX_NESTING     256
+#endif
+
+/**
  * @}
  */
 

--- a/pjlib-util/src/pjlib-util-test/json_test.c
+++ b/pjlib-util/src/pjlib-util-test/json_test.c
@@ -22,6 +22,7 @@
 #if INCLUDE_JSON_TEST
 
 #include <pjlib-util/json.h>
+#include <pjlib-util/config.h>
 #include <pj/log.h>
 #include <pj/string.h>
 
@@ -87,11 +88,64 @@ on_error:
 }
 
 
+/* A document nested deeper than PJ_JSON_MAX_NESTING must be rejected rather
+ * than overflowing the parser stack; one nested exactly at the limit must
+ * still parse.
+ */
+static int json_verify_nesting()
+{
+    pj_pool_t *pool;
+    pj_json_elem *elem;
+    unsigned size, i;
+    const unsigned too_deep = PJ_JSON_MAX_NESTING + 1;
+    char buf[2 * (PJ_JSON_MAX_NESTING + 4) + 1];
+
+    pool = pj_pool_create(mem, "json", 1000, 1000, NULL);
+
+    /* Over the limit: "[[[...]]]" nested too_deep levels, expect rejection. */
+    for (i = 0; i < too_deep; ++i)
+        buf[i] = '[';
+    for (i = 0; i < too_deep; ++i)
+        buf[too_deep + i] = ']';
+    buf[2 * too_deep] = '\0';
+    size = 2 * too_deep;
+
+    elem = pj_json_parse(pool, buf, &size, NULL);
+    if (elem) {
+        PJ_LOG(1, (THIS_FILE, "  Error: over-deep JSON was not rejected"));
+        pj_pool_release(pool);
+        return 20;
+    }
+
+    /* At the limit: must still parse successfully. */
+    for (i = 0; i < PJ_JSON_MAX_NESTING; ++i)
+        buf[i] = '[';
+    for (i = 0; i < PJ_JSON_MAX_NESTING; ++i)
+        buf[PJ_JSON_MAX_NESTING + i] = ']';
+    buf[2 * PJ_JSON_MAX_NESTING] = '\0';
+    size = 2 * PJ_JSON_MAX_NESTING;
+
+    elem = pj_json_parse(pool, buf, &size, NULL);
+    if (!elem) {
+        PJ_LOG(1, (THIS_FILE, "  Error: max-depth JSON was rejected"));
+        pj_pool_release(pool);
+        return 21;
+    }
+
+    pj_pool_release(pool);
+    return 0;
+}
+
+
 int json_test(void)
 {
     int rc;
 
     rc = json_verify_1();
+    if (rc)
+        return rc;
+
+    rc = json_verify_nesting();
     if (rc)
         return rc;
 

--- a/pjlib-util/src/pjlib-util-test/json_test.c
+++ b/pjlib-util/src/pjlib-util-test/json_test.c
@@ -137,6 +137,49 @@ static int json_verify_nesting()
 }
 
 
+/* Writing a deeply nested object must not drive the writer's indent past its
+ * buffer (a regression here is caught by ASan/valgrind CI builds).
+ */
+static int json_verify_write_indent()
+{
+    pj_pool_t *pool;
+    pj_json_elem *root, *cur;
+    pj_str_t name = pj_str("a");
+    pj_str_t val = pj_str("x");
+    char *out_buf;
+    unsigned i, size;
+
+    pool = pj_pool_create(mem, "json", 4000, 4000, NULL);
+
+    root = PJ_POOL_ZALLOC_T(pool, pj_json_elem);
+    pj_json_elem_obj(root, NULL);
+    cur = root;
+    /* 50 named-object levels -> indent hits its cap (old code overran it). */
+    for (i = 0; i < 50; ++i) {
+        pj_json_elem *child = PJ_POOL_ZALLOC_T(pool, pj_json_elem);
+        pj_json_elem_obj(child, &name);
+        pj_json_elem_add(cur, child);
+        cur = child;
+    }
+    {
+        pj_json_elem *leaf = PJ_POOL_ZALLOC_T(pool, pj_json_elem);
+        pj_json_elem_string(leaf, &name, &val);
+        pj_json_elem_add(cur, leaf);
+    }
+
+    size = 32768;
+    out_buf = pj_pool_alloc(pool, size);
+    if (pj_json_write(root, out_buf, &size)) {
+        PJ_LOG(1, (THIS_FILE, "  Error: deep-object write failed"));
+        pj_pool_release(pool);
+        return 22;
+    }
+
+    pj_pool_release(pool);
+    return 0;
+}
+
+
 int json_test(void)
 {
     int rc;
@@ -146,6 +189,10 @@ int json_test(void)
         return rc;
 
     rc = json_verify_nesting();
+    if (rc)
+        return rc;
+
+    rc = json_verify_write_indent();
     if (rc)
         return rc;
 

--- a/pjlib-util/src/pjlib-util/json.c
+++ b/pjlib-util/src/pjlib-util/json.c
@@ -513,7 +513,12 @@ static pj_status_t write_children(const pj_json_list *list,
                 child = child->next;
             }
         } else {
-            if (st->indent < (int)sizeof(st->indent_buf)) {
+            /* Only deepen the indent while a full step still fits the buffer,
+             * otherwise st->indent could exceed sizeof(indent_buf) and the
+             * writer would read past it.
+             */
+            if (st->indent + PJ_JSON_INDENT_SIZE <= (int)sizeof(st->indent_buf))
+            {
                 st->indent += PJ_JSON_INDENT_SIZE;
                 indent_added = PJ_TRUE;
             }

--- a/pjlib-util/src/pjlib-util/json.c
+++ b/pjlib-util/src/pjlib-util/json.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 #include <pjlib-util/json.h>
+#include <pjlib-util/config.h>
 #include <pjlib-util/errno.h>
 #include <pjlib-util/scanner.h>
 #include <pj/assert.h>
@@ -95,12 +96,19 @@ struct parse_state
     pj_scanner           scanner;
     pj_json_err_info    *err_info;
     pj_cis_t             float_spec;    /* numbers with dot! */
+    unsigned             depth;         /* current array/object nesting */
 };
 
 static pj_status_t parse_children(struct parse_state *st,
                                   pj_json_elem *parent)
 {
     char end_quote = (parent->type == PJ_JSON_VAL_ARRAY)? ']' : '}';
+
+    /* Bound the recursion so a deeply nested document cannot exhaust the
+     * stack. Each nesting level recurses through parse_elem_throw().
+     */
+    if (++st->depth > PJ_JSON_MAX_NESTING)
+        return PJLIB_UTIL_EINJSON;
 
     pj_scan_get_char(&st->scanner);
 
@@ -121,6 +129,7 @@ static pj_status_t parse_children(struct parse_state *st,
     }
 
     pj_scan_get_char(&st->scanner);
+    --st->depth;
     return PJ_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

Two JSON hardening fixes in `pjlib-util` (`json.c`).

### 1. Parser nesting depth limit

`pj_json_parse()` recurses through `parse_children()` → `parse_elem_throw()` → `parse_children()` once per array/object nesting level, with **no depth limit**. A deeply nested document (e.g. a long run of `[`) can exhaust the stack and crash the process. This is the JSON counterpart of the unbounded-recursion issue already fixed in the XML parser (`PJ_XML_MAX_NESTING`).

Fix:
- Add `PJ_JSON_MAX_NESTING` (default **256**) in `config.h`.
- Track the current nesting depth in `struct parse_state`; `parse_children()` increments on entry and fails cleanly with `PJLIB_UTIL_EINJSON` once the limit is exceeded, decrementing on normal completion so sibling containers don't accumulate depth.
- A document nested exactly at the limit still parses.

Test `json_verify_nesting()`: one level beyond the limit is rejected, exactly at the limit succeeds.

### 2. Writer indentation bound

The JSON *writer* deepened `st->indent` by `PJ_JSON_INDENT_SIZE` whenever the current indent was still below `sizeof(indent_buf)`. At indent 99 (default step 3, 100-byte buffer) it advanced to **102**, and the writer then read 2 bytes past `indent_buf` (CWE-193/125 — a small over-read within the struct, producing stray indent bytes). The indent is now deepened only while a full step still fits the buffer.

Test `json_verify_write_indent()`: writes a deeply nested object so the indent reaches its cap (a regression is caught by ASan/valgrind CI builds).

## Reachability

Parser recursion is reachable via pjsua2 config parsing and the OpenAI AI-media port; the writer over-read affects serialization of deeply nested elements. Both are hardening fixes, hence a public PR.

## Validation

- `make -j3` clean, no new warnings.
- `pjlib-util-test json_test` — OK (both new cases).