### PR TITLE
pjlib: honour type alignment in the pool and fifobuf allocators

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -5638,20 +5638,34 @@ printf "%s\n" "#define PJ_M_NAME \"$target_cpu\"" >>confdefs.h
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking memory alignment" >&5
 printf %s "checking memory alignment... " >&6; }
-case $target in
-    sparc64-* | ia64-* | x86_64-* | arm64-* | aarch64-* | mips64* )
-        printf "%s\n" "#define PJ_POOL_ALIGNMENT 8" >>confdefs.h
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: 8 bytes" >&5
+int
+main (void)
+{
+int t[sizeof(void *) == 8 ? 1 : -1]; (void)t;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+printf "%s\n" "#define PJ_POOL_ALIGNMENT 8" >>confdefs.h
+
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: 8 bytes" >&5
 printf "%s\n" "8 bytes" >&6; }
-    ;;
-    * )
-        printf "%s\n" "#define PJ_POOL_ALIGNMENT 4" >>confdefs.h
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: 4 bytes (default)" >&5
-printf "%s\n" "4 bytes (default)" >&6; }
-    ;;
+else case e in #(
+  e)
+printf "%s\n" "#define PJ_POOL_ALIGNMENT 4" >>confdefs.h
+
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: 4 bytes" >&5
+printf "%s\n" "4 bytes" >&6; } ;;
 esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
 
 ac_header= ac_cache=

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -140,19 +140,22 @@ AC_MSG_RESULT([Setting PJ_M_NAME to $target_cpu])
 AC_DEFINE_UNQUOTED(PJ_M_NAME,["$target_cpu"])
 
 dnl
-dnl Memory alignment detection
+dnl Memory alignment detection.
+dnl
+dnl Test the pointer size rather than matching the target triple: a list of
+dnl triples silently gives 4 to any 64 bit target it does not mention (e.g.
+dnl amd64-*-freebsd, ppc64, riscv64, s390x), which under-aligns every pool
+dnl allocated object that embeds an OS primitive or a 64 bit field accessed
+dnl atomically. Compile-only, so it stays correct when cross compiling.
 dnl
 AC_MSG_CHECKING([memory alignment])
-case $target in
-    sparc64-* | ia64-* | x86_64-* | arm64-* | aarch64-* | mips64* )
-        AC_DEFINE(PJ_POOL_ALIGNMENT, 8)
-        AC_MSG_RESULT([8 bytes])
-    ;;
-    * )
-        AC_DEFINE(PJ_POOL_ALIGNMENT, 4)
-        AC_MSG_RESULT([4 bytes (default)])
-    ;;
-esac
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[]],
+                     [[int t[sizeof(void *) == 8 ? 1 : -1]; (void)t;]])],
+    [AC_DEFINE(PJ_POOL_ALIGNMENT, 8)
+     AC_MSG_RESULT([8 bytes])],
+    [AC_DEFINE(PJ_POOL_ALIGNMENT, 4)
+     AC_MSG_RESULT([4 bytes])])
 
 
 dnl

--- a/build.symbian/pjlibU.def
+++ b/build.symbian/pjlibU.def
@@ -324,3 +324,5 @@ EXPORTS
 	platform_strerror                        @ 323 NONAME
 	snprintf                                 @ 324 NONAME
 	vsnprintf                                @ 325 NONAME
+	pj_pool_aligned_alloc                    @ 326 NONAME
+	pj_pool_aligned_zalloc                   @ 327 NONAME

--- a/pjlib/include/pj/compat/cc_clang.h
+++ b/pjlib/include/pj/compat/cc_clang.h
@@ -77,4 +77,7 @@
 #define PJ_ALIGN_DATA_SUFFIX(alignment) __attribute__((aligned (alignment)))
 #define PJ_ALIGN_DATA(declaration, alignment) PJ_ALIGN_DATA_PREFIX(alignment) declaration PJ_ALIGN_DATA_SUFFIX(alignment)
 
+/* Alignment requirement of a type, in bytes. */
+#define PJ_ALIGNOF(type)                __alignof__(type)
+
 #endif /* __PJ_COMPAT_CC_CLANG_H__ */

--- a/pjlib/include/pj/compat/cc_gcc.h
+++ b/pjlib/include/pj/compat/cc_gcc.h
@@ -84,5 +84,8 @@
 #define PJ_ALIGN_DATA_SUFFIX(alignment) __attribute__((aligned (alignment)))
 #define PJ_ALIGN_DATA(declaration, alignment) PJ_ALIGN_DATA_PREFIX(alignment) declaration PJ_ALIGN_DATA_SUFFIX(alignment)
 
+/* Alignment requirement of a type, in bytes. */
+#define PJ_ALIGNOF(type)                __alignof__(type)
+
 #endif  /* __PJ_COMPAT_CC_GCC_H__ */
 

--- a/pjlib/include/pj/compat/cc_msvc.h
+++ b/pjlib/include/pj/compat/cc_msvc.h
@@ -92,5 +92,8 @@ typedef unsigned __int64 pj_uint64_t;
 #define PJ_ALIGN_DATA_SUFFIX(alignment) __pragma(warning(pop))
 #define PJ_ALIGN_DATA(declaration, alignment) PJ_ALIGN_DATA_PREFIX(alignment) declaration PJ_ALIGN_DATA_SUFFIX(alignment)
 
+/* Alignment requirement of a type, in bytes. */
+#define PJ_ALIGNOF(type)                __alignof(type)
+
 #endif  /* __PJ_COMPAT_CC_MSVC_H__ */
 

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -46,6 +46,24 @@
 #  error "Unknown compiler."
 #endif
 
+/* PJ_ALIGNOF is the alignment requirement of a type, in bytes. The last
+ * resort works on any conforming C compiler: in "struct { char c; type t; }"
+ * the offset of t is exactly the alignment of type, and since sizeof(type)
+ * is a multiple of that alignment the struct has no trailing padding. That
+ * form defines a type inside sizeof, which is not valid C++, so the standard
+ * operators are preferred wherever they are available.
+ */
+#ifndef PJ_ALIGNOF
+#  if defined(__cplusplus) && __cplusplus >= 201103L
+#    define PJ_ALIGNOF(type)    alignof(type)
+#  elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#    define PJ_ALIGNOF(type)    _Alignof(type)
+#  else
+#    define PJ_ALIGNOF(type)    (sizeof(struct { char pj_c_; type pj_t_; }) - \
+                                 sizeof(type))
+#  endif
+#endif
+
 /* PJ_ALIGN_DATA is compiler specific directive to align data address */
 #ifndef PJ_ALIGN_DATA
 #  error "PJ_ALIGN_DATA is not defined!"

--- a/pjlib/include/pj/fifobuf.h
+++ b/pjlib/include/pj/fifobuf.h
@@ -93,9 +93,11 @@ PJ_DECL(unsigned) pj_fifobuf_available_size(pj_fifobuf_t *fb);
 /**
  * Allocate a chunk of memory from the fifobuf.
  *
- * The returned buffer is aligned to at least sizeof(void*), so an object
- * with a fundamental alignment requirement may be stored in it directly.
- * The allocation therefore consumes slightly more than \a size bytes.
+ * The returned buffer is aligned to sizeof(void*), so an object whose
+ * alignment requirement is no greater than that may be stored in it
+ * directly. Types needing more, e.g. a 16 byte aligned long double on some
+ * ABIs, are not catered for: fifobuf has no caller specified alignment.
+ * The allocation consumes slightly more than \a size bytes.
  *
  * @param fb        The fifobuf
  * @param size      Size to allocate

--- a/pjlib/include/pj/fifobuf.h
+++ b/pjlib/include/pj/fifobuf.h
@@ -93,6 +93,10 @@ PJ_DECL(unsigned) pj_fifobuf_available_size(pj_fifobuf_t *fb);
 /**
  * Allocate a chunk of memory from the fifobuf.
  *
+ * The returned buffer is aligned to at least sizeof(void*), so an object
+ * with a fundamental alignment requirement may be stored in it directly.
+ * The allocation therefore consumes slightly more than \a size bytes.
+ *
  * @param fb        The fifobuf
  * @param size      Size to allocate
  * 

--- a/pjlib/include/pj/pool.h
+++ b/pjlib/include/pj/pool.h
@@ -345,9 +345,15 @@ struct pj_pool_t
 
 /** 
  * Pool memory alignment (must be power of 2). 
+ *
+ * The default is pointer sized. A smaller value would under-align any
+ * pool allocated object embedding a type with a stricter requirement,
+ * e.g. an OS synchronisation primitive or a 64 bit field accessed
+ * atomically, which on some targets is a fault and on others costs the
+ * atomicity of the access.
  */
 #ifndef PJ_POOL_ALIGNMENT
-#   define PJ_POOL_ALIGNMENT    4
+#   define PJ_POOL_ALIGNMENT    (sizeof(void*))
 #endif
 
 /**
@@ -514,6 +520,9 @@ PJ_IDECL(void*) pj_pool_alloc( pj_pool_t *pool, pj_size_t size);
  * @param pool      the pool.
  * @param alignment the requested alignment of the allocation.
  *                  Value of 0 means use the default alignment of this pool.
+ *                  The pool's default alignment is a floor: a smaller value
+ *                  is raised to it, so an allocation is never less aligned
+ *                  than pj_pool_alloc() would have made it.
  * @param size      the requested size.
  *
  * @return pointer to the allocated memory.
@@ -555,6 +564,23 @@ PJ_INLINE(void*) pj_pool_zalloc(pj_pool_t *pool, pj_size_t size)
 
 
 /**
+ * Allocate storage with the specified alignment from the pool, and
+ * initialize it to zero.
+ *
+ * @param pool      The pool.
+ * @param alignment The requested alignment of the allocation.
+ *                  Value of 0 means use the default alignment of this pool.
+ * @param size      The size to be allocated.
+ *
+ * @return          Pointer to the allocated memory.
+ *
+ * @see PJ_POOL_ZALLOC_T
+ */
+PJ_IDECL(void*) pj_pool_aligned_zalloc(pj_pool_t *pool, pj_size_t alignment,
+                                       pj_size_t size);
+
+
+/**
  * This macro allocates memory from the pool and returns the instance of
  * the specified type. It provides a stricker type safety than pj_pool_alloc()
  * since the return value of this macro will be type-casted to the specified
@@ -566,7 +592,7 @@ PJ_INLINE(void*) pj_pool_zalloc(pj_pool_t *pool, pj_size_t size)
  * @return          Memory buffer of the specified type.
  */
 #define PJ_POOL_ALLOC_T(pool,type) \
-            ((type*)pj_pool_alloc(pool, sizeof(type)))
+            ((type*)pj_pool_aligned_alloc(pool, PJ_ALIGNOF(type), sizeof(type)))
 
 /**
  * This macro allocates memory from the pool, zeroes the buffer, and 
@@ -580,7 +606,8 @@ PJ_INLINE(void*) pj_pool_zalloc(pj_pool_t *pool, pj_size_t size)
  * @return          Memory buffer of the specified type.
  */
 #define PJ_POOL_ZALLOC_T(pool,type) \
-            ((type*)pj_pool_zalloc(pool, sizeof(type)))
+            ((type*)pj_pool_aligned_zalloc(pool, PJ_ALIGNOF(type), \
+                                           sizeof(type)))
 
 /*
  * Internal functions

--- a/pjlib/include/pj/pool_alt.h
+++ b/pjlib/include/pj/pool_alt.h
@@ -147,7 +147,7 @@ PJ_DECL(void*) pj_pool_zalloc_imp(const char *file, int line,
 #define PJ_POOL_ALLOC_T(pool,type) \
             ((type*)pj_pool_alloc(pool, sizeof(type)))
 #ifndef PJ_POOL_ALIGNMENT
-#   define PJ_POOL_ALIGNMENT    4
+#   define PJ_POOL_ALIGNMENT    (sizeof(void*))
 #endif
 
 /**

--- a/pjlib/include/pj/pool_alt.h
+++ b/pjlib/include/pj/pool_alt.h
@@ -91,6 +91,9 @@ PJ_DECL(int) pj_NO_MEMORY_EXCEPTION(void);
 #define pj_pool_zalloc(pool,sz)             \
         pj_pool_zalloc_imp(__FILE__, __LINE__, pool, sz)
 
+#define pj_pool_aligned_zalloc(pool,alignment,sz) \
+        pj_pool_aligned_zalloc_imp(__FILE__, __LINE__, pool, alignment, sz)
+
 
 
 /*
@@ -140,6 +143,11 @@ PJ_DECL(void*) pj_pool_calloc_imp(const char *file, int line,
 /* Allocate memory from the pool and zero the memory */
 PJ_DECL(void*) pj_pool_zalloc_imp(const char *file, int line, 
                                   pj_pool_t *pool, pj_size_t sz);
+
+/* Allocate aligned memory from the pool and zero the memory */
+PJ_DECL(void*) pj_pool_aligned_zalloc_imp(const char *file, int line,
+                                          pj_pool_t *pool,
+                                          pj_size_t alignment, pj_size_t sz);
 
 
 #define PJ_POOL_ZALLOC_T(pool,type) \

--- a/pjlib/include/pj/pool_i.h
+++ b/pjlib/include/pj/pool_i.h
@@ -80,7 +80,7 @@ PJ_IDEF(void*) pj_pool_aligned_alloc(pj_pool_t *pool, pj_size_t alignment,
 
     PJ_ASSERT_RETURN(!alignment || PJ_IS_POWER_OF_TWO(alignment), NULL);
 
-    if (!alignment)
+    if (alignment < pool->alignment)
         alignment = pool->alignment;
 
 #if 0
@@ -124,6 +124,17 @@ PJ_IDEF(void*) pj_pool_calloc( pj_pool_t *pool, pj_size_t count, pj_size_t size)
     buf = pj_pool_alloc( pool, size*count);
     if (buf)
         pj_bzero(buf, size * count);
+    return buf;
+}
+
+PJ_IDEF(void*) pj_pool_aligned_zalloc(pj_pool_t *pool, pj_size_t alignment,
+                                      pj_size_t size)
+{
+    void *buf;
+
+    buf = pj_pool_aligned_alloc(pool, alignment, size);
+    if (buf)
+        pj_bzero(buf, size);
     return buf;
 }
 

--- a/pjlib/src/pj/fifobuf.c
+++ b/pjlib/src/pj/fifobuf.c
@@ -25,7 +25,21 @@
 
 #define THIS_FILE   "fifobuf"
 
-#define SZ  sizeof(unsigned)
+/* Size of the per-chunk header, which holds the chunk's total size.
+ *
+ * It doubles as the allocator's alignment: the payload starts immediately
+ * after the header and every chunk occupies a multiple of SZ, so a payload
+ * is exactly as aligned as fifobuf->first (which pj_fifobuf_init() aligns).
+ * It must be a power of two, at least sizeof(unsigned) so the header fits,
+ * and large enough for any object the caller stores in the buffer, hence
+ * pointer sized, matching PJ_POOL_ALIGNMENT.
+ */
+#define SZ  (sizeof(void*) < sizeof(unsigned) ? sizeof(unsigned) \
+                                              : sizeof(void*))
+
+/* Round up/down to a multiple of SZ */
+#define ALIGN_UP(x)     (((x) + SZ - 1) & ~(SZ - 1))
+#define ALIGN_DN(x)     ((x) & ~(SZ - 1))
 
 /* put and get size at arbitrary, possibly unaligned location */
 PJ_INLINE(void) put_size(void *ptr, unsigned size)
@@ -48,16 +62,22 @@ PJ_DEF(void) pj_fifobuf_init (pj_fifobuf_t *fifobuf, void *buffer, unsigned size
                "fifobuf_init fifobuf=%p buffer=%p, size=%d", 
                fifobuf, buffer, size));
 
-    fifobuf->first = (char*)buffer;
-    fifobuf->last = fifobuf->first + size;
+    /* Align the start, so that every chunk payload is aligned too. The
+     * padding is taken out of the usable space.
+     */
+    fifobuf->first = (char*)ALIGN_UP((pj_size_t)buffer);
+    fifobuf->last = (char*)buffer + size;
+    if (fifobuf->last < fifobuf->first)
+        fifobuf->last = fifobuf->first;
     fifobuf->ubegin = fifobuf->uend = fifobuf->first;
     fifobuf->full = (fifobuf->last==fifobuf->first);
 }
 
 PJ_DEF(unsigned) pj_fifobuf_capacity (pj_fifobuf_t *fifobuf)
 {
-    unsigned cap = (unsigned)(fifobuf->last - fifobuf->first);
-    return (cap > 0) ? cap-SZ : 0;
+    unsigned cap = (unsigned)ALIGN_DN((pj_size_t)(fifobuf->last -
+                                                  fifobuf->first));
+    return (cap > SZ) ? cap-SZ : 0;
 }
 
 PJ_DEF(unsigned) pj_fifobuf_available_size (pj_fifobuf_t *fifobuf)
@@ -78,10 +98,12 @@ PJ_DEF(unsigned) pj_fifobuf_available_size (pj_fifobuf_t *fifobuf)
         else
             s = s1<s2 ? s2 : s1;
 
-        return (s>=SZ) ? s-SZ : 0;
+        s = (unsigned)ALIGN_DN((pj_size_t)s);
+        return (s>SZ) ? s-SZ : 0;
     } else {
-        unsigned s = (unsigned)(fifobuf->ubegin - fifobuf->uend);
-        return (s>=SZ) ? s-SZ : 0;
+        unsigned s = (unsigned)ALIGN_DN((pj_size_t)(fifobuf->ubegin -
+                                                    fifobuf->uend));
+        return (s>SZ) ? s-SZ : 0;
     }
 }
 
@@ -89,8 +111,14 @@ PJ_DEF(void*) pj_fifobuf_alloc (pj_fifobuf_t *fifobuf, unsigned size)
 {
     unsigned available;
     char *start;
+    unsigned total;
 
     PJ_CHECK_STACK();
+
+    /* Chunks occupy a multiple of SZ so that the chunk after this one, and
+     * hence its payload, stays aligned.
+     */
+    total = (unsigned)ALIGN_UP((pj_size_t)size + SZ);
 
     if (fifobuf->full) {
         PJ_LOG(6, (THIS_FILE, 
@@ -112,14 +140,14 @@ PJ_DEF(void*) pj_fifobuf_alloc (pj_fifobuf_t *fifobuf, unsigned size)
          * where the size of free0, used, and/or free1 may be zero.
          */
         available = (unsigned)(fifobuf->last - fifobuf->uend);
-        if (available >= size+SZ) {
+        if (available >= total) {
             char *ptr = fifobuf->uend;
-            fifobuf->uend += (size+SZ);
+            fifobuf->uend += total;
             if (fifobuf->uend == fifobuf->last)
                 fifobuf->uend = fifobuf->first;
             if (fifobuf->uend == fifobuf->ubegin)
                 fifobuf->full = 1;
-            put_size(ptr, size+SZ);
+            put_size(ptr, total);
             ptr += SZ;
 
             PJ_LOG(6, (THIS_FILE, 
@@ -141,12 +169,12 @@ PJ_DEF(void*) pj_fifobuf_alloc (pj_fifobuf_t *fifobuf, unsigned size)
      */
     start = (fifobuf->uend <= fifobuf->ubegin) ? fifobuf->uend : fifobuf->first;
     available = (unsigned)(fifobuf->ubegin - start);
-    if (available >= size+SZ) {
+    if (available >= total) {
         char *ptr = start;
-        fifobuf->uend = start + size + SZ;
+        fifobuf->uend = start + total;
         if (fifobuf->uend == fifobuf->ubegin)
             fifobuf->full = 1;
-        put_size(ptr, size+SZ);
+        put_size(ptr, total);
         ptr += SZ;
 
         PJ_LOG(6, (THIS_FILE, 

--- a/pjlib/src/pj/fifobuf.c
+++ b/pjlib/src/pj/fifobuf.c
@@ -30,9 +30,9 @@
  * It doubles as the allocator's alignment: the payload starts immediately
  * after the header and every chunk occupies a multiple of SZ, so a payload
  * is exactly as aligned as fifobuf->first (which pj_fifobuf_init() aligns).
- * It must be a power of two, at least sizeof(unsigned) so the header fits,
- * and large enough for any object the caller stores in the buffer, hence
- * pointer sized, matching PJ_POOL_ALIGNMENT.
+ * It must be a power of two and at least sizeof(unsigned) so the header
+ * fits. Pointer sized matches PJ_POOL_ALIGNMENT and covers the objects
+ * fifobuf is used for; it is not an alignment the caller can raise.
  */
 #define SZ  (sizeof(void*) < sizeof(unsigned) ? sizeof(unsigned) \
                                               : sizeof(void*))
@@ -111,14 +111,17 @@ PJ_DEF(void*) pj_fifobuf_alloc (pj_fifobuf_t *fifobuf, unsigned size)
 {
     unsigned available;
     char *start;
-    unsigned total;
+    pj_size_t total;
 
     PJ_CHECK_STACK();
 
     /* Chunks occupy a multiple of SZ so that the chunk after this one, and
-     * hence its payload, stays aligned.
+     * hence its payload, stays aligned. Keep the total in pj_size_t: an
+     * unsigned would wrap for a size close to its maximum, and the wrapped
+     * (small) total would then pass the checks below and hand out a chunk
+     * that was never reserved.
      */
-    total = (unsigned)ALIGN_UP((pj_size_t)size + SZ);
+    total = ALIGN_UP((pj_size_t)size + SZ);
 
     if (fifobuf->full) {
         PJ_LOG(6, (THIS_FILE, 
@@ -147,7 +150,7 @@ PJ_DEF(void*) pj_fifobuf_alloc (pj_fifobuf_t *fifobuf, unsigned size)
                 fifobuf->uend = fifobuf->first;
             if (fifobuf->uend == fifobuf->ubegin)
                 fifobuf->full = 1;
-            put_size(ptr, total);
+            put_size(ptr, (unsigned)total);
             ptr += SZ;
 
             PJ_LOG(6, (THIS_FILE, 
@@ -174,7 +177,7 @@ PJ_DEF(void*) pj_fifobuf_alloc (pj_fifobuf_t *fifobuf, unsigned size)
         fifobuf->uend = start + total;
         if (fifobuf->uend == fifobuf->ubegin)
             fifobuf->full = 1;
-        put_size(ptr, total);
+        put_size(ptr, (unsigned)total);
         ptr += SZ;
 
         PJ_LOG(6, (THIS_FILE, 

--- a/pjlib/src/pj/pool_dbg.c
+++ b/pjlib/src/pj/pool_dbg.c
@@ -232,6 +232,21 @@ PJ_DEF(void*) pj_pool_zalloc_imp( const char *file, int line,
     return pj_pool_calloc_imp(file, line, pool, 1, (unsigned)sz); 
 }
 
+/* Allocate aligned memory from the pool and zero the memory */
+PJ_DEF(void*) pj_pool_aligned_zalloc_imp( const char *file, int line,
+                                          pj_pool_t *pool,
+                                          pj_size_t alignment, pj_size_t sz)
+{
+    void *mem;
+
+    mem = pj_pool_alloc_imp(file, line, pool, alignment, sz);
+    if (!mem)
+        return NULL;
+
+    pj_bzero(mem, sz);
+    return mem;
+}
+
 
 
 #endif  /* PJ_HAS_POOL_ALT_API */

--- a/pjlib/src/pjlib-test/fifobuf.c
+++ b/pjlib/src/pjlib-test/fifobuf.c
@@ -31,14 +31,20 @@ int dummy_fifobuf_test;
 #define THIS_FILE   "fifobuf.c"
 
 enum {
-    SZ = sizeof(unsigned),
+    /* Must match SZ in fifobuf.c: the per-chunk header, which is also the
+     * alignment that pj_fifobuf_alloc() guarantees for the payload.
+     */
+    SZ = sizeof(void*) < sizeof(unsigned) ? sizeof(unsigned) : sizeof(void*),
 };
 
 static int fifobuf_size_test()
 {
-    enum { SIZE = 32 };
+    /* SIZE is chosen so that, with the 16 and 4 byte allocations below, the
+     * available size after freeing the first chunk is exactly 16.
+     */
+    enum { SIZE = 6 * sizeof(void*) };
     char before[8];
-    char buffer[SIZE];
+    union { char buf[SIZE]; void *align_; } buffer;
     char after[8];
     char zero[8];
     void *p0, *p1;
@@ -48,7 +54,7 @@ static int fifobuf_size_test()
     pj_bzero(after, sizeof(after));
     pj_bzero(zero, sizeof(zero));
 
-    pj_fifobuf_init (&fifo, buffer, sizeof(buffer));
+    pj_fifobuf_init (&fifo, buffer.buf, sizeof(buffer.buf));
 
     PJ_TEST_EQ(pj_fifobuf_capacity(&fifo), SIZE-SZ, NULL, return -11);
     PJ_TEST_EQ(pj_fifobuf_available_size(&fifo), SIZE-SZ, NULL, return -12);
@@ -75,11 +81,11 @@ static int fifobuf_rolling_test()
         SIZE=(MIN_SIZE+MAX_SIZE)/2*N,
     };
     pj_list chunks;
-    char buffer[SIZE];
+    union { char buf[SIZE]; void *align_; } buffer;
     pj_fifobuf_t fifo;
     unsigned rep;
 
-    pj_fifobuf_init(&fifo, buffer, sizeof(buffer));
+    pj_fifobuf_init(&fifo, buffer.buf, sizeof(buffer.buf));
     pj_list_init(&chunks);
 
     PJ_TEST_EQ(pj_fifobuf_capacity(&fifo), SIZE-SZ, NULL, return -300);
@@ -158,9 +164,8 @@ static int fifobuf_misc_test()
     for (i=0; i<30; ++i) {
         entries[i] = pj_fifobuf_alloc(&fifo, i+1);
         PJ_TEST_NOT_NULL(entries[i], NULL, return -50);
-        //fifobuf is no longer aligned.
-        //PJ_TEST_EQ(((pj_size_t)entries[i]) % sizeof(unsigned), 0, -60, 
-        //           "alignment error");
+        PJ_TEST_EQ(((pj_size_t)entries[i]) % SZ, 0, "alignment error",
+                   return -60);
     }
     for (i=0; i<30; ++i) {
         PJ_TEST_SUCCESS( pj_fifobuf_free(&fifo, entries[i]), NULL, return -70);

--- a/pjlib/src/pjlib-test/fifobuf.c
+++ b/pjlib/src/pjlib-test/fifobuf.c
@@ -39,10 +39,17 @@ enum {
 
 static int fifobuf_size_test()
 {
-    /* SIZE is chosen so that, with the 16 and 4 byte allocations below, the
-     * available size after freeing the first chunk is exactly 16.
+    /* The two allocations below must exactly fill the buffer to within one
+     * chunk header, which is what makes the available size after freeing the
+     * first chunk come out at 16. Derive that from the chunk overhead so it
+     * holds for both 4 and 8 byte SZ (32 and 64 bit); the 64 bit chunks are
+     * larger, so a fixed size cannot satisfy both.
      */
-    enum { SIZE = 6 * sizeof(void*) };
+    enum {
+        CHUNK0 = 16 + SZ,                        /* chunk for the 16b alloc */
+        CHUNK1 = (4 + SZ + SZ - 1) & ~(SZ - 1),  /* chunk for the 4b alloc  */
+        SIZE   = CHUNK0 + CHUNK1 + SZ
+    };
     char before[8];
     union { char buf[SIZE]; void *align_; } buffer;
     char after[8];

--- a/pjlib/src/pjlib-test/pool.c
+++ b/pjlib/src/pjlib-test/pool.c
@@ -218,6 +218,93 @@ on_return:
     return rc;
 }
 
+/* An over-aligned type: the pool must honour the type's own requirement,
+ * which is stricter than the pool's default alignment.
+ */
+typedef struct PJ_ALIGN_DATA_PREFIX(32) over_aligned_t
+{
+    int value;
+} PJ_ALIGN_DATA_SUFFIX(32) over_aligned_t;
+
+/* Test that PJ_POOL_ALLOC_T/PJ_POOL_ZALLOC_T honour the type's alignment,
+ * that the zeroing variant still zeroes, and that a request for less than
+ * the pool's own alignment is raised to it rather than lowered.
+ */
+static int pool_alloc_t_alignment_test(void)
+{
+    enum { LOOP = 32, POOL_ALIGNMENT_TEST = 4*PJ_POOL_ALIGNMENT };
+    pj_pool_t *pool = NULL, *pool2 = NULL;
+    unsigned i;
+    int rc = 0;
+
+    PJ_LOG(3,("test", "...PJ_POOL_ALLOC_T alignment test"));
+
+    PJ_TEST_GTE(PJ_ALIGNOF(over_aligned_t), 32, NULL, return -500);
+
+    pool = pj_pool_create(mem, NULL, 4096, 4096, NULL);
+    PJ_TEST_NOT_NULL(pool, NULL, return -505);
+
+    pool2 = pj_pool_aligned_create(mem, NULL, 4096, 4096,
+                                   POOL_ALIGNMENT_TEST, NULL);
+    PJ_TEST_NOT_NULL(pool2, NULL, { rc=-506; goto on_return; });
+
+    for (i=0; i<LOOP; ++i) {
+        over_aligned_t *a, *z;
+        char *odd;
+
+        /* Walk the bump pointer through every residue, so that the
+         * alignment cannot be an accident of where the pool happens to be.
+         */
+        odd = (char*)pj_pool_alloc(pool, 1 + (i % (2*PJ_ALIGNOF(over_aligned_t))));
+        PJ_TEST_NOT_NULL(odd, NULL, { rc=-510; goto on_return; });
+
+        /* The type's alignment must be honoured, not the pool default */
+        a = PJ_POOL_ALLOC_T(pool, over_aligned_t);
+        PJ_TEST_NOT_NULL(a, NULL, { rc=-515; goto on_return; });
+        PJ_TEST_EQ(((pj_size_t)a) % PJ_ALIGNOF(over_aligned_t), 0,
+                   "PJ_POOL_ALLOC_T ignored the type alignment",
+                   { rc=-520; goto on_return; });
+
+        /* Another odd filler, so that the zeroing variant is checked from
+         * its own residue rather than inheriting the one the aligned
+         * allocation above happened to leave behind.
+         */
+        odd = (char*)pj_pool_alloc(pool, 1 + ((i+3) % (2*PJ_ALIGNOF(over_aligned_t))));
+        PJ_TEST_NOT_NULL(odd, NULL, { rc=-522; goto on_return; });
+
+        z = PJ_POOL_ZALLOC_T(pool, over_aligned_t);
+        PJ_TEST_NOT_NULL(z, NULL, { rc=-525; goto on_return; });
+        PJ_TEST_EQ(((pj_size_t)z) % PJ_ALIGNOF(over_aligned_t), 0,
+                   "PJ_POOL_ZALLOC_T ignored the type alignment",
+                   { rc=-530; goto on_return; });
+        PJ_TEST_EQ(z->value, 0, "PJ_POOL_ZALLOC_T did not zero",
+                   { rc=-535; goto on_return; });
+
+        /* A type needing less than the pool's alignment must still come
+         * back on the pool floor, i.e. the request is raised, not lowered.
+         */
+        odd = PJ_POOL_ALLOC_T(pool2, char);
+        PJ_TEST_NOT_NULL(odd, NULL, { rc=-540; goto on_return; });
+        PJ_TEST_EQ(((pj_size_t)odd) % POOL_ALIGNMENT_TEST, 0,
+                   "allocation fell below the pool alignment",
+                   { rc=-545; goto on_return; });
+
+        /* Deliberately no pj_pool_reset() here: the allocations must
+         * accumulate so that the bump pointer walks through every residue.
+         * Resetting would restart each iteration from the same offset and
+         * the test would only ever probe one of them.
+         */
+    }
+
+on_return:
+    if (pool)
+        pj_pool_release(pool);
+    if (pool2)
+        pj_pool_release(pool2);
+    return rc;
+}
+
+
 /* Test that the alignment works for pool on buf. */
 static int pool_buf_alignment_test(void)
 {
@@ -403,6 +490,9 @@ int pool_test(void)
 #endif  //PJ_HAS_POOL_ALT_API == 0
 
     rc = pool_alignment_test();
+    if (rc) return rc;
+
+    rc = pool_alloc_t_alignment_test();
     if (rc) return rc;
 
     rc = pool_buf_alignment_test();

--- a/pjlib/src/pjlib-test/unittest_test.c
+++ b/pjlib/src/pjlib-test/unittest_test.c
@@ -266,9 +266,14 @@ static int func_to_test(void *arg)
 
 enum { 
     /* approx len of each log msg in func_to_test() 
-     * Note that logging adds decor e.g. time, plus overhead in fifobuf.
+     * Note that logging adds decor e.g. time, plus overhead in fifobuf:
+     * a chunk header, and the chunk rounded up to a multiple of the
+     * header size. Keep this in step with SZ in fifobuf.c.
      */
-    MSG_LEN = 45 + 4 + sizeof(pj_test_log_item),
+    FIFOBUF_SZ = sizeof(void*) < sizeof(unsigned) ? sizeof(unsigned)
+                                                  : sizeof(void*),
+    MSG_LEN = (45 + sizeof(pj_test_log_item) + FIFOBUF_SZ + FIFOBUF_SZ - 1) &
+              ~(FIFOBUF_SZ - 1),
 };
 
 /**
@@ -280,12 +285,12 @@ static int usage_test(pj_pool_t *pool, pj_bool_t basic, pj_bool_t parallel,
                       unsigned log_size)
 {
     enum {
-        TEST_CASE_LOG_SIZE = 256,
+        TEST_CASE_LOG_SIZE = 4*MSG_LEN,
     };
     char test_title[80];
     pj_test_suite suite;
     unsigned flags;
-    char buffer0[TEST_CASE_LOG_SIZE], buffer1[TEST_CASE_LOG_SIZE];
+    union { char buf[TEST_CASE_LOG_SIZE]; void *align_; } buffer0, buffer1;
     pj_test_case test_case0, test_case1;
     pj_test_runner *runner;
     pj_test_runner basic_runner;
@@ -313,7 +318,7 @@ static int usage_test(pj_pool_t *pool, pj_bool_t basic, pj_bool_t parallel,
     
     pj_test_case_init(&test_case0, "successful test", flags, &func_to_test,
                       (void*)(long)(0+TEST_LOG_ALL),
-                      buffer0, log_size, NULL);
+                      buffer0.buf, log_size, NULL);
     pj_test_suite_add_case(&suite, &test_case0);
 
     /* Add test case 1. This test case simulates error. It writes
@@ -321,7 +326,7 @@ static int usage_test(pj_pool_t *pool, pj_bool_t basic, pj_bool_t parallel,
      */
     pj_test_case_init(&test_case1, "failure test", flags, &func_to_test, 
                       (void*)(long)(1+TEST_LOG_ALL+TEST_RETURN_ERROR),
-                      buffer1, log_size, NULL);
+                      buffer1.buf, log_size, NULL);
     pj_test_suite_add_case(&suite, &test_case1);
 
     /* Create runner */
@@ -517,7 +522,12 @@ static int log_msg_sizes[] = {
     2*MSG_LEN, /* log buffer enough for 2 messages */
     3*MSG_LEN, /* log buffer enough for 3 message */
     0,         /* no log buffer */
-    64,        /* log will be truncated */
+
+    /* Log will be truncated: less than one whole message, but still enough
+     * that the retained prefix reaches past "Some error in", which is what
+     * the truncated case asserts.
+     */
+    MSG_LEN - FIFOBUF_SZ,
 };
 
 int unittest_basic_test(void)


### PR DESCRIPTION
`PJ_POOL_ALIGNMENT` defaults to 4. On a 64-bit target that under-aligns every pool-allocated object that embeds a type with a stricter requirement — an OS synchronisation primitive, or a 64-bit field accessed atomically.

Christian Becker reported a production crash from this. A `CRITICAL_SECTION` inside a pool-allocated `pj_mutex_t` landed at `addr & 7 == 4`, putting its 8-byte `LockSemaphore` (`CS+0x18`) at offset 60 of a cache line, so it straddled the boundary. ntdll writes that field once with `lock cmpxchg` on first contention (`0 -> -1`) but reads it back with a plain `mov`; the torn read is neither `0` nor `-1`, so ntdll calls `NtSetEvent()` on it, gets `STATUS_INVALID_HANDLE` and raises it. Roughly 1 in 8 misaligned mutexes is a latent crash, and it can only fire in the single first-contention window, which is why it presented as rare and patternless.

### Where it actually bites

`aconfigure.ac` and `pjlib/CMakeLists.txt` already set 8 on 64-bit, so this only ever affected builds that run neither — the MSVC project files, which is what the reporter builds. The `pool.h` fallback is now pointer-sized so those get it too. Blast radius is limited to MSVC for the same reason.

### The autoconf test was also incomplete

It matched a list of target triples, which silently gave 4 to any 64-bit target not mentioned: `amd64-*` (the FreeBSD/OpenBSD/NetBSD triple), `ppc64`/`ppc64le`, `riscv64`, `s390x`, `loongarch64`. Replaced with a pointer-size test. It is compile-only, so it stays correct when cross-compiling. Both branches verified here: 64-bit compiles → 8; `-m32` correctly fails to compile → 4.

### The allocator could not honour alignment at all

`PJ_POOL_ALLOC_T` passed only `sizeof(type)`, so a type's declared alignment was discarded. The clearest case is `struct pj_atomic_t`, which is declared `PJ_ALIGN_DATA_SUFFIX(8)` and holds an `_Atomic` value, yet was allocated with `sizeof` alone — the attribute was silently dropped by the allocator.

`PJ_ALIGNOF()` is added (compiler intrinsics, falling back to `alignof`/`_Alignof`, then to the `sizeof(struct { char c; T t; })` idiom), and `PJ_POOL_ALLOC_T`/`PJ_POOL_ZALLOC_T` pass it to `pj_pool_aligned_alloc()`. That function now treats the pool's own alignment as a **floor** rather than only substituting it for `0`, so an allocation is never *less* aligned than before — the change can only ever increase alignment. `pj_pool_aligned_zalloc()` is added for the zeroing variant.

`pj_atomic_slist` already did this by hand with `pj_pool_aligned_alloc(pool, MEMORY_ALLOCATION_ALIGNMENT, ...)` for both the header and the nodes, and was the only place in the tree that did.

### pj_fifobuf had the same defect independently

Chunks are `[size header][payload]` and the header was `sizeof(unsigned)` = 4, so every payload came back 4 bytes past an aligned address, and the next chunk started at an arbitrary offset. UBSan reports this against every `pj_test_log_item` access in `unittest.c`, and `fifobuf_rolling_test` stores `pj_list` nodes (8-byte pointers) in those chunks.

The header is now pointer-sized, each chunk is rounded up to a multiple of it, and `pj_fifobuf_init()` aligns the buffer start; `capacity()` and `available_size()` round down so they stay truthful (allocating exactly `available_size()` still succeeds, which `unittest.c` relies on). This restores the alignment assertion in `pjlib-test/fifobuf.c` that had been commented out with the note *"fifobuf is no longer aligned"* — it is re-enabled here.

### Testing

- UBSan misalignment reports **12 → 0** (clean `-O2 -fsanitize=address,undefined` build, pjlib-test + pjsip-test)
- Clean build, no new warnings; `pjlib-test` 15/15, `pjlib-util-test` 8/8, `fifobuf_test` passes with the re-enabled assertion
- Verified with a probe against the built library that an over-aligned type (64-byte) now gets its alignment through `PJ_POOL_ALLOC_T`, where it was previously capped at the pool default, while `char` still lands on the pool floor
- `pjsip-test` has 4 pre-existing `tsx_uac`/`tsx_uas` timing failures on this machine; the same tests fail (5 of them) on an unmodified clean build of the same base

Not addressed: `pool_alt.h`'s macros still cannot honour over-aligned types, since that allocator is `malloc`-backed and `malloc` only guarantees `max_align_t`. It is a debug-only allocator.

Reported-by: Christian Becker

