### PR TITLE
pjlib: fix certificate memory handling in the Darwin SSL backend

### DIFF
--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -273,8 +273,12 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
         options = CFDictionaryCreate(NULL, (const void **)keys,
                                      (const void **)values,
                                      (password? 1: 0), NULL, NULL);
-        if (!options)
+        if (!options) {
+            if (password)
+                CFRelease(password);
+            CFRelease(cert_data);
             return PJ_ENOMEM;
+        }
         
 #if TARGET_OS_IPHONE
         err = SecPKCS12Import(cert_data, options, &items);
@@ -322,6 +326,11 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
                 identity = (SecIdentityRef)
                            CFDictionaryGetValue((CFDictionaryRef) item,
                                                 kSecImportItemIdentity);
+                /* Get rule: this reference is owned by the dictionary, which
+                 * is released along with items below, so take our own.
+                 */
+                if (identity)
+                    CFRetain(identity);
                 break;
             }
 #if !TARGET_OS_IPHONE
@@ -352,8 +361,10 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
         cert_arr[0] = identity;
         cert_refs = CFArrayCreate(NULL, (const void **)cert_arr, 1,
                               &kCFTypeArrayCallBacks);
-        if (!cert_refs)
+        if (!cert_refs) {
+            CFRelease(identity);
             return PJ_ENOMEM;
+        }
     
         err = SSLSetCertificate(dssock->ssl_ctx, cert_refs);
     
@@ -878,6 +889,12 @@ static CFDictionaryRef get_cert_oid(SecCertificateRef cert, CFStringRef oid,
 
     vals = SecCertificateCopyValues(cert, key_arr, NULL);
     dict = CFDictionaryGetValue(vals, key[0]);
+    if (!dict) {
+        CFRelease(key_arr);
+        CFRelease(vals);
+        return NULL;
+    }
+
     *value = CFDictionaryGetValue(dict, kSecPropertyKeyValue);
 
     CFRelease(key_arr);


### PR DESCRIPTION
## Summary

Fixes the memory-handling half of #5215 for `ssl_sock_darwin.c`. The headline is worse than that issue implied: **on iOS this backend segfaults on any valid PKCS#12 today.** Not a latent over-release — a guaranteed crash the moment a TLS connection arrives.

`set_cert()` takes the identity out of the import result with `CFDictionaryGetValue()`, which follows the CoreFoundation Get rule, then releases the array that owns it before using and releasing the identity itself. On iOS `SecPKCS12Import()` is the only import path and always yields dictionaries, so the borrowed branch is the only branch. af82c9085 (#3664, fixing #3617) fixed exactly this in `ssl_sock_apple.m` in 2023; the byte-identical code here never got the backport.

Measured on the iOS Simulator (arm64), master, loading a valid `.p12` with the correct password and driving one TCP connection into the listener:

```
Child process terminated with signal 11: Segmentation fault

EXC_BAD_ACCESS, KERN_INVALID_ADDRESS at 0x0000beadde8d66a0
  libobjc.A.dylib   objc_retain
  CoreFoundation    __NSSingleObjectArrayI_new
  repro             ssl_create
  repro             asock_on_accept_complete2
  repro             pj_ioqueue_poll
```

`0xbeadde…` is freed-memory poison: `CFArrayCreate()` in `set_cert()` retaining an identity that `CFRelease(items)` already deallocated.

## Changes

Three fixes, all backports of what `ssl_sock_apple.m` already does:

1. **`CFRetain()` the borrowed identity** before `CFRelease(items)` drops it — the af82c9085 backport. Guarded against a dictionary carrying no identity, since `CFRetain(NULL)` would itself crash; `ssl_sock_apple.m:579` has no such guard and arguably should.
2. **NULL check on the `SecCertificateCopyValues()` result** in `get_cert_oid()`, present at `ssl_sock_apple.m:1847`, absent here.
3. **Release `cert_data` and `password`** when `CFDictionaryCreate()` fails, instead of leaking both.

Deliberately not included: the 8 KB truncation in `create_data_from_file()`, and deduplication. Both touch `ssl_sock_apple.m` too and so depend on the answer to the open question in #5215 — fix in place twice, or dedupe first and fix once.

## Test plan

Built with `PJ_SSL_SOCK_IMP_DARWIN` forced via `config_site.h`, since `./configure` cannot select this backend on a current SDK (#5217). Same repro on both platforms, five certificate configurations, driving a real TCP connection into each listener.

**iOS Simulator, arm64 — before:** segfault, backtrace above.
**iOS Simulator, arm64 — after:**

| certificate configuration | `start_accept` | first connection |
|---|---|---|
| no certificate configured | `PJ_SUCCESS` | timeout (my client sends no ClientHello) |
| valid .p12, correct password | `PJ_SUCCESS` | timeout — identity loaded, listener healthy |
| valid .p12, wrong password | `PJ_SUCCESS` | OSStatus -25293 |
| unparsable file | `PJ_SUCCESS` | OSStatus -26275 |
| nonexistent file | `PJ_SUCCESS` | `PJ_EINVAL` |

No crash, and a valid `.p12` now loads and serves.

**macOS, arm64:** no behaviour change, before or after. The crash is iOS-specific because the macOS `SecItemImport()` path returns a `SecCertificateRef` and takes the `SecIdentityCreateWithCertificate()` branch, which follows the Create rule and is correctly owned. That is also why the bug survived this long: it is invisible on the platform most likely to be used for development.

Worth recording for anyone testing this backend: the same `.p12` that loads on iOS fails on macOS with `errSecItemNotFound`, because the macOS branch resolves the private key through the keychain rather than from the file. A `.p12` is self-contained on iOS and is not on macOS.
