### PR TITLE
pjlib: fix Darwin SSL detection and let --disable-ssl override it

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -9705,6 +9705,8 @@ esac
 fi
 
 
+ac_ssl_disabled_by_user=$enable_ssl
+
 if test "x$ac_cross_compile" != "x" -a "x$with_ssl" = "xno" -a "x$with_gnutls" = "xno" -a "x$with_mbedtls" = "xno"; then
     enable_ssl=no
 fi
@@ -9727,6 +9729,16 @@ else case e in #(
   e)
         case $target in
             *darwin*)
+              if test "x$ac_ssl_disabled_by_user" = "xno"; then
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Checking if Darwin SSL is available... skipped (--disable-ssl)" >&5
+printf "%s\n" "Checking if Darwin SSL is available... skipped (--disable-ssl)" >&6; }
+              elif test "x$with_gnutls" != "xno" -a "x$with_gnutls" != "x"; then
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Checking if Darwin SSL is available... skipped (--with-gnutls)" >&5
+printf "%s\n" "Checking if Darwin SSL is available... skipped (--with-gnutls)" >&6; }
+              elif test "x$with_mbedtls" != "xno" -a "x$with_mbedtls" != "x"; then
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Checking if Darwin SSL is available... skipped (--with-mbedtls)" >&5
+printf "%s\n" "Checking if Darwin SSL is available... skipped (--with-mbedtls)" >&6; }
+              else
                 SAVED_CFLAGS="$CFLAGS"
                 CFLAGS="-Werror"
                 SAVED_LIBS="$LIBS"
@@ -9741,7 +9753,7 @@ int
 main (void)
 {
 if (__builtin_available(macOS 10.12, iOS 10.0, *)) {
-                                SSLContextRef ssl_ctx;
+                                SSLContextRef ssl_ctx = NULL;
                                 SSLReHandshake(ssl_ctx);
                             }
   ;
@@ -9769,6 +9781,7 @@ printf "%s\n" "Checking if Darwin SSL is available... yes" >&6; }
                         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Checking if Darwin SSL is available... no" >&5
 printf "%s\n" "Checking if Darwin SSL is available... no" >&6; }
                 fi
+              fi
             ;;
         esac
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -2118,6 +2118,17 @@ AC_ARG_WITH(mbedtls,
     [with_mbedtls=no]
 )
 
+dnl # Remember an explicit --disable-ssl before the cross-compile default
+dnl # below overwrites enable_ssl, so the two cannot be confused later.
+dnl #
+dnl # The Darwin probe deliberately keys off this rather than off enable_ssl:
+dnl # the cross-compile default exists to stop a cross build picking up *host*
+dnl # OpenSSL/GnuTLS/MbedTLS installations, whereas Secure Transport is a
+dnl # system framework on the target with nothing to detect on the host. So a
+dnl # cross build still probes for it; only an explicit --disable-ssl suppresses
+dnl # it.
+ac_ssl_disabled_by_user=$enable_ssl
+
 dnl # Do not use default SSL installation if we are cross-compiling
 if test "x$ac_cross_compile" != "x" -a "x$with_ssl" = "xno" -a "x$with_gnutls" = "xno" -a "x$with_mbedtls" = "xno"; then
     enable_ssl=no
@@ -2138,7 +2149,20 @@ AC_ARG_ENABLE(darwin-ssl,
     [
         case $target in
             *darwin*)
+              if test "x$ac_ssl_disabled_by_user" = "xno"; then
+                AC_MSG_RESULT([Checking if Darwin SSL is available... skipped (--disable-ssl)])
+              elif test "x$with_gnutls" != "xno" -a "x$with_gnutls" != "x"; then
+                AC_MSG_RESULT([Checking if Darwin SSL is available... skipped (--with-gnutls)])
+              elif test "x$with_mbedtls" != "xno" -a "x$with_mbedtls" != "x"; then
+                AC_MSG_RESULT([Checking if Darwin SSL is available... skipped (--with-mbedtls)])
+              else
                 SAVED_CFLAGS="$CFLAGS"
+dnl # The probe replaces CFLAGS rather than inheriting them, deliberately.
+dnl # Several flags a caller may pass decide the answer rather than describe
+dnl # the target: -w and -Wno-deprecated-declarations suppress the deprecation
+dnl # this probe trips over, and a deployment target predating the deprecation
+dnl # (-m*-version-min=, or a triple carrying one) does the same. Inheriting
+dnl # any of them would let an unrelated flag choose the TLS backend.
                 CFLAGS="-Werror"
                 SAVED_LIBS="$LIBS"
 
@@ -2148,7 +2172,7 @@ AC_ARG_ENABLE(darwin-ssl,
                         AC_LANG_PROGRAM([
                             [#include <Security/SecureTransport.h>]],
                             [if (__builtin_available(macOS 10.12, iOS 10.0, *)) {
-                                SSLContextRef ssl_ctx;
+                                SSLContextRef ssl_ctx = NULL;
                                 SSLReHandshake(ssl_ctx);
                             }])
                     ],
@@ -2165,6 +2189,7 @@ AC_ARG_ENABLE(darwin-ssl,
                     else
                         AC_MSG_RESULT([Checking if Darwin SSL is available... no])
                 fi
+              fi
             ;;
         esac
     ]


### PR DESCRIPTION
> **Scope.** This PR does **not** repair the Darwin probe so it can succeed. That change was removed after it hijacked nine macOS CI jobs, and is held pending the decision in the comments. What is here is a precedence fix, latent on a current SDK.

## What is committed

Three things, and nothing else — this description is written from the diff rather than edited forward, after drifting from the branch three times.

**1. An explicit backend choice now beats the Darwin autodetect.** The `AC_ARG_ENABLE(darwin-ssl, …)` block runs before `AC_ARG_ENABLE(ssl, …)` and emits `PJ_HAS_SSL_SOCK` / `PJ_SSL_SOCK_IMP` directly, so `--disable-ssl` cannot retract them and nothing consumes `ac_no_ssl` to try. The same ordering makes `--with-gnutls=DIR` and `--with-mbedtls=DIR` lose, since those arms are gated on `ac_ssl_backend` still being empty — asking for MbedTLS on macOS applied its `-I`/`-L` flags, printed nothing, and built Secure Transport.

The probe is now skipped for `--disable-ssl`, `--with-gnutls` and `--with-mbedtls`.

`--with-ssl` is deliberately **not** guarded: it is documented as a prefix to search, not a backend selector, and Darwin TLS plus OpenSSL for DTLS is an intended pairing. An earlier revision did guard it; that was an overreach and was removed.

**2. `--disable-ssl` is distinguished from the cross-compile default.** The user's flag is captured into `ac_ssl_disabled_by_user` *before* `aconfigure.ac:2127` assigns `enable_ssl=no` for cross builds, so the two cannot be confused. A cross build therefore still probes — deliberate, and the comment says why: that default exists to stop a cross build picking up *host* SSL libraries, whereas Secure Transport is a system framework on the target with nothing to detect on the host.

**3. `ssl_ctx` is initialised in the probe body.** Defensive hygiene only. With `CFLAGS` replaced wholesale no caller `-W` flag reaches the probe, so this is not fixing anything reachable today; it makes the body correct C regardless of what it is later compiled with.

**Not changed:** `CFLAGS="-Werror"` is untouched from master. A comment was added explaining why replacement is deliberate — several flags a caller may pass decide the answer rather than describe the target (`-w`, `-Wno-deprecated-declarations`, and a deployment target predating the deprecation all make the probe pass). An earlier revision filtered `$CFLAGS` instead; that was removed after review showed it reintroduced exactly the non-determinism it was meant to prevent.

## Effect

| invocation | before | after |
|---|---|---|
| `./configure` | `available... no` | `available... no` |
| `CFLAGS="-w" ./configure` | `available... no` | `available... no` |
| `CFLAGS="-mmacosx-version-min=10.13" ./configure` | `available... no` | `available... no` |
| `./configure --disable-ssl` | probe ran anyway | `skipped (--disable-ssl)` |
| `./configure --with-gnutls=DIR` | probe ran, could win | `skipped (--with-gnutls)` |
| `./configure --with-mbedtls=DIR` | probe ran, could win | `skipped (--with-mbedtls)` |
| `./configure --with-ssl=DIR` | probe runs | probe runs (unchanged) |
| `./configure-iphone` | probe runs | probe runs (unchanged) |
| `./configure-iphone --disable-ssl` | probe ran anyway | `skipped (--disable-ssl)` |

On a current SDK the probe still fails in every row, so only the console line and the precedence change are observable today. This takes effect on an older SDK, or once the probe is repaired.

## On `aconfigure`

Hand-updated rather than regenerated, because the committed file comes from autoconf 2.72 and regenerating with 2.73 rewrites ~3000 unrelated lines.

Verified by regenerating the previous and current `aconfigure.ac` with the *same* autoconf and diffing those two outputs against each other, which isolates this change's hunk from version noise: the changed region of the committed `aconfigure` matches that hunk apart from autoconf 2.72 vs 2.73 `printf` quoting. The `dnl` blocks are at column 0, so they do not regenerate as leading whitespace.
