### PR TITLE
pjlib-util: assorted minor hardening/correctness fixes

### DIFF
--- a/pjlib-util/src/pjlib-util-test/websock_test.c
+++ b/pjlib-util/src/pjlib-util-test/websock_test.c
@@ -45,6 +45,7 @@ static struct echo_server_t
     pj_thread_t    *thread;
     pj_bool_t       quit;
     pj_pool_t      *pool;
+    pj_bool_t       send_masked;  /* Send masked frames (protocol violation) */
 } g_server;
 
 /* Minimal Base64 encode (RFC 4648) for the server handshake */
@@ -135,26 +136,42 @@ static pj_size_t server_decode_frame(const pj_uint8_t *data, pj_size_t len,
     return pos + pl;
 }
 
-/* Encode a server WebSocket frame (unmasked) */
+/* Encode a server WebSocket frame. Server frames are normally unmasked;
+ * when g_server.send_masked is set the frame is masked, which a compliant
+ * client must reject (used to test that rejection).
+ */
 static pj_size_t server_encode_frame(pj_uint8_t *buf, pj_uint8_t opcode,
                                      const pj_uint8_t *payload,
                                      pj_size_t plen)
 {
     pj_size_t pos = 0;
+    pj_bool_t masked = g_server.send_masked;
+    pj_uint8_t mask_bit = (pj_uint8_t)(masked ? 0x80 : 0);
+
     buf[pos++] = (pj_uint8_t)(0x80 | opcode); /* FIN + opcode */
     if (plen < 126) {
-        buf[pos++] = (pj_uint8_t)plen;
+        buf[pos++] = (pj_uint8_t)(mask_bit | plen);
     } else if (plen <= 0xFFFF) {
-        buf[pos++] = 126;
+        buf[pos++] = (pj_uint8_t)(mask_bit | 126);
         buf[pos++] = (pj_uint8_t)((plen >> 8) & 0xFF);
         buf[pos++] = (pj_uint8_t)(plen & 0xFF);
     } else {
-        buf[pos++] = 127;
+        buf[pos++] = (pj_uint8_t)(mask_bit | 127);
         buf[pos++] = 0; buf[pos++] = 0; buf[pos++] = 0; buf[pos++] = 0;
         buf[pos++] = (pj_uint8_t)((plen >> 24) & 0xFF);
         buf[pos++] = (pj_uint8_t)((plen >> 16) & 0xFF);
         buf[pos++] = (pj_uint8_t)((plen >> 8) & 0xFF);
         buf[pos++] = (pj_uint8_t)(plen & 0xFF);
+    }
+    if (masked) {
+        pj_uint8_t mask[4];
+        pj_size_t i;
+        mask[0] = 0x12; mask[1] = 0x34; mask[2] = 0x56; mask[3] = 0x78;
+        pj_memcpy(&buf[pos], mask, 4);
+        pos += 4;
+        for (i = 0; i < plen; ++i)
+            buf[pos + i] = (pj_uint8_t)(payload[i] ^ mask[i & 3]);
+        return pos + plen;
     }
     if (plen > 0)
         pj_memcpy(&buf[pos], payload, plen);
@@ -896,6 +913,69 @@ static int test_public_wss_echo(void)
 
 
 /* ======== Main entry ======== */
+/* ======== Test: masked server frame is rejected (RFC 6455 5.1) ======== */
+static int test_masked_frame_rejected(void)
+{
+    test_state_t st;
+    pj_str_t url;
+    char url_buf[64];
+    const char *msg = "hello";
+    pj_status_t status;
+
+    PJ_LOG(3, (THIS_FILE, "  test_masked_frame_rejected"));
+
+    PJ_TEST_SUCCESS(setup_test_state(&st), NULL, return -600);
+
+    pj_ansi_snprintf(url_buf, sizeof(url_buf),
+                     "ws://127.0.0.1:%d/masked", g_server.port);
+    pj_cstr(&url, url_buf);
+
+    /* Make the echo server reply with masked frames. */
+    g_server.send_masked = PJ_TRUE;
+
+    status = pj_websock_connect(st.ws, &url, NULL);
+    PJ_TEST_TRUE(status == PJ_SUCCESS || status == PJ_EPENDING, NULL, {
+        g_server.send_masked = PJ_FALSE;
+        teardown_test_state(&st); return -610;
+    });
+
+    poll_events_ex(&st, 2000, PJ_TRUE);
+    PJ_TEST_TRUE(st.connected, "WebSocket connect failed", {
+        g_server.send_masked = PJ_FALSE;
+        teardown_test_state(&st); return -620;
+    });
+
+    /* Send a message; the server echoes it masked, which the client must
+     * reject by failing the connection with close code 1002.
+     */
+    status = pj_websock_send(st.ws, PJ_WEBSOCK_OP_TEXT,
+                             msg, pj_ansi_strlen(msg));
+    PJ_TEST_SUCCESS(status, NULL, {
+        g_server.send_masked = PJ_FALSE;
+        teardown_test_state(&st); return -630;
+    });
+
+    poll_events(&st, 1000);
+
+    g_server.send_masked = PJ_FALSE;
+
+    /* The masked frame must not be delivered as a message... */
+    PJ_TEST_EQ(st.rx_count, 0U, "Masked frame should not be delivered", {
+        teardown_test_state(&st); return -640;
+    });
+    /* ...and the connection must have been failed with code 1002. */
+    PJ_TEST_TRUE(st.closed, "Connection was not closed", {
+        teardown_test_state(&st); return -650;
+    });
+    PJ_TEST_EQ(st.close_code, 1002, "Expected close code 1002", {
+        teardown_test_state(&st); return -660;
+    });
+
+    teardown_test_state(&st);
+    return 0;
+}
+
+
 int websock_test(void)
 {
     int rc;
@@ -918,6 +998,9 @@ int websock_test(void)
     if (rc) goto on_return;
 
     rc = test_close();
+    if (rc) goto on_return;
+
+    rc = test_masked_frame_rejected();
     if (rc) goto on_return;
 
 on_return:

--- a/pjlib-util/src/pjlib-util/dns.c
+++ b/pjlib-util/src/pjlib-util/dns.c
@@ -65,8 +65,12 @@ PJ_DEF(pj_status_t) pj_dns_make_query( void *packet,
     /* Sanity check */
     PJ_ASSERT_RETURN(packet && size && qtype && name, PJ_EINVAL);
 
-    /* Calculate total number of bytes required. */
-    d = sizeof(pj_dns_hdr) + name->slen + 4;
+    /* Calculate total number of bytes required: DNS header, the encoded
+     * query name, and the query type & class (4 bytes). The encoded name
+     * needs 2 octets more than the dotted string - a leading length octet
+     * and the trailing root (zero) octet.
+     */
+    d = sizeof(pj_dns_hdr) + (name->slen + 2) + 4;
 
     /* Check that size is sufficient. */
     PJ_ASSERT_RETURN(*size >= d, PJLIB_UTIL_EDNSQRYTOOSMALL);

--- a/pjlib-util/src/pjlib-util/scanner.c
+++ b/pjlib-util/src/pjlib-util/scanner.c
@@ -323,8 +323,14 @@ PJ_DEF(void) pj_scan_get_unescape( pj_scanner *scanner,
                 ++dst;
                 s += 3;
             } else {
+                /* Not a valid "%XX" escape: copy the '%' (and the next
+                 * character if any) literally. Guard the second copy so a
+                 * '%' at the very end does not read past the buffer and
+                 * leave curptr beyond scanner->end.
+                 */
                 *dst++ = *s++;
-                *dst++ = *s++;
+                if (PJ_SCAN_CHECK_EOF(s))
+                    *dst++ = *s++;
                 break;
             }
         }

--- a/pjlib-util/src/pjlib-util/string.c
+++ b/pjlib-util/src/pjlib-util/string.c
@@ -57,8 +57,10 @@ PJ_DEF(pj_str_t*) pj_strcpy_unescape(pj_str_t *dst_str,
     char *dst = dst_str->ptr;
     
     while (src != end) {
-        if (*src == '%' && src < end-2) {
-            *dst = (pj_uint8_t) ((pj_hex_digit_to_val(*(src+1)) << 4) + 
+        if (*src == '%' && src < end-2 && pj_isxdigit(*(src+1)) &&
+            pj_isxdigit(*(src+2)))
+        {
+            *dst = (pj_uint8_t) ((pj_hex_digit_to_val(*(src+1)) << 4) +
                                  pj_hex_digit_to_val(*(src+2)));
             ++dst;
             src += 3;

--- a/pjlib-util/src/pjlib-util/websock.c
+++ b/pjlib-util/src/pjlib-util/websock.c
@@ -974,6 +974,30 @@ static void process_rx_frame(pj_websock *ws, pj_uint8_t *data,
         pj_size_t payload_len;
         pj_size_t consumed;
 
+        /* RFC 6455 section 5.1: a client MUST fail the connection upon
+         * receiving a masked frame. This is a client-only implementation, so
+         * a masked frame (MASK bit in the second header byte) from the server
+         * is a protocol error. Check as soon as that byte is available.
+         */
+        if (len >= 2 && (data[1] & 0x80)) {
+            pj_str_t reason;
+
+            reason.ptr = (char*)"masked frame";
+            reason.slen = 12;
+            PJ_LOG(3, (THIS_FILE,
+                       "Received masked frame from server; failing connection"));
+
+            pj_grp_lock_acquire(ws->grp_lock);
+            if (ws->state == PJ_WEBSOCK_STATE_OPEN)
+                send_close_frame(ws, 1002 /* protocol error */, &reason);
+            ws->state = PJ_WEBSOCK_STATE_CLOSED;
+            pj_grp_lock_release(ws->grp_lock);
+
+            if (!ws->destroying && ws->cb.on_close)
+                ws->cb.on_close(ws, 1002, &reason);
+            return;
+        }
+
         consumed = decode_frame_header(data, len, &fin, &opcode,
                                        &payload, &payload_len);
         if (consumed == 0) {


### PR DESCRIPTION
## Summary

Four small, independent fixes found during a review of pjlib-util. Grouped into one PR as minor fixes.

### 1. websock: reject masked frames from the server (RFC 6455 §5.1)

This is a client-only implementation. RFC 6455 requires a client to *fail the connection* upon receiving a masked frame; previously such a frame was silently unmasked and delivered to the application. `process_rx_frame()` now detects the MASK bit and closes the connection with code `1002` (protocol error). A test (`test_masked_frame_rejected`) drives the echo server to reply with a masked frame and asserts the client rejects it (no message delivered, `on_close` with 1002).

### 2. dns: `pj_dns_make_query()` undersized buffer check

The required-size check was `header + name->slen + 4`, but the encoded query name needs **2 octets more** than the dotted string — a leading length octet and the trailing root (zero) octet. The check could therefore pass for a buffer 2 bytes too small (CWE-131). In-tree callers pass a full-size buffer, so no overflow occurred in practice; this corrects the bound for external callers.

### 3. string: `pj_strcpy_unescape()` missing hex-digit validation

Unlike `pj_str_unescape()`, `pj_strcpy_unescape()` decoded a `%` sequence without checking that the next two characters are hex digits, producing garbage for malformed input (e.g. `%zz`). A `%` not followed by two hex digits now passes through literally, matching `pj_str_unescape()`.

### 4. scanner: `pj_scan_get_unescape()` 1-byte over-read on trailing `%`

For a malformed `%` escape the code copied two bytes even when `%` was the last character, reading one byte past the token (the terminating NUL) and leaving `curptr` beyond `scanner->end`. The second byte is now copied only when present.

## Reachability

All are low-severity: #1 is a protocol-compliance gap in a client used for AI-media signaling; #2 has no in-tree overflow; #3 is a correctness gap reachable via multipart handling; #4 is bounded to reading the NUL terminator of a NUL-terminated scanner buffer. None is a remotely-exploitable memory-safety bug, hence a single minor-fix PR.

## Validation

- `make -j3` clean, no new warnings.
- `pjlib-util-test`: `websock_test` (with the new masked-frame case) and `resolver_test` (exercises `pj_dns_make_query`) pass. The scanner and string changes are exercised indirectly by the SIP parser (pjsip-test) and are behavior-preserving for valid input.