### PR TITLE
pjlib-util: invoke cancel_query callback with the resolver lock released

### DIFF
--- a/pjlib-util/src/pjlib-util-test/resolver_test.c
+++ b/pjlib-util/src/pjlib-util-test/resolver_test.c
@@ -86,6 +86,11 @@ static int cancel_child_child_count;
 static pj_dns_async_query *cancel_child_query;
 static pj_bool_t cancel_child_cancelled;
 static pj_status_t cancel_child_status;
+static pj_dns_resolver *cancel_unlocked_res;
+static pj_sem_t *cancel_unlocked_entered;
+static pj_sem_t *cancel_unlocked_probed;
+static pj_bool_t cancel_unlocked_probe_seen;
+static int cancel_unlocked_count;
 
 #define MAX_LABEL   32
 
@@ -1471,6 +1476,123 @@ static int dns_cancel_child_in_callback_test(void)
 }
 
 
+
+/* Probe thread for the cancel-unlocked test: once the callback signals that
+ * it is running, take the resolver group lock through a read-only API. This
+ * blocks until the callback returns if the callback still holds the lock.
+ */
+static int cancel_unlocked_probe_thread(void *arg)
+{
+    pj_dns_settings lset;
+
+    PJ_UNUSED_ARG(arg);
+
+    pj_sem_wait(cancel_unlocked_entered);
+    pj_dns_resolver_get_settings(cancel_unlocked_res, &lset);
+    pj_sem_post(cancel_unlocked_probed);
+
+    return 0;
+}
+
+
+/* Callback delivered by pj_dns_resolver_cancel_query(): signals the probe
+ * thread, then waits for it to acquire the resolver lock. The probe can only
+ * succeed while this callback is running if the lock was released before the
+ * callback was invoked.
+ */
+static void dns_callback_cancel_unlocked(void *user_data,
+                                         pj_status_t status,
+                                         pj_dns_parsed_packet *resp)
+{
+    unsigned i;
+
+    PJ_UNUSED_ARG(user_data);
+    PJ_UNUSED_ARG(status);
+    PJ_UNUSED_ARG(resp);
+
+    cancel_unlocked_count++;
+
+    pj_sem_post(cancel_unlocked_entered);
+
+    /* Bounded wait, so the test fails rather than hangs when the callback
+     * is invoked under the lock.
+     */
+    for (i=0; i<500; ++i) {
+        if (pj_sem_trywait(cancel_unlocked_probed) == PJ_SUCCESS) {
+            cancel_unlocked_probe_seen = PJ_TRUE;
+            break;
+        }
+        pj_thread_sleep(10);
+    }
+}
+
+
+/* pj_dns_resolver_cancel_query() must invoke the application callback with
+ * the group lock released, as every other delivery site does, so that a
+ * callback re-entering the resolver or taking another lock cannot deadlock
+ * or invert the lock order.
+ */
+static int dns_cancel_unlocked_test(void)
+{
+    pj_str_t name = pj_str("name_cancel_unlocked");
+    pj_str_t nameservers[2];
+    pj_uint16_t ports[2];
+    pj_dns_async_query *q = NULL;
+    pj_thread_t *probe = NULL;
+
+    PJ_LOG(3,(THIS_FILE, "  cancel query delivers callback unlocked test"));
+
+    cancel_unlocked_count = 0;
+    cancel_unlocked_probe_seen = PJ_FALSE;
+
+    /* Servers ignore the query so it stays pending until cancelled. */
+    g_server[0].action = ACTION_IGNORE;
+    g_server[1].action = ACTION_IGNORE;
+
+    nameservers[0] = nameservers[1] = pj_str("127.0.0.1");
+    ports[0] = g_server[0].port;
+    ports[1] = g_server[1].port;
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_create(mem, NULL, 0, timer_heap, ioqueue,
+                                           &cancel_unlocked_res),
+                    NULL, return -760);
+    PJ_TEST_SUCCESS(pj_dns_resolver_set_ns(cancel_unlocked_res, 2,
+                                           nameservers, ports),
+                    NULL, return -761);
+
+    PJ_TEST_SUCCESS(pj_sem_create(pool, NULL, 0, 1, &cancel_unlocked_entered),
+                    NULL, return -762);
+    PJ_TEST_SUCCESS(pj_sem_create(pool, NULL, 0, 1, &cancel_unlocked_probed),
+                    NULL, return -763);
+    PJ_TEST_SUCCESS(pj_thread_create(pool, NULL, &cancel_unlocked_probe_thread,
+                                     NULL, 0, 0, &probe),
+                    NULL, return -764);
+
+    PJ_TEST_SUCCESS(pj_dns_resolver_start_query(
+                        cancel_unlocked_res, &name, PJ_DNS_TYPE_A, 0,
+                        &dns_callback_cancel_unlocked, NULL, &q),
+                    NULL, return -765);
+
+    pj_dns_resolver_cancel_query(q, PJ_TRUE);
+
+    pj_thread_join(probe);
+    pj_thread_destroy(probe);
+    pj_sem_destroy(cancel_unlocked_entered);
+    pj_sem_destroy(cancel_unlocked_probed);
+    pj_dns_resolver_destroy(cancel_unlocked_res, PJ_FALSE);
+
+    /* The cancelled query was already on the wire. Let the servers consume it
+     * while they are still ignoring, so that it is not mistaken for the first
+     * query of whichever test installs an action_cb next.
+     */
+    pj_thread_sleep(1000);
+
+    PJ_TEST_EQ(cancel_unlocked_count, 1, NULL, return -766);
+    PJ_TEST_EQ(cancel_unlocked_probe_seen, PJ_TRUE, NULL, return -767);
+
+    return 0;
+}
+
 /* DNS test */
 static int dns_test(void)
 {
@@ -2384,6 +2506,11 @@ int resolver_test(void)
 
     PJ_LOG(3,(THIS_FILE, "dns_destroy_pending_test"));
     rc = dns_destroy_pending_test();
+    if (rc != 0)
+        goto on_error;
+
+    PJ_LOG(3,(THIS_FILE, "dns_cancel_unlocked_test"));
+    rc = dns_cancel_unlocked_test();
     if (rc != 0)
         goto on_error;
 

--- a/pjlib-util/src/pjlib-util/resolver.c
+++ b/pjlib-util/src/pjlib-util/resolver.c
@@ -1216,24 +1216,35 @@ on_return:
 PJ_DEF(pj_status_t) pj_dns_resolver_cancel_query(pj_dns_async_query *query,
                                                  pj_bool_t notify)
 {
+    pj_grp_lock_t *grp_lock;
     pj_dns_callback *cb;
+    void *user_data;
 
     PJ_ASSERT_RETURN(query, PJ_EINVAL);
 
-    pj_grp_lock_acquire(query->resolver->grp_lock);
+    grp_lock = query->resolver->grp_lock;
+    pj_grp_lock_acquire(grp_lock);
 
     if (query->timer_entry.id == 1) {
         pj_timer_heap_cancel_if_active(query->resolver->timer,
                                        &query->timer_entry, 0);
     }
 
+    /* Capture the callback and its user data under the lock. Unlike the
+     * other delivery sites, this one does not remove the query from the
+     * hash tables, so it may be completed and recycled once the lock is
+     * released.
+     */
     cb = query->cb;
+    user_data = query->user_data;
     query->cb = NULL;
 
-    if (notify && cb)
-        (*cb)(query->user_data, PJ_ECANCELLED, NULL);
+    pj_grp_lock_release(grp_lock);
 
-    pj_grp_lock_release(query->resolver->grp_lock);
+    /* Invoke the callback unlocked, as the other delivery sites do. */
+    if (notify && cb)
+        (*cb)(user_data, PJ_ECANCELLED, NULL);
+
     return PJ_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes #5187, reported by @vlaushkin while reviewing #5181.

## Problem

`pj_dns_resolver_cancel_query()` invoked the application callback while still holding the resolver group lock. Every other delivery site releases the lock first — the deadlock-avoidance pattern for #1108 and #1565 — leaving this one as the only exception:

| Site | capture/clear | release | invoke |
|---|---|---|---|
| `on_timeout()` parent | 1814-1815 | 1818 | 1821 |
| `on_timeout()` child | 1830-1831 | 1832 | 1835 |
| `on_read_complete()` parent | 2023-2024 | 2027 | 2030 |
| `on_read_complete()` child | 2042-2043 | 2044 | 2047 |
| `pj_dns_resolver_destroy()` | yes | yes | yes |
| `pj_dns_resolver_cancel_query()` | 1230-1231 | **1236** | **1234** |

A callback that re-enters the resolver or takes another lock can deadlock or invert the lock order. #5181 fixed the four other sites and left this one behind.

## Fix

Capture the callback under the lock as before — so the single-delivery arbitration from #5181 is preserved — then release and invoke it unlocked.

`user_data` is captured under the lock as well. Unlike the other sites, `cancel_query()` performs no `pj_hash_set()` removal, so the query stays reachable and can be completed and recycled onto `query_free_nodes` as soon as the lock drops; reading `query->user_data` after the release could then see a recycled node. `grp_lock` is cached up front for the same reason.

## Test

`dns_cancel_unlocked_test()` starts a query the mock servers ignore, cancels it with `notify=PJ_TRUE`, and has a probe thread take the group lock through `pj_dns_resolver_get_settings()` while the `PJ_ECANCELLED` callback is running. The callback's wait for the probe is bounded (500 x 10ms), so a regression fails the test on `-767` rather than hanging it.

It is registered in the last slot alongside `dns_start_during_destroy_test`, and drains before returning: the cancelled query is already on the wire, and if a later test installs an `action_cb` before the servers consume it, that stray datagram is mistaken for the test's own first query.

## Validation

Clean `make realclean && ./configure && make` each time, x86_64-pc-linux-gnu:

| Configuration | Result |
|---|---|
| Pristine master | `resolver_test` OK (78.9s) |
| Fix only, no new test | `resolver_test` OK (78.9s) |
| Fix + test | pjlib-util suite **8/8 OK**, 4m28s |
| Test only, fix reverted | **Err -767**, `cancel_unlocked_probe_seen=0`, 5s wait exhausted |

The last row confirms the test actually catches the bug rather than passing vacuously.

## Risk

Small. All three in-tree callers (`srv_resolver.c:329`, `:337`, `:344`) pass `notify = PJ_FALSE` and never reach the callback, so only the application-facing `notify = PJ_TRUE` path changes behaviour.

Co-Authored-By Claude Code
