### PR TITLE
Fix orphaned recycle-list node in call_media_on_event()

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1919,7 +1919,7 @@ pj_status_t call_media_on_event(pjmedia_event *event,
             break;
     }
 
-    if (pjsua_var.ua_cfg.cb.on_call_media_event) {
+    if (pjsua_var.ua_cfg.cb.on_call_media_event && !call->hanging_up) {
         pjsua_event_list *eve = NULL;
  
         pj_mutex_lock(pjsua_var.timer_mutex);
@@ -1932,9 +1932,6 @@ pj_status_t call_media_on_event(pjmedia_event *event,
         }
 
         pj_mutex_unlock(pjsua_var.timer_mutex);
-
-        if (call->hanging_up)
-            return status;
 
         eve->call_id = call->index;
         eve->med_idx = call_med->idx;


### PR DESCRIPTION
Fixes #5204.

`call_media_on_event()` takes a `pjsua_event_list` node off the recycle free list and then returns
early when the call is hanging up, without putting the node back. Nodes are returned in exactly one
place — `call_med_event_cb()` — which only runs if `pjsua_schedule_timer2()` was reached, so every
media event dropped during hangup orphans one node: the free list drains, or `timer_pool` grows
when the list was already empty.

The fix moves the `hanging_up` check into the enclosing condition, so the node is never acquired
when it will not be used:

```diff
-    if (pjsua_var.ua_cfg.cb.on_call_media_event) {
+    if (pjsua_var.ua_cfg.cb.on_call_media_event && !call->hanging_up) {
@@
-        if (call->hanging_up)
-            return status;
-
```

This also matches the other `hanging_up` guards in pjsua, which gate the callback itself rather
than its bookkeeping.

**Safety of the moved read:** `call` is dereferenced unconditionally at the top of the function
(`call->index` in the entry `PJ_LOG`), so reading `call->hanging_up` earlier cannot introduce a
null dereference. `&&` short-circuits, so it is still not read when no callback is installed.

**Behaviour:** unchanged for callers — the event was already being dropped in this case; only the
bookkeeping differs.