### PR TITLE
pjsip: guard against missing Call-ID in create_tsx_key_2543()

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -290,6 +290,7 @@ static pj_status_t create_tsx_key_2543( pj_pool_t *pool,
     PJ_ASSERT_RETURN(rdata->msg_info.via, PJSIP_EMISSINGHDR);
     PJ_ASSERT_RETURN(rdata->msg_info.cseq, PJSIP_EMISSINGHDR);
     PJ_ASSERT_RETURN(rdata->msg_info.from, PJSIP_EMISSINGHDR);
+    PJ_ASSERT_RETURN(rdata->msg_info.cid, PJSIP_EMISSINGHDR);
 
     host = &rdata->msg_info.via->sent_by.host;
 

--- a/tests/fuzz/fuzz-auth.c
+++ b/tests/fuzz/fuzz-auth.c
@@ -130,7 +130,7 @@ static void test_auth_server_challenge(pj_pool_t *pool, pjsip_msg *msg)
     rdata.msg_info.cseq = (pjsip_cseq_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_CSEQ, NULL);
     rdata.msg_info.cid = (pjsip_cid_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_CALL_ID, NULL);
     if (!rdata.msg_info.via || !rdata.msg_info.from || !rdata.msg_info.to ||
-        !rdata.msg_info.cseq || !rdata.msg_info.cid)
+        !rdata.msg_info.cseq || !rdata.msg_info.cid || !rdata.msg_info.cid->id.slen)
         return;
 
     if (msg->line.req.method.id == PJSIP_ACK_METHOD)

--- a/tests/fuzz/fuzz-sip-dialog.c
+++ b/tests/fuzz/fuzz-sip-dialog.c
@@ -142,7 +142,7 @@ static void test_uas_dialog(pj_pool_t *pool, const uint8_t *data, size_t size)
 
     /* Validate required headers */
     if (!rdata.msg_info.via || !rdata.msg_info.from || !rdata.msg_info.to ||
-        !rdata.msg_info.cseq || !rdata.msg_info.cid)
+        !rdata.msg_info.cseq || !rdata.msg_info.cid || !rdata.msg_info.cid->id.slen)
         return;
 
     /* Set recvd_param required by PJSIP transport layer */

--- a/tests/fuzz/fuzz-sip-transaction.c
+++ b/tests/fuzz/fuzz-sip-transaction.c
@@ -175,9 +175,9 @@ static void test_create_response(pj_pool_t *pool, const uint8_t *data, size_t si
     rdata.msg_info.cseq = (pjsip_cseq_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_CSEQ, NULL);
     rdata.msg_info.cid = (pjsip_cid_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_CALL_ID, NULL);
 
-    /* Skip if required headers are missing */
+    /* Skip if required headers are missing, as the transport layer does */
     if (!rdata.msg_info.via || !rdata.msg_info.from || !rdata.msg_info.to ||
-        !rdata.msg_info.cseq || !rdata.msg_info.cid)
+        !rdata.msg_info.cseq || !rdata.msg_info.cid || !rdata.msg_info.cid->id.slen)
         return;
 
     pjsip_tx_data *tdata = NULL;

--- a/tests/fuzz/fuzz-sip-transaction.c
+++ b/tests/fuzz/fuzz-sip-transaction.c
@@ -69,9 +69,11 @@ static void test_uas_transaction(pj_pool_t *pool, const uint8_t *data, size_t si
     rdata.msg_info.from = (pjsip_from_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_FROM, NULL);
     rdata.msg_info.to = (pjsip_to_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_TO, NULL);
     rdata.msg_info.cseq = (pjsip_cseq_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_CSEQ, NULL);
+    rdata.msg_info.cid = (pjsip_cid_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_CALL_ID, NULL);
 
-    /* Skip if required headers are missing */
-    if (!rdata.msg_info.via || !rdata.msg_info.from || !rdata.msg_info.to || !rdata.msg_info.cseq)
+    /* Skip if required headers are missing, as the transport layer does */
+    if (!rdata.msg_info.via || !rdata.msg_info.from || !rdata.msg_info.to ||
+        !rdata.msg_info.cseq || !rdata.msg_info.cid || !rdata.msg_info.cid->id.slen)
         return;
 
     /* Create UAS transaction with rdata */


### PR DESCRIPTION
## Problem

`create_tsx_key_2543()` asserts that Via, CSeq and From are present, but dereferences `rdata->msg_info.cid` unconditionally (`pjsip/src/pjsip/sip_transaction.c:300` and `:331`). A request without a Call-ID header therefore crashes when the RFC2543 transaction key is built (NULL read at `cid->id.slen`).

Reported by OSS-Fuzz against the `fuzz-sip-transaction` target. The testcase is a request carrying To/CSeq/From/Via but no Call-ID, whose Via has no `z9hG4bK` branch, so key creation takes the RFC2543 path.

## Reachability

Not reachable through the normal receive path: the transport layer already drops messages with a missing or empty Call-ID before delivering them (`pjsip/src/pjsip/sip_transport.c:2399`). The crash comes from the fuzz harness building `rdata` by hand: `test_uas_transaction()` populated only via/from/to/cseq and left `msg_info.cid` NULL, while the other test functions in the same file already populate and require it.

## Changes

- `pjsip/src/pjsip/sip_transaction.c`: add the missing `PJ_ASSERT_RETURN(rdata->msg_info.cid, PJSIP_EMISSINGHDR)` alongside the existing mandatory-header checks. `PJ_ASSERT_RETURN` returns the error value in release/NDEBUG builds too, so this is a real check, not debug-only.
- `tests/fuzz/`: make every harness that builds `rdata` by hand enforce the same mandatory header set as the transport layer (Call-ID present and non-empty, From, To, Via, CSeq), so they can no longer feed the stack a message the transport layer would have dropped:
  - `fuzz-sip-transaction.c` `test_uas_transaction()`: populate `msg_info.cid` and require it (the actual OSS-Fuzz gap).
  - `fuzz-sip-transaction.c` `test_create_response()`, `fuzz-sip-dialog.c`, `fuzz-auth.c`: add the missing `cid->id.slen` check for consistency (review follow-up). `fuzz-sip.c` already had it.

## Testing

- `cd pjsip/build && make` — clean, no warnings; all touched harnesses compile clean with `-Wall`.
- Standalone driver around the harness plus the OSS-Fuzz testcase, built with `-DNDEBUG` as OSS-Fuzz does: pre-fix sources SIGSEGV (exit 139), post-fix returns normally.
- Direct call to `pjsip_tsx_create_key()` with `cid == NULL` now returns `PJSIP_EMISSINGHDR` instead of crashing; with Call-ID present the generated key is unchanged.
- `pjsip-test`: `tsx_basic_test tsx_uac_test tsx_uas_test tsx_destroy_test` — 10/10 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)