### PR TITLE
pjsip: Second call to pjsip_register_hdr_parser does not overwrite first

### DIFF
--- a/pjsip/include/pjsip/sip_parser.h
+++ b/pjsip/include/pjsip/sip_parser.h
@@ -141,8 +141,7 @@ typedef void* (pjsip_parse_uri_func)(pj_scanner *scanner, pj_pool_t *pool,
 
 /**
  * Register header parser handler. The parser handler MUST follow the 
- * specification of header parser handler function. New registration 
- * overwrites previous registration with the same name.
+ * specification of header parser handler function.
  *
  * @param hname         The header name.
  * @param hshortname    The short header name or NULL.


### PR DESCRIPTION
A second call to `pjsip_register_hdr_parser()` with the same header name just returns `PJ_EEXISTS` and doesn't overwrite the previous registration.