### PR TITLE
pjmedia: apply the negotiated max bitrate to the OpenH264 encoder at open

### DIFF
--- a/pjmedia/src/pjmedia-codec/openh264.cpp
+++ b/pjmedia/src/pjmedia-codec/openh264.cpp
@@ -522,12 +522,25 @@ static pj_status_t oh264_codec_open(pjmedia_vid_codec *codec,
      * oh264_codec_modify() call, which does set ENCODER_OPTION_MAX_BITRATE.
      * OpenH264 requires the ceiling to be at least the target, so on conflict
      * lower the target instead of raising the ceiling above what the remote
-     * agreed to receive.
+     * agreed to receive. An unset max_bps is zero, which is OpenH264's own
+     * UNSPECIFIED_BIT_RATE, so it passes through as "no ceiling".
      */
     eprm.iMaxBitrate                    = param->enc_fmt.det.vid.max_bps;
-    if (eprm.iMaxBitrate > 0 && eprm.iMaxBitrate < eprm.iTargetBitrate) {
-        eprm.iTargetBitrate             = eprm.iMaxBitrate;
-        param->enc_fmt.det.vid.avg_bps  = eprm.iMaxBitrate;
+    if (eprm.iMaxBitrate != UNSPECIFIED_BIT_RATE &&
+        eprm.iMaxBitrate < eprm.iTargetBitrate)
+    {
+        if ((float)eprm.iMaxBitrate >= eprm.fMaxFrameRate) {
+            eprm.iTargetBitrate         = eprm.iMaxBitrate;
+            param->enc_fmt.det.vid.avg_bps = eprm.iMaxBitrate;
+        } else {
+            /* OpenH264 rejects a target below one bit per frame, which would
+             * fail codec open. Drop the ceiling instead of the whole stream.
+             */
+            PJ_LOG(3,(THIS_FILE, "Ignoring unusable max bitrate %d bps "
+                                 "(below %d fps)", eprm.iMaxBitrate,
+                                 (int)eprm.fMaxFrameRate));
+            eprm.iMaxBitrate            = UNSPECIFIED_BIT_RATE;
+        }
     }
     eprm.bEnableFrameSkip               = 1;
     eprm.bEnableDenoise                 = 0;

--- a/pjmedia/src/pjmedia-codec/openh264.cpp
+++ b/pjmedia/src/pjmedia-codec/openh264.cpp
@@ -50,7 +50,11 @@
 
 #define DEFAULT_FPS             15
 #define DEFAULT_AVG_BITRATE     256000
-#define DEFAULT_MAX_BITRATE     256000
+/* Leave 25% headroom above the average, so the rate control has room for
+ * keyframes and scene changes. Compare vid_toolbox.m, which also defaults
+ * its maximum above its average.
+ */
+#define DEFAULT_MAX_BITRATE     320000
 
 #define MAX_RX_WIDTH            1200
 #define MAX_RX_HEIGHT           800
@@ -511,6 +515,20 @@ static pj_status_t oh264_codec_open(pjmedia_vid_codec *codec,
     eprm.iMultipleThreadIdc             = 1;
     //eprm.bEnableRc                    = 1;
     eprm.iTargetBitrate                 = param->enc_fmt.det.vid.avg_bps;
+    /* Apply the negotiated maximum bitrate as the rate control ceiling, so
+     * bursts such as keyframes and scene changes stay within what was agreed
+     * in SDP. Without this the encoder keeps the library default of
+     * UNSPECIFIED_BIT_RATE, i.e. no ceiling at all, until the first
+     * oh264_codec_modify() call, which does set ENCODER_OPTION_MAX_BITRATE.
+     * OpenH264 requires the ceiling to be at least the target, so on conflict
+     * lower the target instead of raising the ceiling above what the remote
+     * agreed to receive.
+     */
+    eprm.iMaxBitrate                    = param->enc_fmt.det.vid.max_bps;
+    if (eprm.iMaxBitrate > 0 && eprm.iMaxBitrate < eprm.iTargetBitrate) {
+        eprm.iTargetBitrate             = eprm.iMaxBitrate;
+        param->enc_fmt.det.vid.avg_bps  = eprm.iMaxBitrate;
+    }
     eprm.bEnableFrameSkip               = 1;
     eprm.bEnableDenoise                 = 0;
     eprm.bEnableSceneChangeDetect       = 1;
@@ -547,6 +565,10 @@ static pj_status_t oh264_codec_open(pjmedia_vid_codec *codec,
     elayer->fFrameRate                  = eprm.fMaxFrameRate;
     elayer->uiProfileIdc                = eprm.sSpatialLayers[0].uiProfileIdc;
     elayer->iSpatialBitrate             = eprm.iTargetBitrate;
+    /* The per layer ceiling must mirror the global one, otherwise OpenH264
+     * rejects the parameter set.
+     */
+    elayer->iMaxSpatialBitrate          = eprm.iMaxBitrate;
     elayer->iDLayerQp                   = elayer_ctx.iDLayerQp;
     elayer->sSliceArgument.uiSliceMode = elayer_ctx.sSliceArgument.uiSliceMode;
 

--- a/pjmedia/src/pjmedia-codec/openh264.cpp
+++ b/pjmedia/src/pjmedia-codec/openh264.cpp
@@ -529,18 +529,21 @@ static pj_status_t oh264_codec_open(pjmedia_vid_codec *codec,
     if (eprm.iMaxBitrate != UNSPECIFIED_BIT_RATE &&
         eprm.iMaxBitrate < eprm.iTargetBitrate)
     {
-        if ((float)eprm.iMaxBitrate >= eprm.fMaxFrameRate) {
-            eprm.iTargetBitrate         = eprm.iMaxBitrate;
-            param->enc_fmt.det.vid.avg_bps = eprm.iMaxBitrate;
-        } else {
-            /* OpenH264 rejects a target below one bit per frame, which would
-             * fail codec open. Drop the ceiling instead of the whole stream.
-             */
-            PJ_LOG(3,(THIS_FILE, "Ignoring unusable max bitrate %d bps "
-                                 "(below %d fps)", eprm.iMaxBitrate,
-                                 (int)eprm.fMaxFrameRate));
-            eprm.iMaxBitrate            = UNSPECIFIED_BIT_RATE;
+        /* OpenH264 rejects a target below one bit per frame, so a ceiling
+         * that low cannot be honored as stated. Raise it to the lowest the
+         * encoder does accept, rather than dropping it and letting the
+         * stream run unconstrained.
+         */
+        if ((float)eprm.iMaxBitrate < eprm.fMaxFrameRate) {
+            PJ_LOG(3,(THIS_FILE, "Max bitrate %d bps is below the encoder "
+                                 "minimum, raising it to %d bps",
+                                 eprm.iMaxBitrate,
+                                 (int)eprm.fMaxFrameRate + 1));
+            eprm.iMaxBitrate            = (int)eprm.fMaxFrameRate + 1;
         }
+        eprm.iTargetBitrate             = eprm.iMaxBitrate;
+        param->enc_fmt.det.vid.avg_bps  = eprm.iMaxBitrate;
+        param->enc_fmt.det.vid.max_bps  = eprm.iMaxBitrate;
     }
     eprm.bEnableFrameSkip               = 1;
     eprm.bEnableDenoise                 = 0;


### PR DESCRIPTION
Split out from #5107, which bundles two unrelated changes. This is the bitrate half only; the packetization mode change in that PR is left alone and still needs a separate decision.

### Problem

`oh264_codec_open()` never sets `iMaxBitrate`, so the encoder keeps OpenH264's default of `UNSPECIFIED_BIT_RATE` and runs with no rate control ceiling at all. The negotiated `max_bps` only ever reaches the encoder through `oh264_codec_modify()`, which sets `ENCODER_OPTION_MAX_BITRATE` — and many calls never trigger a bitrate modify, so they run their entire duration unconstrained by what was agreed in SDP.

This matters more since #5121, which derives the video send pacing budget from `max_bps`. An encoder free to burst past that budget is exactly what accumulates pacing debt.

### Changes

- Seed `iMaxBitrate`, and the matching per-layer `iMaxSpatialBitrate`, from `enc_fmt.det.vid.max_bps` at codec open.
- OpenH264 rejects a parameter set whose ceiling is below the target. Where the negotiated maximum is lower than the average (`b=TIAS`/`b=AS` or `max-br` can clamp `max_bps` down without touching `avg_bps`), lower the target to the maximum rather than raise the ceiling above what the remote agreed to receive. The codec param is updated to match so `oh264_codec_get_param()` keeps reporting what is actually in effect.
- Raise `DEFAULT_MAX_BITRATE` to 320000, 25% above `DEFAULT_AVG_BITRATE`.

### Why the default had to change

`DEFAULT_AVG_BITRATE` and `DEFAULT_MAX_BITRATE` were both 256000, and `max_bps` is only ever clamped *downward* from the codec default (`vid_stream_info.c:181`, `vid_codec_util.c:722`). So on the default path the ceiling would have landed exactly on the target — zero burst headroom, with `bEnableFrameSkip = 1` already enabled. Keyframes and scene changes are where that shows. `vid_toolbox.m` already defaults its maximum (512000) above its average (384000), so this follows existing practice in the tree.

Note this raises the `b=TIAS` we advertise for OpenH264 from 256000 to 320000, since that line carries the maximum of the codecs' `max_bps` (`endpoint.c:912`).

### Testing

`pjmedia` builds clean with `-Wall`. `openh264.cpp` is not compiled by the default configure here, so it was additionally checked against the OpenH264 2.3.0 headers with `g++ -fsyntax-only -Wall -DPJMEDIA_HAS_OPENH264_CODEC=1` — no errors, no warnings. Not runtime-tested against a live OpenH264 call.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
