### PR TITLE
build: track header dependencies and relink executables automatically

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ Open-source multimedia communication library in C (SIP, SDP, RTP, STUN, TURN, IC
 ## Build & Test
 
 - **Build**: `./configure && make -j3` (timeout 120s+, NEVER CANCEL)
-- **Skip `make dep`** — it often produces corrupt `.depend` files. `make` generates deps automatically. If build fails with "missing separator" in `.depend`, run `find . -name "*.depend" -delete` and retry.
+- **`make dep` is not needed** — with GCC/Clang the compiler emits a `.d` file per object (`-MMD -MP`), so header dependencies are always up to date and `make dep` is a no-op. On a tree built before that change, a stale `.depend` can still fail with "missing separator": run `find . -name "*.depend" -delete` and retry.
 - **Targeted build**: `cd pjlib/build && make` (or `pjsip/build`, etc.)
 - **Full clean**: `make clean` (required when switching SSL backends or configure options)
 - Get target arch: `make infotarget` (e.g., `x86_64-pc-linux-gnu`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Open-source multimedia communication library in C (SIP, SDP, RTP, STUN, TURN, IC
 ## Build & Test
 
 - **Build**: `./configure && make -j3` (timeout 120s+, NEVER CANCEL)
-- **Skip `make dep`** — it often produces corrupt `.depend` files. `make` generates deps automatically. If build fails with "missing separator" in `.depend`, run `find . -name "*.depend" -delete` and retry.
+- **`make dep` is not needed** — with GCC/Clang the compiler emits a `.d` file per object (`-MMD -MP`), so header dependencies are always up to date and `make dep` is a no-op. On a tree built before that change, a stale `.depend` can still fail with "missing separator": run `find . -name "*.depend" -delete` and retry.
 - **Targeted build**: `cd pjlib/build && make` (or `pjsip/build`, etc.)
 - **Full clean**: `make clean` (required when switching SSL backends or configure options)
 - Get target arch: `make infotarget` (e.g., `x86_64-pc-linux-gnu`)

--- a/aconfigure
+++ b/aconfigure
@@ -744,6 +744,7 @@ ac_shlib_suffix
 ac_cflags
 ac_build_mak_vars
 ac_pjdir
+CC_DEPFLAGS
 CC_CFLAGS
 CC_OPTIMIZE
 CC_DEF
@@ -4947,6 +4948,9 @@ if test "$CC_DEF" = ""; then CC_DEF="-D"; fi
 if test "$CC_OPTIMIZE" = ""; then CC_OPTIMIZE="-O2"; fi
 
 if test "$CC_CFLAGS" = ""; then CC_CFLAGS="-Wall"; fi
+if test "$CC_DEPFLAGS" = ""; then
+    if test "$GCC" = "yes"; then CC_DEPFLAGS="-MMD -MP"; fi
+fi
 
 
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -68,6 +68,14 @@ if test "$CC_OPTIMIZE" = ""; then CC_OPTIMIZE="-O2"; fi
 AC_SUBST(CC_OPTIMIZE)
 if test "$CC_CFLAGS" = ""; then CC_CFLAGS="-Wall"; fi
 AC_SUBST(CC_CFLAGS)
+dnl Flags that make the compiler emit a .d dependency file as a side effect of
+dnl compiling. This is what keeps incremental builds correct when a header
+dnl changes; without it only the .c files are tracked. -MP additionally emits
+dnl a phony target per header so that deleting one does not break the build.
+if test "$CC_DEPFLAGS" = ""; then
+    if test "$GCC" = "yes"; then CC_DEPFLAGS="-MMD -MP"; fi
+fi
+AC_SUBST(CC_DEPFLAGS)
 
 AC_SUBST(ac_pjdir)
 AC_SUBST(ac_build_mak_vars)

--- a/build/cc-auto.mak.in
+++ b/build/cc-auto.mak.in
@@ -18,5 +18,6 @@ export CC_LIB := -l
 
 export CC_SOURCES :=
 export CC_CFLAGS := @CC_CFLAGS@
+export CC_DEPFLAGS := @CC_DEPFLAGS@
 export CC_LDFLAGS :=
 

--- a/build/cc-gcc.mak
+++ b/build/cc-gcc.mak
@@ -16,6 +16,7 @@ export CC_LIB := -l
 
 export CC_SOURCES :=
 export CC_CFLAGS := -Wall 
+export CC_DEPFLAGS := -MMD -MP
 #export CC_CFLAGS += -Wdeclaration-after-statement
 #export CC_CXXFLAGS := -Wdeclaration-after-statement
 export CC_LDFLAGS :=

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -255,6 +255,20 @@ endif
 dep: depend
 
 ifneq ($(CC_DEPFLAGS),)
+# A tree built before dependency generation was enabled has objects but no .d
+# files. A missing included makefile is not an error and carries no rules, so
+# make would consider those objects up to date and header edits would stay
+# invisible until each source happened to compile again for another reason.
+# Make the objects depend on a sentinel instead: creating it is newer than any
+# pre-existing object, which forces one rebuild that produces the .d files.
+# After that it never changes, and on a clean tree it costs nothing.
+DEP_SENTINEL := $(OBJDIR)/.depflags
+
+$(OBJS): $(DEP_SENTINEL)
+
+$(DEP_SENTINEL): | $(OBJDIRS)
+	@echo "$(CC_DEPFLAGS)" > $@
+
 -include $(OBJS:$(OBJEXT)=.d)
 else
 -include $(DEP_FILE)

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -155,32 +155,32 @@ $(OBJDIR)/$(app).ko: $(OBJDIR)/$(app).o | $(OBJDIRS)
 	cp $(OBJDIR)/$(app).ko ../lib
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.m | $(@D)
-	$(CC) $($(APP)_CFLAGS) \
+	$(CC) $($(APP)_CFLAGS) $(CC_DEPFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<) 
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.c | $(@D)
-	$(CC) $($(APP)_CFLAGS) \
+	$(CC) $($(APP)_CFLAGS) $(CC_DEPFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<) 
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.S | $(@D)
-	$(CC) $($(APP)_CFLAGS) \
+	$(CC) $($(APP)_CFLAGS) $(CC_DEPFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<) 
 
 $(OBJDIR)/dshowclasses.o: $(SRCDIR)/dshowclasses.cpp | $(@D)
-	$(CXX) $($(APP)_CXXFLAGS) -I$(SRCDIR)/../../../third_party/BaseClasses -fpermissive \
+	$(CXX) $($(APP)_CXXFLAGS) $(CC_DEPFLAGS) -I$(SRCDIR)/../../../third_party/BaseClasses -fpermissive \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<)
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.cpp | $(@D)
-	$(CXX) $($(APP)_CXXFLAGS) \
+	$(CXX) $($(APP)_CXXFLAGS) $(CC_DEPFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<)
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.cc | $(@D)
-	$(CXX) $($(APP)_CXXFLAGS) \
+	$(CXX) $($(APP)_CXXFLAGS) $(CC_DEPFLAGS) \
 		$(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 		$(subst /,$(HOST_PSEP),$<)
 
@@ -223,6 +223,14 @@ ifeq ($(OS_NAME),linux-kernel)
 	rm -f ../lib/$(app).ko
 endif
 
+# When the compiler emits a .d file per object (CC_DEPFLAGS), dependencies are
+# always up to date and this hand-rolled scan is both unnecessary and unsafe:
+# a partial run leaves a truncated $(DEP_FILE) that make later reports as
+# "missing separator".
+ifneq ($(CC_DEPFLAGS),)
+depend:
+	@echo "Dependencies are generated during compilation; nothing to do."
+else
 depend:
 	$(subst @@,$(DEP_FILE),$(HOST_RM))
 	for F in $(FULL_SRCS); do \
@@ -242,8 +250,13 @@ depend:
 	     fi; \
 	   fi; \
 	done;
+endif
 
 dep: depend
 
+ifneq ($(CC_DEPFLAGS),)
+-include $(OBJS:$(OBJEXT)=.d)
+else
 -include $(DEP_FILE)
+endif
 

--- a/pjlib-util/build/Makefile
+++ b/pjlib-util/build/Makefile
@@ -115,6 +115,12 @@ realclean:
 	$(MAKE) -f $(RULES_MAK) APP=PJLIB_UTIL app=pjlib-util $@
 	$(MAKE) -f $(RULES_MAK) APP=UTIL_TEST app=pjlib-util-test $@
 
+# Relink the executables when a library they link against is rebuilt.
+# rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
+# These used to be appended to the .depend file by the 'depend' target,
+# which meant they only took effect if 'make dep' had been run.
+export UTIL_TEST_EXTRA_DEP := $(LIBDIR)/$(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+
 depend:
 	$(MAKE) -f $(RULES_MAK) APP=PJLIB_UTIL app=pjlib-util $@
 	$(MAKE) -f $(RULES_MAK) APP=UTIL_TEST app=pjlib-util-test $@

--- a/pjlib/build/Makefile
+++ b/pjlib/build/Makefile
@@ -87,6 +87,12 @@ print:
 	$(MAKE) -f $(RULES_MAK) APP=PJLIB app=pjlib print_lib
 	$(MAKE) -f $(RULES_MAK) APP=TEST app=pjlib-test print_bin
 	
+# Relink the executables when a library they link against is rebuilt.
+# rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
+# These used to be appended to the .depend file by the 'depend' target,
+# which meant they only took effect if 'make dep' had been run.
+export TEST_EXTRA_DEP := $(LIBDIR)/$(PJLIB_LIB)
+
 depend: ../include/pj/config_site.h
 	$(MAKE) -f $(RULES_MAK) APP=PJLIB app=pjlib depend
 	$(MAKE) -f $(RULES_MAK) APP=TEST app=pjlib-test depend

--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -286,7 +286,10 @@ realclean:
 # rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
 # These used to be appended to the .depend file by the 'depend' target,
 # which meant they only took effect if 'make dep' had been run.
-export PJMEDIA_TEST_EXTRA_DEP := $(LIBDIR)/$(PJMEDIA_LIB) $(LIBDIR)/$(PJMEDIA_CODEC_LIB) \
+export PJMEDIA_TEST_EXTRA_DEP := $(LIBDIR)/$(PJMEDIA_LIB) \
+                                 $(LIBDIR)/$(PJMEDIA_CODEC_LIB) \
+                                 $(LIBDIR)/$(PJMEDIA_VIDEODEV_LIB) \
+                                 $(LIBDIR)/$(PJMEDIA_AUDIODEV_LIB) \
                                  $(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
 
 depend:

--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -282,6 +282,13 @@ realclean:
 	$(MAKE) -f $(RULES_MAK) APP=PJMEDIA_TEST app=pjmedia-test $@
 	$(MAKE) -f $(RULES_MAK) APP=PJSDP app=pjsdp $@
 
+# Relink the executables when a library they link against is rebuilt.
+# rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
+# These used to be appended to the .depend file by the 'depend' target,
+# which meant they only took effect if 'make dep' had been run.
+export PJMEDIA_TEST_EXTRA_DEP := $(LIBDIR)/$(PJMEDIA_LIB) $(LIBDIR)/$(PJMEDIA_CODEC_LIB) \
+                                 $(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+
 depend:
 	$(MAKE) -f $(RULES_MAK) APP=PJMEDIA app=pjmedia $@
 	$(MAKE) -f $(RULES_MAK) APP=PJMEDIA_VIDEODEV app=pjmedia-videodev $@

--- a/pjnath/build/Makefile
+++ b/pjnath/build/Makefile
@@ -155,6 +155,13 @@ realclean:
 	$(MAKE) -f $(RULES_MAK) APP=PJTURN_CLIENT app=pjturn-client $@
 	$(MAKE) -f $(RULES_MAK) APP=PJTURN_SRV app=pjturn-srv $@
 
+# Relink the executables when a library they link against is rebuilt.
+# rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
+# These used to be appended to the .depend file by the 'depend' target,
+# which meant they only took effect if 'make dep' had been run.
+export PJNATH_TEST_EXTRA_DEP := $(LIBDIR)/$(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+export PJTURN_CLIENT_EXTRA_DEP := $(LIBDIR)/$(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+
 depend:
 	$(MAKE) -f $(RULES_MAK) APP=PJNATH app=pjnath $@
 	$(MAKE) -f $(RULES_MAK) APP=PJNATH_TEST app=pjnath-test $@

--- a/pjnath/build/Makefile
+++ b/pjnath/build/Makefile
@@ -161,6 +161,7 @@ realclean:
 # which meant they only took effect if 'make dep' had been run.
 export PJNATH_TEST_EXTRA_DEP := $(LIBDIR)/$(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
 export PJTURN_CLIENT_EXTRA_DEP := $(LIBDIR)/$(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+export PJTURN_SRV_EXTRA_DEP := $(LIBDIR)/$(PJNATH_LIB) $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
 
 depend:
 	$(MAKE) -f $(RULES_MAK) APP=PJNATH app=pjnath $@

--- a/pjsip-apps/build/Makefile
+++ b/pjsip-apps/build/Makefile
@@ -31,6 +31,11 @@ export PJSUA_OBJS += $(OS_OBJS) $(M_OBJS) $(CC_OBJS) $(HOST_OBJS) \
 export PJSUA_CFLAGS += $(PJ_CFLAGS) $(CFLAGS)
 export PJSUA_CXXFLAGS += $(PJ_CXXFLAGS) $(CFLAGS)
 export PJSUA_LDFLAGS += $(PJ_LDFLAGS) $(PJ_LDLIBS) $(LDFLAGS)
+# Relink when a library pjsua links against is rebuilt. rules.mak adds
+# $(<APP>_EXTRA_DEP) to the executable's prerequisites. This edge used to be
+# appended to the .depend file by the 'depend' target below, which meant it
+# only took effect if 'make dep' had been run.
+export PJSUA_EXTRA_DEP := $(APP_LIB_FILES)
 ifeq ($(EXCLUDE_APP),0)
 export PJSUA_EXE:=pjsua-$(TARGET_NAME)$(HOST_EXE)
 endif
@@ -44,6 +49,7 @@ export PJSYSTEST_OBJS += $(OS_OBJS) $(M_OBJS) $(CC_OBJS) $(HOST_OBJS) \
 export PJSYSTEST_CFLAGS += $(PJ_CFLAGS) $(CFLAGS)
 export PJSYSTEST_CXXFLAGS += $(PJ_CXXFLAGS) $(CFLAGS)
 export PJSYSTEST_LDFLAGS += $(PJ_LDFLAGS) $(PJ_LDLIBS) $(LDFLAGS)
+export PJSYSTEST_EXTRA_DEP := $(APP_LIB_FILES)
 ifeq ($(EXCLUDE_APP),0)
 export PJSYSTEST_EXE:=pjsystest-$(TARGET_NAME)$(HOST_EXE)
 endif

--- a/pjsip/build/Makefile
+++ b/pjsip/build/Makefile
@@ -359,15 +359,9 @@ clean:
 # rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
 # These used to be appended to the .depend file by the 'depend' target,
 # which meant they only took effect if 'make dep' had been run.
-export TEST_EXTRA_DEP := $(PJMEDIA_LIB) $(LIBDIR)/$(PJSUA_LIB_LIB) $(LIBDIR)/$(PJSIP_SIMPLE_LIB) \
-        $(LIBDIR)/$(PJSIP_UA_LIB) $(LIBDIR)/$(PJSIP_LIB) $(PJNATH_LIB) \
-        $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
-export PJSUA_STRESS_EXTRA_DEP := $(PJMEDIA_LIB) $(LIBDIR)/$(PJSUA_LIB_LIB) $(LIBDIR)/$(PJSIP_SIMPLE_LIB) \
-        $(LIBDIR)/$(PJSIP_UA_LIB) $(LIBDIR)/$(PJSIP_LIB) $(PJNATH_LIB) \
-        $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
-export PJSUA2_TEST_EXTRA_DEP := $(LIBDIR)/$(PJSUA2_LIB_LIB) $(PJMEDIA_LIB) $(LIBDIR)/$(PJSUA_LIB_LIB) $(LIBDIR)/$(PJSIP_SIMPLE_LIB) \
-        $(LIBDIR)/$(PJSIP_UA_LIB) $(LIBDIR)/$(PJSIP_LIB) $(PJNATH_LIB) \
-        $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+export TEST_EXTRA_DEP := $(APP_LIB_FILES)
+export PJSUA_STRESS_EXTRA_DEP := $(APP_LIB_FILES)
+export PJSUA2_TEST_EXTRA_DEP := $(APP_LIBXX_FILES)
 
 depend:
 	$(MAKE) -f $(RULES_MAK) APP=PJSIP app=pjsip $@

--- a/pjsip/build/Makefile
+++ b/pjsip/build/Makefile
@@ -355,6 +355,20 @@ clean:
 	$(MAKE) -f $(RULES_MAK) APP=PJSUA_STRESS app=pjsua-stress $@
 	$(MAKE) -f $(RULES_MAK) APP=PJSUA2_TEST app=pjsua2-test $@
 
+# Relink the executables when a library they link against is rebuilt.
+# rules.mak adds $(<APP>_EXTRA_DEP) to the executable's prerequisites.
+# These used to be appended to the .depend file by the 'depend' target,
+# which meant they only took effect if 'make dep' had been run.
+export TEST_EXTRA_DEP := $(PJMEDIA_LIB) $(LIBDIR)/$(PJSUA_LIB_LIB) $(LIBDIR)/$(PJSIP_SIMPLE_LIB) \
+        $(LIBDIR)/$(PJSIP_UA_LIB) $(LIBDIR)/$(PJSIP_LIB) $(PJNATH_LIB) \
+        $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+export PJSUA_STRESS_EXTRA_DEP := $(PJMEDIA_LIB) $(LIBDIR)/$(PJSUA_LIB_LIB) $(LIBDIR)/$(PJSIP_SIMPLE_LIB) \
+        $(LIBDIR)/$(PJSIP_UA_LIB) $(LIBDIR)/$(PJSIP_LIB) $(PJNATH_LIB) \
+        $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+export PJSUA2_TEST_EXTRA_DEP := $(LIBDIR)/$(PJSUA2_LIB_LIB) $(PJMEDIA_LIB) $(LIBDIR)/$(PJSUA_LIB_LIB) $(LIBDIR)/$(PJSIP_SIMPLE_LIB) \
+        $(LIBDIR)/$(PJSIP_UA_LIB) $(LIBDIR)/$(PJSIP_LIB) $(PJNATH_LIB) \
+        $(PJLIB_UTIL_LIB) $(PJLIB_LIB)
+
 depend:
 	$(MAKE) -f $(RULES_MAK) APP=PJSIP app=pjsip $@
 	$(MAKE) -f $(RULES_MAK) APP=PJSIP_UA app=pjsip-ua $@


### PR DESCRIPTION
Editing a public header and rebuilding does not recompile the sources that include it.

The GNU makefiles take header dependencies only from a `.depend` file produced by the manual `depend` target, which shells out to `gcc -M` once per source. Nobody runs `make dep` — `CLAUDE.md` explicitly tells you not to, because a partial run leaves a truncated `.depend` that make then reports as `missing separator`. So in practice a header change recompiled **nothing**.

That is worse than a slow rebuild: the resulting binary links objects built against two different versions of the same header. If the header changed an inline function or a macro that expands to a different call, the two halves disagree and it misbehaves somewhere unrelated to the edit. I hit exactly this while working on a `pool.h` change — `pjsua_auth_test` segfaulted 100% of the time on the incremental build, and a clean rebuild of identical source passed. Debugging that cost more than the original change.

### Fix

Let the compiler emit the dependencies. `CC_DEPFLAGS` is `-MMD -MP` for GCC and Clang, so each object's `.d` file is written as a side effect of compiling it and cannot go stale. `-MP` emits a phony target per header, so deleting or renaming one does not break the build with *"No rule to make target"*.

- `build/rules.mak` passes `$(CC_DEPFLAGS)` in every compile rule and does `-include $(OBJS:$(OBJEXT)=.d)`
- Set in `build/cc-gcc.mak`, and in `build/cc-auto.mak.in` from a new `AC_SUBST(CC_DEPFLAGS)` gated on `$GCC` — true for gcc *and* clang, empty otherwise, so MSVC/armcc behaviour is unchanged
- Where `CC_DEPFLAGS` is set, `make dep` becomes a no-op and the old `.depend` is not included at all. That retires the corrupt-`.depend` failure mode entirely.

### The same target also hid the relink dependencies

`depend` was the only place that recorded executable→library dependencies, appending them to `.depend`. So a test binary was not relinked when a library it links against was rebuilt — `make` would report `'../bin/pjsip-test-...' is up to date` even after `sip_inv.o` and `libpjsip-ua.a` had just been rebuilt. Any A/B test of a library change against `pjsip-test` silently exercised the old binary.

These now use `<APP>_EXTRA_DEP`, an existing hook in `rules.mak` that no module was using. The `echo ... >> .depend` lines are deliberately left in place: they are still the mechanism for compilers where `.depend` is used.

### Testing

On a clean build, touching `pjlib/include/pj/pool.h`:

|  | before | after |
|---|---|---|
| sources recompiled | 0 | 372 |
| executables relinked | 0 | 12 |

`make dep` now prints `Dependencies are generated during compilation; nothing to do.` Clean full build with no new warnings; `pjlib-test` 15/15, `pjlib-util-test` 8/8.

`CLAUDE.md` and `.github/copilot-instructions.md` are updated together, since the `make dep` guidance in them describes exactly the behaviour this changes.
