### PR TITLE
pjmedia: don't allocate the clock destroy lock from the pool that stop() resets

### DIFF
--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -209,15 +209,15 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
      * *both* return success, leading to double pj_thread_destroy()
      * and double pj_pool_reset().
      *
-     * Allocated from clock->pool — not the caller's pool — so the
-     * lock and the memory it guards share one lifetime and are torn
-     * down together in pjmedia_clock_destroy() by a single owner.
-     * pj_mutex_destroy(destroy_lock) runs immediately before
-     * pj_pool_safe_release(&clock->pool) there. This relies on the
-     * caller not issuing concurrent destroy on the same handle —
-     * which the higher-layer is_destroying flag + dec_vid_win under
-     * PJSUA_LOCK guarantees for the pjsua video path. */
-    status = pj_mutex_create_recursive(clock->pool, "clockdestroy",
+     * Allocated from the caller's pool, which outlives the clock:
+     * clock->pool is reset by pjmedia_clock_stop() to reclaim the
+     * clock thread descriptor, so nothing but that descriptor may
+     * live there. The lock itself is destroyed in
+     * pjmedia_clock_destroy(). This relies on the caller not issuing
+     * concurrent destroy on the same handle — which the higher-layer
+     * is_destroying flag + dec_vid_win under PJSUA_LOCK guarantees
+     * for the pjsua video path. */
+    status = pj_mutex_create_recursive(pool, "clockdestroy",
                                        &clock->destroy_lock);
     if (status != PJ_SUCCESS) {
         pj_lock_destroy(clock->lock);
@@ -506,9 +506,7 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
         clock->lock = NULL;
     }
 
-    /* destroy_lock memory lives in clock->pool, so tear it down here
-     * before pool release. Caller must not race stop/destroy past
-     * this point. */
+    /* Caller must not race stop/destroy past this point. */
     pj_mutex_unlock(clock->destroy_lock);
     pj_mutex_destroy(clock->destroy_lock);
     clock->destroy_lock = NULL;


### PR DESCRIPTION
### Bug

`pjmedia_clock_stop()` calls `pj_pool_reset(clock->pool)` to reclaim the clock thread descriptor, but the `destroy_lock` added in #5002 is allocated from that very pool. The reset invalidates the lock's memory, and the next `pjmedia_clock_start()` allocates the new thread descriptor over it, so the following `pjmedia_clock_stop()`/`pjmedia_clock_destroy()` blocks forever on a corrupted mutex.

So any clock that is started, stopped and started again deadlocks on its second stop. Reachable paths include:

- `vid_conf`: clock stopped when the last port is removed, started again when a port is added
- `transport_srtp_dtls`: clock stopped and restarted per negotiation
- `sound_port`, `master_port`, `vid_port`, `colorbar_dev`: plain start/stop cycles

Reproduced with a small program that creates one 300 msec clock and does start → sleep → stop ten times. It hangs on the second stop:

```
Thread 1 (main):
 #11 pj_mutex_lock ()
 #12 pjmedia_clock_stop ()
 #13 main ()
```

with no other thread holding that mutex. With this patch the same program completes all ten cycles.

### Fix

Allocate `destroy_lock` from the caller's pool, which outlives the clock, so that the pool being reset holds nothing but the thread descriptor. The lock is still destroyed explicitly in `pjmedia_clock_destroy()`, so its lifetime is unchanged.

### Testing

- `make realclean` + `./configure` + `make -j3`, no new warnings.
- `pjlib-test` essential tests + `sleep_test`/`timer_test`/`timestamp_test` pass (`sock_test` and `udp_ioqueue_test` hang in my sandbox on unmodified master too).

Found while working on #5227. The PR for that issue touches adjacent lines of the same function, I will rebase whichever of the two lands second.
