### PR TITLE
pjlib: apply the Darwin certificate fixes to the Apple backend too

### DIFF
--- a/pjlib/src/pj/ssl_sock_apple.m
+++ b/pjlib/src/pj/ssl_sock_apple.m
@@ -527,8 +527,12 @@ static pj_status_t create_identity_from_cert(applessl_sock_t *assock,
         options = CFDictionaryCreate(NULL, (const void **)keys,
                                      (const void **)values,
                                      (password? 1: 0), NULL, NULL);
-        if (!options)
+        if (!options) {
+            if (password)
+                CFRelease(password);
+            CFRelease(cert_data);
             return PJ_ENOMEM;
+        }
         
 #if TARGET_OS_IPHONE
         err = SecPKCS12Import(cert_data, options, &items);
@@ -576,7 +580,13 @@ static pj_status_t create_identity_from_cert(applessl_sock_t *assock,
                 identity = (SecIdentityRef)
                            CFDictionaryGetValue((CFDictionaryRef) item,
                                                 kSecImportItemIdentity);
-                CFRetain(identity);
+                /* Get rule: this reference is owned by the dictionary, which
+                 * is released along with items below, so take our own. A
+                 * PKCS#12 carrying certificates but no private key yields no
+                 * identity here, and CFRetain(NULL) would abort.
+                 */
+                if (identity)
+                    CFRetain(identity);
                 break;
             }
 #if !TARGET_OS_IPHONE
@@ -605,6 +615,10 @@ static pj_status_t create_identity_from_cert(applessl_sock_t *assock,
         }
 
         *p_identity = sec_identity_create(identity);
+        if (!*p_identity) {
+            CFRelease(identity);
+            return PJ_ENOMEM;
+        }
     
         CFRelease(identity);
     }


### PR DESCRIPTION
Preparatory PR for #5224, and a fix in its own right.

d441e5d8a (#5220) fixed two defects in `ssl_sock_darwin.c`'s identity import and left the byte-identical code in `ssl_sock_apple.m` untouched — so while fixing three-year-old drift between these two files, I introduced two fresh instances of it. Spotted by @sauwming reviewing #5224.

- **`ssl_sock_apple.m:579`** — `CFRetain(identity)` is unguarded. `CFDictionaryGetValue(item, kSecImportItemIdentity)` returns NULL for a PKCS#12 carrying certificates but no private key, and `CFRetain(NULL)` aborts. `ssl_sock_darwin.c:342` guards it and returns `PJ_EINVAL` with a log line instead.
- **`ssl_sock_apple.m:530`** — `if (!options) return PJ_ENOMEM;` leaks `cert_data` and `password`; fixed in `ssl_sock_darwin.c:286-291`.

With this applied the two copies are functionally identical again, which lets #5224 stay a pure move of code that is already the same in both files, rather than a move that also has to carry fixes. Sequencing per the discussion on that PR: this, then the move, then the five carried-over defects fixed once in the shared file.

Compile-checked for `PJ_SSL_SOCK_IMP_APPLE`; no new diagnostics.