### PR TITLE
pjlib: eagerly load/validate TLS server cert on listener start (Darwin)

### DIFF
--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -222,7 +222,18 @@ static pj_status_t create_data_from_file(CFDataRef *data,
     return (*data? PJ_SUCCESS: PJ_EINVAL);
 }
 
-static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
+/* Load the certificate configured in cert into a SecIdentityRef. The private
+ * key is not read from cert: it must come from the PKCS#12 bundle itself or
+ * already be present in the keychain.
+ *
+ * On success *p_identity is set to NULL when no certificate is configured at
+ * all, and otherwise to an identity the caller owns and must CFRelease() --
+ * in both import branches, since the dictionary branch takes its own
+ * reference to what CFDictionaryGetValue() only lends it.
+ */
+static pj_status_t create_identity_from_cert(darwinssl_sock_t *dssock,
+                                             pj_ssl_cert_t *cert,
+                                             SecIdentityRef *p_identity)
 {
     CFStringRef password = NULL;
     CFDataRef cert_data = NULL;
@@ -232,11 +243,10 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
     CFArrayRef items;
     CFIndex i, count;
     SecIdentityRef identity = NULL;
-    CFTypeRef cert_arr[1];
-    CFArrayRef cert_refs;
     OSStatus err;
     pj_status_t status;
 
+    *p_identity = NULL;
 
     if (cert->privkey_file.slen || cert->privkey_buf.slen ||
         cert->privkey_pass.slen)
@@ -357,7 +367,26 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
                                   "the cert file"));
             return PJ_EINVAL;
         }
-        
+
+        *p_identity = identity;
+    }
+
+    return PJ_SUCCESS;
+}
+
+static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
+{
+    SecIdentityRef identity = NULL;
+    CFTypeRef cert_arr[1];
+    CFArrayRef cert_refs;
+    OSStatus err;
+    pj_status_t status;
+
+    status = create_identity_from_cert(dssock, cert, &identity);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    if (identity) {
         cert_arr[0] = identity;
         cert_refs = CFArrayCreate(NULL, (const void **)cert_arr, 1,
                               &kCFTypeArrayCallBacks);
@@ -375,6 +404,41 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
     }
 
     return PJ_SUCCESS;
+}
+
+/* Eagerly load and validate the certificate on the listener socket, so that a
+ * certificate that is missing, unparsable, or has no matching private key
+ * fails pj_ssl_sock_start_accept() up front. Without this, set_cert() (via
+ * ssl_create() below) does not run until the first connection is accepted, so
+ * the listener reports success and it is every inbound connection that fails
+ * its handshake instead.
+ *
+ * The identity is released again here rather than cached: unlike the OpenSSL
+ * backend, this backend builds no shared server context, and every accepted
+ * connection loads the certificate itself in its own ssl_create(). This
+ * validates the configuration, it does not pin it.
+ *
+ * Note this covers loading only, not the SSLSetCertificate() that set_cert()
+ * goes on to make against a per-connection context. A listener can therefore
+ * still start for a configuration that every connection subsequently
+ * rejects -- the check fails open, never closed.
+ */
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
+{
+    darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
+    SecIdentityRef identity = NULL;
+    pj_status_t status;
+
+    pj_assert(ssock->is_server && !ssock->parent);
+
+    if (!ssock->cert)
+        return PJ_SUCCESS;
+
+    status = create_identity_from_cert(dssock, ssock->cert, &identity);
+    if (identity)
+        CFRelease(identity);
+
+    return status;
 }
 
 /* Create and initialize new Darwin SSL context and instance */

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -273,8 +273,12 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
         options = CFDictionaryCreate(NULL, (const void **)keys,
                                      (const void **)values,
                                      (password? 1: 0), NULL, NULL);
-        if (!options)
+        if (!options) {
+            if (password)
+                CFRelease(password);
+            CFRelease(cert_data);
             return PJ_ENOMEM;
+        }
         
 #if TARGET_OS_IPHONE
         err = SecPKCS12Import(cert_data, options, &items);
@@ -322,6 +326,11 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
                 identity = (SecIdentityRef)
                            CFDictionaryGetValue((CFDictionaryRef) item,
                                                 kSecImportItemIdentity);
+                /* Get rule: this reference is owned by the dictionary, which
+                 * is released along with items below, so take our own.
+                 */
+                if (identity)
+                    CFRetain(identity);
                 break;
             }
 #if !TARGET_OS_IPHONE
@@ -352,8 +361,10 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
         cert_arr[0] = identity;
         cert_refs = CFArrayCreate(NULL, (const void **)cert_arr, 1,
                               &kCFTypeArrayCallBacks);
-        if (!cert_refs)
+        if (!cert_refs) {
+            CFRelease(identity);
             return PJ_ENOMEM;
+        }
     
         err = SSLSetCertificate(dssock->ssl_ctx, cert_refs);
     
@@ -878,6 +889,12 @@ static CFDictionaryRef get_cert_oid(SecCertificateRef cert, CFStringRef oid,
 
     vals = SecCertificateCopyValues(cert, key_arr, NULL);
     dict = CFDictionaryGetValue(vals, key[0]);
+    if (!dict) {
+        CFRelease(key_arr);
+        CFRelease(vals);
+        return NULL;
+    }
+
     *value = CFDictionaryGetValue(dict, kSecPropertyKeyValue);
 
     CFRelease(key_arr);

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2233,7 +2233,8 @@ pj_ssl_sock_start_accept2(pj_ssl_sock_t *ssock,
 
     ssock->is_server = PJ_TRUE;
 
-#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL) || \
+    (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_DARWIN)
     /* Eagerly load and validate the certificate/private key now, instead
      * of leaving it to the first accepted connection, so that a bad
      * credential fails the listener startup itself.

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -293,9 +293,12 @@ static pj_ssl_cipher ssl_get_cipher(pj_ssl_sock_t *ssock);
 static void ssl_update_certs_info(pj_ssl_sock_t *ssock);
 #if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
 static void ssl_free_cert(pj_ssl_cert_t *cert);
-/* Eagerly create/validate the server SSL_CTX (incl. certificate and
- * private key loading) on a listener socket, instead of deferring it
- * to the first accepted connection.
+#endif
+#if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL) || \
+    (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_DARWIN)
+/* Eagerly create/validate the server credentials -- for OpenSSL the whole
+ * SSL_CTX, including certificate and private key loading -- on a listener
+ * socket, instead of deferring it to the first accepted connection.
  */
 static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock);
 #endif


### PR DESCRIPTION
> **Stacked on #5220.** That PR fixes the certificate over-release in this backend, without which the eager check added here crashes at listener startup on iOS. Review the top commit only; the diff collapses to one file once #5220 merges.

## Summary

- Extends #5210's eager server-cert validation to the Darwin (Secure Transport) backend, which has the same half of #5209. `set_cert()` is reachable only from `ssl_create()`, which never runs on the listener socket, so `pj_ssl_sock_start_accept()` returns `PJ_SUCCESS` for a certificate that is missing, unparsable, or has no matching private key, and every inbound connection then fails its handshake instead. Reproduction table in my comment on #5209.
- Splits the identity loading out of `set_cert()` into `create_identity_from_cert()`, mirroring how `ssl_sock_apple.m` already factors the same code out of `network_create_params()`, and calls it from `pj_ssl_sock_start_accept2()`. `set_cert()` keeps only the `SSLSetCertificate()` call.
- Now that #5210 has merged, the two backends share one call site: the guard is `PJ_SSL_SOCK_IMP_OPENSSL || PJ_SSL_SOCK_IMP_DARWIN` rather than a second `#if` block, and the header declares `ssl_init_server_ctx()` once. Same hook, same placement.
- **Caches nothing on the listener.** Unlike OpenSSL this backend has no shared server context; every accepted connection still loads the certificate in its own `ssl_create()`, so a certificate file replaced while the listener is up continues to be picked up per connection. Preserved deliberately — this validates, it does not pin.
- Carries #5210's `!ssock->cert` guard, so a listener with no certificate configured at all still starts, exactly as on the OpenSSL side.

## Scope of the check

The eager path exercises `create_identity_from_cert()` but not the `SSLSetCertificate()` that `set_cert()` goes on to make against a per-connection context, so a listener can still start for a configuration that every connection then rejects. The check fails open, never closed. Noted in the function comment.

## Verified on both platforms

Same repro, five certificate configurations, one real TCP connection driven into each listener that starts. Built with `PJ_SSL_SOCK_IMP_DARWIN` forced via `config_site.h`, since `./configure` cannot select this backend on a current SDK (#5217).

**iOS Simulator, arm64** — with #5220 applied:

| certificate configuration | master: `start_accept` | master: first connection | this PR: `start_accept` |
|---|---|---|---|
| no certificate configured | `PJ_SUCCESS` | timeout[^1] | `PJ_SUCCESS` |
| valid .p12, correct password | `PJ_SUCCESS` | timeout[^1] | `PJ_SUCCESS` |
| valid .p12, wrong password | `PJ_SUCCESS` | OSStatus -25293 | OSStatus -25293 |
| unparsable file | `PJ_SUCCESS` | OSStatus -26275 | OSStatus -26275 |
| nonexistent file | `PJ_SUCCESS` | `PJ_EINVAL` | `PJ_EINVAL` |

The valid `.p12` row is the positive control: it loads, the listener starts, and this PR does not reject it.

**macOS, arm64** — same shape, with the valid `.p12` row failing on both master and this PR because the macOS import path resolves the private key through the keychain rather than from the file (`errSecItemNotFound`), and I did not install one. Pre-existing platform behaviour, not a change from this PR:

| certificate configuration | master: `start_accept` | master: first connection | this PR: `start_accept` |
|---|---|---|---|
| no certificate configured | `PJ_SUCCESS` | timeout[^1] | `PJ_SUCCESS` |
| valid .p12, correct password | `PJ_SUCCESS` | `PJ_EINVAL` | `PJ_EINVAL` |
| valid .p12, wrong password | `PJ_SUCCESS` | OSStatus -25256 | OSStatus -25256 |
| unparsable file | `PJ_SUCCESS` | OSStatus -25256 | OSStatus -25256 |
| nonexistent file | `PJ_SUCCESS` | `PJ_EINVAL` | `PJ_EINVAL` |

In every row that fails, the status is identical to what master produced at first connection; only *when* it is reported changes.

[^1]: my client opens a TCP connection but sends no ClientHello, so a healthy listener times out waiting. That is the "listener is fine" outcome.

## Also

- Compile-checked for `PJ_SSL_SOCK_IMP_APPLE` and `PJ_SSL_SOCK_IMP_OPENSSL` — unaffected, as the guard implies.
- `pjlib-test ssl_sock_test` not run: it does not link in this configuration on a current SDK (configure omits `-framework Security` because the probe in #5217 fails), and its server path expects a keychain identity. No existing test starts a listener with a deliberately bad certificate.

## Possible follow-up, not in this PR

Caching the `SecIdentityRef` on the listener and having accepted sockets borrow it via `ssock->parent` would also remove a file read and a PKCS#12 import from every inbound connection; `ssl_sock_ossl.c` already has the ownership pattern (`own_ctx`, child reads the parent's context, child holds a group-lock reference on the parent). It would pin the certificate for the listener's lifetime, matching OpenSSL and the Apple backend. Left out because it is a behaviour change rather than a fix.
