### PR TITLE
pjlib: reject PJ_SSL_SOCK_IMP_APPLE with a non-select ioqueue

### DIFF
--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -1234,10 +1234,20 @@
 #define PJ_SSL_SOCK_IMP_MBEDTLS     6
 
 /**
- * Select which SSL socket implementation to use. Currently pjlib supports
- * PJ_SSL_SOCK_IMP_OPENSSL, which uses OpenSSL, and PJ_SSL_SOCK_IMP_GNUTLS,
- * which uses GnuTLS. Setting this to PJ_SSL_SOCK_IMP_NONE will disable
- * secure socket.
+ * Select which SSL socket implementation to use. Setting this to
+ * PJ_SSL_SOCK_IMP_NONE will disable secure socket. The available
+ * implementations are:
+ *  - PJ_SSL_SOCK_IMP_OPENSSL, which uses OpenSSL,
+ *  - PJ_SSL_SOCK_IMP_GNUTLS, which uses GnuTLS,
+ *  - PJ_SSL_SOCK_IMP_MBEDTLS, which uses Mbed TLS,
+ *  - PJ_SSL_SOCK_IMP_SCHANNEL, which uses Windows Schannel,
+ *  - PJ_SSL_SOCK_IMP_APPLE, which uses Apple's Network framework, and
+ *  - PJ_SSL_SOCK_IMP_DARWIN, which uses Apple's Secure Transport
+ *    (deprecated by Apple in macOS 10.15 and iOS 13.0).
+ *
+ * Note that PJ_SSL_SOCK_IMP_APPLE requires PJ_IOQUEUE_IMP_SELECT: it
+ * delivers its events through ssl_network_event_poll(), which only the
+ * select() ioqueue calls.
  *
  * Default is PJ_SSL_SOCK_IMP_NONE if PJ_HAS_SSL_SOCK is not set, otherwise
  * it is PJ_SSL_SOCK_IMP_OPENSSL.
@@ -1248,6 +1258,20 @@
 #   else
 #       define PJ_SSL_SOCK_IMP              PJ_SSL_SOCK_IMP_OPENSSL
 #   endif
+#endif
+
+
+/* The Apple Network framework backend delivers every asynchronous event
+ * through ssl_network_event_poll(), whose only caller is the select()
+ * ioqueue. With any other ioqueue the event queue is never drained, so the
+ * build links and then no connection ever completes. Reject it here, where
+ * both macros are final regardless of whether they came from autoconf,
+ * CMake or config_site.h.
+ */
+#if defined(PJ_HAS_SSL_SOCK) && PJ_HAS_SSL_SOCK != 0 && \
+    PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_APPLE && \
+    PJ_IOQUEUE_IMP != PJ_IOQUEUE_IMP_SELECT
+#   error PJ_SSL_SOCK_IMP_APPLE requires PJ_IOQUEUE_IMP_SELECT
 #endif
 
 


### PR DESCRIPTION
§6.1 of #5229, scoped as you asked. Targeting 2.18.

`ssl_network_event_poll()` has one caller, `ioqueue_select.c:975`. With kqueue or epoll the Network.framework event queue is never drained, so the build links and no connection ever completes, with nothing at runtime naming the cause.

Placed in `config.h` after both macros are final — `os_auto.h` at `:61` and `config_site.h` at `:317`, both ahead of `PJ_IOQUEUE_IMP` (`:752`) and `PJ_SSL_SOCK_IMP` — so it sees the resolved values whichever mechanism produced them. Your point that the combination is reachable from the GNU Makefile build too, not only CMake, is in the commit message; that is the argument for this living here rather than in `pjlib/CMakeLists.txt`.

## Held to your two constraints

**Only the known-broken pair.** Apple + non-`select`, nothing else. No attempt at the other 35 cells.

**No `PJ_HAS_SSL_SOCK` / `PJ_SSL_SOCK_IMP` coherence check** — and the guard is written specifically so that case keeps building. The check is gated on `PJ_HAS_SSL_SOCK`, so a `config_site.h` that sets only `PJ_SSL_SOCK_IMP` compiles exactly as it does today. Verified as its own case below, since it was the failure mode you were protecting against.

**Doc fix folded in.** The `PJ_SSL_SOCK_IMP` comment named only OpenSSL and GnuTLS, four backends out of date. It now lists all six and notes the select-ioqueue requirement, so the constraint is discoverable next to the macro rather than only as a build error.

## Verified

Through `config_site.h`, which is the path that matters — a command-line `-D` cannot exercise this, because `os_auto.h:127` redefines `PJ_IOQUEUE_IMP` after it:

| `config_site.h` sets | result |
|---|---|
| `APPLE` + `KQUEUE` | **`#error` fires** |
| `APPLE` + `SELECT` | builds |
| `DARWIN` + `KQUEUE` | builds — not the guarded pair |
| `PJ_SSL_SOCK_IMP=APPLE`, `PJ_HAS_SSL_SOCK` never set | **builds** — the case you flagged |
| empty | builds |

`ssl_sock_apple.m` still compiles for `PJ_SSL_SOCK_IMP_APPLE` with no new diagnostics.

Not included, per your §6.3: the log-level divergence between `ssl_sock_darwin.c:189` (level 3) and `ssl_sock_apple.m:434` (level 5), and the `pj_ssl_cert_t` Doxygen. Both belong with #5224 or its follow-up rather than in a `config.h` change — happy to take them there.
