### PR TITLE
pjlib-util: validate precomputed digest length in HTTP client auth

### DIFF
--- a/pjlib-util/src/pjlib-util/http_client.c
+++ b/pjlib-util/src/pjlib-util/http_client.c
@@ -1273,22 +1273,22 @@ static void digest2str(const unsigned char digest[], char *output)
     }
 }
 
-static void auth_create_digest_response(pj_str_t *result,
-                                        const pj_http_auth_cred *cred,
-                                        const pj_str_t *nonce,
-                                        const pj_str_t *nc,
-                                        const pj_str_t *cnonce,
-                                        const pj_str_t *qop,
-                                        const pj_str_t *uri,
-                                        const pj_str_t *realm,
-                                        const pj_str_t *method)
+static pj_status_t auth_create_digest_response(pj_str_t *result,
+                                               const pj_http_auth_cred *cred,
+                                               const pj_str_t *nonce,
+                                               const pj_str_t *nc,
+                                               const pj_str_t *cnonce,
+                                               const pj_str_t *qop,
+                                               const pj_str_t *uri,
+                                               const pj_str_t *realm,
+                                               const pj_str_t *method)
 {
     char ha1[MD5_STRLEN];
     char ha2[MD5_STRLEN];
     unsigned char digest[16];
     pj_md5_context pms;
 
-    pj_assert(result->slen >= MD5_STRLEN);
+    PJ_ASSERT_RETURN(result->slen >= MD5_STRLEN, PJ_ETOOSMALL);
 
     TRACE_((THIS_FILE, "Begin creating digest"));
 
@@ -1307,10 +1307,11 @@ static void auth_create_digest_response(pj_str_t *result,
         digest2str(digest, ha1);
 
     } else if (cred->data_type == 1) {
-        pj_assert(cred->data.slen == 32);
-        pj_memcpy( ha1, cred->data.ptr, cred->data.slen );
+        PJ_ASSERT_RETURN(cred->data.slen >= MD5_STRLEN, PJ_EINVAL);
+        pj_memcpy( ha1, cred->data.ptr, MD5_STRLEN );
     } else {
         pj_assert(!"Invalid data_type");
+        return PJ_EINVAL;
     }
 
     TRACE_((THIS_FILE, "  ha1=%.32s", ha1));
@@ -1358,6 +1359,8 @@ static void auth_create_digest_response(pj_str_t *result,
 
     TRACE_((THIS_FILE, "  digest=%.32s", result->ptr));
     TRACE_((THIS_FILE, "Digest created"));
+
+    return PJ_SUCCESS;
 }
 
 /* Find out if qop offer contains "auth" token */
@@ -1400,6 +1403,7 @@ static pj_status_t auth_respond_digest(pj_http_req *hreq)
     char digest_response_buf[MD5_STRLEN];
     int len;
     pj_str_t digest_response;
+    pj_status_t status;
 
     /* Check algorithm is supported. We only support MD5 */
     if (chal->algorithm.slen!=0 &&
@@ -1442,10 +1446,12 @@ static pj_status_t auth_respond_digest(pj_http_req *hreq)
         int max_len;
 
         /* Server doesn't require quality of protection. */
-        auth_create_digest_response(&digest_response, cred,
-                                    &chal->nonce, NULL, NULL,  NULL,
-                                    &hreq->hurl.path, &chal->realm,
-                                    &hreq->param.method);
+        status = auth_create_digest_response(&digest_response, cred,
+                                             &chal->nonce, NULL, NULL, NULL,
+                                             &hreq->hurl.path, &chal->realm,
+                                             &hreq->param.method);
+        if (status != PJ_SUCCESS)
+            return status;
 
         max_len = len;
         len = pj_ansi_snprintf(
@@ -1476,10 +1482,12 @@ static pj_status_t auth_respond_digest(pj_http_req *hreq)
         const pj_str_t cnonce = pj_str("b39971");
         int max_len;
 
-        auth_create_digest_response(&digest_response, cred,
-                                    &chal->nonce, &nc, &cnonce, &qop,
-                                    &hreq->hurl.path, &chal->realm,
-                                    &hreq->param.method);
+        status = auth_create_digest_response(&digest_response, cred,
+                                             &chal->nonce, &nc, &cnonce, &qop,
+                                             &hreq->hurl.path, &chal->realm,
+                                             &hreq->param.method);
+        if (status != PJ_SUCCESS)
+            return status;
         max_len = len;
         len = pj_ansi_snprintf(
                 phdr->value.ptr, max_len,


### PR DESCRIPTION
### Problem

`auth_create_digest_response()` in `pjlib-util/src/pjlib-util/http_client.c` copies the caller-supplied credential into the fixed 32-byte `ha1` stack buffer using the caller's `cred->data.slen`:

```c
char ha1[MD5_STRLEN];               /* 32 bytes */
...
} else if (cred->data_type == 1) {
    pj_assert(cred->data.slen == 32);
    pj_memcpy( ha1, cred->data.ptr, cred->data.slen );
}
```

`pj_assert()` compiles to a log-only check when `PJ_DEBUG` is 0, which is the default for release builds, so the guard does not prevent the copy. An application that supplies a `data_type == 1` (precomputed MD5) credential longer than 32 characters overflows the stack buffer as soon as the contacted server answers a request with a Digest challenge (`http_on_data_read` → `restart_req_with_auth` → `auth_respond_digest` → `auth_create_digest_response`).

The equivalent SIP code path already validates this — `pjsip_auth_create_digest2()` in `pjsip/src/pjsip/sip_auth_client.c` uses `PJ_ASSERT_RETURN(cred_info->data.slen >= digest_strlen, PJ_EINVAL)` and copies a fixed length. The HTTP client never received the same treatment.

This is hardening of an application-facing contract rather than a remotely triggerable vulnerability: a remote server can cause the code path to execute, but both the contents and the length of the overflowing buffer come from `pj_http_req_param.auth_cred`, which the application sets. Nothing shipped in pjproject uses the precomputed-digest credential mode. It is the same class of issue, in the same file, as #4784 (Basic authentication response path).

### Changes

- Validate with `PJ_ASSERT_RETURN(cred->data.slen >= MD5_STRLEN, PJ_EINVAL)`, which returns regardless of `PJ_DEBUG`, and copy exactly `MD5_STRLEN` bytes. Matches `pjsip_auth_create_digest2()`.
- `auth_create_digest_response()` now returns `pj_status_t`; both call sites in `auth_respond_digest()` propagate the failure.
- The `result->slen` check becomes `PJ_ASSERT_RETURN(..., PJ_ETOOSMALL)` for the same release-build reason.
- An invalid `data_type` now returns `PJ_EINVAL` instead of falling through and hashing an uninitialized `ha1`.

### Testing

- `cd pjlib-util/build && make` — clean, no warnings under `-Wall`.
- `pjlib-util-test http_client_test` — 1/1 `[OK]`, 0 failures.

### Credit

Thank you to @Vectrain51 for the report and suggested patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)