### PR TITLE
pjmedia: use the OpenSSL 3.0 key generation API for the DTLS-SRTP certificate (follow-up to #5194)

### DIFF
--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -29,6 +29,7 @@
 #include <openssl/bn.h>
 #include <openssl/ec.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/obj_mac.h>
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
@@ -419,9 +420,28 @@ static pj_status_t ssl_get_fingerprint(X509 *cert, pj_bool_t is_sha256,
 /* Generate private key for the self-signed cert */
 static pj_status_t ssl_generate_key(EVP_PKEY **p_priv_key)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
+    /* The EC key is generated with the curve referred to by name, as some
+     * peers reject certificate with explicit curve parameters.
+     */
+#  if PJMEDIA_SRTP_DTLS_USE_EC_KEY
+    EVP_PKEY *priv_key = EVP_EC_gen("P-256");
+#  else
+    EVP_PKEY *priv_key = EVP_RSA_gen(2048);
+#  endif
+
+    if (!priv_key)
+        return PJ_EUNKNOWN;
+
+    *p_priv_key = priv_key;
+    return PJ_SUCCESS;
+
+#else
+
     EVP_PKEY *priv_key = NULL;
 
-#if PJMEDIA_SRTP_DTLS_USE_EC_KEY
+#  if PJMEDIA_SRTP_DTLS_USE_EC_KEY
 
     EC_KEY *ec_key;
 
@@ -451,7 +471,7 @@ on_error:
     if (priv_key) EVP_PKEY_free(priv_key);
     return PJ_EUNKNOWN;
 
-#else
+#  else
 
     BIGNUM *bne = NULL;
     RSA *rsa_key = NULL;
@@ -485,6 +505,8 @@ on_error:
     if (rsa_key) RSA_free(rsa_key);
     if (priv_key) EVP_PKEY_free(priv_key);
     return PJ_EUNKNOWN;
+
+#  endif
 
 #endif
 }

--- a/pjmedia/src/pjmedia/transport_srtp_dtls.c
+++ b/pjmedia/src/pjmedia/transport_srtp_dtls.c
@@ -422,10 +422,10 @@ static pj_status_t ssl_generate_key(EVP_PKEY **p_priv_key)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 
-    /* The EC key is generated with the curve referred to by name, as some
-     * peers reject certificate with explicit curve parameters.
-     */
 #  if PJMEDIA_SRTP_DTLS_USE_EC_KEY
+    /* Refer to the curve by name, as some peers reject certificates with
+     * explicit curve parameters.
+     */
     EVP_PKEY *priv_key = EVP_EC_gen("P-256");
 #  else
     EVP_PKEY *priv_key = EVP_RSA_gen(2048);


### PR DESCRIPTION
Follow-up to #5194, addressing @dev31337's report there.

The EC key generation added in #5194 uses `EC_KEY_new_by_curve_name()`, `EC_KEY_set_asn1_flag()`, `EC_KEY_generate_key()`, `EVP_PKEY_assign_EC_KEY()` and `EC_KEY_free()`, all `OSSL_DEPRECATEDIN_3_0`, so every build with `PJMEDIA_SRTP_HAS_DTLS` enabled emits five deprecation warnings against OpenSSL 3.x. The pre-existing RSA fallback (`PJMEDIA_SRTP_DTLS_USE_EC_KEY 0`) has the same problem with `RSA_new()`, `RSA_generate_key_ex()`, `EVP_PKEY_assign_RSA()` and `RSA_free()`, so both branches are converted.

- On OpenSSL 3.0 and later, generate the key with `EVP_EC_gen("P-256")` / `EVP_RSA_gen(2048)`. These return an `EVP_PKEY` directly, so the intermediate object, the assign step and the whole error path go away.
- Older OpenSSL, and the forks that report an earlier `OPENSSL_VERSION_NUMBER` such as LibreSSL (`0x20000000L`), keep the existing code unchanged.

**The certificate is unaffected.** `EVP_EC_gen()` produces a named-curve key, which is what `EC_KEY_set_asn1_flag(OPENSSL_EC_NAMED_CURVE)` was there to guarantee; #5194 needed it explicitly because the `EC_KEY_*` default is explicit parameters, which some peers reject. Comparing the two APIs on OpenSSL 3.0.13:

```
EVP_EC_gen:  id=408 bits=256 SPKI len=91
EC_KEY_*  :  id=408 bits=256 SPKI len=91
alg id identical: yes
```

Same key type (`NID_X9_62_id_ecPublicKey`), same size, same SubjectPublicKeyInfo length and the same 26 byte AlgorithmIdentifier prefix, i.e. a named curve in both cases. `EVP_RSA_gen()` likewise defaults to the F4 public exponent that `BN_set_word(bne, RSA_F4)` was setting.

`<openssl/evp.h>` is now included explicitly rather than relied upon transitively via `<openssl/ssl.h>`.

## Test plan

Full `make realclean && ./configure && make` with `PJMEDIA_SRTP_HAS_DTLS 1`, OpenSSL 3.0.13, gcc 13:

| | build | `160_srtp_dtls` | `320_ice_dtls_srtp` |
|---|---|---|---|
| `PJMEDIA_SRTP_DTLS_USE_EC_KEY 1` (default) | clean, 0 warnings from `transport_srtp_dtls.c` | passed | passed |
| `PJMEDIA_SRTP_DTLS_USE_EC_KEY 0` (RSA) | clean, 0 warnings from `transport_srtp_dtls.c` | passed | passed |

Both tests complete a real DTLS-SRTP handshake between two pjsua instances, so the generated key is exercised end to end in each configuration.

The pre-3.0 branch cannot be built natively here, so it was compile checked by forcing the version guard to false. It builds in both key configurations and reproduces exactly the warnings reported on #5194 (5 for EC, 4 for RSA), which confirms the guard selects the intended code and that the new path is what removes them.

Co-Authored-By Claude Code
