### PR TITLE
pjlib-util: fix STUN simple client second-server and truncated-attr read

### DIFF
--- a/pjlib-util/src/pjlib-util/stun_simple_client.c
+++ b/pjlib-util/src/pjlib-util/stun_simple_client.c
@@ -89,7 +89,7 @@ PJ_DEF(pj_status_t) pjstun_get_mapped_addr2(pj_pool_factory *pf,
 
     srv1 = &opt->srv1;
     port1 = opt->port1;
-    srv2 = &opt->srv1;
+    srv2 = &opt->srv2;
     port2 = opt->port2;
 
     TRACE_((THIS_FILE, "Entering pjstun_get_mapped_addr()"));
@@ -328,15 +328,31 @@ PJ_DEF(pj_status_t) pjstun_get_mapped_addr2(pj_pool_factory *pf,
                     continue;
                 }
 
-                attr = (pjstun_mapped_addr_attr*) 
+                attr = (pjstun_mapped_addr_attr*)
                        pjstun_msg_find_attr(&msg, PJSTUN_ATTR_MAPPED_ADDR);
                 if (!attr) {
-                    attr = (pjstun_mapped_addr_attr*) 
+                    attr = (pjstun_mapped_addr_attr*)
                            pjstun_msg_find_attr(&msg, PJSTUN_ATTR_XOR_MAPPED_ADDR);
-                    if (!attr || attr->family != 1) {
-                        status = PJLIB_UTIL_ESTUNNOMAP;
-                        continue;
-                    }
+                }
+
+                /* Reject a missing or truncated attribute before reading the
+                 * address fields below. The parser only guarantees that the
+                 * attribute's declared length fits the packet, so a short
+                 * (XOR-)MAPPED-ADDRESS would otherwise be read past its end,
+                 * and past recv_buf when it sits at the tail of the packet.
+                 * A valid attribute value is 8 bytes (family, port, IPv4).
+                 */
+                if (!attr || pj_ntohs(attr->hdr.length) < 8) {
+                    status = PJLIB_UTIL_ESTUNNOMAP;
+                    continue;
+                }
+
+                /* For XOR-MAPPED-ADDRESS, require IPv4 family as before. */
+                if (pj_ntohs(attr->hdr.type) == PJSTUN_ATTR_XOR_MAPPED_ADDR &&
+                    attr->family != 1)
+                {
+                    status = PJLIB_UTIL_ESTUNNOMAP;
+                    continue;
                 }
 
                 rec[sock_idx].srv[srv_idx].mapped_addr = attr->addr;


### PR DESCRIPTION
## Summary

Two fixes in the legacy simple STUN client, `pjstun_get_mapped_addr2()` (`pjlib-util/src/pjlib-util/stun_simple_client.c`).

### 1. Second server was never queried

```c
srv2 = &opt->srv1;   /* should be &opt->srv2 */
```

The second server address was copied from `opt->srv1`, so both binding requests went to the first server (with server 1's address but server 2's port). Dual-server operation — e.g. the classic two-server NAT-type probe — never actually queried the second server. Corrected to `&opt->srv2`.

### 2. Truncated MAPPED-ADDRESS attribute over-read

The `(XOR-)MAPPED-ADDRESS` attribute was dereferenced for its `family`, `port`, and `addr` fields without checking its length. `pjstun_parse_msg()` only guarantees that an attribute's *declared* length fits the packet; it does not guarantee the attribute is long enough for what a consumer reads. A response carrying a MAPPED-ADDRESS attribute with a value shorter than 8 bytes therefore had those fields read past the end of the attribute — and past the 128-byte `recv_buf` when the short attribute sat at the tail of the packet (an out-of-bounds stack read, CWE-125).

Fix: reject a missing or too-short attribute (value < 8 bytes: 1 reserved + 1 family + 2 port + 4 IPv4 address) before reading its fields. The existing IPv4-family requirement for XOR-MAPPED-ADDRESS is preserved.

## Reachability

Reachable via the STUN NAT-detection path used by PJSUA (`pjsua_media`/`pjsua_core`), when the application is configured with a STUN server. The over-read is bounded (a few bytes of adjacent stack) and does not by itself yield code execution, hence a public hardening PR.

## Note on U17-2 (already fixed)

The transaction-ID matching hardening in this function (`GHSA-893w-fmvw-qvg7`, "Legacy simple STUN client accepts forged Binding Responses") is already present on master and is untouched here.

## Test coverage

The legacy simple STUN client currently has no unit-test harness (`pjlib-util-test/stun.c` contains only stub `decode_test`/`decode_verify`), and exercising `pjstun_get_mapped_addr2()` requires live sockets and a mock STUN server. These fixes were validated by build (clean, `-Wall`) and code review; no automated test is added.

## Validation

- `make -j3` clean, no new warnings.
- `pjlib-util-test` builds and runs unchanged.