### PR TITLE
Fix Coverity CHECKED_RETURN defects and build warnings

### DIFF
--- a/pjlib/src/pjlib-test/ssl_sock_stress.c
+++ b/pjlib/src/pjlib-test/ssl_sock_stress.c
@@ -2104,8 +2104,9 @@ static int concurrent_send_test(void)
         }
 
         PJ_LOG(3, ("", "...concurrent_send_test: threads=%d "
-                   "total_sends=%d recv=%lu/%lu",
-                   CS_SENDER_THREADS, total_sends,
+                   "total_sends=%d pending=%d sent=%lu recv=%lu/%lu",
+                   CS_SENDER_THREADS, total_sends, total_pending,
+                   (unsigned long)total_sent,
                    (unsigned long)state_cli.recv,
                    (unsigned long)total_expected));
     }

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -1340,7 +1340,9 @@ static pj_status_t darwin_stream_set_cap(pjmedia_vid_dev_stream *s,
                 const CGFloat cap_ori[4] = { 0, 90, 180, 270};
                 int idx;
                 int rotation;
+#if TARGET_OS_IPHONE
                 int effective_portrait_angle;
+#endif
 
                 if (strm->param.orient < PJMEDIA_ORIENT_NATURAL ||
                     strm->param.orient > PJMEDIA_ORIENT_ROTATE_270DEG)

--- a/pjmedia/src/pjmedia/conf_switch.c
+++ b/pjmedia/src/pjmedia/conf_switch.c
@@ -944,6 +944,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_ports_info(pjmedia_conf *conf,
                                                 pjmedia_conf_port_info info[])
 {
     unsigned i, count=0;
+    pj_status_t status;
 
     PJ_ASSERT_RETURN(conf && size && info, PJ_EINVAL);
 
@@ -954,8 +955,9 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_ports_info(pjmedia_conf *conf,
         if (!conf->ports[i])
             continue;
 
-        pjmedia_conf_get_port_info(conf, i, &info[count]);
-        ++count;
+        status = pjmedia_conf_get_port_info(conf, i, &info[count]);
+        if (status == PJ_SUCCESS)
+            ++count;
     }
 
     /* Unlock mutex */

--- a/pjmedia/src/pjmedia/conf_thread.c
+++ b/pjmedia/src/pjmedia/conf_thread.c
@@ -3176,6 +3176,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_ports_info(pjmedia_conf *conf,
                                                 pjmedia_conf_port_info info[])
 {
     unsigned i, count=0;
+    pj_status_t status;
 
     PJ_ASSERT_RETURN(conf && size && info, PJ_EINVAL);
 
@@ -3186,8 +3187,9 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_ports_info(pjmedia_conf *conf,
         if (!conf->ports[i])
             continue;
 
-        pjmedia_conf_get_port_info(conf, i, &info[count]);
-        ++count;
+        status = pjmedia_conf_get_port_info(conf, i, &info[count]);
+        if (status == PJ_SUCCESS)
+            ++count;
     }
 
     /* Unlock mutex */

--- a/pjmedia/src/pjmedia/conference.c
+++ b/pjmedia/src/pjmedia/conference.c
@@ -2628,6 +2628,7 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_ports_info(pjmedia_conf *conf,
                                                 pjmedia_conf_port_info info[])
 {
     unsigned i, count=0;
+    pj_status_t status;
 
     PJ_ASSERT_RETURN(conf && size && info, PJ_EINVAL);
 
@@ -2638,8 +2639,9 @@ PJ_DEF(pj_status_t) pjmedia_conf_get_ports_info(pjmedia_conf *conf,
         if (!conf->ports[i])
             continue;
 
-        pjmedia_conf_get_port_info(conf, i, &info[count]);
-        ++count;
+        status = pjmedia_conf_get_port_info(conf, i, &info[count]);
+        if (status == PJ_SUCCESS)
+            ++count;
     }
 
     /* Unlock mutex */

--- a/pjsip/src/pjsip-ua/sip_100rel.c
+++ b/pjsip/src/pjsip-ua/sip_100rel.c
@@ -194,6 +194,7 @@ PJ_DEF(pj_status_t) pjsip_100rel_init_module(pjsip_endpoint *endpt)
 PJ_DEF(pj_status_t) pjsip_100rel_attach(pjsip_inv_session *inv)
 {
     dlg_data *dd;
+    pj_status_t status;
 
     /* Check that 100rel module has been initialized */
     PJ_ASSERT_RETURN(mod_100rel.mod.id >= 0, PJ_EINVALIDOP);
@@ -201,7 +202,9 @@ PJ_DEF(pj_status_t) pjsip_100rel_attach(pjsip_inv_session *inv)
     /* Create and attach as dialog usage */
     dd = PJ_POOL_ZALLOC_T(inv->dlg->pool, dlg_data);
     dd->inv = inv;
-    pjsip_dlg_add_usage(inv->dlg, &mod_100rel.mod, (void*)dd);
+    status = pjsip_dlg_add_usage(inv->dlg, &mod_100rel.mod, (void*)dd);
+    if (status != PJ_SUCCESS)
+        return status;
 
     PJ_LOG(5,(dd->inv->dlg->obj_name, "100rel module attached"));
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -1144,11 +1144,15 @@ PJ_DEF(pj_status_t) pjsip_inv_create_uac( pjsip_dialog *dlg,
         return status;
     }
 
+    /* Create 100rel handler */
+    status = pjsip_100rel_attach(inv);
+    if (status != PJ_SUCCESS) {
+        pjsip_dlg_dec_lock(dlg);
+        return status;
+    }
+
     /* Increment dialog session */
     pjsip_dlg_inc_session(dlg, &mod_inv.mod);
-
-    /* Create 100rel handler */
-    pjsip_100rel_attach(inv);
 
     /* Done */
     pjsip_inv_add_ref(inv);
@@ -1938,6 +1942,15 @@ PJ_DEF(pj_status_t) pjsip_inv_create_uas( pjsip_dialog *dlg,
         return status;
     }
 
+    /* Create 100rel handler */
+    if (inv->options & PJSIP_INV_REQUIRE_100REL) {
+        status = pjsip_100rel_attach(inv);
+        if (status != PJ_SUCCESS) {
+            pjsip_dlg_dec_lock(dlg);
+            return status;
+        }
+    }
+
     /* Increment session in the dialog. */
     pjsip_dlg_inc_session(dlg, &mod_inv.mod);
 
@@ -1949,11 +1962,6 @@ PJ_DEF(pj_status_t) pjsip_inv_create_uas( pjsip_dialog *dlg,
     tsx_inv_data->inv = inv;
     tsx_inv_data->has_sdp = (sdp_info->sdp!=NULL);
     inv->invite_tsx->mod_data[mod_inv.mod.id] = tsx_inv_data;
-
-    /* Create 100rel handler */
-    if (inv->options & PJSIP_INV_REQUIRE_100REL) {
-        pjsip_100rel_attach(inv);
-    }
 
     /* Done */
     pjsip_inv_add_ref(inv);

--- a/pjsip/src/test/dlg_target_refresh_test.c
+++ b/pjsip/src/test/dlg_target_refresh_test.c
@@ -440,9 +440,12 @@ int dlg_target_refresh_test(void)
         pjsip_ua_init_module(endpt, &ua_param);
     }
 
-    pjsip_endpt_register_module(endpt, &mod_dlg_tr_test);
-    pjsip_endpt_register_module(endpt, &mod_dlg_usage);
-    pjsip_endpt_register_module(endpt, &mod_dlg_tr_logger);
+    PJ_TEST_SUCCESS(pjsip_endpt_register_module(endpt, &mod_dlg_tr_test),
+                    NULL, return -2);
+    PJ_TEST_SUCCESS(pjsip_endpt_register_module(endpt, &mod_dlg_usage),
+                    NULL, return -3);
+    PJ_TEST_SUCCESS(pjsip_endpt_register_module(endpt, &mod_dlg_tr_logger),
+                    NULL, return -4);
 
     /* Create SIP UDP transport on ephemeral port */
     {

--- a/pjsip/src/test/pjsua_call_test.c
+++ b/pjsip/src/test/pjsua_call_test.c
@@ -537,6 +537,7 @@ static void drain_all_calls(void)
     wait_until(NULL, PJSUA_INVALID_ID, PJ_IOQUEUE_KEY_FREE_DELAY + 200);
 }
 
+#if PJSUA_HAS_SIPREC
 /* Mark every live call as a recording session (PJSIP_INV_REQUIRE_SIPREC),
  * i.e. as if it had been established with Require: siprec. Metadata-only
  * UPDATE/re-INVITE is only accepted on recording sessions, ordinary calls
@@ -553,6 +554,7 @@ static void siprec_test_mark_siprec_sessions(void)
             call->inv->options |= PJSIP_INV_REQUIRE_SIPREC;
     }
 }
+#endif
 
 /*****************************************************************************
  * Sub-tests


### PR DESCRIPTION
## Coverity CHECKED_RETURN

- **CID 1685791** `pjsip/src/pjsip-ua/sip_100rel.c`: `pjsip_100rel_attach()` ignored the `pjsip_dlg_add_usage()` result; it is now returned on failure, matching the two call sites in `sip_inv.c`.
- **CID 1685939** `pjmedia/src/pjmedia/conference.c`: `pjmedia_conf_get_ports_info()` ignored `pjmedia_conf_get_port_info()` and advanced `count` unconditionally, so a failed slot would be reported as a filled entry. The identical loop in `conf_switch.c` and `conf_thread.c` is fixed as well.
- **CID 1685792** `pjsip/src/test/dlg_target_refresh_test.c`: the three `pjsip_endpt_register_module()` calls are now wrapped in `PJ_TEST_SUCCESS()`, as done elsewhere in the file.

## Build warnings

- `pjlib/src/pjlib-test/ssl_sock_stress.c`: `total_pending`/`total_sent` were accumulated but never used; they are now reported in the existing summary log (`-Wunused-but-set-variable`).
- `pjmedia/src/pjmedia-videodev/darwin_dev.m`: `effective_portrait_angle` is only used in the `TARGET_OS_IPHONE` branch, so its declaration is guarded the same way (`-Wunused-variable` on macOS).
- `pjsip/src/test/pjsua_call_test.c`: `siprec_test_mark_siprec_sessions()` is only called from within `#if PJSUA_HAS_SIPREC`, so the definition is guarded too (`-Wunused-function` when SIPREC is disabled).

## Testing

- `pjlib/build`, `pjmedia/build` and `pjsip/build` rebuild clean (no warnings) on macOS.
- `conf_switch.c` / `conf_thread.c` are not in the default build; syntax-checked with `gcc -fsyntax-only -Wall`.
- `pjsua_call_test.c` also syntax-checked with `-DPJSIP_HAS_SIPREC=0`, the configuration that produced the warning.
- `pjsip-test dlg_target_refresh_test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)