### PR TITLE
Fix use-after-free in inv_session_destroy()

### DIFF
--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -334,7 +334,6 @@ static void inv_session_destroy(pjsip_inv_session *inv)
     }
     pjsip_100rel_end_session(inv);
     pjsip_timer_end_session(inv);
-    pjsip_dlg_dec_session(inv->dlg, &mod_inv.mod);
 
     /* Release the flip-flop pools */
     pj_pool_release(inv->pool_prov);
@@ -344,6 +343,13 @@ static void inv_session_destroy(pjsip_inv_session *inv)
 
     pj_atomic_destroy(inv->ref_cnt);
     inv->ref_cnt = NULL;
+
+    /* This must be the last thing we do with inv. The session is allocated
+     * from the dialog pool, and decrementing the dialog session count may
+     * destroy the dialog if it has no other session and no transaction,
+     * which frees inv along with it.
+     */
+    pjsip_dlg_dec_session(inv->dlg, &mod_inv.mod);
 }
 
 static pj_status_t inv_async_auth_send_impl(

--- a/pjsip/src/test/inv_offer_answer_test.c
+++ b/pjsip/src/test/inv_offer_answer_test.c
@@ -737,6 +737,77 @@ static void on_new_session(pjsip_inv_session *inv, pjsip_event *e)
 }
 
 
+
+/*
+ * Regression test for the use-after-free in inv_session_destroy() (#5241).
+ *
+ * pjsip_inv_session is zalloc'd from dlg->pool, and so is inv->ref_cnt
+ * (pjsip_inv_create_uac/uas). The session holds exactly one dialog session
+ * count for its whole life, released by inv_session_destroy() through
+ * pjsip_dlg_dec_session(). When that call takes dlg->sess_count to zero with
+ * no transaction outstanding, pjsip_dlg_dec_lock() destroys the dialog and
+ * releases dlg->pool synchronously, via dlg_on_destroy() on the group lock's
+ * destroy list. Everything inv_session_destroy() reads from `inv` after that
+ * point is read from freed memory.
+ *
+ * sip_inv.h documents no locking requirement on pjsip_inv_dec_ref(), so an
+ * application that takes its own reference and drops the last one outside the
+ * dialog lock, once the session is already DISCONNECTED, lands exactly there.
+ * No second thread and no network are involved: this is an ordering defect,
+ * not a race, so the test is deterministic.
+ *
+ * Detection is by AddressSanitizer, which pjsip-test already runs under in
+ * CI. For ASan to see anything the dialog pool must be freed rather than
+ * recycled, so the test first grows dlg->pool past the caching pool's largest
+ * cached size -- see the comment on the pj_pool_alloc() below.
+ */
+static int inv_dec_ref_unlocked_test(void)
+{
+    pjsip_dialog *dlg;
+    pjsip_inv_session *inv;
+    pj_str_t uri = contact_uri;
+
+    PJ_LOG(3,(THIS_FILE, "  dropping the last inv reference unlocked"));
+
+    PJ_TEST_SUCCESS(pjsip_dlg_create_uac(pjsip_ua_instance(),
+                                         &uri, &uri, &uri, &uri, &dlg),
+                    NULL, return -400);
+
+    /* pj_caching_pool recycles a released pool unless its capacity exceeds
+     * the largest cached size, in which case cpool_release_pool() destroys it
+     * outright. A recycled pool is only reset, so the stale reads still
+     * return their old values and the defect stays invisible -- which is why
+     * it has gone unnoticed. Grow the dialog pool past that bound so that the
+     * release is a real free and the sanitizer can see the access.
+     */
+    PJ_TEST_NOT_NULL(pj_pool_alloc(dlg->pool, 128 * 1024), NULL, return -410);
+
+    PJ_TEST_SUCCESS(pjsip_inv_create_uac(dlg, NULL, 0, &inv), NULL,
+                    return -420);
+
+    /* The invite session must be the dialog's only session holder, otherwise
+     * the dec_session() below cannot reach zero and the test proves nothing. */
+    PJ_TEST_EQ(dlg->sess_count, 1, "unexpected dialog session count",
+               return -430);
+
+    /* The application takes its own reference, as sip_inv.h invites it to. */
+    PJ_TEST_SUCCESS(pjsip_inv_add_ref(inv), NULL, return -440);
+
+    /* End the session. This drops the stack's own reference from
+     * inv_set_state(), under the lock pjsip_inv_terminate() holds. */
+    pjsip_inv_terminate(inv, PJSIP_SC_REQUEST_TERMINATED, PJ_FALSE);
+    PJ_TEST_EQ(dlg->sess_count, 1, "invite session count released too early",
+               return -450);
+
+    /* Drop the last reference with no dialog lock held. inv_session_destroy()
+     * must not touch `inv` after pjsip_dlg_dec_session() has freed the dialog
+     * that `inv` is allocated from. */
+    PJ_TEST_EQ(pjsip_inv_dec_ref(inv), PJ_EGONE,
+               "invite session was not destroyed", return -460);
+
+    return 0;
+}
+
 int inv_offer_answer_test(void)
 {
     unsigned i;
@@ -791,6 +862,10 @@ int inv_offer_answer_test(void)
         if (rc != 0)
             goto on_return;
     }
+
+    rc = inv_dec_ref_unlocked_test();
+    if (rc != 0)
+        goto on_return;
 
 
 on_return:


### PR DESCRIPTION
## Problem

`inv_session_destroy()` calls `pjsip_dlg_dec_session()` **before** releasing the session's flip-flop pools and reference counter:

```c
    pjsip_dlg_dec_session(inv->dlg, &mod_inv.mod);

    /* Release the flip-flop pools */
    pj_pool_release(inv->pool_prov);      /* reads inv->pool_prov */
    ...
    pj_atomic_destroy(inv->ref_cnt);      /* reads inv->ref_cnt */
```

The `pjsip_inv_session` is allocated from the dialog pool (`PJ_POOL_ZALLOC_T(dlg->pool, ...)`). When the dialog has no other session and no pending transaction, `pjsip_dlg_dec_session()` → `pjsip_dlg_dec_lock()` destroys the dialog and releases its pool right there. The three reads that follow are then made from freed memory.

## Why it usually goes unnoticed

PJSIP itself only drops the last reference from inside `pjsip_dlg_on_tsx_state()`, which brackets the module callbacks with `pjsip_dlg_inc_lock()` / `pjsip_dlg_dec_lock()`. The lock holds a session count of its own, so the dialog survives until the final `dec_lock()`, after `inv_session_destroy()` has returned.

An application that holds its own reference (`pjsip_inv_add_ref()`) and drops it from another thread, outside of any dialog lock, after the BYE transaction has already terminated, does hit it. With a caching pool that actually frees released pools (`max_capacity` exhausted or 0), the memory is reused quickly and `pj_pool_release()` faults on a garbage pool pointer:

```
#00 pj_pool_release+4
#01 pjsip_inv_dec_ref+288
#02 <application code dropping its reference>
```

We are seeing this in the field in [Jami](https://jami.net) on Android.

## Fix

Move `pjsip_dlg_dec_session()` to the very end of `inv_session_destroy()`, so that nothing dereferences `inv` after the dialog may have been destroyed. `inv->dlg` is read as the call argument, before the decrement happens.

No behaviour change for callers that already hold the dialog lock.
