### PR TITLE
pjsip: retry the listener when restarting a TCP or TLS transport that has none

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -457,10 +457,14 @@ PJ_DECL(pj_status_t) pj_ssl_cert_load_from_store(
  *
  * Application should maintain the objects lifetime until the credential
  * instance is no longer used (e.g: SSL socket is destroyed).
- * In OpenSSL version 3, the SSL socket utilizes the reference counting
- * feature to manage object lifetimes. Specifically,
- * pj_ssl_sock_set_certificate() increments the reference count and
- * pj_ssl_sock_close() decrements it.
+ * In OpenSSL version 3, reference counting is used to manage object
+ * lifetimes, and every holder takes its own reference: this function
+ * increments the count for the credential it fills in and
+ * pj_ssl_cert_wipe_keys() decrements it again, while
+ * pj_ssl_sock_set_certificate() increments it for the socket and
+ * pj_ssl_sock_close() decrements that one. The application's own reference
+ * is never consumed by any of them, so it remains the application's to
+ * release.
  *
  * @param pool          The pool.
  * @param cert_direct   The backend specific objects.
@@ -513,6 +517,11 @@ PJ_DECL(pj_status_t) pj_ssl_cert_get_verify_status_strings(
 
 /** 
  * Wipe out the keys in the SSL certificate. 
+ *
+ * For a credential carrying backend specific objects (see
+ * pj_ssl_cert_load_direct()), this also releases the reference that the
+ * credential holds on them. It does not touch the application's own
+ * reference.
  *
  * @param cert          The SSL certificate. 
  *

--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -466,6 +466,11 @@ PJ_DECL(pj_status_t) pj_ssl_cert_load_from_store(
  * is never consumed by any of them, so it remains the application's to
  * release.
  *
+ * Loading direct credentials twice into the same instance releases the
+ * reference held from the first load before taking one on the new objects,
+ * so a caller following the cumulative-loader pattern must not assume the
+ * earlier pair stays referenced by the credential.
+ *
  * @param pool          The pool.
  * @param cert_direct   The backend specific objects.
  * @param p_cert        Pointer to credential instance.

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2737,6 +2737,12 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_direct(
     if (!cert)
         return PJ_ENOMEM;
 
+    /* Release any reference this credential already holds, so that loading
+     * twice into the same pj_ssl_cert_t replaces the pair rather than
+     * stranding it. On a freshly allocated credential this is a no-op.
+     */
+    ssl_free_cert(cert);
+
     cert->direct = *cert_direct;
 
     /* For OpenSSL version >= 3.0, add ref EVP_PKEY & X509.
@@ -2744,8 +2750,8 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_direct(
      * The credential now holds its own reference, which pj_ssl_cert_wipe_keys()
      * releases through ssl_free_cert(). Without this the credential borrows the
      * application's reference while the wipe still releases one, so wiping a
-     * credential loaded this way would drop the application's last reference and
-     * leave pj_ssl_cert_direct pointing at freed objects.
+     * credential loaded this way would drop the application's last
+     * reference and leave pj_ssl_cert_direct pointing at freed objects.
      */
 #   if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
     if ((cert->direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_EVP_PKEY) &&

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2739,6 +2739,28 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_direct(
 
     cert->direct = *cert_direct;
 
+    /* For OpenSSL version >= 3.0, add ref EVP_PKEY & X509.
+     *
+     * The credential now holds its own reference, which pj_ssl_cert_wipe_keys()
+     * releases through ssl_free_cert(). Without this the credential borrows the
+     * application's reference while the wipe still releases one, so wiping a
+     * credential loaded this way would drop the application's last reference and
+     * leave pj_ssl_cert_direct pointing at freed objects.
+     */
+#   if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    if ((cert->direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_EVP_PKEY) &&
+        cert->direct.privkey)
+    {
+        EVP_PKEY_up_ref(cert->direct.privkey);
+    }
+
+    if ((cert->direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_X509_CERT) &&
+        cert->direct.cert)
+    {
+        X509_up_ref(cert->direct.cert);
+    }
+#   endif
+
     *p_cert = cert;
 
     return PJ_SUCCESS;

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2728,6 +2728,7 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_direct(
 {
 #if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
     pj_ssl_cert_t *cert;
+    pj_ssl_cert_direct direct;
 
     PJ_ASSERT_RETURN(pool && p_cert && cert_direct, PJ_EINVAL);
 
@@ -2737,35 +2738,45 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_direct(
     if (!cert)
         return PJ_ENOMEM;
 
-    /* Release any reference this credential already holds, so that loading
-     * twice into the same pj_ssl_cert_t replaces the pair rather than
-     * stranding it. On a freshly allocated credential this is a no-op.
+    /* Copy the source before releasing anything below: it may be this
+     * credential's own pj_ssl_cert_direct, which ssl_free_cert() clears as
+     * it releases.
      */
-    ssl_free_cert(cert);
-
-    cert->direct = *cert_direct;
+    direct = *cert_direct;
 
     /* For OpenSSL version >= 3.0, add ref EVP_PKEY & X509.
      *
-     * The credential now holds its own reference, which pj_ssl_cert_wipe_keys()
-     * releases through ssl_free_cert(). Without this the credential borrows the
-     * application's reference while the wipe still releases one, so wiping a
-     * credential loaded this way would drop the application's last
+     * The credential takes its own reference, which pj_ssl_cert_wipe_keys()
+     * releases through ssl_free_cert(). Without this the credential borrows
+     * the application's reference while the wipe still releases one, so
+     * wiping a credential loaded this way would drop the application's last
      * reference and leave pj_ssl_cert_direct pointing at freed objects.
+     *
+     * Referencing before releasing matters when the same objects are loaded
+     * again into a credential that already holds their last reference:
+     * releasing first would destroy them before they could be referenced.
      */
 #   if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
-    if ((cert->direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_EVP_PKEY) &&
-        cert->direct.privkey)
+    if ((direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_EVP_PKEY) &&
+        direct.privkey)
     {
-        EVP_PKEY_up_ref(cert->direct.privkey);
+        EVP_PKEY_up_ref(direct.privkey);
     }
 
-    if ((cert->direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_X509_CERT) &&
-        cert->direct.cert)
+    if ((direct.type & PJ_SSL_CERT_DIRECT_OPENSSL_X509_CERT) &&
+        direct.cert)
     {
-        X509_up_ref(cert->direct.cert);
+        X509_up_ref(direct.cert);
     }
 #   endif
+
+    /* Release what this credential held, so loading twice into the same
+     * pj_ssl_cert_t replaces the pair rather than stranding it. On a freshly
+     * allocated credential this is a no-op.
+     */
+    ssl_free_cert(cert);
+
+    cert->direct = direct;
 
     *p_cert = cert;
 

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -953,6 +953,15 @@ static int echo_test(pj_ssl_sock_proto srv_proto, pj_ssl_sock_proto cli_proto,
                (unsigned long)state_cli.recv));
 
 on_return:
+    /* Release the reference pj_ssl_cert_load_direct() took. Each socket
+     * deep-copied and up-ref'd its own in pj_ssl_sock_set_certificate(), so
+     * this drops only the credential's.
+     */
+#if TEST_LOAD_DIRECT && (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+    if (cert)
+        pj_ssl_cert_wipe_keys(cert);
+#endif
+
 #if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_DARWIN) || \
     (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_APPLE)
     if (status != PJ_SUCCESS) {
@@ -1706,6 +1715,15 @@ static int perf_test(unsigned clients, unsigned ms_handshake_timeout)
                (unsigned long)tot_sent, (unsigned long)tot_recv));
 
 on_return:
+    /* Release the reference pj_ssl_cert_load_direct() took. Each socket
+     * deep-copied and up-ref'd its own in pj_ssl_sock_set_certificate(), so
+     * this drops only the credential's.
+     */
+#if TEST_LOAD_DIRECT && (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
+    if (cert)
+        pj_ssl_cert_wipe_keys(cert);
+#endif
+
     if (ssock_serv) 
         pj_ssl_sock_close(ssock_serv);
 

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -625,13 +625,17 @@ static pj_status_t load_cert_direct(pj_pool_t *pool,
         X509* x = NULL;
 
         in = BIO_new_file(CERT_FILE, "r");
-        if (!in)
-            return PJ_ENOTFOUND;
+        if (!in) {
+            status = PJ_ENOTFOUND;
+            goto on_error;
+        }
 
         x = PEM_read_bio_X509(in, NULL, 0, NULL);
         BIO_free(in);
-        if (!x)
-            return PJ_EINVAL;
+        if (!x) {
+            status = PJ_EINVAL;
+            goto on_error;
+        }
 
         cd.type |= PJ_SSL_CERT_DIRECT_OPENSSL_X509_CERT;
         cd.cert = x;
@@ -655,6 +659,16 @@ static pj_status_t load_cert_direct(pj_pool_t *pool,
     if (cd.cert)
         X509_free(cd.cert);
 #endif
+
+    return status;
+
+on_error:
+    /* No credential was created, so nothing else can be holding these and
+     * the release is correct on every OpenSSL version -- unlike the tail
+     * above, which is surplus only where the credential took its own.
+     */
+    if (cd.privkey)
+        EVP_PKEY_free(cd.privkey);
 
     return status;
 }

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -596,6 +596,7 @@ static pj_status_t load_cert_direct(pj_pool_t *pool,
 {
     BIO *in;
     pj_ssl_cert_direct cd;
+    pj_status_t status;
 
     PJ_UNUSED_ARG(pool);
 
@@ -637,7 +638,18 @@ static pj_status_t load_cert_direct(pj_pool_t *pool,
     }
 
     /* Create credential */
-    return pj_ssl_cert_load_direct(pool, &cd, p_cert);
+    status = pj_ssl_cert_load_direct(pool, &cd, p_cert);
+
+    /* The credential holds its own reference on success, so drop the one
+     * taken by PEM_read_bio_*() here. On failure it holds none and this is
+     * still the release that frees them.
+     */
+    if (cd.privkey)
+        EVP_PKEY_free(cd.privkey);
+    if (cd.cert)
+        X509_free(cd.cert);
+
+    return status;
 }
 #else
 #   define load_cert_direct(pool,p_cert)

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -640,14 +640,21 @@ static pj_status_t load_cert_direct(pj_pool_t *pool,
     /* Create credential */
     status = pj_ssl_cert_load_direct(pool, &cd, p_cert);
 
-    /* The credential holds its own reference on success, so drop the one
-     * taken by PEM_read_bio_*() here. On failure it holds none and this is
-     * still the release that frees them.
+    /* Drop the reference taken by PEM_read_bio_*(), but only where
+     * pj_ssl_cert_load_direct() took one of its own -- it up-refs under the
+     * same guard, and ssl_free_cert() is likewise a no-op below 3.0. Freeing
+     * unconditionally would release the last reference on OpenSSL 1.x and
+     * LibreSSL and leave the credential pointing at freed objects.
+     *
+     * Below 3.0 the header contract holds instead: the application keeps the
+     * objects alive for as long as the credential is used.
      */
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
     if (cd.privkey)
         EVP_PKEY_free(cd.privkey);
     if (cd.cert)
         X509_free(cd.cert);
+#endif
 
     return status;
 }

--- a/pjnath/src/pjnath/turn_sock.c
+++ b/pjnath/src/pjnath/turn_sock.c
@@ -1483,6 +1483,16 @@ static void turn_on_state(pj_turn_session *sess,
                                         &turn_sock->ssl_sock);
 
             if (status != PJ_SUCCESS) {
+                /* Release what pj_ssl_cert_load_direct() referenced. The
+                 * success path below does this after set_certificate(), but
+                 * turn_sock_on_destroy() only releases the pool, so without
+                 * it this exit strands the application's objects.
+                 */
+                if (turn_sock->cert) {
+                    pj_ssl_cert_wipe_keys(turn_sock->cert);
+                    turn_sock->cert = NULL;
+                }
+
                 turn_sock_destroy(turn_sock, status);
                 pj_grp_lock_release(turn_sock->grp_lock);
                 return;

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -56,6 +56,15 @@ struct tcp_listener
     pjsip_endpoint          *endpt;
     pjsip_tpmgr             *tpmgr;
     pj_activesock_t         *asock;
+
+    /* PJ_TRUE once a listener has been asked for, i.e. once
+     * pjsip_tcp_transport_lis_start() has been entered. It stays set whether
+     * or not that start succeeded, and whether or not the socket was later
+     * lost, so a restart can tell "no listener was ever wanted here" from
+     * "one was wanted and is not up".
+     */
+    pj_bool_t                lis_wanted;
+
     pj_sockaddr              bound_addr;
     pj_qos_type              qos_type;
     pj_qos_params            qos_params;
@@ -1767,6 +1776,12 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_lis_start(pjsip_tpfactory *factory,
     pj_sockaddr *listener_addr = &factory->local_addr;
     pj_status_t status = PJ_SUCCESS;
 
+    /* A listener has been asked for. Record it before anything can fail, so
+     * that a first start which does not succeed is still distinguishable from
+     * a factory that never wanted a listener at all.
+     */
+    listener->lis_wanted = PJ_TRUE;
+
     /* Nothing to be done, if listener already started. */
     if (listener->asock)
         return PJ_SUCCESS;
@@ -1875,8 +1890,16 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_restart(pjsip_tpfactory *factory,
     pj_status_t status = PJ_SUCCESS;
     struct tcp_listener *listener = (struct tcp_listener *)factory;
 
-    /* Just update the published address if currently no listener */
-    if (!listener->asock) {
+    /* A listener nobody ever asked for has nothing to bring back, so a
+     * restart can only mean updating the published address. That is the
+     * PJSIP_TCP_TRANSPORT_DONT_CREATE_LISTENER case, where the factory is
+     * started without ever calling lis_start().
+     *
+     * Once a listener has been asked for, no shortcut: having no socket then
+     * means either the first start failed or a later restart failed to bring
+     * it back, and the restart below is the only way to recover either.
+     */
+    if (!listener->lis_wanted) {
         PJ_LOG(3,(factory->obj_name,
                       "TCP restart requested while no listener created, "
                       "update the published address only"));
@@ -1893,9 +1916,12 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_restart(pjsip_tpfactory *factory,
 
     /* Close the listener socket only; keep the factory registered so it
      * stays usable for outgoing transports if the restart below fails.
+     * It is already gone if an earlier start or restart failed.
      */
-    pj_activesock_close(listener->asock);
-    listener->asock = NULL;
+    if (listener->asock) {
+        pj_activesock_close(listener->asock);
+        listener->asock = NULL;
+    }
 
     status = pjsip_tcp_transport_lis_start(factory, local, a_name);
     if (status != PJ_SUCCESS) {

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -380,6 +380,24 @@ static void update_transport_info(struct tcp_listener *listener)
     }
 }
 
+
+/* Publish the address after a restart that could not bring the listener up.
+ * The listener is down either way, but the factory stays usable for outgoing
+ * transports, so the caller's error is what propagates and a failure here is
+ * only logged.
+ */
+static void publish_addr_after_failure(struct tcp_listener *listener,
+                                       const pjsip_host_port *a_name)
+{
+    pj_status_t status = update_factory_addr(listener, a_name);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(3,(listener->factory.obj_name, status,
+                     "Failed to update published address"));
+    }
+
+    update_transport_info(listener);
+}
+
 /*
  * This is the public API to create, initialize, register, and start the
  * TCP listener.
@@ -1929,8 +1947,7 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_restart(pjsip_tpfactory *factory,
                    "Unable to start listener after closing it", status);
 
         /* Update the published address anyway (client only) */
-        update_factory_addr(listener, a_name);
-        update_transport_info(listener);
+        publish_addr_after_failure(listener, a_name);
     }
 
     return status;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -55,11 +55,13 @@ struct tls_listener
     pjsip_tpmgr             *tpmgr;
     pj_ssl_sock_t           *ssock;
 
-    /* PJ_TRUE once the listener socket has been accepting. It stays set if
-     * the listener later fails to come back from a restart, which is what
-     * distinguishes "never created" from "created, then lost".
+    /* PJ_TRUE once a listener has been asked for, i.e. once
+     * pjsip_tls_transport_lis_start() has been entered. It stays set whether
+     * or not that start succeeded, and whether or not the socket was later
+     * lost, so a restart can tell "no listener was ever wanted here" from
+     * "one was wanted and is not up".
      */
-    pj_bool_t                lis_started;
+    pj_bool_t                lis_wanted;
 
     pj_sockaddr              bound_addr;
 
@@ -524,6 +526,13 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
     struct tls_listener *listener = (struct tls_listener *)factory;
     pj_sockaddr *listener_addr = &listener->factory.local_addr;
 
+    /* A listener has been asked for. Record it before anything can fail, so
+     * that a first start which does not succeed -- credentials not yet
+     * available, for instance -- is still distinguishable from a factory
+     * that never wanted a listener at all.
+     */
+    listener->lis_wanted = PJ_TRUE;
+
     if (listener->ssock)
         return PJ_SUCCESS;
 
@@ -562,11 +571,6 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
     if (status == PJ_SUCCESS || status == PJ_EPENDING) {
         pj_ssl_sock_info info;
 
-        /* The listener is accepting; remember it so a later restart knows
-         * this factory is meant to have a socket.
-         */
-        listener->lis_started = PJ_TRUE;
-
         /* Retrieve the bound address */
         status = pj_ssl_sock_get_info(listener->ssock, &info);
         if (status == PJ_SUCCESS)
@@ -587,6 +591,95 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
     update_transport_info(listener);
 
     return status;    
+}
+
+
+/* Load the listener's credentials from its pjsip_tls_setting.
+ *
+ * This is the only place that assigns listener->cert. It wipes the previous
+ * credentials first and leaves the field NULL when a load fails, so a caller
+ * must come through here rather than invoking pj_ssl_cert_load_from_files2(),
+ * pj_ssl_cert_load_from_buffer(), pj_ssl_cert_load_from_store() or
+ * pj_ssl_cert_load_direct() for a listener itself.
+ *
+ * The four sources are cumulative rather than exclusive: each loader adds to
+ * the same pj_ssl_cert_t, which is why they are separate "if" blocks and not
+ * an if/else chain.
+ */
+static pj_status_t load_listener_cert(struct tls_listener *listener)
+{
+    pj_pool_t *pool = listener->factory.pool;
+    pj_status_t status;
+
+    /* Wipe the previous credentials before replacing them */
+    if (listener->cert) {
+        pj_ssl_cert_wipe_keys(listener->cert);
+        listener->cert = NULL;
+    }
+
+    if (listener->tls_setting.cert_file.slen ||
+        listener->tls_setting.ca_list_file.slen ||
+        listener->tls_setting.ca_list_path.slen ||
+        listener->tls_setting.privkey_file.slen)
+    {
+        status = pj_ssl_cert_load_from_files2(pool,
+                        &listener->tls_setting.ca_list_file,
+                        &listener->tls_setting.ca_list_path,
+                        &listener->tls_setting.cert_file,
+                        &listener->tls_setting.privkey_file,
+                        &listener->tls_setting.password,
+                        &listener->cert);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(2,(listener->factory.obj_name, status,
+                         "Failed to set TLS credentials from files"));
+            return status;
+        }
+    }
+
+    if (listener->tls_setting.ca_buf.slen ||
+        listener->tls_setting.cert_buf.slen ||
+        listener->tls_setting.privkey_buf.slen)
+    {
+        status = pj_ssl_cert_load_from_buffer(pool,
+                        &listener->tls_setting.ca_buf,
+                        &listener->tls_setting.cert_buf,
+                        &listener->tls_setting.privkey_buf,
+                        &listener->tls_setting.password,
+                        &listener->cert);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(2,(listener->factory.obj_name, status,
+                         "Failed to set TLS credentials from buffer"));
+            return status;
+        }
+    }
+
+    if (listener->tls_setting.cert_lookup.type != PJ_SSL_CERT_LOOKUP_NONE &&
+        listener->tls_setting.cert_lookup.keyword.slen)
+    {
+        status = pj_ssl_cert_load_from_store(
+                                pool,
+                                &listener->tls_setting.cert_lookup,
+                                &listener->cert);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(2,(listener->factory.obj_name, status,
+                         "Failed to set TLS credentials from store"));
+            return status;
+        }
+    }
+
+    if (listener->tls_setting.cert_direct.type != PJ_SSL_CERT_DIRECT_NONE) {
+        status = pj_ssl_cert_load_direct(
+                                pool,
+                                &listener->tls_setting.cert_direct,
+                                &listener->cert);
+        if (status != PJ_SUCCESS) {
+            PJ_PERROR(2,(listener->factory.obj_name, status,
+                         "Failed to set direct TLS credentials"));
+            return status;
+        }
+    }
+
+    return PJ_SUCCESS;
 }
 
 
@@ -655,68 +748,9 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_start2( pjsip_endpoint *endpt,
                             &lis_on_destroy);
 
     /* Set SSL/TLS credentials */
-
-    if (listener->tls_setting.cert_file.slen ||
-        listener->tls_setting.ca_list_file.slen ||
-        listener->tls_setting.ca_list_path.slen || 
-        listener->tls_setting.privkey_file.slen) 
-    {
-        status = pj_ssl_cert_load_from_files2(pool,
-                        &listener->tls_setting.ca_list_file,
-                        &listener->tls_setting.ca_list_path,
-                        &listener->tls_setting.cert_file,
-                        &listener->tls_setting.privkey_file,
-                        &listener->tls_setting.password,
-                        &listener->cert);
-        if (status != PJ_SUCCESS) {
-            PJ_PERROR(2,(listener->factory.obj_name, status,
-                         "Failed to set TLS credentials from files"));
-            goto on_error;
-        }
-    }
-    
-    if (listener->tls_setting.ca_buf.slen ||
-        listener->tls_setting.cert_buf.slen||
-        listener->tls_setting.privkey_buf.slen)
-    {
-        status = pj_ssl_cert_load_from_buffer(pool,
-                        &listener->tls_setting.ca_buf,
-                        &listener->tls_setting.cert_buf,
-                        &listener->tls_setting.privkey_buf,
-                        &listener->tls_setting.password,
-                        &listener->cert);
-        if (status != PJ_SUCCESS) {
-            PJ_PERROR(2,(listener->factory.obj_name, status,
-                         "Failed to set TLS credentials from buffer"));
-            goto on_error;    
-        }
-    }
-    
-    if (listener->tls_setting.cert_lookup.type != PJ_SSL_CERT_LOOKUP_NONE &&
-        listener->tls_setting.cert_lookup.keyword.slen)
-    {
-        status = pj_ssl_cert_load_from_store(
-                                pool,
-                                &listener->tls_setting.cert_lookup,
-                                &listener->cert);
-        if (status != PJ_SUCCESS) {
-            PJ_PERROR(2,(listener->factory.obj_name, status,
-                         "Failed to set TLS credentials from store"));
-            goto on_error;
-        }
-    }
-
-    if (listener->tls_setting.cert_direct.type != PJ_SSL_CERT_DIRECT_NONE) {
-        status = pj_ssl_cert_load_direct(
-                                pool,
-                                &listener->tls_setting.cert_direct,
-                                &listener->cert);
-        if (status != PJ_SUCCESS) {
-            PJ_PERROR(2,(listener->factory.obj_name, status,
-                         "Failed to set direct TLS credentials"));
-            goto on_error;
-        }
-    }
+    status = load_listener_cert(listener);
+    if (status != PJ_SUCCESS)
+        goto on_error;
 
     /* Register to transport manager */
     listener->endpt = endpt;
@@ -818,76 +852,6 @@ static pj_status_t lis_destroy(pjsip_tpfactory *factory)
 }
 
 
-/* Load the listener's credentials from its pjsip_tls_setting.
- *
- * This is the only place that assigns listener->cert. It wipes the previous
- * credentials first and leaves the field NULL when a load fails, so a caller
- * must come through here rather than invoking pj_ssl_cert_load_from_files2(),
- * pj_ssl_cert_load_from_buffer() or pj_ssl_cert_load_from_store() for a
- * listener itself.
- */
-static pj_status_t load_listener_cert(struct tls_listener *listener)
-{
-    pj_status_t status;
-
-    /* Free old certificate if present */
-    if (listener->cert) {
-        pj_ssl_cert_wipe_keys(listener->cert);
-        listener->cert = NULL;
-    }
-
-    /* Load new certificate based on updated settings */
-    if (listener->tls_setting.cert_file.slen ||
-        listener->tls_setting.ca_list_file.slen ||
-        listener->tls_setting.ca_list_path.slen || 
-        listener->tls_setting.privkey_file.slen) 
-    {
-        status = pj_ssl_cert_load_from_files2(listener->factory.pool,
-                        &listener->tls_setting.ca_list_file,
-                        &listener->tls_setting.ca_list_path,
-                        &listener->tls_setting.cert_file,
-                        &listener->tls_setting.privkey_file,
-                        &listener->tls_setting.password,
-                        &listener->cert);
-        if (status != PJ_SUCCESS) {
-            tls_perror(listener->factory.obj_name,
-                       "Failed to load certificate from files", status, NULL);
-            return status;
-        }
-    } else if (listener->tls_setting.ca_buf.slen ||
-               listener->tls_setting.cert_buf.slen ||
-               listener->tls_setting.privkey_buf.slen)
-    {
-        status = pj_ssl_cert_load_from_buffer(listener->factory.pool,
-                        &listener->tls_setting.ca_buf,
-                        &listener->tls_setting.cert_buf,
-                        &listener->tls_setting.privkey_buf,
-                        &listener->tls_setting.password,
-                        &listener->cert);
-        if (status != PJ_SUCCESS) {
-            tls_perror(listener->factory.obj_name,
-                       "Failed to load certificate from buffer", status, NULL);
-            return status;
-        }
-    } else if (listener->tls_setting.cert_lookup.type !=
-                                                PJ_SSL_CERT_LOOKUP_NONE &&
-               listener->tls_setting.cert_lookup.keyword.slen)
-    {
-        status = pj_ssl_cert_load_from_store(
-                                listener->factory.pool,
-                                &listener->tls_setting.cert_lookup,
-                                &listener->cert);
-        if (status != PJ_SUCCESS) {
-            tls_perror(listener->factory.obj_name,
-                       "Failed to load certificate from store", status, NULL);
-            return status;
-        }
-    }
-
-    return PJ_SUCCESS;
-}
-
-
 PJ_DEF(pj_status_t) pjsip_tls_transport_restart(pjsip_tpfactory *factory,
                                                 const pj_sockaddr *local,
                                                 const pjsip_host_port *a_name)
@@ -904,15 +868,16 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
     pj_status_t status = PJ_SUCCESS;
     struct tls_listener *listener = (struct tls_listener *)factory;
 
-    /* A listener that was never started has nothing to bring back, so a
-     * restart can only mean updating the published address. That covers
-     * PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER builds and any listener whose
-     * start was never attempted. A listener that did start once but has no
-     * socket now failed to come back from an earlier restart, and the restart
-     * below is the only way to recover it -- so do not take this shortcut
-     * there.
+    /* A listener nobody ever asked for has nothing to bring back, so a
+     * restart can only mean updating the published address. That is the
+     * PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER case, where start2() never
+     * calls lis_start() at all.
+     *
+     * Once a listener has been asked for, no shortcut: having no socket then
+     * means either the first start failed or a later restart failed to bring
+     * it back, and the restart below is the only way to recover either.
      */
-    if (!listener->lis_started) {
+    if (!listener->lis_wanted) {
         PJ_LOG(3,(factory->obj_name,
                   "TLS restart requested while no listener created, "
                   "update the published address only"));
@@ -925,6 +890,22 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
             /* Copy new settings */
             pjsip_tls_setting_copy(listener->factory.pool,
                                    &listener->tls_setting, opt);
+
+            /* Keep the credentials in step with the settings. Without this
+             * the listener would still hold the old ones, and the next
+             * pjsip_tls_transport_lis_start() -- the only way to bring a
+             * listener up in a PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER
+             * build -- would bind with them.
+             */
+            status = load_listener_cert(listener);
+            if (status != PJ_SUCCESS) {
+                /* Publish the new address anyway; the factory is still
+                 * usable for outgoing transports.
+                 */
+                update_factory_addr(listener, a_name);
+                update_transport_info(listener);
+                return status;
+            }
         }
 
         status = update_factory_addr(listener, a_name);
@@ -964,8 +945,15 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
      */
     if (opt || !listener->cert) {
         status = load_listener_cert(listener);
-        if (status != PJ_SUCCESS)
+        if (status != PJ_SUCCESS) {
+            /* Update the published address anyway, as the lis_start()
+             * failure path below does: the listener is down either way, and
+             * the factory stays usable for outgoing transports.
+             */
+            update_factory_addr(listener, a_name);
+            update_transport_info(listener);
             return status;
+        }
     }
 
     status = pjsip_tls_transport_lis_start(factory, local, a_name);

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -54,7 +54,18 @@ struct tls_listener
     pjsip_endpoint          *endpt;
     pjsip_tpmgr             *tpmgr;
     pj_ssl_sock_t           *ssock;
+
+    /* PJ_TRUE once the listener socket has been accepting. It stays set if
+     * the listener later fails to come back from a restart, which is what
+     * distinguishes "never created" from "created, then lost".
+     */
+    pj_bool_t                lis_started;
+
     pj_sockaddr              bound_addr;
+
+    /* Assign only via load_listener_cert(), never by calling one of the
+     * pj_ssl_cert_load_from_*() functions directly.
+     */
     pj_ssl_cert_t           *cert;
     pjsip_tls_setting        tls_setting;    
     unsigned                 async_cnt;    
@@ -551,6 +562,11 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
     if (status == PJ_SUCCESS || status == PJ_EPENDING) {
         pj_ssl_sock_info info;
 
+        /* The listener is accepting; remember it so a later restart knows
+         * this factory is meant to have a socket.
+         */
+        listener->lis_started = PJ_TRUE;
+
         /* Retrieve the bound address */
         status = pj_ssl_sock_get_info(listener->ssock, &info);
         if (status == PJ_SUCCESS)
@@ -802,6 +818,76 @@ static pj_status_t lis_destroy(pjsip_tpfactory *factory)
 }
 
 
+/* Load the listener's credentials from its pjsip_tls_setting.
+ *
+ * This is the only place that assigns listener->cert. It wipes the previous
+ * credentials first and leaves the field NULL when a load fails, so a caller
+ * must come through here rather than invoking pj_ssl_cert_load_from_files2(),
+ * pj_ssl_cert_load_from_buffer() or pj_ssl_cert_load_from_store() for a
+ * listener itself.
+ */
+static pj_status_t load_listener_cert(struct tls_listener *listener)
+{
+    pj_status_t status;
+
+    /* Free old certificate if present */
+    if (listener->cert) {
+        pj_ssl_cert_wipe_keys(listener->cert);
+        listener->cert = NULL;
+    }
+
+    /* Load new certificate based on updated settings */
+    if (listener->tls_setting.cert_file.slen ||
+        listener->tls_setting.ca_list_file.slen ||
+        listener->tls_setting.ca_list_path.slen || 
+        listener->tls_setting.privkey_file.slen) 
+    {
+        status = pj_ssl_cert_load_from_files2(listener->factory.pool,
+                        &listener->tls_setting.ca_list_file,
+                        &listener->tls_setting.ca_list_path,
+                        &listener->tls_setting.cert_file,
+                        &listener->tls_setting.privkey_file,
+                        &listener->tls_setting.password,
+                        &listener->cert);
+        if (status != PJ_SUCCESS) {
+            tls_perror(listener->factory.obj_name,
+                       "Failed to load certificate from files", status, NULL);
+            return status;
+        }
+    } else if (listener->tls_setting.ca_buf.slen ||
+               listener->tls_setting.cert_buf.slen ||
+               listener->tls_setting.privkey_buf.slen)
+    {
+        status = pj_ssl_cert_load_from_buffer(listener->factory.pool,
+                        &listener->tls_setting.ca_buf,
+                        &listener->tls_setting.cert_buf,
+                        &listener->tls_setting.privkey_buf,
+                        &listener->tls_setting.password,
+                        &listener->cert);
+        if (status != PJ_SUCCESS) {
+            tls_perror(listener->factory.obj_name,
+                       "Failed to load certificate from buffer", status, NULL);
+            return status;
+        }
+    } else if (listener->tls_setting.cert_lookup.type !=
+                                                PJ_SSL_CERT_LOOKUP_NONE &&
+               listener->tls_setting.cert_lookup.keyword.slen)
+    {
+        status = pj_ssl_cert_load_from_store(
+                                listener->factory.pool,
+                                &listener->tls_setting.cert_lookup,
+                                &listener->cert);
+        if (status != PJ_SUCCESS) {
+            tls_perror(listener->factory.obj_name,
+                       "Failed to load certificate from store", status, NULL);
+            return status;
+        }
+    }
+
+    return PJ_SUCCESS;
+}
+
+
 PJ_DEF(pj_status_t) pjsip_tls_transport_restart(pjsip_tpfactory *factory,
                                                 const pj_sockaddr *local,
                                                 const pjsip_host_port *a_name)
@@ -818,26 +904,27 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
     pj_status_t status = PJ_SUCCESS;
     struct tls_listener *listener = (struct tls_listener *)factory;
 
-#if defined(PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER) && \
-    PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER != 0
-    /* This build never creates a listener, so a restart can only mean
-     * updating the published address. Where listeners are created normally,
-     * a registered factory without a socket means an earlier restart closed
-     * the listener and failed to bring it back, and the restart below is the
-     * only way to recover it -- so do not take this shortcut there.
+    /* A listener that was never started has nothing to bring back, so a
+     * restart can only mean updating the published address. That covers
+     * PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER builds and any listener whose
+     * start was never attempted. A listener that did start once but has no
+     * socket now failed to come back from an earlier restart, and the restart
+     * below is the only way to recover it -- so do not take this shortcut
+     * there.
      */
-    if (!listener->ssock) {
+    if (!listener->lis_started) {
         PJ_LOG(3,(factory->obj_name,
-                      "TLS restart requested while no listener created, "
-                      "update the published address only"));
+                  "TLS restart requested while no listener created, "
+                  "update the published address only"));
 
         /* Update TLS settings if provided */
         if (opt) {
             /* Wipe old certificate keys for security */
             pjsip_tls_setting_wipe_keys(&listener->tls_setting);
-            
+
             /* Copy new settings */
-            pjsip_tls_setting_copy(listener->factory.pool, &listener->tls_setting, opt);
+            pjsip_tls_setting_copy(listener->factory.pool,
+                                   &listener->tls_setting, opt);
         }
 
         status = update_factory_addr(listener, a_name);
@@ -845,11 +932,10 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
             return status;
 
         /* Set transport info. */
-       update_transport_info(listener);
+        update_transport_info(listener);
 
-       return PJ_SUCCESS;
+        return PJ_SUCCESS;
     }
-#endif
 
     /* Close the listener socket only; keep the factory registered so it
      * stays usable for outgoing transports if the restart below fails.
@@ -864,63 +950,22 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
     if (opt) {
         /* Wipe old certificate keys for security */
         pjsip_tls_setting_wipe_keys(&listener->tls_setting);
-        
+
         /* Copy new settings */
-        pjsip_tls_setting_copy(listener->factory.pool, &listener->tls_setting, opt);
-        
-        /* Free old certificate if present */
-        if (listener->cert) {
-            pj_ssl_cert_wipe_keys(listener->cert);
-            listener->cert = NULL;
-        }
-        
-        /* Load new certificate based on updated settings */
-        if (listener->tls_setting.cert_file.slen ||
-            listener->tls_setting.ca_list_file.slen ||
-            listener->tls_setting.ca_list_path.slen || 
-            listener->tls_setting.privkey_file.slen) 
-        {
-            status = pj_ssl_cert_load_from_files2(listener->factory.pool,
-                            &listener->tls_setting.ca_list_file,
-                            &listener->tls_setting.ca_list_path,
-                            &listener->tls_setting.cert_file,
-                            &listener->tls_setting.privkey_file,
-                            &listener->tls_setting.password,
-                            &listener->cert);
-            if (status != PJ_SUCCESS) {
-                tls_perror(listener->factory.obj_name,
-                           "Failed to load certificate from files", status, NULL);
-                return status;
-            }
-        } else if (listener->tls_setting.ca_buf.slen ||
-                   listener->tls_setting.cert_buf.slen ||
-                   listener->tls_setting.privkey_buf.slen)
-        {
-            status = pj_ssl_cert_load_from_buffer(listener->factory.pool,
-                            &listener->tls_setting.ca_buf,
-                            &listener->tls_setting.cert_buf,
-                            &listener->tls_setting.privkey_buf,
-                            &listener->tls_setting.password,
-                            &listener->cert);
-            if (status != PJ_SUCCESS) {
-                tls_perror(listener->factory.obj_name,
-                           "Failed to load certificate from buffer", status, NULL);
-                return status;
-            }
-        } else if (listener->tls_setting.cert_lookup.type !=
-                                                    PJ_SSL_CERT_LOOKUP_NONE &&
-                   listener->tls_setting.cert_lookup.keyword.slen)
-        {
-            status = pj_ssl_cert_load_from_store(
-                                    listener->factory.pool,
-                                    &listener->tls_setting.cert_lookup,
-                                    &listener->cert);
-            if (status != PJ_SUCCESS) {
-                tls_perror(listener->factory.obj_name,
-                           "Failed to load certificate from store", status, NULL);
-                return status;
-            }
-        }
+        pjsip_tls_setting_copy(listener->factory.pool, &listener->tls_setting,
+                               opt);
+    }
+
+    /* Reload the credentials when the settings changed, and also when the
+     * listener is holding none: an earlier restart that failed to bring the
+     * listener back leaves listener->cert NULL, and a later restart carrying
+     * no new settings would otherwise start a listener with no server
+     * certificate.
+     */
+    if (opt || !listener->cert) {
+        status = load_listener_cert(listener);
+        if (status != PJ_SUCCESS)
+            return status;
     }
 
     status = pjsip_tls_transport_lis_start(factory, local, a_name);

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -818,7 +818,14 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
     pj_status_t status = PJ_SUCCESS;
     struct tls_listener *listener = (struct tls_listener *)factory;
 
-    /* Just update the published address if currently no listener */
+#if defined(PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER) && \
+    PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER != 0
+    /* This build never creates a listener, so a restart can only mean
+     * updating the published address. Where listeners are created normally,
+     * a registered factory without a socket means an earlier restart closed
+     * the listener and failed to bring it back, and the restart below is the
+     * only way to recover it -- so do not take this shortcut there.
+     */
     if (!listener->ssock) {
         PJ_LOG(3,(factory->obj_name,
                       "TLS restart requested while no listener created, "
@@ -842,12 +849,16 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
 
        return PJ_SUCCESS;
     }
+#endif
 
     /* Close the listener socket only; keep the factory registered so it
      * stays usable for outgoing transports if the restart below fails.
+     * It is already gone if an earlier restart failed to restart it.
      */
-    pj_ssl_sock_close(listener->ssock);
-    listener->ssock = NULL;
+    if (listener->ssock) {
+        pj_ssl_sock_close(listener->ssock);
+        listener->ssock = NULL;
+    }
 
     /* Update TLS settings if provided */
     if (opt) {

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -919,7 +919,6 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
             /* Copy new settings */
             pjsip_tls_setting_copy(listener->factory.pool,
                                    &listener->tls_setting, opt);
-
         }
 
         /* Keep the credentials in step with the settings, on the same
@@ -995,8 +994,7 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
                    "Unable to start listener after closing it", status, NULL);
 
         /* Update the published address anyway (client only) */
-        update_factory_addr(listener, a_name);
-        update_transport_info(listener);
+        publish_addr_after_failure(listener, a_name);
     }
 
     return status;

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -606,6 +606,24 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
  * the same pj_ssl_cert_t, which is why they are separate "if" blocks and not
  * an if/else chain.
  */
+/* Publish the address after a restart that could not bring the listener up.
+ * The listener is down either way, but the factory stays usable for outgoing
+ * transports, so the caller's error is what propagates and a failure here is
+ * only logged.
+ */
+static void publish_addr_after_failure(struct tls_listener *listener,
+                                       const pjsip_host_port *a_name)
+{
+    pj_status_t status = update_factory_addr(listener, a_name);
+    if (status != PJ_SUCCESS) {
+        PJ_PERROR(3,(listener->factory.obj_name, status,
+                     "Failed to update published address"));
+    }
+
+    update_transport_info(listener);
+}
+
+
 static pj_status_t load_listener_cert(struct tls_listener *listener)
 {
     pj_pool_t *pool = listener->factory.pool;
@@ -632,7 +650,7 @@ static pj_status_t load_listener_cert(struct tls_listener *listener)
         if (status != PJ_SUCCESS) {
             PJ_PERROR(2,(listener->factory.obj_name, status,
                          "Failed to set TLS credentials from files"));
-            return status;
+            goto on_error;
         }
     }
 
@@ -649,7 +667,7 @@ static pj_status_t load_listener_cert(struct tls_listener *listener)
         if (status != PJ_SUCCESS) {
             PJ_PERROR(2,(listener->factory.obj_name, status,
                          "Failed to set TLS credentials from buffer"));
-            return status;
+            goto on_error;
         }
     }
 
@@ -663,7 +681,7 @@ static pj_status_t load_listener_cert(struct tls_listener *listener)
         if (status != PJ_SUCCESS) {
             PJ_PERROR(2,(listener->factory.obj_name, status,
                          "Failed to set TLS credentials from store"));
-            return status;
+            goto on_error;
         }
     }
 
@@ -675,11 +693,22 @@ static pj_status_t load_listener_cert(struct tls_listener *listener)
         if (status != PJ_SUCCESS) {
             PJ_PERROR(2,(listener->factory.obj_name, status,
                          "Failed to set direct TLS credentials"));
-            return status;
+            goto on_error;
         }
     }
 
     return PJ_SUCCESS;
+
+on_error:
+    /* The sources are cumulative, so an earlier block may have succeeded.
+     * Do not leave a partially populated credential behind: callers test
+     * listener->cert to decide whether a reload is still needed.
+     */
+    if (listener->cert) {
+        pj_ssl_cert_wipe_keys(listener->cert);
+        listener->cert = NULL;
+    }
+    return status;
 }
 
 
@@ -891,19 +920,21 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
             pjsip_tls_setting_copy(listener->factory.pool,
                                    &listener->tls_setting, opt);
 
-            /* Keep the credentials in step with the settings. Without this
-             * the listener would still hold the old ones, and the next
-             * pjsip_tls_transport_lis_start() -- the only way to bring a
-             * listener up in a PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER
-             * build -- would bind with them.
-             */
+        }
+
+        /* Keep the credentials in step with the settings, on the same
+         * condition the restart path below uses. Without this the listener
+         * would still hold the old ones, and the next
+         * pjsip_tls_transport_lis_start() -- the only way to bring a listener
+         * up in a PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER build -- would bind
+         * with them. Reloading when the listener holds none as well keeps a
+         * failed load recoverable through a plain restart, which carries no
+         * settings of its own.
+         */
+        if (opt || !listener->cert) {
             status = load_listener_cert(listener);
             if (status != PJ_SUCCESS) {
-                /* Publish the new address anyway; the factory is still
-                 * usable for outgoing transports.
-                 */
-                update_factory_addr(listener, a_name);
-                update_transport_info(listener);
+                publish_addr_after_failure(listener, a_name);
                 return status;
             }
         }
@@ -946,12 +977,14 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_restart2(pjsip_tpfactory *factory,
     if (opt || !listener->cert) {
         status = load_listener_cert(listener);
         if (status != PJ_SUCCESS) {
-            /* Update the published address anyway, as the lis_start()
-             * failure path below does: the listener is down either way, and
-             * the factory stays usable for outgoing transports.
+            /* Publish the address anyway, as the lis_start() failure path
+             * below does. update_bound_addr() runs first because lis_start()
+             * would have run it before failing, and without it
+             * update_factory_addr() re-derives from the previous bind address
+             * and republishes the old one.
              */
-            update_factory_addr(listener, a_name);
-            update_transport_info(listener);
+            update_bound_addr(listener, local);
+            publish_addr_after_failure(listener, a_name);
             return status;
         }
     }

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -594,18 +594,6 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_lis_start(pjsip_tpfactory *factory,
 }
 
 
-/* Load the listener's credentials from its pjsip_tls_setting.
- *
- * This is the only place that assigns listener->cert. It wipes the previous
- * credentials first and leaves the field NULL when a load fails, so a caller
- * must come through here rather than invoking pj_ssl_cert_load_from_files2(),
- * pj_ssl_cert_load_from_buffer(), pj_ssl_cert_load_from_store() or
- * pj_ssl_cert_load_direct() for a listener itself.
- *
- * The four sources are cumulative rather than exclusive: each loader adds to
- * the same pj_ssl_cert_t, which is why they are separate "if" blocks and not
- * an if/else chain.
- */
 /* Publish the address after a restart that could not bring the listener up.
  * The listener is down either way, but the factory stays usable for outgoing
  * transports, so the caller's error is what propagates and a failure here is
@@ -624,6 +612,18 @@ static void publish_addr_after_failure(struct tls_listener *listener,
 }
 
 
+/* Load the listener's credentials from its pjsip_tls_setting.
+ *
+ * This is the only place that assigns listener->cert. It wipes the previous
+ * credentials first and leaves the field NULL when a load fails, so a caller
+ * must come through here rather than invoking pj_ssl_cert_load_from_files2(),
+ * pj_ssl_cert_load_from_buffer(), pj_ssl_cert_load_from_store() or
+ * pj_ssl_cert_load_direct() for a listener itself.
+ *
+ * The four sources are cumulative rather than exclusive: each loader adds to
+ * the same pj_ssl_cert_t, which is why they are separate "if" blocks and not
+ * an if/else chain.
+ */
 static pj_status_t load_listener_cert(struct tls_listener *listener)
 {
     pj_pool_t *pool = listener->factory.pool;

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -221,6 +221,24 @@ static int restart_failure_test(void)
 
     pjsip_transport_dec_ref(tcp);
     pjsip_transport_destroy(tcp);
+    tcp = NULL;
+
+    /* A second restart, with the port still occupied, must fail too.
+     *
+     * This is the regression itself. Keyed off "the listener has no socket"
+     * rather than "no listener was ever wanted", the shortcut at the top of
+     * pjsip_tcp_transport_restart() is taken from here on: every later
+     * restart returns PJ_SUCCESS having only republished the address, the
+     * listener stays down, and nothing ever retries it. The first restart
+     * above is what leaves that state behind.
+     */
+    status = pjsip_tcp_transport_restart(tpfactory, &restart_addr, NULL);
+    if (status == PJ_SUCCESS) {
+        PJ_LOG(3,(THIS_FILE, "   Error: second restart to an occupied port "
+                             "reported success without restarting"));
+        ret = -116;
+        goto on_return;
+    }
 
     /* The listener can be started again once the port is free. */
     pj_sock_close(blocker);


### PR DESCRIPTION
Item 5 of #5232, and the one I would rank highest of the unclaimed items there.

`pjsip_tls_transport_restart2()` returns `PJ_SUCCESS` after updating only the published address whenever `listener->ssock` is NULL. That is right for a `PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER` build, which creates a client-only factory on purpose — but the branch is reached in ordinary builds too, where it means something quite different.

In a default build, a *registered* factory with no socket has one cause. The restart path closes the socket, sets it NULL, and keeps the factory registered deliberately so outgoing transports survive — then `pjsip_tls_transport_lis_start()` fails. From that point every later restart takes the address-only branch, reports success, and never rebuilds the listener.

Observed while testing TLS transport restart on iOS: after one restart that failed loading credentials, subsequent restarts returned `PJ_SUCCESS` indefinitely while the listener stayed down. The state is unrecoverable and indistinguishable from a healthy transport.

This got sharper with #5210 and #5216. Now that the certificate is loaded and validated at listener start, a listener whose credentials are briefly unavailable fails to start — and restart is the documented way to recover once they are available. That recovery currently cannot work.

## The change

**One flag, in both transports.** `lis_wanted` is set on entry to `lis_start()` — recording that a
listener was asked for, whether or not that start succeeded and whether or not the socket was later
lost. A restart on a factory that never wanted a listener updates the published address only; a
restart on one that did falls through to the path that reloads credentials, restarts the listener
and returns its real status.

This is applied to `sip_transport_tcp.c` as well as `sip_transport_tls.c`. TCP had the byte-identical
shortcut, `pjsip_tcp_transport_lis_start()` NULLs `asock` on every `on_error` exit, and
`pjsua_transport_lis_restart()` routes TCP restarts into it, so the same bug was there for the same
API call. Fixing only TLS would have left the two transports diverging.

**One credential loader (TLS).** `load_listener_cert()` is the only place that assigns
`listener->cert`, used by both `pjsip_tls_transport_start2()` and `pjsip_tls_transport_restart2()`.
It covers all four sources — files, buffer, store, `cert_direct` — in independent blocks, because
they are cumulative: each loader adds to the same `pj_ssl_cert_t`. Every failure exit clears the
field, so `!listener->cert` reliably means "holds nothing", which is what the reload condition
depends on. Both restart paths reload on the same `opt || !listener->cert`.

**One pjlib fix.** `pj_ssl_cert_load_direct()` stored the application's `EVP_PKEY`/`X509` without
taking a reference while `pj_ssl_cert_wipe_keys()` releases one, so wiping a credential loaded that
way dropped the application's reference. It takes its own reference now, matching
`pj_ssl_sock_set_certificate()`, and the ownership rule is documented at both functions. This is the
one commit outside pjsip; it can be split out if preferred.

Each of these replaced something in an earlier revision that did not survive review — the
compile-time guard, then the flag set on success, then an if/else loader chain that dropped sources
after the first match, then a wipe that freed objects it never owned. The history is in the
commits.

**Behaviour change for out-of-tree callers.** `pj_ssl_cert_load_direct()` now takes a reference on the `EVP_PKEY`/`X509` it stores. An application that called it and then `pj_ssl_cert_wipe_keys()` previously had its own reference consumed, which was the bug; one that calls it without a matching wipe now holds a reference it did not before. Both in-tree consumers (`lis_on_destroy()`, `pjnath/src/pjnath/turn_sock.c`) release what they take, and pjsua2's `TlsConfig` only borrows the application pointer.

**Known follow-up: the credential swap is unlocked.** `load_listener_cert()` replaces `listener->cert` while `lis_create_transport()` reads it with no lock, so an outgoing transport created concurrently with a restart can see NULL or, for a `cert_direct` credential, a pointer that is about to be freed. The window pre-exists on the listener branch, but master's client-only branch never touched `listener->cert`, so it is new for the `DONT_CREATE_LISTENER` configuration this PR targets. It is left open deliberately: `factory.lock` is created and destroyed in this file but never acquired, and `lis_create_transport()` would have to hold it across `pj_ssl_sock_set_certificate()` to close the window, which is a new locking discipline rather than a one-line guard.

**Not fixed here — pool growth, two sites.** Repeated credential loads grow `listener->factory.pool`, which is never reset: once from the loader, and again from `pj_ssl_sock_set_certificate()` in `lis_start()`, which deep-copies every string field into the pool it is handed. The address-only restart branch is a second site, and a newer one — `pjsua_transport_lis_restart()` always passes a non-NULL `opt`, so in a `DONT_CREATE_LISTENER` build every restart now re-`strdup`s the credential paths into that pool, on a branch where master allocated nothing at all. Same underlying cause throughout: `pj_ssl_cert_wipe_keys()` zeroes and releases but cannot return pool memory. The fix wants a dedicated resettable credentials pool whose reset is ordered against group-locked socket teardown, which is why it is not in this branch.

Also unchanged: the address-only branch takes `local` and ignores it.

Verified: compiles clean with `PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER` and
`PJSIP_TCP_TRANSPORT_DONT_CREATE_LISTENER` at both `0` and `1`, and `ssl_sock_ossl.c` against
OpenSSL 3.6.3 with the new reference counting compiled in.


