### PR TITLE
fix(pjsip): answer an oversized request with 513 Message Too Large

### DIFF
--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -1003,10 +1003,10 @@ on_return:
 static void endpt_respond_msg_too_large( pjsip_endpoint *endpt,
                                          pjsip_rx_data *rdata )
 {
-    char *buf = rdata->msg_info.msg_buf;
-    pj_size_t len = (pj_size_t)rdata->msg_info.len;
-    pj_size_t hdr_len = 0;
-    pj_size_t i;
+    const pj_str_t end_hdr = { "\n\r\n", 3 };
+    pj_str_t received;
+    pj_size_t hdr_len;
+    char *pos;
     char *hdr_buf;
     pjsip_msg *msg;
     pjsip_warning_hdr *warn;
@@ -1015,32 +1015,25 @@ static void endpt_respond_msg_too_large( pjsip_endpoint *endpt,
     pj_str_t warn_str;
     pj_status_t status;
 
-    if (buf == NULL || len == 0)
+    received.ptr = rdata->msg_info.msg_buf;
+    received.slen = rdata->msg_info.len;
+    if (received.ptr == NULL || received.slen <= 0)
         return;
 
-    /* Locate the empty line that ends the header block, and keep it: the
-     * parser needs it to see that the headers are complete.
+    /* Locate the empty line that ends the header block, with the sentinel
+     * pjsip_find_msg() uses, so the two cannot disagree on where the headers
+     * end. Keep the line: the parser needs it to see that they are complete.
      */
-    for (i = 0; i + 1 < len; ++i) {
-        if (buf[i] == '\r' && i + 3 < len && buf[i+1] == '\n' &&
-            buf[i+2] == '\r' && buf[i+3] == '\n')
-        {
-            hdr_len = i + 4;
-            break;
-        }
-        if (buf[i] == '\n' && buf[i+1] == '\n') {
-            hdr_len = i + 2;
-            break;
-        }
-    }
-    if (hdr_len == 0)
+    pos = pj_strstr(&received, &end_hdr);
+    if (pos == NULL)
         return;
+    hdr_len = (pj_size_t)(pos + 3 - received.ptr);
 
     /* Parse from a copy: the scanner writes into the buffer it is given, and
      * the transport still hands the original on to its dropped-data callback.
      */
     hdr_buf = (char*) pj_pool_alloc(rdata->tp_info.pool, hdr_len + 1);
-    pj_memcpy(hdr_buf, buf, hdr_len);
+    pj_memcpy(hdr_buf, received.ptr, hdr_len);
     hdr_buf[hdr_len] = '\0';
 
     pj_bzero(&rdata->msg_info, sizeof(rdata->msg_info));

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -996,7 +996,7 @@ on_return:
  * msg_info and the sender is left waiting for a response that never comes.
  * It is the body that overflows in practice while the header block still fits
  * the buffer, so parse the headers back into rdata and answer through the
- * normal stateless path - RFC 3261 section 21.4.11 defines 513 for exactly
+ * normal stateless path - RFC 3261 section 21.5.7 defines 513 for exactly
  * this. If not even the headers arrived complete there is nobody we can
  * address a response to, and the request stays silently dropped.
  */

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -1069,8 +1069,7 @@ static void endpt_respond_msg_too_large( pjsip_endpoint *endpt,
 
     pj_list_init(&hdr_list);
     warn = pjsip_warning_hdr_create(rdata->tp_info.pool, 399,
-                                    &rdata->tp_info.transport->local_name.host,
-                                    &warn_str);
+                                    pjsip_endpt_name(endpt), &warn_str);
     if (warn)
         pj_list_push_back(&hdr_list, (pjsip_hdr*)warn);
 

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -1043,7 +1043,8 @@ static void endpt_respond_msg_too_large( pjsip_endpoint *endpt,
     pj_bzero(&rdata->endpt_info, sizeof(rdata->endpt_info));
 
     msg = pjsip_parse_rdata(hdr_buf, hdr_len, rdata);
-    if (msg == NULL || msg->type != PJSIP_REQUEST_MSG ||
+    if (msg == NULL || !pj_list_empty(&rdata->msg_info.parse_err) ||
+        msg->type != PJSIP_REQUEST_MSG ||
         msg->line.req.method.id == PJSIP_ACK_METHOD ||
         rdata->msg_info.via == NULL || rdata->msg_info.from == NULL ||
         rdata->msg_info.to == NULL || rdata->msg_info.cseq == NULL ||

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -999,6 +999,13 @@ on_return:
  * normal stateless path - RFC 3261 section 21.5.7 defines 513 for exactly
  * this. If not even the headers arrived complete there is nobody we can
  * address a response to, and the request stays silently dropped.
+ *
+ * The response is best-effort. With an initial timeout configured
+ * (PJSIP_TCP_INITIAL_TIMEOUT, tls_opt.initial_timeout or
+ * PJSIP_TRANSPORT_SERVER_IDLE_TIME_FIRST, all 0 by default) the caller shuts
+ * the transport down as soon as we return. The rest of the oversized body is
+ * still unread, so that close emits an RST rather than a FIN, and on BSD an
+ * RST discards what the peer has not read yet - including this 513.
  */
 static void endpt_respond_msg_too_large( pjsip_endpoint *endpt,
                                          pjsip_rx_data *rdata )

--- a/pjsip/src/pjsip/sip_endpoint.c
+++ b/pjsip/src/pjsip/sip_endpoint.c
@@ -989,6 +989,113 @@ on_return:
 }
 
 /*
+ * Answer an oversized request with 513 Message Too Large.
+ *
+ * The transport layer gives up on a stream message larger than
+ * PJSIP_MAX_PKT_LEN without ever parsing it, so rdata reaches us with an empty
+ * msg_info and the sender is left waiting for a response that never comes.
+ * It is the body that overflows in practice while the header block still fits
+ * the buffer, so parse the headers back into rdata and answer through the
+ * normal stateless path - RFC 3261 section 21.4.11 defines 513 for exactly
+ * this. If not even the headers arrived complete there is nobody we can
+ * address a response to, and the request stays silently dropped.
+ */
+static void endpt_respond_msg_too_large( pjsip_endpoint *endpt,
+                                         pjsip_rx_data *rdata )
+{
+    char *buf = rdata->msg_info.msg_buf;
+    pj_size_t len = (pj_size_t)rdata->msg_info.len;
+    pj_size_t hdr_len = 0;
+    pj_size_t i;
+    char *hdr_buf;
+    pjsip_msg *msg;
+    pjsip_warning_hdr *warn;
+    pjsip_hdr hdr_list;
+    char warn_text[80];
+    pj_str_t warn_str;
+    pj_status_t status;
+
+    if (buf == NULL || len == 0)
+        return;
+
+    /* Locate the empty line that ends the header block, and keep it: the
+     * parser needs it to see that the headers are complete.
+     */
+    for (i = 0; i + 1 < len; ++i) {
+        if (buf[i] == '\r' && i + 3 < len && buf[i+1] == '\n' &&
+            buf[i+2] == '\r' && buf[i+3] == '\n')
+        {
+            hdr_len = i + 4;
+            break;
+        }
+        if (buf[i] == '\n' && buf[i+1] == '\n') {
+            hdr_len = i + 2;
+            break;
+        }
+    }
+    if (hdr_len == 0)
+        return;
+
+    /* Parse from a copy: the scanner writes into the buffer it is given, and
+     * the transport still hands the original on to its dropped-data callback.
+     */
+    hdr_buf = (char*) pj_pool_alloc(rdata->tp_info.pool, hdr_len + 1);
+    pj_memcpy(hdr_buf, buf, hdr_len);
+    hdr_buf[hdr_len] = '\0';
+
+    pj_bzero(&rdata->msg_info, sizeof(rdata->msg_info));
+    pj_list_init(&rdata->msg_info.parse_err);
+    rdata->msg_info.msg_buf = hdr_buf;
+    rdata->msg_info.len = (int)hdr_len;
+    pj_bzero(&rdata->endpt_info, sizeof(rdata->endpt_info));
+
+    msg = pjsip_parse_rdata(hdr_buf, hdr_len, rdata);
+    if (msg == NULL || msg->type != PJSIP_REQUEST_MSG ||
+        msg->line.req.method.id == PJSIP_ACK_METHOD ||
+        rdata->msg_info.via == NULL || rdata->msg_info.from == NULL ||
+        rdata->msg_info.to == NULL || rdata->msg_info.cseq == NULL ||
+        rdata->msg_info.cid == NULL || rdata->msg_info.cid->id.slen == 0)
+    {
+        return;
+    }
+
+    /* The transport layer adds these for every request it accepts, and
+     * pjsip_get_response_addr() relies on them. We bypassed it, so do it here.
+     */
+    pj_strdup2(rdata->tp_info.pool, &rdata->msg_info.via->recvd_param,
+               rdata->pkt_info.src_name);
+    if (rdata->msg_info.via->rport_param == 0)
+        rdata->msg_info.via->rport_param = rdata->pkt_info.src_port;
+
+    /* Name the actual limit, so the peer learns what to stay under. */
+    pj_ansi_snprintf(warn_text, sizeof(warn_text),
+                     "Message exceeds the %d byte receive buffer",
+                     PJSIP_MAX_PKT_LEN);
+    warn_str = pj_str(warn_text);
+
+    pj_list_init(&hdr_list);
+    warn = pjsip_warning_hdr_create(rdata->tp_info.pool, 399,
+                                    &rdata->tp_info.transport->local_name.host,
+                                    &warn_str);
+    if (warn)
+        pj_list_push_back(&hdr_list, (pjsip_hdr*)warn);
+
+    status = pjsip_endpt_respond_stateless(endpt, rdata,
+                                           PJSIP_SC_MESSAGE_TOO_LARGE, NULL,
+                                           &hdr_list, NULL);
+    if (status != PJ_SUCCESS) {
+        char errmsg[PJ_ERR_MSG_SIZE];
+
+        pj_strerror(status, errmsg, sizeof(errmsg));
+        PJ_LOG(3, (THIS_FILE, "Unable to respond %d to the oversized request "
+                              "from %s:%d: %s",
+                   PJSIP_SC_MESSAGE_TOO_LARGE, rdata->pkt_info.src_name,
+                   rdata->pkt_info.src_port, errmsg));
+    }
+}
+
+
+/*
  * This is the callback that is called by the transport manager when it 
  * receives a message from the network.
  */
@@ -1040,6 +1147,10 @@ static void endpt_on_rx_msg( pjsip_endpoint *endpt,
                   status,
                   (int)rdata->msg_info.len,     
                   rdata->msg_info.msg_buf));
+
+        if (status == PJSIP_ERXOVERFLOW)
+            endpt_respond_msg_too_large(endpt, rdata);
+
         return;
     }
 

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -370,6 +370,7 @@ int test_main(int argc, char *argv[])
 #if INCLUDE_TCP_TEST
     UT_ADD_TEST(&test_app.ut_app, transport_tcp_test, 0);
     UT_ADD_TEST(&test_app.ut_app, transport_tcp_keep_alive_test, 0);
+    UT_ADD_TEST(&test_app.ut_app, transport_rx_overflow_test, 0);
 #endif
 
     /* Note: put exclusive tests last */

--- a/pjsip/src/test/test.h
+++ b/pjsip/src/test/test.h
@@ -111,6 +111,7 @@ int transport_loop_multi_test(void);
 int transport_loop_resolve_error_test(void);
 int transport_tcp_test(void);
 int transport_tcp_keep_alive_test(void);
+int transport_rx_overflow_test(void);
 int resolve_test(void);
 int regc_test(void);
 int auth_async_test(void);

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -606,12 +606,190 @@ on_return:
     return 0;
 #endif  /* PJSIP_TCP_KEEP_ALIVE_RESPONSE */
 }
+
+
+/*
+ * A request too large for the receive buffer must be answered with
+ * 513 Message Too Large.
+ *
+ * A stream message is assembled in rdata->pkt_info.packet, a fixed
+ * PJSIP_MAX_PKT_LEN buffer. A request bigger than that can never be completed,
+ * so the transport layer discards it. Without a response the sender has no way
+ * of learning why its request went unanswered; RFC 3261 section 21.4.11
+ * defines 513 for exactly this case.
+ *
+ * The request is written straight to a socket rather than sent through PJSIP,
+ * because a pjsip_tx_data buffer is itself capped at PJSIP_MAX_PKT_LEN.
+ */
+int transport_rx_overflow_test(void)
+{
+    enum { TIMEOUT_MSEC = 10000, CHUNK = 1024 };
+    const char *EXPECTED = "SIP/2.0 513";
+    pjsip_tpfactory *tpfactory = NULL;
+    pj_pool_t *pool = NULL;
+    pj_sock_t sock = PJ_INVALID_SOCKET;
+    pj_sockaddr_in rem_addr;
+    pj_time_val deadline, now;
+    pj_size_t body_len, buf_size, req_len, sent_total;
+    char *req;
+    char reply[512];
+    int len;
+    int rc = 0;
+    pj_status_t status;
+
+    PJ_LOG(3,(THIS_FILE, "  oversized request gets 513 Message Too Large"));
+
+    body_len = PJSIP_MAX_PKT_LEN;
+    buf_size = body_len + 1024;
+
+    pool = pjsip_endpt_create_pool(endpt, "rxovf", buf_size + 1024, 1024);
+    if (pool == NULL)
+        return -500;
+
+    /* Listener on an arbitrary port, and a plain socket connected to it. */
+    status = pjsip_tcp_transport_start(endpt, NULL, 1, &tpfactory);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: unable to start TCP listener", status);
+        rc = -505;
+        goto on_return;
+    }
+
+    status = pj_sockaddr_in_init(&rem_addr, &tpfactory->addr_name.host,
+                                 (pj_uint16_t)tpfactory->addr_name.port);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: invalid TCP address name", status);
+        rc = -510;
+        goto on_return;
+    }
+
+    status = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0, &sock);
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: unable to create socket", status);
+        rc = -515;
+        goto on_return;
+    }
+
+    status = pj_sock_connect(sock, &rem_addr, sizeof(rem_addr));
+    if (status != PJ_SUCCESS) {
+        app_perror("   error: unable to connect to TCP listener", status);
+        rc = -520;
+        goto on_return;
+    }
+
+    /* A body of PJSIP_MAX_PKT_LEN bytes puts the request over the receive
+     * buffer whatever the header block adds.
+     */
+    req = (char*) pj_pool_alloc(pool, buf_size);
+    len = pj_ansi_snprintf(req, buf_size,
+                    "NOTIFY sip:overflow@127.0.0.1 SIP/2.0\r\n"
+                    "Via: SIP/2.0/TCP 127.0.0.1:5060;branch=z9hG4bK-rxovf;rport\r\n"
+                    "Max-Forwards: 70\r\n"
+                    "From: <sip:tester@127.0.0.1>;tag=rxovf\r\n"
+                    "To: <sip:overflow@127.0.0.1>\r\n"
+                    "Call-ID: rx-overflow-test\r\n"
+                    "CSeq: 1 NOTIFY\r\n"
+                    "Event: dialog\r\n"
+                    "Subscription-State: active;expires=60\r\n"
+                    "Content-Type: text/plain\r\n"
+                    "Content-Length: %u\r\n"
+                    "\r\n",
+                    (unsigned)body_len);
+    if (len < 0 || (pj_size_t)len + body_len > buf_size) {
+        rc = -525;
+        goto on_return;
+    }
+    pj_memset(req + len, 'x', body_len);
+    req_len = (pj_size_t)len + body_len;
+
+    /* Nothing else polls the endpoint from this thread, so let it drain the
+     * connection between chunks instead of filling the socket buffer.
+     */
+    for (sent_total = 0; sent_total < req_len; ) {
+        pj_ssize_t chunk = req_len - sent_total;
+        if (chunk > CHUNK)
+            chunk = CHUNK;
+
+        status = pj_sock_send(sock, req + sent_total, &chunk, 0);
+        if (status != PJ_SUCCESS) {
+            app_perror("   error: unable to send the oversized request", status);
+            rc = -530;
+            goto on_return;
+        }
+        sent_total += chunk;
+        flush_events(1);
+    }
+
+    pj_gettimeofday(&deadline);
+    deadline.msec += TIMEOUT_MSEC;
+    pj_time_val_normalize(&deadline);
+
+    for (;;) {
+        pj_fd_set_t rset;
+        pj_time_val zero = { 0, 0 };
+        pj_ssize_t received;
+
+        flush_events(10);
+
+        PJ_FD_ZERO(&rset);
+        PJ_FD_SET(sock, &rset);
+        if (pj_sock_select((int)sock + 1, &rset, NULL, NULL, &zero) > 0 &&
+            PJ_FD_ISSET(sock, &rset))
+        {
+            received = sizeof(reply) - 1;
+            status = pj_sock_recv(sock, reply, &received, 0);
+            if (status != PJ_SUCCESS || received <= 0) {
+                PJ_LOG(3,(THIS_FILE, "   error: the connection was closed "
+                                     "without a response"));
+                rc = -535;
+                goto on_return;
+            }
+            reply[received] = '\0';
+            break;
+        }
+
+        pj_gettimeofday(&now);
+        if (PJ_TIME_VAL_GTE(now, deadline)) {
+            PJ_LOG(3,(THIS_FILE, "   error: the oversized request was dropped "
+                                 "without any response to the sender"));
+            rc = -540;
+            goto on_return;
+        }
+    }
+
+    if (pj_ansi_strncmp(reply, EXPECTED, pj_ansi_strlen(EXPECTED)) != 0) {
+        PJ_LOG(3,(THIS_FILE, "   error: expected a \"%s\" status line, got "
+                             "\"%.32s\"", EXPECTED, reply));
+        rc = -545;
+        goto on_return;
+    }
+
+on_return:
+    if (sock != PJ_INVALID_SOCKET)
+        pj_sock_close(sock);
+
+    if (tpfactory) {
+        flush_events(100);
+        pjsip_tpmgr_unregister_tpfactory(pjsip_endpt_get_tpmgr(endpt),
+                                         tpfactory);
+    }
+
+    flush_events(500);
+
+    if (pool)
+        pjsip_endpt_release_pool(endpt, pool);
+
+    return rc;
+}
 #else   /* PJ_HAS_TCP */
 int transport_tcp_test(void)
 {
     return 0;
 }
 int transport_tcp_keep_alive_test(void)
+{
+    return 0;
+}
+int transport_rx_overflow_test(void)
 {
     return 0;
 }

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -615,7 +615,7 @@ on_return:
  * A stream message is assembled in rdata->pkt_info.packet, a fixed
  * PJSIP_MAX_PKT_LEN buffer. A request bigger than that can never be completed,
  * so the transport layer discards it. Without a response the sender has no way
- * of learning why its request went unanswered; RFC 3261 section 21.4.11
+ * of learning why its request went unanswered; RFC 3261 section 21.5.7
  * defines 513 for exactly this case.
  *
  * The request is written straight to a socket rather than sent through PJSIP,

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -621,7 +621,7 @@ on_return:
  * The request is written straight to a socket rather than sent through PJSIP,
  * because a pjsip_tx_data buffer is itself capped at PJSIP_MAX_PKT_LEN.
  */
-int transport_rx_overflow_test(void)
+static int rx_overflow_test(const char *last_hdr_eol, const char *branch)
 {
     enum { TIMEOUT_MSEC = 10000, CHUNK = 1024 };
     const char *EXPECTED = "SIP/2.0 513";
@@ -637,7 +637,9 @@ int transport_rx_overflow_test(void)
     int rc = 0;
     pj_status_t status;
 
-    PJ_LOG(3,(THIS_FILE, "  oversized request gets 513 Message Too Large"));
+    PJ_LOG(3,(THIS_FILE, "  oversized request gets 513 Message Too Large "
+                         "(header block ends %s)",
+              (*last_hdr_eol == '\r')? "CRLF CRLF" : "LF CRLF"));
 
     body_len = PJSIP_MAX_PKT_LEN;
     buf_size = body_len + 1024;
@@ -682,18 +684,18 @@ int transport_rx_overflow_test(void)
     req = (char*) pj_pool_alloc(pool, buf_size);
     len = pj_ansi_snprintf(req, buf_size,
                     "NOTIFY sip:overflow@127.0.0.1 SIP/2.0\r\n"
-                    "Via: SIP/2.0/TCP 127.0.0.1:5060;branch=z9hG4bK-rxovf;rport\r\n"
+                    "Via: SIP/2.0/TCP 127.0.0.1:5060;branch=%s;rport\r\n"
                     "Max-Forwards: 70\r\n"
                     "From: <sip:tester@127.0.0.1>;tag=rxovf\r\n"
                     "To: <sip:overflow@127.0.0.1>\r\n"
-                    "Call-ID: rx-overflow-test\r\n"
+                    "Call-ID: %s\r\n"
                     "CSeq: 1 NOTIFY\r\n"
                     "Event: dialog\r\n"
                     "Subscription-State: active;expires=60\r\n"
                     "Content-Type: text/plain\r\n"
-                    "Content-Length: %u\r\n"
+                    "Content-Length: %u%s"
                     "\r\n",
-                    (unsigned)body_len);
+                    branch, branch, (unsigned)body_len, last_hdr_eol);
     if (len < 0 || (pj_size_t)len + body_len > buf_size) {
         rc = -525;
         goto on_return;
@@ -779,6 +781,23 @@ on_return:
         pjsip_endpt_release_pool(endpt, pool);
 
     return rc;
+}
+
+
+/*
+ * Both header block terminators the parser accepts: pjsip_find_msg() ends
+ * the headers at "\n\r\n", so a last header line closed by a bare LF is a
+ * complete header block too.
+ */
+int transport_rx_overflow_test(void)
+{
+    int rc;
+
+    rc = rx_overflow_test("\r\n", "z9hG4bK-rxovf-crlf");
+    if (rc != 0)
+        return rc;
+
+    return rx_overflow_test("\n", "z9hG4bK-rxovf-lf");
 }
 #else   /* PJ_HAS_TCP */
 int transport_tcp_test(void)

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -630,7 +630,7 @@ static int rx_overflow_test(const char *last_hdr_eol, const char *branch)
     pj_sock_t sock = PJ_INVALID_SOCKET;
     pj_sockaddr_in rem_addr;
     pj_time_val deadline, now;
-    pj_size_t body_len, buf_size, req_len, sent_total;
+    pj_size_t body_len, buf_size, req_len, sent_total, reply_len;
     char *req;
     char reply[512];
     int len;
@@ -725,6 +725,7 @@ static int rx_overflow_test(const char *last_hdr_eol, const char *branch)
     deadline.msec += TIMEOUT_MSEC;
     pj_time_val_normalize(&deadline);
 
+    reply_len = 0;
     for (;;) {
         pj_fd_set_t rset;
         pj_time_val zero = { 0, 0 };
@@ -737,16 +738,21 @@ static int rx_overflow_test(const char *last_hdr_eol, const char *branch)
         if (pj_sock_select((int)sock + 1, &rset, NULL, NULL, &zero) > 0 &&
             PJ_FD_ISSET(sock, &rset))
         {
-            received = sizeof(reply) - 1;
-            status = pj_sock_recv(sock, reply, &received, 0);
+            received = (pj_ssize_t)(sizeof(reply) - 1 - reply_len);
+            status = pj_sock_recv(sock, reply + reply_len, &received, 0);
             if (status != PJ_SUCCESS || received <= 0) {
                 PJ_LOG(3,(THIS_FILE, "   error: the connection was closed "
-                                     "without a response"));
+                                     "after %u bytes, without a complete "
+                                     "status line", (unsigned)reply_len));
                 rc = -535;
                 goto on_return;
             }
-            reply[received] = '\0';
-            break;
+            reply_len += (pj_size_t)received;
+            reply[reply_len] = '\0';
+
+            /* A segment boundary may split the status line. */
+            if (reply_len >= pj_ansi_strlen(EXPECTED))
+                break;
         }
 
         pj_gettimeofday(&now);


### PR DESCRIPTION
A stream message is assembled in rdata->pkt_info.packet, a fixed PJSIP_MAX_PKT_LEN buffer. A request larger than that can never be completed, so pjsip_tpmgr_receive_packet() reports PJSIP_ERXOVERFLOW and discards it. endpt_on_rx_msg() only logged that, so nothing went back on the wire and the sender could not tell "too large" from a lost connection. RFC 3261 section 21.5.7 defines 513 for this case, yet the status code had no sender anywhere in the stack.

Re-parse the truncated buffer up to the blank line ending the header block, restore the received/rport Via params the transport layer would have added, and reply via pjsip_endpt_respond_stateless(). A Warning: 399 header names the byte limit so the peer learns what to stay under.

Only an overflowing body is recoverable: a request whose header block alone exceeds the buffer has no Via to address a response to and is still dropped, as is an oversized response. The overflow branch is stream-only, so this adds no reflection vector for datagram transports.

transport_rx_overflow_test covers it, writing the request from a plain socket because a pjsip_tx_data buffer is itself capped at PJSIP_MAX_PKT_LEN.