### PR TITLE
pjmedia: wake the clock thread on stop/destroy instead of waiting for the tick

### DIFF
--- a/pjlib/include/pj/os.h
+++ b/pjlib/include/pj/os.h
@@ -1120,6 +1120,19 @@ PJ_DECL(pj_status_t) pj_event_create(pj_pool_t *pool, const char *name,
 PJ_DECL(pj_status_t) pj_event_wait(pj_event_t *event);
 
 /**
+ * Wait for event to be signaled, with timeout.
+ *
+ * @param event     The event object.
+ * @param timeout   Timeout in miliseconds. Value zero makes this function
+ *                  return immediately, i.e. it only polls the event.
+ *
+ * @return PJ_SUCCESS if the event is signaled, PJ_ETIMEDOUT if the timeout
+ *         elapsed before the event is signaled, or the appropriate error
+ *         code.
+ */
+PJ_DECL(pj_status_t) pj_event_timedwait(pj_event_t *event, unsigned timeout);
+
+/**
  * Try wait for event object to be signalled.
  *
  * @param event The event object.

--- a/pjlib/src/pj/os_core_unix.c
+++ b/pjlib/src/pj/os_core_unix.c
@@ -45,6 +45,7 @@
 
 #include <unistd.h>         // getpid()
 #include <errno.h>          // errno
+#include <time.h>           // clock_gettime()
 
 #if PJ_HAS_THREADS
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
@@ -149,6 +150,18 @@ struct pj_sem_t
 #endif /* PJ_HAS_SEMAPHORE */
 
 #if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+/* Whether the condition variable clock can be selected. If it can, the
+ * event uses a monotonic clock, so pj_event_timedwait() is immune to
+ * wall clock adjustments.
+ */
+#if defined(_POSIX_CLOCK_SELECTION) && _POSIX_CLOCK_SELECTION > 0 && \
+    defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK >= 0 && \
+    defined(CLOCK_MONOTONIC)
+#   define EVENT_HAS_MONOTONIC_COND     1
+#else
+#   define EVENT_HAS_MONOTONIC_COND     0
+#endif
+
 struct pj_event_t
 {
     enum event_state {
@@ -159,6 +172,7 @@ struct pj_event_t
 
     pj_mutex_t          mutex;
     pthread_cond_t      cond;
+    pj_bool_t           mono_cond;
 
     pj_bool_t           auto_reset;
     int                 threads_waiting;
@@ -2182,7 +2196,24 @@ PJ_DEF(pj_status_t) pj_event_create(pj_pool_t *pool, const char *name,
     if (rc != PJ_SUCCESS)
         return rc;
 
-    prc = pthread_cond_init(&event->cond, 0);
+    prc = 0;
+    event->mono_cond = PJ_FALSE;
+#if EVENT_HAS_MONOTONIC_COND
+    {
+        pthread_condattr_t attr;
+
+        if (pthread_condattr_init(&attr) == 0) {
+            if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) == 0) {
+                prc = pthread_cond_init(&event->cond, &attr);
+                event->mono_cond = (prc == 0);
+            }
+            pthread_condattr_destroy(&attr);
+        }
+    }
+#endif
+    if (!event->mono_cond)
+        prc = pthread_cond_init(&event->cond, 0);
+
     if (prc != 0) {
         pj_mutex_destroy(&event->mutex);
         return PJ_RETURN_OS_ERROR(prc);
@@ -2239,6 +2270,60 @@ PJ_DEF(pj_status_t) pj_event_wait(pj_event_t *event)
     event_on_one_release(event);
     pthread_mutex_unlock(&event->mutex.mutex);
     return PJ_SUCCESS;
+}
+
+/*
+ * pj_event_timedwait()
+ */
+PJ_DEF(pj_status_t) pj_event_timedwait(pj_event_t *event, unsigned timeout)
+{
+    struct timespec abstime;
+    pj_status_t status = PJ_SUCCESS;
+    int prc = 0;
+
+    PJ_ASSERT_RETURN(event, PJ_EINVAL);
+
+    if (timeout == 0) {
+        /* Report the same status as the Win32 implementation does. */
+        return pj_event_trywait(event)==PJ_SUCCESS? PJ_SUCCESS : PJ_ETIMEDOUT;
+    }
+
+#if EVENT_HAS_MONOTONIC_COND
+    if (event->mono_cond) {
+        clock_gettime(CLOCK_MONOTONIC, &abstime);
+    } else
+#endif
+    {
+        pj_time_val tv;
+
+        pj_gettimeofday(&tv);
+        abstime.tv_sec = tv.sec;
+        abstime.tv_nsec = tv.msec * 1000000;
+    }
+    abstime.tv_sec += timeout / 1000;
+    abstime.tv_nsec += (timeout % 1000) * 1000000;
+    if (abstime.tv_nsec >= 1000000000) {
+        abstime.tv_sec++;
+        abstime.tv_nsec -= 1000000000;
+    }
+
+    pthread_mutex_lock(&event->mutex.mutex);
+    event->threads_waiting++;
+    while (event->state == EV_STATE_OFF && prc == 0) {
+        prc = pthread_cond_timedwait(&event->cond, &event->mutex.mutex,
+                                     &abstime);
+    }
+    event->threads_waiting--;
+    if (event->state != EV_STATE_OFF) {
+        event_on_one_release(event);
+    } else if (prc == ETIMEDOUT) {
+        status = PJ_ETIMEDOUT;
+    } else {
+        status = PJ_RETURN_OS_ERROR(prc);
+    }
+    pthread_mutex_unlock(&event->mutex.mutex);
+
+    return status;
 }
 
 /*

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -1702,6 +1702,16 @@ PJ_DEF(pj_status_t) pj_event_wait(pj_event_t *event)
 }
 
 /*
+ * pj_event_timedwait()
+ */
+PJ_DEF(pj_status_t) pj_event_timedwait(pj_event_t *event, unsigned timeout)
+{
+    PJ_ASSERT_RETURN(event, PJ_EINVAL);
+
+    return pj_event_wait_for(event, timeout);
+}
+
+/*
  * pj_event_trywait()
  */
 PJ_DEF(pj_status_t) pj_event_trywait(pj_event_t *event)

--- a/pjlib/src/pj/os_core_win32.c
+++ b/pjlib/src/pj/os_core_win32.c
@@ -1708,6 +1708,12 @@ PJ_DEF(pj_status_t) pj_event_timedwait(pj_event_t *event, unsigned timeout)
 {
     PJ_ASSERT_RETURN(event, PJ_EINVAL);
 
+    /* INFINITE is the all-ones value, so the largest timeout would wait
+     * forever here while it is finite everywhere else.
+     */
+    if (timeout == INFINITE)
+        --timeout;
+
     return pj_event_wait_for(event, timeout);
 }
 

--- a/pjlib/src/pjlib-test/mutex.c
+++ b/pjlib/src/pjlib-test/mutex.c
@@ -286,10 +286,20 @@ static int event_test(pj_pool_t *pool)
         return -183;
     }
 
+    /* A zero timeout on an unsignaled event only polls it. */
+    pj_event_reset(event);
+    status = pj_event_timedwait(event, 0);
+    if (status != PJ_ETIMEDOUT) {
+        app_perror("...error: pj_event_timedwait() with zero timeout did "
+                   "not time out", status);
+        pj_event_destroy(event);
+        return -185;
+    }
+
     status = pj_event_destroy(event);
     if (status != PJ_SUCCESS) {
         app_perror("...error: pj_event_destroy()", status);
-        return -185;
+        return -187;
     }
 
     return 0;

--- a/pjlib/src/pjlib-test/mutex.c
+++ b/pjlib/src/pjlib-test/mutex.c
@@ -201,6 +201,102 @@ static int semaphore_test(pj_pool_t *pool)
 #endif  /* PJ_HAS_SEMAPHORE */
 
 
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+
+/* Signal the event after a short delay, to release the waiter in
+ * event_test() before its timeout expires.
+ */
+static int event_setter_thread(void *arg)
+{
+    pj_event_t *event = (pj_event_t*)arg;
+
+    pj_thread_sleep(100);
+    pj_event_set(event);
+
+    return 0;
+}
+
+static int event_test(pj_pool_t *pool)
+{
+    pj_event_t *event;
+    pj_thread_t *thread;
+    pj_timestamp t0, t1;
+    unsigned msec;
+    pj_status_t status;
+
+    PJ_LOG(3,("", "...testing event"));
+
+    status = pj_event_create(pool, NULL, PJ_TRUE, PJ_FALSE, &event);
+    if (status != PJ_SUCCESS) {
+        app_perror("...error: pj_event_create()", status);
+        return -171;
+    }
+
+    /* Timed wait on an unsignaled event must time out. */
+    pj_get_timestamp(&t0);
+    status = pj_event_timedwait(event, 500);
+    pj_get_timestamp(&t1);
+    if (status != PJ_ETIMEDOUT) {
+        app_perror("...error: pj_event_timedwait() did not time out", status);
+        pj_event_destroy(event);
+        return -173;
+    }
+    msec = pj_elapsed_msec(&t0, &t1);
+    if (msec < 400) {
+        PJ_LOG(3,("", "...error: pj_event_timedwait() returned too early "
+                      "(%d msec)", msec));
+        pj_event_destroy(event);
+        return -175;
+    }
+
+    /* Timed wait must be released as soon as the event is signaled. */
+    status = pj_thread_create(pool, "evt", &event_setter_thread, event,
+                              0, 0, &thread);
+    if (status != PJ_SUCCESS) {
+        app_perror("...error: pj_thread_create()", status);
+        pj_event_destroy(event);
+        return -177;
+    }
+
+    pj_get_timestamp(&t0);
+    status = pj_event_timedwait(event, 30000);
+    pj_get_timestamp(&t1);
+    pj_thread_join(thread);
+    pj_thread_destroy(thread);
+
+    if (status != PJ_SUCCESS) {
+        app_perror("...error: pj_event_timedwait()", status);
+        pj_event_destroy(event);
+        return -179;
+    }
+    msec = pj_elapsed_msec(&t0, &t1);
+    if (msec > 10000) {
+        PJ_LOG(3,("", "...error: pj_event_timedwait() was not released by "
+                      "pj_event_set() (%d msec)", msec));
+        pj_event_destroy(event);
+        return -181;
+    }
+
+    /* The event is manual reset, so it is still signaled. */
+    status = pj_event_timedwait(event, 0);
+    if (status != PJ_SUCCESS) {
+        app_perror("...error: pj_event_timedwait() with zero timeout",
+                   status);
+        pj_event_destroy(event);
+        return -183;
+    }
+
+    status = pj_event_destroy(event);
+    if (status != PJ_SUCCESS) {
+        app_perror("...error: pj_event_destroy()", status);
+        return -185;
+    }
+
+    return 0;
+}
+#endif  /* PJ_HAS_EVENT_OBJ */
+
+
 int mutex_test(void)
 {
     pj_pool_t *pool;
@@ -218,6 +314,12 @@ int mutex_test(void)
 
 #if PJ_HAS_SEMAPHORE
     rc = semaphore_test(pool);
+    if (rc != 0)
+        return rc;
+#endif
+
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    rc = event_test(pool);
     if (rc != 0)
         return rc;
 #endif

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -123,6 +123,12 @@ struct pjmedia_clock
     pj_bool_t                running;
     pj_bool_t                quitting;
     pj_lock_t               *lock;
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    /* Signalled by stop/destroy to interrupt the clock thread's wait for
+     * the next tick, so those don't have to block until the tick expires.
+     */
+    pj_event_t              *quit_ev;
+#endif
     /* Serializes pjmedia_clock_stop() and pjmedia_clock_destroy()
      * across concurrent callers. Cannot be the same as `lock` above,
      * because `lock` is held by the clock thread inside the callback
@@ -136,6 +142,60 @@ static int clock_thread(void *arg);
 
 #define MAX_JUMP_MSEC   500
 #define USEC_IN_SEC     (pj_uint64_t)1000000
+
+/* Maximum duration of a single sleep while waiting for the next tick, used
+ * only on platforms without event object, where the wait cannot be
+ * interrupted. It bounds how long stop/destroy has to wait for the thread.
+ */
+#define MAX_SLEEP_MSEC  20
+
+
+/* Signal the clock thread to stop waiting for the next tick. */
+static void clock_signal_quit(pjmedia_clock *clock)
+{
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    if (clock->quit_ev)
+        pj_event_set(clock->quit_ev);
+#else
+    PJ_UNUSED_ARG(clock);
+#endif
+}
+
+
+/* Destroy the quit event, if any. */
+static void clock_destroy_quit_ev(pjmedia_clock *clock)
+{
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    if (clock->quit_ev) {
+        pj_event_destroy(clock->quit_ev);
+        clock->quit_ev = NULL;
+    }
+#else
+    PJ_UNUSED_ARG(clock);
+#endif
+}
+
+
+/* Wait for the next tick, returning immediately when the clock is being
+ * stopped or destroyed.
+ */
+static void clock_sleep(pjmedia_clock *clock, unsigned msec)
+{
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    if (clock->quit_ev) {
+        pj_event_timedwait(clock->quit_ev, msec);
+        return;
+    }
+#endif
+
+    /* No event object on this platform, sleep in slices instead. */
+    while (msec > MAX_SLEEP_MSEC && !clock->quitting) {
+        pj_thread_sleep(MAX_SLEEP_MSEC);
+        msec -= MAX_SLEEP_MSEC;
+    }
+    if (!clock->quitting)
+        pj_thread_sleep(msec);
+}
 
 /*
  * Create media clock.
@@ -194,10 +254,29 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
     clock->quitting = PJ_FALSE;
     clock->destroy_lock = NULL;
 
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    clock->quit_ev = NULL;
+    if ((options & PJMEDIA_CLOCK_NO_ASYNC) == 0) {
+        /* Manual reset, so the thread never misses the signal. It is
+         * reset again when the clock is restarted. Note that it must not
+         * be allocated from clock->pool, which stop() resets.
+         */
+        status = pj_event_create(pool, "clock%p", PJ_TRUE, PJ_FALSE,
+                                 &clock->quit_ev);
+        if (status != PJ_SUCCESS) {
+            pj_pool_safe_release(&clock->pool);
+            return status;
+        }
+    }
+#endif
+
     /* I don't think we need a mutex, so we'll use null. */
     status = pj_lock_create_null_mutex(pool, "clock", &clock->lock);
-    if (status != PJ_SUCCESS)
+    if (status != PJ_SUCCESS) {
+        clock_destroy_quit_ev(clock);
+        pj_pool_safe_release(&clock->pool);
         return status;
+    }
 
     /* But we *do* need a real mutex to serialize stop/destroy: under
      * stress, multiple threads can land in pjmedia_clock_stop() on the
@@ -222,6 +301,7 @@ PJ_DEF(pj_status_t) pjmedia_clock_create2(pj_pool_t *pool,
     if (status != PJ_SUCCESS) {
         pj_lock_destroy(clock->lock);
         clock->lock = NULL;
+        clock_destroy_quit_ev(clock);
         pj_pool_safe_release(&clock->pool);
         return status;
     }
@@ -252,6 +332,10 @@ PJ_DEF(pj_status_t) pjmedia_clock_start(pjmedia_clock *clock)
     clock->next_tick.u64 = now.u64 + clock->interval.u64;
     clock->running = PJ_TRUE;
     clock->quitting = PJ_FALSE;
+#if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
+    if (clock->quit_ev)
+        pj_event_reset(clock->quit_ev);
+#endif
 
     if ((clock->options & PJMEDIA_CLOCK_NO_ASYNC) == 0) {
         if (clock->thread) {
@@ -290,6 +374,7 @@ PJ_DEF(pj_status_t) pjmedia_clock_stop(pjmedia_clock *clock)
 
     clock->running = PJ_FALSE;
     clock->quitting = PJ_TRUE;
+    clock_signal_quit(clock);
 
     if (clock->thread) {
         pj_status_t status = pj_thread_join(clock->thread);
@@ -431,7 +516,7 @@ static int clock_thread(void *arg)
         if (now.u64 < clock->next_tick.u64) {
             unsigned msec;
             msec = pj_elapsed_msec(&now, &clock->next_tick);
-            pj_thread_sleep(msec);
+            clock_sleep(clock, msec);
         }
 
         /* Skip if not running */
@@ -481,6 +566,7 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
 
     clock->running = PJ_FALSE;
     clock->quitting = PJ_TRUE;
+    clock_signal_quit(clock);
 
     if (clock->thread) {
         pj_status_t status = pj_thread_join(clock->thread);
@@ -505,6 +591,8 @@ PJ_DEF(pj_status_t) pjmedia_clock_destroy(pjmedia_clock *clock)
         pj_lock_destroy(clock->lock);
         clock->lock = NULL;
     }
+
+    clock_destroy_quit_ev(clock);
 
     /* Caller must not race stop/destroy past this point. */
     pj_mutex_unlock(clock->destroy_lock);


### PR DESCRIPTION
Fixes #5227.

### Problem

The clock thread waits for the next tick in `pj_thread_sleep()`, which cannot be interrupted, so `pjmedia_clock_stop()` and `pjmedia_clock_destroy()` block in `pj_thread_join()` for up to one full clock interval.

This is most visible with text streams, as reported in #5227: every text stream runs its own clock at the buffering time (300 msec by default), and the stream is destroyed on the thread that processes the hangup or the re-INVITE/UPDATE. Tearing down a call with text media therefore stalls that thread by ~150 msec on average, and dozens of calls hung up at once make the application iterate visibly slowly.

Note that the stall is in `pjmedia_clock_stop()`, which `pjmedia_txt_stream_destroy()` calls first; the later `pjmedia_clock_destroy()` then finds the thread already gone.

### Fix

Wait on an event object that stop/destroy signal, so the thread leaves its loop immediately instead of sleeping out the tick. This needs a timed wait, which pjlib did not have, so the first commit adds `pj_event_timedwait()`:

- Win32: exposes the existing internal `pj_event_wait_for()`.
- Unix: `pthread_cond_timedwait()`, with the condition variable clock set to `CLOCK_MONOTONIC` where the platform supports clock selection, so the wait is not affected by wall clock adjustments. Platforms without clock selection (e.g. macOS) keep using the realtime clock.
- A zero timeout only polls the event, returning `PJ_ETIMEDOUT` on both platforms.

Where `PJ_HAS_EVENT_OBJ` is 0 there is no event object at all, so the clock falls back to sleeping in slices, which bounds the stall to 20 msec.

The event is only created for asynchronous clocks, and it is allocated from the caller's pool because `pjmedia_clock_stop()` resets `clock->pool`.

No text stream change is needed: `pjmedia_clock_stop()` now returns immediately.

### Testing

Teardown latency measured with a 300 msec clock, one clock per iteration (which is what one clock per text stream looks like), stopping at a random point of the tick:

| | worst | average |
|---|---|---|
| master | 293 msec | ~150 msec |
| this PR | 0 msec | 0 msec |

- `make realclean` + `./configure` + `make -j3`, no new warnings.
- New `event_test()` in `pjlib-test` `mutex_test`, covering the timeout, the early release by `pj_event_set()` from another thread, and the zero timeout.
- `pjlib-test` essential tests + `sleep_test`/`timer_test`/`timestamp_test`/`tcp_ioqueue_test`/`activesock_test` pass (`sock_test` and `udp_ioqueue_test` hang in my sandbox on unmodified master too).

Note that while measuring this I ran into a separate, pre-existing deadlock: a clock that is stopped and started again deadlocks on its next stop, because `pjmedia_clock_stop()` resets the pool the destroy lock is allocated from. That is not caused by this PR, and is fixed separately in #5242; the restart part of my testing was done with both applied.
