### PR TITLE
pjlib: implement the Apple SSL backends in the CMake build

### DIFF
--- a/pjlib/CMakeLists.txt
+++ b/pjlib/CMakeLists.txt
@@ -301,11 +301,35 @@ elseif(PJLIB_WITH_SSL STREQUAL "mbedtls")
       MbedTLS::mbedx509
   )
 elseif(PJLIB_WITH_SSL STREQUAL "darwin")
-  message(FATAL_ERROR "TODO")
-elseif(PJLIB_WITH_SSL STREQUAL "darwin")
-  message(FATAL_ERROR "TODO")
+  if(NOT APPLE)
+    message(FATAL_ERROR "PJLIB_WITH_SSL=darwin requires an Apple platform")
+  endif()
+  find_library(Security_LIBRARY Security REQUIRED)
+  target_link_libraries(pjlib-ssl INTERFACE "${Security_LIBRARY}")
 elseif(PJLIB_WITH_SSL STREQUAL "apple")
-  message(FATAL_ERROR "TODO")
+  if(NOT APPLE)
+    message(FATAL_ERROR "PJLIB_WITH_SSL=apple requires an Apple platform")
+  endif()
+  # ssl_sock_apple.m delivers every asynchronous event through
+  # ssl_network_event_poll(), which is only called from ioqueue_select.c.
+  # With any other ioqueue the Network.framework event queue is never
+  # drained and no connection ever completes, so reject the combination
+  # here rather than at runtime.
+  if(NOT PJLIB_WITH_IOQUEUE STREQUAL "select")
+    message(FATAL_ERROR
+      "PJLIB_WITH_SSL=apple requires PJLIB_WITH_IOQUEUE=select "
+      "(got '${PJLIB_WITH_IOQUEUE}')")
+  endif()
+  find_library(Security_LIBRARY Security REQUIRED)
+  find_library(Network_LIBRARY Network REQUIRED)
+  # ssl_sock_apple.m uses NSLock
+  find_library(Foundation_LIBRARY Foundation REQUIRED)
+  target_link_libraries(pjlib-ssl
+    INTERFACE
+      "${Security_LIBRARY}"
+      "${Network_LIBRARY}"
+      "${Foundation_LIBRARY}"
+  )
 elseif(PJLIB_WITH_SSL STREQUAL "schannel")
   message(FATAL_ERROR "TODO")
 endif()


### PR DESCRIPTION
Covers the CMake half of item 3 in #5217. Independent of the autoconf side and of the autodetect question in #5221 — CMake has no autodetect, the backend is named explicitly, so this is the same fix whichever way that decision goes.

Almost everything was already in place: `PJLIB_WITH_SSL` accepts `darwin` and `apple` (`pjlib/CMakeLists.txt:23-26`), `string(TOUPPER "PJ_SSL_SOCK_IMP_${PJLIB_WITH_SSL}")` derives the macro correctly, and `ssl_sock_apple.m` is already compiled under `if(APPLE)`. Both selections then ran into `message(FATAL_ERROR "TODO")`, so neither Apple TLS backend could be built with CMake at all:

```
$ cmake -S . -B build -DPJLIB_WITH_SSL=apple
CMake Error at pjlib/CMakeLists.txt:308 (message):
  TODO
```

The only missing piece was the framework linkage. `Security` for Secure Transport; `Security`, `Network` and `Foundation` for the Network.framework backend. CoreFoundation is already linked for `APPLE` at line 244-250.

The `darwin` branch was also duplicated at 303 and 305, so the second copy was unreachable — dropped.

`schannel` is left as a stub, deliberately. Verifying that linkage needs a Windows host I do not have, and a guess seemed worse than an honest TODO.

## Verified

| `-DPJLIB_WITH_SSL=` | configure | `PJ_SSL_SOCK_IMP` in generated `os_auto.h` | build `pjlib-test` |
|---|---|---|---|
| `darwin` | ok | `PJ_SSL_SOCK_IMP_DARWIN` | links |
| `apple` | ok | `PJ_SSL_SOCK_IMP_APPLE` | links |

Both were `FATAL_ERROR` at configure before. I also checked the selected backend object is not an empty translation unit — `ssl_sock_darwin.c.o` and `ssl_sock_apple.m.o` carry 496 and 559 symbols respectively — since every `ssl_sock_*` source compiles unconditionally and self-gates on the macro, so a wrong macro would still "build" and produce nothing.

`Foundation` is in that list because linking found it, not because I predicted it: configure and the static-library build both passed without it, and only the executable link surfaced

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_NSLock", referenced from:
       in libpjlib.a[56](ssl_sock_apple.m.o)
```

`ssl_sock_apple.m` uses `NSLock` for its event-manager lock (`:140`, `:193`).
