### PR TITLE
pjlib: read the whole certificate file in the Apple SSL backends

### DIFF
--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -408,13 +408,22 @@ static pj_status_t pj_status_from_err(applessl_sock_t *assock,
 }
 
 /* Read cert or key file */
+/* Certificates and PKCS#12 bundles are small. This bound is far above any
+ * legitimate one and exists so that a cert_file or CA_file which is not a
+ * regular file -- a FIFO with no writer, or /dev/zero -- cannot block the
+ * calling thread indefinitely or grow the buffer until the process dies.
+ */
+#define MAX_CERT_FILE_SIZE      (1024 * 1024)
+
 static pj_status_t create_data_from_file(CFDataRef *data,
                                          pj_str_t *fname, pj_str_t *path)
 {
     CFURLRef file;
     CFReadStreamRef read_stream;
+    CFMutableDataRef buf;
     UInt8 data_buf[8192];
     CFIndex nbytes = 0;
+    pj_bool_t too_big = PJ_FALSE;
     
     if (path) {
         CFURLRef filepath;
@@ -462,17 +471,50 @@ static pj_status_t create_data_from_file(CFDataRef *data,
         return PJ_EINVAL;
     }
     
-    nbytes = CFReadStreamRead(read_stream, data_buf,
-                              sizeof(data_buf));
-    if (nbytes > 0)
-        *data = CFDataCreate(NULL, data_buf, nbytes);
-    else
-        *data = NULL;
-    
+    *data = NULL;
+
+    buf = CFDataCreateMutable(NULL, 0);
+    if (!buf) {
+        CFReadStreamClose(read_stream);
+        CFRelease(read_stream);
+        return PJ_ENOMEM;
+    }
+
+    /* Read until end of stream: one CFReadStreamRead() returns at most
+     * sizeof(data_buf) bytes and is not obliged to fill the buffer even
+     * when more is available, so a single call would silently truncate.
+     * Bounded so that a stream which never ends cannot run us out of memory;
+     * every iteration that continues has appended at least one byte, so the
+     * size limit bounds the iteration count too.
+     */
+    while ((nbytes = CFReadStreamRead(read_stream, data_buf,
+                                      sizeof(data_buf))) > 0)
+    {
+        if (CFDataGetLength(buf) + nbytes > MAX_CERT_FILE_SIZE) {
+            PJ_LOG(2, (THIS_FILE, "Certificate file exceeds %d bytes",
+                       MAX_CERT_FILE_SIZE));
+            too_big = PJ_TRUE;
+            break;
+        }
+        CFDataAppendBytes(buf, data_buf, nbytes);
+    }
+
     CFReadStreamClose(read_stream);
     CFRelease(read_stream);
-    
-    return (*data? PJ_SUCCESS: PJ_EINVAL);
+
+    if (too_big) {
+        CFRelease(buf);
+        return PJ_ETOOBIG;
+    }
+
+    if (nbytes < 0 || CFDataGetLength(buf) == 0) {
+        CFRelease(buf);
+        return PJ_EINVAL;
+    }
+
+    *data = buf;
+
+    return PJ_SUCCESS;
 }
 
 static pj_status_t create_identity_from_cert(applessl_sock_t *assock,

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -155,13 +155,22 @@ static pj_ssl_sock_t *ssl_alloc(pj_pool_t *pool)
     return (pj_ssl_sock_t *)PJ_POOL_ZALLOC_T(pool, darwinssl_sock_t);
 }
 
+/* Certificates and PKCS#12 bundles are small. This bound is far above any
+ * legitimate one and exists so that a cert_file or CA_file which is not a
+ * regular file -- a FIFO with no writer, or /dev/zero -- cannot block the
+ * calling thread indefinitely or grow the buffer until the process dies.
+ */
+#define MAX_CERT_FILE_SIZE      (1024 * 1024)
+
 static pj_status_t create_data_from_file(CFDataRef *data,
                                          pj_str_t *fname, pj_str_t *path)
 {
     CFURLRef file;
     CFReadStreamRef read_stream;
+    CFMutableDataRef buf;
     UInt8 data_buf[8192];
     CFIndex nbytes = 0;
+    pj_bool_t too_big = PJ_FALSE;
     
     if (path) {
         CFURLRef filepath;
@@ -209,17 +218,50 @@ static pj_status_t create_data_from_file(CFDataRef *data,
         return PJ_EINVAL;
     }
     
-    nbytes = CFReadStreamRead(read_stream, data_buf,
-                              sizeof(data_buf));
-    if (nbytes > 0)
-        *data = CFDataCreate(NULL, data_buf, nbytes);
-    else
-        *data = NULL;
-    
+    *data = NULL;
+
+    buf = CFDataCreateMutable(NULL, 0);
+    if (!buf) {
+        CFReadStreamClose(read_stream);
+        CFRelease(read_stream);
+        return PJ_ENOMEM;
+    }
+
+    /* Read until end of stream: one CFReadStreamRead() returns at most
+     * sizeof(data_buf) bytes and is not obliged to fill the buffer even
+     * when more is available, so a single call would silently truncate.
+     * Bounded so that a stream which never ends cannot run us out of memory;
+     * every iteration that continues has appended at least one byte, so the
+     * size limit bounds the iteration count too.
+     */
+    while ((nbytes = CFReadStreamRead(read_stream, data_buf,
+                                      sizeof(data_buf))) > 0)
+    {
+        if (CFDataGetLength(buf) + nbytes > MAX_CERT_FILE_SIZE) {
+            PJ_LOG(2, (THIS_FILE, "Certificate file exceeds %d bytes",
+                       MAX_CERT_FILE_SIZE));
+            too_big = PJ_TRUE;
+            break;
+        }
+        CFDataAppendBytes(buf, data_buf, nbytes);
+    }
+
     CFReadStreamClose(read_stream);
     CFRelease(read_stream);
-    
-    return (*data? PJ_SUCCESS: PJ_EINVAL);
+
+    if (too_big) {
+        CFRelease(buf);
+        return PJ_ETOOBIG;
+    }
+
+    if (nbytes < 0 || CFDataGetLength(buf) == 0) {
+        CFRelease(buf);
+        return PJ_EINVAL;
+    }
+
+    *data = buf;
+
+    return PJ_SUCCESS;
 }
 
 /* Load the certificate configured in cert into a SecIdentityRef. The private


### PR DESCRIPTION
Fixes the truncating read from #5215, and the "or, better, a separate fix" you asked for on #5216.

`create_data_from_file()` issued one `CFReadStreamRead()` into an 8 KB stack buffer and treated whatever came back as the whole file. Anything larger was silently truncated, then failed inside `SecItemImport()`/`SecPKCS12Import()` as an unparsable file rather than an oversized one. `CFReadStreamRead()` is also not obliged to fill the buffer in a single call, so a short read could truncate a smaller file too.

It now reads in a loop into a `CFMutableDataRef` until end of stream, and distinguishes a read error from an empty file.

Two things that make this worth more than its size:

- **It reads `CA_file` as well as `cert_file`**, so the same 8 KB ceiling applied to anyone pinning to a CA, not just to server certificates.
- **A `.p12` carrying an intermediate chain passes 8 KB routinely.** Your point on #5216 was the right one: with eager validation this stops being a per-connection handshake failure and becomes a listener that will not start, which is the most likely shape of the first regression report.

Fixed in both `ssl_sock_darwin.c` and `ssl_sock_apple.m`, which carry byte-identical copies. Fixing one would have left the other with the ceiling — this is the same duplication #5215 is about, and the open question there (fix in place twice, or dedupe first) is unchanged by this PR; I just did not want the fix to wait on it.

## Verified

iOS Simulator, arm64, `PJ_SSL_SOCK_IMP_DARWIN`, measured on top of #5216 so that `pj_ssl_sock_start_accept()` actually loads the certificate:

| certificate | without this fix | with this fix |
|---|---|---|
| 2.4 KB `.p12` | loads | loads |
| 12 KB `.p12` with chain | **fails, OSStatus -26275** | loads |

The 12 KB bundle is a 4096-bit leaf plus a six-certificate chain — nothing exotic.

Worth noting for anyone reproducing on master alone: the test shows nothing there, because without #5216 `pj_ssl_sock_start_accept()` never reads the file, so both sizes report success and the truncation only surfaces later, per connection. I measured against master first and got two false passes before spotting that.

Compile-checked for `PJ_SSL_SOCK_IMP_DARWIN` and `PJ_SSL_SOCK_IMP_APPLE`; same diagnostics as master, no new ones.
