### PR TITLE
pjsua: cfg_add offset and a shared settings buffer allocation

### DIFF
--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -1838,19 +1838,7 @@ static pj_status_t cmd_stat_dump(pj_bool_t detail)
 
 static pj_status_t cmd_show_config()
 {
-    pj_pool_t *pool;
-    char *settings;
-    int len;
-
-    settings = alloc_settings(&app_config, &pool, &len);
-    if (!settings)
-        return PJ_ENOMEM;
-
-    PJ_LOG(3,(THIS_FILE, "Dumping configuration (%d bytes):\n%s\n",
-              len, settings));
-
-    pj_pool_secure_release(&pool);
-    return PJ_SUCCESS;
+    return dump_settings(&app_config);
 }
 
 static pj_status_t cmd_write_config(pj_cli_cmd_val *cval)

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -1842,21 +1842,12 @@ static pj_status_t cmd_show_config()
     char *settings;
     int len;
 
-    pool = pjsua_pool_create("settings", PJSUA_APP_SETTINGS_SIZE + 1024,
-                             1024);
-    if (!pool) {
-        PJ_LOG(1,(THIS_FILE, "Error: unable to allocate settings buffer"));
+    settings = alloc_settings(&app_config, &pool, &len);
+    if (!settings)
         return PJ_ENOMEM;
-    }
-    settings = (char*)pj_pool_alloc(pool, PJSUA_APP_SETTINGS_SIZE);
 
-    len = write_settings(&app_config, settings, PJSUA_APP_SETTINGS_SIZE);
-    if (len < 1)
-        PJ_LOG(1,(THIS_FILE, "Error: not enough buffer"));
-    else
-        PJ_LOG(3,(THIS_FILE,
-                  "Dumping configuration (%d bytes):\n%s\n",
-                  len, settings));
+    PJ_LOG(3,(THIS_FILE, "Dumping configuration (%d bytes):\n%s\n",
+              len, settings));
 
     pj_pool_secure_release(&pool);
     return PJ_SUCCESS;
@@ -1868,39 +1859,29 @@ static pj_status_t cmd_write_config(pj_cli_cmd_val *cval)
     char *settings;
     char buf[128] = {0};
     int len;
+    pj_oshandle_t fd;
+    pj_status_t status;
     pj_str_t tmp = pj_str(buf);
 
     pj_strncpy_with_null(&tmp, &cval->argv[1], sizeof(buf));
 
-    pool = pjsua_pool_create("settings", PJSUA_APP_SETTINGS_SIZE + 1024,
-                             1024);
-    if (!pool) {
-        PJ_LOG(1,(THIS_FILE, "Error: unable to allocate settings buffer"));
+    settings = alloc_settings(&app_config, &pool, &len);
+    if (!settings)
         return PJ_ENOMEM;
-    }
-    settings = (char*)pj_pool_alloc(pool, PJSUA_APP_SETTINGS_SIZE);
 
-    len = write_settings(&app_config, settings, PJSUA_APP_SETTINGS_SIZE);
-    if (len < 1)
-        PJ_LOG(1,(THIS_FILE, "Error: not enough buffer"));
-    else {
-        pj_oshandle_t fd;
-        pj_status_t status;
+    status = pj_file_open(app_config.pool, buf, PJ_O_WRONLY, &fd);
+    if (status != PJ_SUCCESS) {
+        pjsua_perror(THIS_FILE, "Unable to open file", status);
+    } else {
+        char out_str[256];
+        pj_ssize_t size = len;
+        pj_file_write(fd, settings, &size);
+        pj_file_close(fd);
 
-        status = pj_file_open(app_config.pool, buf, PJ_O_WRONLY, &fd);
-        if (status != PJ_SUCCESS) {
-            pjsua_perror(THIS_FILE, "Unable to open file", status);
-        } else {
-            char out_str[256];
-            pj_ssize_t size = len;
-            pj_file_write(fd, settings, &size);
-            pj_file_close(fd);
+        pj_ansi_snprintf(out_str, sizeof(out_str),
+                         "Settings successfully written to '%s'\n", buf);
 
-            pj_ansi_snprintf(out_str, sizeof(out_str),
-                             "Settings successfully written to '%s'\n", buf);
-
-            pj_cli_sess_write_msg(cval->sess, out_str, pj_ansi_strlen(out_str));
-        }
+        pj_cli_sess_write_msg(cval->sess, out_str, pj_ansi_strlen(out_str));
     }
 
     pj_pool_secure_release(&pool);

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -226,6 +226,7 @@ void send_request(char *cstr_method, const pj_str_t *dst_uri);
 void log_call_dump(int call_id);
 int write_settings(pjsua_app_config *cfg, char *buf, pj_size_t max);
 char *alloc_settings(pjsua_app_config *cfg, pj_pool_t **p_pool, int *p_len);
+pj_status_t dump_settings(pjsua_app_config *cfg);
 void app_config_init_video(pjsua_acc_config *acc_cfg);
 void arrange_window(pjsua_vid_win_id wid);
 

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -225,6 +225,7 @@ pj_bool_t find_prev_call(void);
 void send_request(char *cstr_method, const pj_str_t *dst_uri);
 void log_call_dump(int call_id);
 int write_settings(pjsua_app_config *cfg, char *buf, pj_size_t max);
+char *alloc_settings(pjsua_app_config *cfg, pj_pool_t **p_pool, int *p_len);
 void app_config_init_video(pjsua_acc_config *acc_cfg);
 void arrange_window(pjsua_vid_win_id wid);
 

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -1974,9 +1974,31 @@ static void cfg_add(pj_str_t *cfg, pj_size_t max, const char *src)
     if (cfg->slen < 0)
         return;
 
-    len = pj_ansi_strxcat(cfg->ptr, src, max);
-    cfg->slen = (len < 0)? -1 : len;
+    len = pj_ansi_strxcpy(cfg->ptr + cfg->slen, src,
+                          max - (pj_size_t)cfg->slen);
+    if (len < 0)
+        cfg->slen = -1;
+    else
+        cfg->slen += len;
 }
+
+#if !PJSUA_MEDIA_HAS_PJMEDIA
+/* Length based, so a value containing a NUL is copied whole. */
+static void cfg_add_str(pj_str_t *cfg, pj_size_t max, const pj_str_t *src)
+{
+    if (cfg->slen < 0)
+        return;
+
+    if ((pj_size_t)cfg->slen + (pj_size_t)src->slen + 1 > max) {
+        cfg->slen = -1;
+        return;
+    }
+
+    pj_memcpy(cfg->ptr + cfg->slen, src->ptr, src->slen);
+    cfg->slen += src->slen;
+    cfg->ptr[cfg->slen] = '\0';
+}
+#endif
 
 static void cfg_addf(pj_str_t *cfg, pj_size_t max, const char *fmt, ...)
 {
@@ -2503,7 +2525,7 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
 
     /* Stereo mode. */
     if (config->media_cfg.channel_count == 2) {
-        cfg_addf(&cfg, max, "--stereo\n");
+        cfg_add(&cfg, max, "--stereo\n");
     }
 
     /* quality */
@@ -2528,7 +2550,7 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
                          config->avi[i].path.ptr);
     }
     if (config->avi_auto_play) {
-        cfg_addf(&cfg, max, "--auto-play-avi\n");
+        cfg_add(&cfg, max, "--auto-play-avi\n");
     }
     if (config->avi_rec.slen) {
         cfg_addf(&cfg, max, "--rec-avi %s\n",
@@ -2539,10 +2561,10 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
                          config->avi_rec_size);
     }
     if (config->avi_rec_audio) {
-        cfg_addf(&cfg, max, "--rec-avi-audio\n");
+        cfg_add(&cfg, max, "--rec-avi-audio\n");
     }
     if (config->avi_auto_rec) {
-        cfg_addf(&cfg, max, "--auto-rec-avi\n");
+        cfg_add(&cfg, max, "--auto-rec-avi\n");
     }
 
     /* ptime */
@@ -2708,7 +2730,7 @@ int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
         escaped.slen = (pj_ssize_t)(ep - ebuf);
 
         cfg_add(&cfg, max, "--custom-sdp \"");
-        cfg_addf(&cfg, max, "%.*s", (int)escaped.slen, escaped.ptr);
+        cfg_add_str(&cfg, max, &escaped);
         cfg_add(&cfg, max, "\"\n");
     }
 #endif /* !PJSUA_MEDIA_HAS_PJMEDIA */

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -2291,6 +2291,42 @@ char *alloc_settings(pjsua_app_config *config, pj_pool_t **p_pool,
     return buf;
 }
 
+/* PJ_LOG truncates a message at PJ_LOG_MAX_SIZE, which the settings buffer
+ * can exceed, so emit the dump in chunks broken at option boundaries.
+ */
+pj_status_t dump_settings(pjsua_app_config *config)
+{
+    enum { CHUNK = (PJ_LOG_MAX_SIZE > 1024)? PJ_LOG_MAX_SIZE - 512 : 512 };
+    pj_pool_t *pool;
+    char *settings;
+    int len, pos;
+
+    settings = alloc_settings(config, &pool, &len);
+    if (!settings)
+        return PJ_ENOMEM;
+
+    PJ_LOG(3,(THIS_FILE, "Dumping configuration (%d bytes):", len));
+
+    for (pos = 0; pos < len; ) {
+        int n = len - pos;
+
+        if (n > CHUNK) {
+            n = CHUNK;
+            while (n > 0 && settings[pos + n - 1] != '\n')
+                --n;
+            if (n == 0)
+                n = CHUNK;
+        }
+
+        PJ_LOG(3,(THIS_FILE, "%.*s", n, settings + pos));
+        pos += n;
+    }
+
+    pj_pool_secure_release(&pool);
+    return PJ_SUCCESS;
+}
+
+
 int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
 {
     unsigned acc_index;

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -2257,6 +2257,40 @@ static void write_account_settings(int acc_index, pj_str_t *result,
 /*
  * Write settings.
  */
+char *alloc_settings(pjsua_app_config *config, pj_pool_t **p_pool,
+                     int *p_len)
+{
+    pj_pool_t *pool;
+    char *buf;
+    int len;
+
+    *p_pool = NULL;
+
+    pool = pjsua_pool_create("settings", PJSUA_APP_SETTINGS_SIZE + 1024, 1024);
+    if (!pool) {
+        PJ_LOG(1,(THIS_FILE, "Error: unable to allocate settings buffer"));
+        return NULL;
+    }
+
+    buf = (char*)pj_pool_alloc(pool, PJSUA_APP_SETTINGS_SIZE);
+    if (!buf) {
+        PJ_LOG(1,(THIS_FILE, "Error: unable to allocate settings buffer"));
+        pj_pool_secure_release(&pool);
+        return NULL;
+    }
+
+    len = write_settings(config, buf, PJSUA_APP_SETTINGS_SIZE);
+    if (len < 1) {
+        PJ_LOG(1,(THIS_FILE, "Error: not enough buffer"));
+        pj_pool_secure_release(&pool);
+        return NULL;
+    }
+
+    *p_pool = pool;
+    *p_len = len;
+    return buf;
+}
+
 int write_settings(pjsua_app_config *config, char *buf, pj_size_t max)
 {
     unsigned acc_index;

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1773,18 +1773,7 @@ static void ui_dump_call_quality()
 
 static void ui_dump_configuration()
 {
-    pj_pool_t *pool;
-    char *settings;
-    int len;
-
-    settings = alloc_settings(&app_config, &pool, &len);
-    if (!settings)
-        return;
-
-    PJ_LOG(3,(THIS_FILE, "Dumping configuration (%d bytes):\n%s\n",
-              len, settings));
-
-    pj_pool_secure_release(&pool);
+    dump_settings(&app_config);
 }
 
 static void ui_write_settings(const char *filename)

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -1777,20 +1777,12 @@ static void ui_dump_configuration()
     char *settings;
     int len;
 
-    pool = pjsua_pool_create("settings", PJSUA_APP_SETTINGS_SIZE + 1024,
-                             1024);
-    if (!pool) {
-        PJ_LOG(1,(THIS_FILE, "Error: unable to allocate settings buffer"));
+    settings = alloc_settings(&app_config, &pool, &len);
+    if (!settings)
         return;
-    }
-    settings = (char*)pj_pool_alloc(pool, PJSUA_APP_SETTINGS_SIZE);
 
-    len = write_settings(&app_config, settings, PJSUA_APP_SETTINGS_SIZE);
-    if (len < 1)
-        PJ_LOG(1,(THIS_FILE, "Error: not enough buffer"));
-    else
-        PJ_LOG(3,(THIS_FILE, "Dumping configuration (%d bytes):\n%s\n",
-                  len, settings));
+    PJ_LOG(3,(THIS_FILE, "Dumping configuration (%d bytes):\n%s\n",
+              len, settings));
 
     pj_pool_secure_release(&pool);
 }
@@ -1800,32 +1792,22 @@ static void ui_write_settings(const char *filename)
     pj_pool_t *pool;
     char *settings;
     int len;
+    pj_oshandle_t fd;
+    pj_status_t status;
 
-    pool = pjsua_pool_create("settings", PJSUA_APP_SETTINGS_SIZE + 1024,
-                             1024);
-    if (!pool) {
-        PJ_LOG(1,(THIS_FILE, "Error: unable to allocate settings buffer"));
+    settings = alloc_settings(&app_config, &pool, &len);
+    if (!settings)
         return;
-    }
-    settings = (char*)pj_pool_alloc(pool, PJSUA_APP_SETTINGS_SIZE);
 
-    len = write_settings(&app_config, settings, PJSUA_APP_SETTINGS_SIZE);
-    if (len < 1)
-        PJ_LOG(1,(THIS_FILE, "Error: not enough buffer"));
-    else {
-        pj_oshandle_t fd;
-        pj_status_t status;
+    status = pj_file_open(app_config.pool, filename, PJ_O_WRONLY, &fd);
+    if (status != PJ_SUCCESS) {
+        pjsua_perror(THIS_FILE, "Unable to open file", status);
+    } else {
+        pj_ssize_t size = len;
+        pj_file_write(fd, settings, &size);
+        pj_file_close(fd);
 
-        status = pj_file_open(app_config.pool, filename, PJ_O_WRONLY, &fd);
-        if (status != PJ_SUCCESS) {
-            pjsua_perror(THIS_FILE, "Unable to open file", status);
-        } else {
-            pj_ssize_t size = len;
-            pj_file_write(fd, settings, &size);
-            pj_file_close(fd);
-
-            printf("Settings successfully written to '%s'\n", filename);
-        }
+        printf("Settings successfully written to '%s'\n", filename);
     }
 
     pj_pool_secure_release(&pool);


### PR DESCRIPTION
## Description

The non-blocking points from the #5208 review, plus one regression that review turned up. Rebased onto master now that #5208 has merged, so this is just the three commits.

- **`cfg_add()` appends at the tracked `cfg->slen`** instead of letting `pj_ansi_strxcat()` rescan the destination on every call — the ~140 appends per `write_settings()` were quadratic in buffer size. `cfg_addf()` alongside it already did this. Four argument-less literals move off `cfg_addf()` while here.
- **`--custom-sdp` goes through a length-based `cfg_add_str()`.** #5208 routed it through `cfg_addf("%.*s", ...)`, which stops at an embedded NUL where the `pj_strcat()` it replaced copied all bytes. The helper sits under `#if !PJSUA_MEDIA_HAS_PJMEDIA` with its only caller — outside that guard it is an unused-function warning in a default `-Wall` build.
- **`alloc_settings()`** holds the pool-create/alloc/write/error-check block that was duplicated near-verbatim at four call sites. The `!pool` guard is kept, per the reasoning in #5208.
- **`dump_settings()` emits the dump in log-sized chunks.** `PJ_LOG` truncates a message at `PJ_LOG_MAX_SIZE` (4000). Before #5208 the buffer was `char settings[2000]` and always fit; at 64 KB it does not, so `dc` reported the full byte count while logging only the first part. This is a regression currently on master. Chunks break at option boundaries so no option is split across log lines, and the helper removes the last copy-paste pair between the legacy and CLI front ends.

Corrected from the earlier description: `alloc_settings()` checking the `pj_pool_alloc()` return is **not** the OOM protection I claimed. Under the default pool policy `pj_pool_allocate_find()` calls `(*pool->callback)()`, which throws, before it can return NULL — so that guard is unreachable. It is `pjsua_pool_create()` that genuinely returns NULL, via `pj_pool_create_int()` (`pool.c:224`), which is why the `!pool` guard stays.

## Motivation and Context

Follow-up to #5208 (issue #5196).

## How Has This Been Tested?

macOS/arm64.

- A config with four 1400-character option values, dumped with `dc` and written with `f`. On master the log shows `Dumping configuration (6228 bytes)` followed by ~4229 characters; with this change all 24 distinct options and all four full-length values reach the log, and no option is split across lines. The file path was already correct and is unchanged.
- A config with three 163-character values round-trips byte-exact, and re-reading the output reproduces it identically.
- With `PJSUA_APP_SETTINGS_SIZE` temporarily lowered to 300, both `dc` and `f` refuse — "not enough buffer", no file created, no partial dump.
- `pjsua_app_config.c`, `pjsua_app_legacy.c` and `pjsua_app_cli.c` compile warning-free under `-Wall` with `PJSUA_MEDIA_HAS_PJMEDIA` set to both 1 and 0.

Not run here: `tests/pjsua/run.py` imports `telnetlib`, removed in Python 3.13, and this host only has 3.14.

One behavioural note: the dump now logs with `THIS_FILE` of `pjsua_app_config.c` rather than of the calling front end, since the helper lives there.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the **[CODING STYLE of this project](https://docs.pjsip.org/en/latest/get-started/coding-style.html)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
