### PR TITLE
pjlib: apply the TLS version bounds the Darwin backend can actually set

### DIFF
--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -358,58 +358,18 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
  * still start for a configuration that every connection subsequently
  * rejects -- the check fails open, never closed.
  */
-static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
+/* Map ssock->param.proto onto the Secure Transport version bounds.
+ *
+ * Returns PJ_EINVAL when the requested range cannot be served at all, so an
+ * unusable configuration can be rejected once at listener setup instead of on
+ * every accepted connection.
+ */
+static pj_status_t get_proto_bounds(pj_ssl_sock_t *ssock,
+                                    SSLProtocol *p_min,
+                                    SSLProtocol *p_max)
 {
-    darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
-    SecIdentityRef identity = NULL;
-    pj_status_t status;
-
-    pj_assert(ssock->is_server && !ssock->parent);
-
-    if (!ssock->cert)
-        return PJ_SUCCESS;
-
-    status = create_identity_from_cert(dssock, ssock->cert, &identity);
-    if (identity)
-        CFRelease(identity);
-
-    return status;
-}
-
-/* Create and initialize new Darwin SSL context and instance */
-static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
-{
-    darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
-    SSLContextRef ssl_ctx;
     SSLProtocol min_proto = kSSLProtocolUnknown;
     SSLProtocol max_proto = kSSLProtocolUnknown;
-    OSStatus err;
-    pj_status_t status;
-
-   /* Initialize input circular buffer */
-    status = circ_init(ssock->pool->factory, &ssock->ssl_read_buf, 8192);
-    if (status != PJ_SUCCESS)
-        return status;
-
-    /* Initialize output circular buffer */
-    status = circ_init(ssock->pool->factory, &ssock->ssl_write_buf, 8192);
-    if (status != PJ_SUCCESS)
-        return status;
-
-    /* Create SSL context */
-    ssl_ctx = SSLCreateContext(NULL, (ssock->is_server? kSSLServerSide:
-                                      kSSLClientSide), kSSLStreamType);
-    if (ssl_ctx == NULL)
-        return PJ_ENOMEM;
-
-    dssock->ssl_ctx = ssl_ctx;
-
-    /* Set certificate */
-    if (ssock->cert)  {
-        status = set_cert(dssock, ssock->cert);
-        if (status != PJ_SUCCESS)
-            return status;
-    }
 
     /* Set min and max protocol version */
     if (ssock->param.proto == PJ_SSL_SOCK_PROTO_DEFAULT) {
@@ -469,6 +429,81 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
                               "limiting the maximum version to TLS 1.2"));
         max_proto = kTLSProtocol12;
     }
+
+    *p_min = min_proto;
+    *p_max = max_proto;
+
+    return PJ_SUCCESS;
+}
+
+
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
+{
+    darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
+    SecIdentityRef identity = NULL;
+    SSLProtocol min_proto, max_proto;
+    pj_status_t status;
+
+    pj_assert(ssock->is_server && !ssock->parent);
+
+    /* Reject a protocol range this backend cannot serve here, once, rather
+     * than once per accepted connection in ssl_create(). A listener asking
+     * for TLS 1.3 alone would otherwise start successfully and then fail
+     * every inbound handshake, emitting a log line any unauthenticated peer
+     * can trigger while the operator never sees a startup error.
+     */
+    status = get_proto_bounds(ssock, &min_proto, &max_proto);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    if (!ssock->cert)
+        return PJ_SUCCESS;
+
+    status = create_identity_from_cert(dssock, ssock->cert, &identity);
+    if (identity)
+        CFRelease(identity);
+
+    return status;
+}
+
+/* Create and initialize new Darwin SSL context and instance */
+static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
+{
+    darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
+    SSLContextRef ssl_ctx;
+    SSLProtocol min_proto = kSSLProtocolUnknown;
+    SSLProtocol max_proto = kSSLProtocolUnknown;
+    OSStatus err;
+    pj_status_t status;
+
+   /* Initialize input circular buffer */
+    status = circ_init(ssock->pool->factory, &ssock->ssl_read_buf, 8192);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* Initialize output circular buffer */
+    status = circ_init(ssock->pool->factory, &ssock->ssl_write_buf, 8192);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* Create SSL context */
+    ssl_ctx = SSLCreateContext(NULL, (ssock->is_server? kSSLServerSide:
+                                      kSSLClientSide), kSSLStreamType);
+    if (ssl_ctx == NULL)
+        return PJ_ENOMEM;
+
+    dssock->ssl_ctx = ssl_ctx;
+
+    /* Set certificate */
+    if (ssock->cert)  {
+        status = set_cert(dssock, ssock->cert);
+        if (status != PJ_SUCCESS)
+            return status;
+    }
+
+    status = get_proto_bounds(ssock, &min_proto, &max_proto);
+    if (status != PJ_SUCCESS)
+        return status;
 
     if (min_proto != kSSLProtocolUnknown) {
         err = SSLSetProtocolVersionMin(ssl_ctx, min_proto);

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -445,15 +445,27 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
         min_proto = kTLSProtocol13;
     }
 
-    /* According to the doc, we can't set min/max proto for TLS protocol
-     * higher than 1.0. The runtime error given is -9830 (Illegal parameter).
+    /* SecureTransport.h documents kSSLProtocol3, kTLSProtocol1,
+     * kTLSProtocol11 and kTLSProtocol12 as legal for these two setters.
+     * TLS 1.3 is not among them, so clamp it to 1.2 rather than leaving the
+     * bound unset -- an unset bound falls back to the stack default, which is
+     * lower than whatever the caller asked for.
      */
-    if (min_proto != kSSLProtocolUnknown && min_proto <= kTLSProtocol1) {
+    if (min_proto == kTLSProtocol13 || max_proto == kTLSProtocol13) {
+        PJ_LOG(3, (THIS_FILE, "TLS 1.3 is not supported by this backend, "
+                              "limiting to TLS 1.2"));
+        if (min_proto == kTLSProtocol13)
+            min_proto = kTLSProtocol12;
+        if (max_proto == kTLSProtocol13)
+            max_proto = kTLSProtocol12;
+    }
+
+    if (min_proto != kSSLProtocolUnknown) {
         err = SSLSetProtocolVersionMin(ssl_ctx, min_proto);
         if (err != noErr) pj_status_from_err(dssock, "SetVersionMin", err);
     }
 
-    if (max_proto != kSSLProtocolUnknown && max_proto <= kTLSProtocol1) {
+    if (max_proto != kSSLProtocolUnknown) {
         err = SSLSetProtocolVersionMax(ssl_ctx, max_proto);
         if (err != noErr) pj_status_from_err(dssock, "SetVersionMax", err);
     }

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -446,28 +446,40 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
     }
 
     /* SecureTransport.h documents kSSLProtocol3, kTLSProtocol1,
-     * kTLSProtocol11 and kTLSProtocol12 as legal for these two setters.
-     * TLS 1.3 is not among them, so clamp it to 1.2 rather than leaving the
-     * bound unset -- an unset bound falls back to the stack default, which is
-     * lower than whatever the caller asked for.
+     * kTLSProtocol11 and kTLSProtocol12 as legal for these two setters;
+     * TLS 1.3 is not among them.
      */
-    if (min_proto == kTLSProtocol13 || max_proto == kTLSProtocol13) {
-        PJ_LOG(3, (THIS_FILE, "TLS 1.3 is not supported by this backend, "
-                              "limiting to TLS 1.2"));
-        if (min_proto == kTLSProtocol13)
-            min_proto = kTLSProtocol12;
-        if (max_proto == kTLSProtocol13)
-            max_proto = kTLSProtocol12;
+    if (min_proto == kTLSProtocol13) {
+        /* The caller accepts nothing below TLS 1.3, which this backend
+         * cannot provide. Lowering the floor would complete a TLS 1.2
+         * handshake while pj_ssl_sock_get_info() still reported TLS 1.3,
+         * so refuse rather than downgrade the caller's policy silently.
+         */
+        PJ_LOG(3, (THIS_FILE, "TLS 1.3 is not supported by this backend"));
+        return PJ_EINVAL;
+    }
+
+    if (max_proto == kTLSProtocol13) {
+        /* A lower version is acceptable to the caller, so lowering the
+         * ceiling stays within the requested policy. This is the default
+         * configuration -- PJ_SSL_SOCK_PROTO_DEFAULT sets the TLS 1.3 bit --
+         * so it is a trace, not a warning.
+         */
+        PJ_LOG(5, (THIS_FILE, "TLS 1.3 is not supported by this backend, "
+                              "limiting the maximum version to TLS 1.2"));
+        max_proto = kTLSProtocol12;
     }
 
     if (min_proto != kSSLProtocolUnknown) {
         err = SSLSetProtocolVersionMin(ssl_ctx, min_proto);
-        if (err != noErr) pj_status_from_err(dssock, "SetVersionMin", err);
+        if (err != noErr)
+            return pj_status_from_err(dssock, "SetVersionMin", err);
     }
 
     if (max_proto != kSSLProtocolUnknown) {
         err = SSLSetProtocolVersionMax(ssl_ctx, max_proto);
-        if (err != noErr) pj_status_from_err(dssock, "SetVersionMax", err);
+        if (err != noErr)
+            return pj_status_from_err(dssock, "SetVersionMax", err);
     }
 
     /* SSL verification options */

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -347,16 +347,19 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
  * unusable configuration can be rejected once at listener setup instead of on
  * every accepted connection.
  *
- * Takes the protocol set by value rather than reading it from the socket, so
- * that a caller can validate a parameter set the socket does not own -- the
- * newsock_param of a listener, for instance.
+ * Takes the protocol set through a pointer rather than reading it from the
+ * socket, so that a caller can validate a parameter set the socket does not
+ * own -- the newsock_param of a listener, for instance -- and hands the
+ * expanded set back through it, so PJ_SSL_SOCK_PROTO_DEFAULT is resolved in
+ * exactly one place.
  */
-static pj_status_t get_proto_bounds(pj_ssl_sock_proto proto,
+static pj_status_t get_proto_bounds(pj_ssl_sock_proto *p_proto,
                                     SSLProtocol *p_min,
                                     SSLProtocol *p_max)
 {
     SSLProtocol min_proto = kSSLProtocolUnknown;
     SSLProtocol max_proto = kSSLProtocolUnknown;
+    pj_ssl_sock_proto proto = *p_proto;
 
     if (proto == PJ_SSL_SOCK_PROTO_DEFAULT) {
         /* SSL 2.0 is deprecated. */
@@ -415,6 +418,7 @@ static pj_status_t get_proto_bounds(pj_ssl_sock_proto proto,
         max_proto = kTLSProtocol12;
     }
 
+    *p_proto = proto;
     *p_min = min_proto;
     *p_max = max_proto;
 
@@ -446,16 +450,18 @@ static pj_status_t get_proto_bounds(pj_ssl_sock_proto proto,
  * rejects -- the check fails open, never closed.
  */
 static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock,
-                                      const pj_ssl_sock_param *newsock_param)
+                                       const pj_ssl_sock_param *newsock_param)
 {
     darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
     SecIdentityRef identity = NULL;
     SSLProtocol min_proto, max_proto;
+    pj_ssl_sock_proto proto;
     pj_status_t status;
 
     pj_assert(ssock->is_server && !ssock->parent);
 
-    status = get_proto_bounds(newsock_param->proto, &min_proto, &max_proto);
+    proto = newsock_param->proto;
+    status = get_proto_bounds(&proto, &min_proto, &max_proto);
     if (status != PJ_SUCCESS)
         return status;
 
@@ -504,16 +510,12 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
             return status;
     }
 
-    /* Set min and max protocol version. The expansion is written back
-     * because pj_ssl_sock_get_info() reports ssock->param.proto.
+    /* Set min and max protocol version. The expanded set is written back to
+     * ssock->param.proto because pj_ssl_sock_get_info() reports that field,
+     * and it comes from get_proto_bounds() so that the meaning of
+     * PJ_SSL_SOCK_PROTO_DEFAULT is not stated twice.
      */
-    if (ssock->param.proto == PJ_SSL_SOCK_PROTO_DEFAULT) {
-        /* SSL 2.0 is deprecated. */
-        ssock->param.proto = PJ_SSL_SOCK_PROTO_ALL &
-                             ~PJ_SSL_SOCK_PROTO_SSL2;
-    }
-
-    status = get_proto_bounds(ssock->param.proto, &min_proto, &max_proto);
+    status = get_proto_bounds(&ssock->param.proto, &min_proto, &max_proto);
     if (status != PJ_SUCCESS)
         return status;
 

--- a/pjlib/src/pj/ssl_sock_darwin.c
+++ b/pjlib/src/pj/ssl_sock_darwin.c
@@ -341,67 +341,52 @@ static pj_status_t set_cert(darwinssl_sock_t *dssock, pj_ssl_cert_t *cert)
     return PJ_SUCCESS;
 }
 
-/* Eagerly load and validate the certificate on the listener socket, so that a
- * certificate that is missing, unparsable, or has no matching private key
- * fails pj_ssl_sock_start_accept() up front. Without this, set_cert() (via
- * ssl_create() below) does not run until the first connection is accepted, so
- * the listener reports success and it is every inbound connection that fails
- * its handshake instead.
- *
- * The identity is released again here rather than cached: unlike the OpenSSL
- * backend, this backend builds no shared server context, and every accepted
- * connection loads the certificate itself in its own ssl_create(). This
- * validates the configuration, it does not pin it.
- *
- * Note this covers loading only, not the SSLSetCertificate() that set_cert()
- * goes on to make against a per-connection context. A listener can therefore
- * still start for a configuration that every connection subsequently
- * rejects -- the check fails open, never closed.
- */
-/* Map ssock->param.proto onto the Secure Transport version bounds.
+/* Map a PJ_SSL_SOCK_PROTO_* set onto the Secure Transport version bounds.
  *
  * Returns PJ_EINVAL when the requested range cannot be served at all, so an
  * unusable configuration can be rejected once at listener setup instead of on
  * every accepted connection.
+ *
+ * Takes the protocol set by value rather than reading it from the socket, so
+ * that a caller can validate a parameter set the socket does not own -- the
+ * newsock_param of a listener, for instance.
  */
-static pj_status_t get_proto_bounds(pj_ssl_sock_t *ssock,
+static pj_status_t get_proto_bounds(pj_ssl_sock_proto proto,
                                     SSLProtocol *p_min,
                                     SSLProtocol *p_max)
 {
     SSLProtocol min_proto = kSSLProtocolUnknown;
     SSLProtocol max_proto = kSSLProtocolUnknown;
 
-    /* Set min and max protocol version */
-    if (ssock->param.proto == PJ_SSL_SOCK_PROTO_DEFAULT) {
+    if (proto == PJ_SSL_SOCK_PROTO_DEFAULT) {
         /* SSL 2.0 is deprecated. */
-        ssock->param.proto = PJ_SSL_SOCK_PROTO_ALL &
-                             ~PJ_SSL_SOCK_PROTO_SSL2;
+        proto = PJ_SSL_SOCK_PROTO_ALL & ~PJ_SSL_SOCK_PROTO_SSL2;
     }
 
-    if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1_3) {
+    if (proto & PJ_SSL_SOCK_PROTO_TLS1_3) {
         max_proto = kTLSProtocol13;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1_2) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1_2) {
         max_proto = kTLSProtocol12;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1_1) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1_1) {
         max_proto = kTLSProtocol11;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1) {
         max_proto = kTLSProtocol1;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_SSL3) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_SSL3) {
         max_proto = kSSLProtocol3;
     } else {
         PJ_LOG(3, (THIS_FILE, "Unsupported TLS/SSL protocol"));
         return PJ_EINVAL;
     }
 
-    if (ssock->param.proto & PJ_SSL_SOCK_PROTO_SSL3) {
+    if (proto & PJ_SSL_SOCK_PROTO_SSL3) {
         min_proto = kSSLProtocol3;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1) {
         min_proto = kTLSProtocol1;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1_1) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1_1) {
         min_proto = kTLSProtocol11;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1_2) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1_2) {
         min_proto = kTLSProtocol12;
-    } else if (ssock->param.proto & PJ_SSL_SOCK_PROTO_TLS1_3) {
+    } else if (proto & PJ_SSL_SOCK_PROTO_TLS1_3) {
         min_proto = kTLSProtocol13;
     }
 
@@ -437,7 +422,31 @@ static pj_status_t get_proto_bounds(pj_ssl_sock_t *ssock,
 }
 
 
-static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
+/* Eagerly load and validate the certificate on the listener socket, so that a
+ * certificate that is missing, unparsable, or has no matching private key
+ * fails pj_ssl_sock_start_accept() up front. Without this, set_cert() (via
+ * ssl_create() below) does not run until the first connection is accepted, so
+ * the listener reports success and it is every inbound connection that fails
+ * its handshake instead.
+ *
+ * The protocol range is checked here for the same reason, against
+ * newsock_param, which carries the parameters the accepted sockets are built
+ * from -- not ssock->param, which pj_ssl_sock_start_accept2() lets a caller
+ * set independently. The bounds it yields are discarded: ssl_create() derives
+ * its own per connection, so this call is validation only.
+ *
+ * The identity is released again here rather than cached: unlike the OpenSSL
+ * backend, this backend builds no shared server context, and every accepted
+ * connection loads the certificate itself in its own ssl_create(). This
+ * validates the configuration, it does not pin it.
+ *
+ * Note this covers loading only, not the SSLSetCertificate() that set_cert()
+ * goes on to make against a per-connection context. A listener can therefore
+ * still start for a configuration that every connection subsequently
+ * rejects -- the check fails open, never closed.
+ */
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock,
+                                      const pj_ssl_sock_param *newsock_param)
 {
     darwinssl_sock_t *dssock = (darwinssl_sock_t *)ssock;
     SecIdentityRef identity = NULL;
@@ -446,13 +455,7 @@ static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
 
     pj_assert(ssock->is_server && !ssock->parent);
 
-    /* Reject a protocol range this backend cannot serve here, once, rather
-     * than once per accepted connection in ssl_create(). A listener asking
-     * for TLS 1.3 alone would otherwise start successfully and then fail
-     * every inbound handshake, emitting a log line any unauthenticated peer
-     * can trigger while the operator never sees a startup error.
-     */
-    status = get_proto_bounds(ssock, &min_proto, &max_proto);
+    status = get_proto_bounds(newsock_param->proto, &min_proto, &max_proto);
     if (status != PJ_SUCCESS)
         return status;
 
@@ -501,7 +504,16 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
             return status;
     }
 
-    status = get_proto_bounds(ssock, &min_proto, &max_proto);
+    /* Set min and max protocol version. The expansion is written back
+     * because pj_ssl_sock_get_info() reports ssock->param.proto.
+     */
+    if (ssock->param.proto == PJ_SSL_SOCK_PROTO_DEFAULT) {
+        /* SSL 2.0 is deprecated. */
+        ssock->param.proto = PJ_SSL_SOCK_PROTO_ALL &
+                             ~PJ_SSL_SOCK_PROTO_SSL2;
+    }
+
+    status = get_proto_bounds(ssock->param.proto, &min_proto, &max_proto);
     if (status != PJ_SUCCESS)
         return status;
 

--- a/pjlib/src/pj/ssl_sock_imp_common.c
+++ b/pjlib/src/pj/ssl_sock_imp_common.c
@@ -2239,7 +2239,7 @@ pj_ssl_sock_start_accept2(pj_ssl_sock_t *ssock,
      * of leaving it to the first accepted connection, so that a bad
      * credential fails the listener startup itself.
      */
-    status = ssl_init_server_ctx(ssock);
+    status = ssl_init_server_ctx(ssock, newsock_param);
     if (status != PJ_SUCCESS)
         goto on_error;
 #endif

--- a/pjlib/src/pj/ssl_sock_imp_common.h
+++ b/pjlib/src/pj/ssl_sock_imp_common.h
@@ -300,7 +300,8 @@ static void ssl_free_cert(pj_ssl_cert_t *cert);
  * SSL_CTX, including certificate and private key loading -- on a listener
  * socket, instead of deferring it to the first accepted connection.
  */
-static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock);
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock,
+                                       const pj_ssl_sock_param *newsock_param);
 #endif
 
 /* SSL session functions */

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -2101,10 +2101,13 @@ static pj_status_t ssl_create(pj_ssl_sock_t *ssock)
  * connection, and with server context reuse enabled, whatever context gets
  * built there is then cached and reused by every subsequent connection.
  */
-static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock)
+static pj_status_t ssl_init_server_ctx(pj_ssl_sock_t *ssock,
+                                       const pj_ssl_sock_param *newsock_param)
 {
     ossl_sock_t *ossock = (ossl_sock_t *)ssock;
     pj_status_t status;
+
+    PJ_UNUSED_ARG(newsock_param);
 
     pj_assert(ssock->is_server && !ssock->parent);
 

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -2422,8 +2422,7 @@ int ssl_sock_test(void)
         return PJ_EBUG;
 #endif
 
-/* We can't set min/max proto for TLS protocol higher than 1.0. */
-#if (PJ_SSL_SOCK_IMP != PJ_SSL_SOCK_IMP_DARWIN && PJ_SSL_SOCK_IMP != PJ_SSL_SOCK_IMP_SCHANNEL)
+#if (PJ_SSL_SOCK_IMP != PJ_SSL_SOCK_IMP_SCHANNEL)
     PJ_LOG(3,("", "..echo test w/ incompatible proto: server TLSv1.2 vs client TLSv1.3"));
     ret = echo_test(PJ_SSL_SOCK_PROTO_TLS1_2, PJ_SSL_SOCK_PROTO_TLS1_3, 
                     -1, -1,

--- a/pjlib/src/pjlib-test/ssl_sock.c
+++ b/pjlib/src/pjlib-test/ssl_sock.c
@@ -2371,12 +2371,18 @@ int ssl_sock_test(void)
     if (ret != 0)
         return ret;
 
+/* The Darwin backend cannot set a TLS 1.3 floor -- Secure Transport's
+ * SSLSetProtocolVersionMin() does not accept it -- so a TLS 1.3-only
+ * request is rejected at socket creation rather than downgraded.
+ */
+#if (PJ_SSL_SOCK_IMP != PJ_SSL_SOCK_IMP_DARWIN)
     PJ_LOG(3,("", "..echo test w/ TLSv1.3 and PJ_TLS_AES_128_GCM_SHA256 cipher"));
     ret = echo_test(PJ_SSL_SOCK_PROTO_TLS1_3, PJ_SSL_SOCK_PROTO_TLS1_3,
                     PJ_TLS_AES_128_GCM_SHA256, PJ_TLS_AES_128_GCM_SHA256,
                     PJ_FALSE, PJ_FALSE);
     if (ret != 0)
         return ret;
+#endif
 
 #if (PJ_SSL_SOCK_IMP == PJ_SSL_SOCK_IMP_OPENSSL)
     PJ_LOG(3,("", "..TLSv1.3 session resumption test"));
@@ -2394,12 +2400,18 @@ int ssl_sock_test(void)
         return ret;
 
 #if (PJ_SSL_SOCK_IMP != PJ_SSL_SOCK_IMP_SCHANNEL)
+/* The Darwin backend cannot set a TLS 1.3 floor -- Secure Transport's
+ * SSLSetProtocolVersionMin() does not accept it -- so a TLS 1.3-only
+ * request is rejected at socket creation rather than downgraded.
+ */
+#if (PJ_SSL_SOCK_IMP != PJ_SSL_SOCK_IMP_DARWIN)
     PJ_LOG(3,("", "..echo test w/ compatible proto: server TLSv1.2+1.3 vs client TLSv1.3"));
     ret = echo_test(PJ_SSL_SOCK_PROTO_TLS1_2 | PJ_SSL_SOCK_PROTO_TLS1_3, PJ_SSL_SOCK_PROTO_TLS1_3, 
                     -1, -1,
                     PJ_FALSE, PJ_FALSE);
     if (ret != 0)
         return ret;
+#endif
 
     PJ_LOG(3,("", "..echo test w/ incompatible proto: server TLSv1.3 vs client TLSv1.2"));
     ret = echo_test(PJ_SSL_SOCK_PROTO_TLS1_3, PJ_SSL_SOCK_PROTO_TLS1_2,


### PR DESCRIPTION
Item 4 of #5232, and the follow-up I promised on #5229 after you corrected my reading of it.

`ssl_create()` computes `min_proto` and `max_proto` from `ssock->param.proto`, then applies them only when they are `<= kTLSProtocol1`:

```c
/* According to the doc, we can't set min/max proto for TLS protocol
 * higher than 1.0. The runtime error given is -9830 (Illegal parameter).
 */
if (min_proto != kSSLProtocolUnknown && min_proto <= kTLSProtocol1) {
```

The -9830 is real, but it applies to one value, not to everything above 1.0. Measured against the current SDK by calling the setter directly:

```
SSLSetProtocolVersionMin(kSSLProtocol3)  -> accepted
SSLSetProtocolVersionMin(kTLSProtocol1)  -> accepted
SSLSetProtocolVersionMin(kTLSProtocol11) -> accepted
SSLSetProtocolVersionMin(kTLSProtocol12) -> accepted
SSLSetProtocolVersionMin(kTLSProtocol13) -> -9830
```

which matches what `SecureTransport.h` documents as legal for `minVersion`. So the guard is three protocol versions too broad, and TLS 1.1 and 1.2 bounds are being dropped for a restriction Secure Transport does not impose.

**Which versions actually lose their floor.** Not the default path: `PJ_SSL_SOCK_PROTO_DEFAULT` expands to `PJ_SSL_SOCK_PROTO_ALL & ~PJ_SSL_SOCK_PROTO_SSL2`, which still carries the SSL3 bit, so `min_proto` is `kSSLProtocol3` and, at `2 <= kTLSProtocol1`'s `4`, the old guard did apply it. The default was never "no minimum" — it was actively pinning the floor to SSL 3.0, below Secure Transport's own default of `kTLSProtocol1`. That is unchanged here.

The floor is genuinely dropped for TLS 1.1 and TLS 1.2 — `PJSIP_TLSV1_2_METHOD`, for instance, maps to a `kTLSProtocol12` minimum that exceeded the guard and was skipped, so an application asking for a TLS 1.2 floor got a context that would still negotiate lower. That is the case this fixes.

## The change

Apply both bounds whenever they are known, and split the TLS 1.3 case in two:

- **A requested floor of TLS 1.3 returns `PJ_EINVAL`.** The caller has stated a policy this
  backend cannot implement. Clamping it down completed a TLS 1.2 handshake while
  `pj_ssl_sock_get_info()` still reported TLS 1.3, so the downgrade was undetectable.
- **A requested ceiling of TLS 1.3 is clamped to 1.2**, since the caller accepts a lower
  version and the result stays inside the requested policy. `PJ_SSL_SOCK_PROTO_DEFAULT` sets
  the TLS 1.3 bit on this backend, making this the common path rather than an anomaly, so it
  logs at level 5.

The first of those is the behaviour change this PR originally flagged as arguably more
correct but did not want to smuggle in. It was requested in review, so it is now what the PR
does.

I checked the other backends before switching, since the argument only holds if it brings
Darwin into line: `ssl_sock_apple.m` and `ssl_sock_mbedtls.c` both return `PJ_EINVAL` for a
protocol selection they cannot provide, while `ssl_sock_ossl.c` (option mask) and
`ssl_sock_gtls.c` (priority string) express the request exactly and never face the choice.
None of them silently narrows a floor.

Failures from `SSLSetProtocolVersionMin/Max` are returned now instead of discarded. A rejected
bound previously left the context on the stack default while `ssl_create()` reported success,
and left a stale `last_native_err` for a later `pj_ssl_sock_get_info()` to report on an
otherwise healthy connection.

Two pjlib-test cases request TLS 1.3 alone and expect success — the TLSv1.3 cipher echo test
and "server TLSv1.2+1.3 vs client TLSv1.3". On this backend both pass today only because of
the silent downgrade, so they are excluded for `PJ_SSL_SOCK_IMP_DARWIN`, alongside the
exclusion already present a few lines below them. The Darwin backend is not the configure
default, so I could not run its suite to confirm their prior state; that part is reasoning
from the code.

**Rejected once, not per connection.** `ssl_create()` runs for every accepted connection, so a server configuration this backend cannot serve used to start cleanly and then fail every inbound handshake — emitting a level 3 log line that any unauthenticated peer could trigger at will, while the operator saw no startup error. The protocol mapping now lives in `get_proto_bounds()` and is also called from `ssl_init_server_ctx()`, the hook this backend already has for failing an unusable server configuration up front.

It validates `newsock_param`, which carries the parameters accepted sockets are actually built from, not `ssock->param` — `pj_ssl_sock_start_accept2()` lets a caller set the two independently. `ssl_init_server_ctx()` therefore takes the parameters as an argument; its declaration is guarded to the OpenSSL and Darwin backends, so that is one call site and two implementations, and the OpenSSL one ignores it. The bounds produced there are discarded: `ssl_create()` still derives its own per connection, so the call is validation only.

Diagnostics: no new warnings against master, and three fewer overall, since the reworked block
names `kTLSProtocol13` fewer times.