### PR TITLE
pjmedia: fix srtp pool growth on every SDES renegotiation

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp.c
+++ b/pjmedia/src/pjmedia/transport_srtp.c
@@ -252,6 +252,8 @@ typedef struct srtp_context
     pjmedia_srtp_crypto  rx_policy;
 
     /* Temporary policy for negotiation */
+    char                 tx_neg_key[MAX_KEY_LEN];
+    char                 rx_neg_key[MAX_KEY_LEN];
     pjmedia_srtp_crypto  tx_policy_neg;
     pjmedia_srtp_crypto  rx_policy_neg;
 
@@ -435,6 +437,10 @@ static pj_bool_t srtp_crypto_empty(const pjmedia_srtp_crypto* c);
 /* Compare crypto, return zero if same */
 static int srtp_crypto_cmp(const pjmedia_srtp_crypto* c1,
                            const pjmedia_srtp_crypto* c2);
+
+/* Copy a negotiated crypto into transport-owned storage */
+static pj_status_t store_crypto_neg(pjmedia_srtp_crypto *dst, char *key_buf,
+                                    const pjmedia_srtp_crypto *src);
 
 /* Start SRTP */
 static pj_status_t start_srtp(transport_srtp *srtp);
@@ -638,6 +644,36 @@ static int get_crypto_idx(const pj_str_t* crypto_name)
     }
 
     return -1;
+}
+
+
+/* Copy a negotiated crypto into transport-owned storage: key bytes into the
+ * given fixed buffer, name into the static crypto-suite table. This lets the
+ * keying parse crypto from a transient per-negotiation pool without leaking
+ * into (or dangling past the release of) any pool.
+ */
+static pj_status_t store_crypto_neg(pjmedia_srtp_crypto *dst, char *key_buf,
+                                    const pjmedia_srtp_crypto *src)
+{
+    int cs_idx = get_crypto_idx(&src->name);
+
+    /* The name must be in the crypto-suite table, otherwise there is no
+     * transport-owned storage to point it to.
+     */
+    if (cs_idx < 0)
+        return PJMEDIA_SRTP_ENOTSUPCRYPTO;
+
+    if (src->key.slen > MAX_KEY_LEN)
+        return PJMEDIA_SRTP_EINKEYLEN;
+
+    *dst = *src;
+
+    if (src->key.slen > 0)
+        pj_memcpy(key_buf, src->key.ptr, src->key.slen);
+    pj_strset(&dst->key, key_buf, src->key.slen);
+    dst->name = pj_str(crypto_suites[cs_idx].name);
+
+    return PJ_SUCCESS;
 }
 
 

--- a/pjmedia/src/pjmedia/transport_srtp_sdes.c
+++ b/pjmedia/src/pjmedia/transport_srtp_sdes.c
@@ -426,7 +426,7 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
                 /* If buffer_len==0, just skip the crypto attribute. */
                 if (buffer_len) {
                     pj_strset(&attr_value, buffer, buffer_len);
-                    attr = pjmedia_sdp_attr_create(srtp->pool, ID_CRYPTO.ptr,
+                    attr = pjmedia_sdp_attr_create(sdp_pool, ID_CRYPTO.ptr,
                                                    &attr_value);
                     m_loc->attr[m_loc->attr_count++] = attr;
                     ++tag;
@@ -487,7 +487,10 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
                 if (cr_attr_count >= PJ_ARRAY_SIZE(tags))
                     return PJMEDIA_SRTP_ESDPINCRYPTO;
 
-                status = parse_attr_crypto(srtp->pool, m_rem->attr[i],
+                /* Parse into the transient SDP pool; chosen crypto is copied
+                 * to transport-owned storage below (see store_crypto_neg()).
+                 */
+                status = parse_attr_crypto(sdp_pool, m_rem->attr[i],
                                            &tmp_rx_crypto,
                                            &tags[cr_attr_count]);
                 if (status != PJ_SUCCESS)
@@ -516,7 +519,13 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
                                 (int)crypto_suites[cs_idx].cipher_key_len)
                                 return PJMEDIA_SRTP_EINKEYLEN;
 
-                            srtp->srtp_ctx.rx_policy_neg = tmp_rx_crypto;
+                            status = store_crypto_neg(
+                                            &srtp->srtp_ctx.rx_policy_neg,
+                                            srtp->srtp_ctx.rx_neg_key,
+                                            &tmp_rx_crypto);
+                            if (status != PJ_SUCCESS)
+                                return status;
+
                             chosen_tag = tags[cr_attr_count];
                             matched_idx = j;
                             break;
@@ -573,7 +582,11 @@ static pj_status_t sdes_encode_sdp( pjmedia_transport *tp,
             if (status != PJ_SUCCESS)
                 return status;
 
-            srtp->srtp_ctx.tx_policy_neg = srtp->setting.crypto[matched_idx];
+            status = store_crypto_neg(&srtp->srtp_ctx.tx_policy_neg,
+                                      srtp->srtp_ctx.tx_neg_key,
+                                      &srtp->setting.crypto[matched_idx]);
+            if (status != PJ_SUCCESS)
+                return status;
 
             /* If buffer_len==0, just skip the crypto attribute. */
             if (buffer_len) {
@@ -692,7 +705,7 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
             return PJ_SUCCESS;
 
         /* Get the local crypto. */
-        fill_local_crypto(srtp->pool, m_loc, PJ_FALSE,
+        fill_local_crypto(pool, m_loc, PJ_FALSE,
                           loc_crypto, &loc_cryto_cnt);
 
         if (loc_cryto_cnt == 0)
@@ -703,15 +716,30 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
             (pj_stricmp(&srtp->srtp_ctx.tx_policy_neg.key,
                         &loc_crypto[0].key) != 0))
         {
-            srtp->srtp_ctx.tx_policy_neg = loc_crypto[0];
+            status = store_crypto_neg(&srtp->srtp_ctx.tx_policy_neg,
+                                      srtp->srtp_ctx.tx_neg_key,
+                                      &loc_crypto[0]);
+            if (status != PJ_SUCCESS)
+                return status;
             for (i = 0; i<srtp->setting.crypto_count ;++i) {
                 if ((pj_stricmp(&srtp->setting.crypto[i].name,
                                 &loc_crypto[0].name) == 0) &&
                     (pj_stricmp(&srtp->setting.crypto[i].key,
                                  &loc_crypto[0].key) != 0))
                 {
-                    pj_strdup(srtp->pool, &srtp->setting.crypto[i].key,
-                              &loc_crypto[0].key);
+                    /* Reuse the existing buffer if it fits, otherwise
+                     * srtp->pool would grow on every renegotiation.
+                     */
+                    if (srtp->setting.crypto[i].key.slen ==
+                        loc_crypto[0].key.slen)
+                    {
+                        pj_memcpy(srtp->setting.crypto[i].key.ptr,
+                                  loc_crypto[0].key.ptr,
+                                  loc_crypto[0].key.slen);
+                    } else {
+                        pj_strdup(srtp->pool, &srtp->setting.crypto[i].key,
+                                  &loc_crypto[0].key);
+                    }
                 }
             }
         }
@@ -737,14 +765,14 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
             //DEACTIVATE_MEDIA(pool, m_loc);
             //return PJMEDIA_SDP_EINPROTO;
         //}
-        fill_local_crypto(srtp->pool, m_loc, PJ_TRUE,
+        fill_local_crypto(pool, m_loc, PJ_TRUE,
                           loc_crypto, &loc_cryto_cnt);
     } else if (srtp->setting.use == PJMEDIA_SRTP_MANDATORY) {
         if (srtp->peer_use != PJMEDIA_SRTP_MANDATORY) {
             DEACTIVATE_MEDIA(pool, m_loc);
             return PJMEDIA_SDP_EINPROTO;
         }
-        fill_local_crypto(srtp->pool, m_loc, PJ_TRUE,
+        fill_local_crypto(pool, m_loc, PJ_TRUE,
                           loc_crypto, &loc_cryto_cnt);
     }
 
@@ -761,7 +789,7 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
 
         has_crypto_attr = PJ_TRUE;
 
-        status = parse_attr_crypto(srtp->pool, m_rem->attr[i],
+        status = parse_attr_crypto(pool, m_rem->attr[i],
                                    &tmp_tx_crypto, &rem_tag);
         if (status != PJ_SUCCESS)
             return status;
@@ -790,12 +818,20 @@ static pj_status_t sdes_media_start( pjmedia_transport *tp,
             if (pj_stricmp(&tmp_tx_crypto.name,
                            &loc_crypto[j].name) == 0)
             {
-                srtp->srtp_ctx.tx_policy_neg = loc_crypto[j];
+                status = store_crypto_neg(&srtp->srtp_ctx.tx_policy_neg,
+                                          srtp->srtp_ctx.tx_neg_key,
+                                          &loc_crypto[j]);
+                if (status != PJ_SUCCESS)
+                    return status;
+
                 break;
             }
         }
 
-        srtp->srtp_ctx.rx_policy_neg = tmp_tx_crypto;
+        status = store_crypto_neg(&srtp->srtp_ctx.rx_policy_neg,
+                                  srtp->srtp_ctx.rx_neg_key, &tmp_tx_crypto);
+        if (status != PJ_SUCCESS)
+            return status;
     }
 
     if (srtp->setting.use == PJMEDIA_SRTP_DISABLED) {


### PR DESCRIPTION
Supersedes/completes #5055 — thanks @motylewski for the report and the initial patch.

## Problem

The SDES keying parses remote/local crypto attributes and duplicates them into `srtp->pool`, which lives as long as the SRTP transport. Every SDP renegotiation therefore adds to that pool permanently, so a long call with periodic re-INVITEs grows without bound (~1886 bytes per re-INVITE in the reported case).

## Approach

#5055 switched the parsing to the transient per-negotiation pool. As noted in review there, that alone would leave `srtp_ctx.tx_policy_neg` / `rx_policy_neg` pointing into memory released with the SDP pool, while they are read later by `start_srtp()` and by the next negotiation's comparisons.

So the negotiated crypto is now copied into transport-owned storage:

* `store_crypto_neg()` (`transport_srtp.c`) copies the key bytes into new fixed `tx_neg_key` / `rx_neg_key` buffers in `srtp_context` and takes the name from the static `crypto_suites[]` table — the same pattern `create_srtp_ctx()` already uses for `tx_policy` / `rx_policy` with `tx_key` / `rx_key`.
* It returns `PJMEDIA_SRTP_ENOTSUPCRYPTO` for a crypto-suite name that is not in the table and `PJMEDIA_SRTP_EINKEYLEN` for an oversized key, instead of storing a pointer it does not own. Every current call site already guarantees both, but the helper is the single chokepoint for "make this crypto transport-owned", so it enforces its own contract rather than relying on an assert that compiles out in release builds.
* With `*_policy_neg` no longer pool-backed, `parse_attr_crypto()` and `fill_local_crypto()` can safely use the per-negotiation pool.

Two further per-renegotiation allocations from `srtp->pool` are fixed as well:

* The **offered** crypto SDP attribute was created from `srtp->pool` while the attribute is stored in `m_loc`; the answer path a few lines below already used `sdp_pool`. Made both consistent.
* On rekey, the new local key was `pj_strdup()`'d into `srtp->pool` on each renegotiation. The existing buffer is reused when the length matches (always the case for the same crypto-suite).

DTLS-SRTP is not affected by the dangling-pointer concern — `dtls_srtp` keeps its crypto in fixed struct members with static names. It does allocate the keying material from `ds->pool` per DTLS negotiation (`ssl_get_srtp_material()`), which is a much smaller and rarer growth; left alone here to keep this change scoped to the reported SDES path.

## Testing

* `make -j3` clean, no new warnings.
* All 36 SRTP tests pass: `tests/pjsua/scripts-call/150_srtp_*`, `160_srtp_dtls`, and the 24 `scripts-sendto/*srtp*` cases (which cover unsupported/malformed crypto suites, i.e. the new error returns).
* `scripts-sipp/uac-srtp-sdes-reinv-hold.xml` passes — this is the SDES re-INVITE renegotiation path.

Co-Authored-By Claude Code
