### PR TITLE
pjlib: eagerly load/validate TLS server cert on listener start (OpenSSL)

### DIFF
--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2233,6 +2233,16 @@ pj_ssl_sock_start_accept2(pj_ssl_sock_t *ssock,
 
     ssock->is_server = PJ_TRUE;
 
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+    /* Eagerly load and validate the certificate/private key now, instead
+     * of leaving it to the first accepted connection, so that a bad
+     * credential fails the listener startup itself.
+     */
+    status = ssl_init_server_ctx(ssock);
+    if (status != PJ_SUCCESS)
+        goto on_error;
+#endif
+
 #ifdef SSL_SOCK_IMP_USE_OWN_NETWORK
     status = network_start_accept(ssock, pool, localaddr, addr_len,
                                   newsock_param);

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -293,6 +293,11 @@ static pj_ssl_cipher ssl_get_cipher(pj_ssl_sock_t *ssock);
 static void ssl_update_certs_info(pj_ssl_sock_t *ssock);
 #if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
 static void ssl_free_cert(pj_ssl_cert_t *cert);
+/* Eagerly create/validate the server SSL_CTX (incl. certificate and
+ * private key loading) on a listener socket, instead of deferring it
+ * to the first accepted connection.
+ */
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock);
 #endif
 
 /* SSL session functions */

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2093,6 +2093,47 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
     return PJ_SUCCESS;
 }
 
+/* Eagerly build and validate the server SSL_CTX (loading and checking the
+ * certificate and private key) on the listener socket itself, so that a
+ * missing, unparsable, or mismatched certificate/key fails
+ * pj_ssl_sock_start_accept() up front. Without this, init_ossl_ctx() (see
+ * ssl_create() above) is only invoked lazily on the first accepted
+ * connection, and with server context reuse enabled, whatever context gets
+ * built there is then cached and reused by every subsequent connection.
+ */
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
+{
+    ossl_sock_t *ossock = (ossl_sock_t *)ssock;
+    pj_status_t status;
+
+    pj_assert(ssock->is_server && !ssock->parent);
+
+    /* Nothing to eagerly validate: without session reuse, each accepted
+     * connection builds and owns its own context anyway; without a
+     * certificate configured yet, there is nothing to load.
+     */
+    if (!SERVER_SUPPORT_SESSION_REUSE || !ssock->cert)
+        return PJ_SUCCESS;
+
+    status = init_openssl();
+    if (status != PJ_SUCCESS)
+        return status;
+
+    set_entropy(ssock);
+
+    status = init_ossl_ctx(ssock);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* This listener now owns the SSL_CTX that accepted connections will
+     * share (see the server-session-reuse branch in ssl_create()), so it
+     * must be the one to free it on destroy.
+     */
+    ossock->own_ctx = PJ_TRUE;
+
+    return PJ_SUCCESS;
+}
+
 static void ssl_free_cert(pj_ssl_cert_t *cert)
 {
     /* For OpenSSL version >= 3.0, dec ref EVP_PKEY & X509 */


### PR DESCRIPTION
## Summary
- Fixes #5209: `pj_ssl_sock_start_accept()` previously reported success without loading or validating the configured TLS server certificate/private key. The OpenSSL backend builds its `SSL_CTX` lazily on the first accepted connection, and with server context reuse enabled, whatever gets built there is cached and reused by every later connection. This meant a listener could start "successfully" with a missing, unparsable, or mismatched cert/key, with the failure only surfacing on the first real TLS handshake — and the served certificate depended on file state at first-accept time rather than at listener-start time.
- Adds `ssl_init_server_ctx()`, which eagerly builds the `SSL_CTX` (loading and validating the cert/key via the existing `init_ossl_ctx()`) directly on the listener socket inside `pj_ssl_sock_start_accept2()`, failing the call up front if the credentials can't be loaded or don't match. Accepted connections continue to reuse this context through the existing session-reuse path in `ssl_create()` — no change to that logic was needed.
- Scoped to the OpenSSL backend only (`#if PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL`); other backends (GnuTLS, mbedTLS, Schannel, Darwin) are unaffected.
- Only addresses the "starts ready with bad/missing creds" half of #5209. The other half — a cert/key file replaced *after* listener start but *before* the first accept isn't picked up until restart — is unchanged; that would need separate mtime-based reload logic.

## Test plan
- [x] `make` in `pjlib/build` — zero warnings/errors (`-Wall`)
- [x] `pjlib-test ssl_sock_test` passes
- [x] Manual repro built against both the patched and original library using two mismatched self-signed cert/key pairs:
  - Before: `pj_ssl_sock_start_accept()` returns `PJ_SUCCESS` for matching, mismatched, and even nonexistent cert/key files.
  - After: matching cert/key still succeeds (and now logs cert/key loaded at listen time); mismatched cert/key and nonexistent cert file both fail `pj_ssl_sock_start_accept()` immediately with the underlying OpenSSL error (e.g. `key values mismatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)