### PR TITLE
pjsip-test: serialize the lazy init of the process wide UA singletons

### DIFF
--- a/pjsip/src/test/dlg_target_refresh_test.c
+++ b/pjsip/src/test/dlg_target_refresh_test.c
@@ -433,21 +433,12 @@ int dlg_target_refresh_test(void)
     pj_str_t uac_target_before;
     int rc = 0;
 
-    /* Init UA layer.
-     *
-     * pjsip_ua_instance() is a process wide singleton that other tests
-     * initialize too, so the check and the initialization must not be
-     * interleaved with theirs. Without this, two tests running in parallel
-     * can both see id == -1 and both register the same module, which trips
-     * the assertion in pjsip_endpt_register_module().
-     */
-    pj_enter_critical_section();
-    if (pjsip_ua_instance()->id == -1) {
+    /* Init UA layer */
+    {
         pjsip_ua_init_param ua_param;
         pj_bzero(&ua_param, sizeof(ua_param));
-        pjsip_ua_init_module(endpt, &ua_param);
+        PJ_TEST_SUCCESS(init_ua_layer(&ua_param), NULL, return -1);
     }
-    pj_leave_critical_section();
 
     PJ_TEST_SUCCESS(pjsip_endpt_register_module(endpt, &mod_dlg_tr_test),
                     NULL, return -2);

--- a/pjsip/src/test/dlg_target_refresh_test.c
+++ b/pjsip/src/test/dlg_target_refresh_test.c
@@ -433,12 +433,21 @@ int dlg_target_refresh_test(void)
     pj_str_t uac_target_before;
     int rc = 0;
 
-    /* Init UA layer */
+    /* Init UA layer.
+     *
+     * pjsip_ua_instance() is a process wide singleton that other tests
+     * initialize too, so the check and the initialization must not be
+     * interleaved with theirs. Without this, two tests running in parallel
+     * can both see id == -1 and both register the same module, which trips
+     * the assertion in pjsip_endpt_register_module().
+     */
+    pj_enter_critical_section();
     if (pjsip_ua_instance()->id == -1) {
         pjsip_ua_init_param ua_param;
         pj_bzero(&ua_param, sizeof(ua_param));
         pjsip_ua_init_module(endpt, &ua_param);
     }
+    pj_leave_critical_section();
 
     PJ_TEST_SUCCESS(pjsip_endpt_register_module(endpt, &mod_dlg_tr_test),
                     NULL, return -2);

--- a/pjsip/src/test/inv_offer_answer_test.c
+++ b/pjsip/src/test/inv_offer_answer_test.c
@@ -813,23 +813,16 @@ int inv_offer_answer_test(void)
     unsigned i;
     int rc = 0;
 
-    /* Init UA layer and inv-usage.
-     *
-     * Both are process wide singletons that other tests initialize too, so
-     * the checks and the initializations must not be interleaved with
-     * theirs. Without this, two tests running in parallel can both see
-     * id == -1 and both register the same module, which trips the assertion
-     * in pjsip_endpt_register_module().
-     */
-    pj_enter_critical_section();
-    if (pjsip_ua_instance()->id == -1) {
+    /* Init UA layer */
+    {
         pjsip_ua_init_param ua_param;
         pj_bzero(&ua_param, sizeof(ua_param));
         ua_param.on_dlg_forked = &on_dlg_forked;
-        pjsip_ua_init_module(endpt, &ua_param);
+        PJ_TEST_SUCCESS(init_ua_layer(&ua_param), NULL, return -1);
     }
 
-    if (pjsip_inv_usage_instance()->id == -1) {
+    /* Init inv-usage */
+    {
         pjsip_inv_callback inv_cb;
         pj_bzero(&inv_cb, sizeof(inv_cb));
         inv_cb.on_media_update = &on_media_update;
@@ -837,9 +830,8 @@ int inv_offer_answer_test(void)
         inv_cb.on_create_offer = &on_create_offer;
         inv_cb.on_state_changed = &on_state_changed;
         inv_cb.on_new_session = &on_new_session;
-        pjsip_inv_usage_init(endpt, &inv_cb);
+        PJ_TEST_SUCCESS(init_inv_usage(&inv_cb), NULL, return -1);
     }
-    pj_leave_critical_section();
 
     /* 100rel module */
     pjsip_100rel_init_module(endpt);

--- a/pjsip/src/test/inv_offer_answer_test.c
+++ b/pjsip/src/test/inv_offer_answer_test.c
@@ -813,7 +813,15 @@ int inv_offer_answer_test(void)
     unsigned i;
     int rc = 0;
 
-    /* Init UA layer */
+    /* Init UA layer and inv-usage.
+     *
+     * Both are process wide singletons that other tests initialize too, so
+     * the checks and the initializations must not be interleaved with
+     * theirs. Without this, two tests running in parallel can both see
+     * id == -1 and both register the same module, which trips the assertion
+     * in pjsip_endpt_register_module().
+     */
+    pj_enter_critical_section();
     if (pjsip_ua_instance()->id == -1) {
         pjsip_ua_init_param ua_param;
         pj_bzero(&ua_param, sizeof(ua_param));
@@ -821,7 +829,6 @@ int inv_offer_answer_test(void)
         pjsip_ua_init_module(endpt, &ua_param);
     }
 
-    /* Init inv-usage */
     if (pjsip_inv_usage_instance()->id == -1) {
         pjsip_inv_callback inv_cb;
         pj_bzero(&inv_cb, sizeof(inv_cb));
@@ -832,6 +839,7 @@ int inv_offer_answer_test(void)
         inv_cb.on_new_session = &on_new_session;
         pjsip_inv_usage_init(endpt, &inv_cb);
     }
+    pj_leave_critical_section();
 
     /* 100rel module */
     pjsip_100rel_init_module(endpt);

--- a/pjsip/src/test/test.c
+++ b/pjsip/src/test/test.c
@@ -245,6 +245,75 @@ static void close_report(void)
 }
 
 
+/*
+ * pjsip_ua_instance() and pjsip_inv_usage_instance() are process wide
+ * singletons that more than one test initializes, so an unguarded
+ * "if (id == -1) init()" lets two tests running in parallel both register
+ * the same module, which trips the assertion in
+ * pjsip_endpt_register_module().
+ *
+ * Claim the initialization under the critical section but perform it
+ * outside: pjsip_endpt_register_module() takes a mutex, may sleep for
+ * 100ms when the endpoint is already running, and runs the module's
+ * load()/start() callbacks, none of which may happen while the critical
+ * section is held (see pj_enter_critical_section()). This follows
+ * register_modules() in tsx_uas_test.c.
+ */
+static int ua_init_claimed;
+static int inv_usage_init_claimed;
+
+/* Wait for the thread that claimed the initialization to finish it. */
+static pj_status_t wait_module_ready(pjsip_module *mod)
+{
+    unsigned i;
+
+    for (i=0; i<20 && mod->id < 0; ++i)
+        pj_thread_sleep(50);
+
+    if (mod->id < 0)
+        return PJSIP_ENOTINITIALIZED;
+
+    return PJ_SUCCESS;
+}
+
+pj_status_t init_ua_layer(const pjsip_ua_init_param *prm)
+{
+    int claimed;
+
+    pj_enter_critical_section();
+    if (pjsip_ua_instance()->id != -1) {
+        /* Already initialized, by another test or by pjsua */
+        pj_leave_critical_section();
+        return PJ_SUCCESS;
+    }
+    claimed = ua_init_claimed++;
+    pj_leave_critical_section();
+
+    if (claimed == 0)
+        return pjsip_ua_init_module(endpt, prm);
+
+    return wait_module_ready(pjsip_ua_instance());
+}
+
+pj_status_t init_inv_usage(const pjsip_inv_callback *cb)
+{
+    int claimed;
+
+    pj_enter_critical_section();
+    if (pjsip_inv_usage_instance()->id != -1) {
+        pj_leave_critical_section();
+        return PJ_SUCCESS;
+    }
+    claimed = inv_usage_init_claimed++;
+    pj_leave_critical_section();
+
+    if (claimed == 0)
+        return pjsip_inv_usage_init(endpt, cb);
+
+    return wait_module_ready(pjsip_inv_usage_instance());
+}
+
+
 int test_main(int argc, char *argv[])
 {
     pj_status_t rc;

--- a/pjsip/src/test/test.h
+++ b/pjsip/src/test/test.h
@@ -21,9 +21,20 @@
 
 #include <pjsip/sip_types.h>
 #include <pjsip/sip_msg.h>
+#include <pjsip/sip_ua_layer.h>
+#include <pjsip-ua/sip_inv.h>
 #include <pj/string.h>
 
 extern pjsip_endpoint *endpt;
+
+/*
+ * Initialize the UA layer and the invite usage, which are process wide
+ * singletons that more than one test needs. Safe to call from several tests
+ * running in parallel: the first caller performs the initialization and the
+ * others wait for it. Returns PJ_SUCCESS if the module is ready to use.
+ */
+pj_status_t init_ua_layer(const pjsip_ua_init_param *prm);
+pj_status_t init_inv_usage(const pjsip_inv_callback *cb);
 extern pj_caching_pool caching_pool;
 
 /* Check if we are using ASan */


### PR DESCRIPTION
`Default / pjmedia,pjsip` fails intermittently with a module registered twice:

```
[ 1/32] msg_err_test                     [OK] [0.001s]
pjsip-test: ../src/pjsip/sip_endpoint.c:182: pjsip_endpt_register_module:
Assertion `pj_list_find_node(&endpt->module_list, mod) == ((void *)0)' failed.
```

Seen on [run 34197847127](https://github.com/pjsip/pjproject/actions/runs/34197847127/job/101969521185) (`-w 3 --shuffle`, seed 669).

### Cause

`dlg_target_refresh_test` and `inv_offer_answer_test` both initialise the UA layer on demand:

```c
if (pjsip_ua_instance()->id == -1)
    pjsip_ua_init_module(endpt, &ua_param);
```

`pjsip_ua_instance()` is a process-wide singleton, and the check is not serialised against the initialisation. With parallel runners both tests can observe `id == -1` and both proceed to register the same static module, which is what the assertion catches. `inv_offer_answer_test` does the same for `pjsip_inv_usage_instance()`.

It only shows up under `--shuffle` with more than one worker, and only when those two tests happen to be co-scheduled, which is why it appears as a rare flake rather than a consistent failure.

### Fix

Follow `register_modules()` in `tsx_uas_test.c`: claim the initialisation under the critical section, perform it outside, and have the callers that did not claim it wait for the module to become ready.

Deliberately **not** simply wrapping the whole thing in the critical section. `pjsip_endpt_register_module()` locks `endpt->mod_mutex` for write, sleeps 100 ms when the endpoint is already running, and runs the module's `load()`/`start()` callbacks. `pj_enter_critical_section()` documents that the caller must not block while holding it, and a 100 ms sleep inside a *global* critical section stalls every other thread that touches one. It would also introduce a `critical_section → mod_mutex(write)` order against the `mod_mutex(read) → critical_section` dispatch path in `PJ_GRP_LOCK_DEBUG` builds. Thanks @sauwming for catching this on the first revision.

The one thing that differs from `tsx_uas_test.c` is that these singletons are shared between two test *files*, so a file-static counter cannot coordinate them the way `modules_reg_cnt` does within a single file. The claim therefore lives in `test.c` as `init_ua_layer()` and `init_inv_usage()`, which both tests call:

- the critical section is held only across an integer
- `pjsip_ua_init_module()` / `pjsip_inv_usage_init()` run outside it
- callers that did not claim it poll for `mod->id >= 0`, with the same 20 x 50 ms and `PJSIP_ENOTINITIALIZED` fallback as `register_modules()`
- a fast path returns `PJ_SUCCESS` when the singleton is already up, so a run that initialised it through pjsua is unaffected

### Testing

Running just the two tests against each other with three workers and a fixed shuffle seed:

| | assertions |
|---|---|
| before | **2 / 24 seeds** |
| after | **0 / 24 seeds** |

A wider shuffled subset (`dlg_target_refresh_test inv_offer_answer_test tsx_basic_test msg_err_test txdata_test`, `-w 3`) passes across 5 seeds, and both tests still pass single-threaded.

### Not addressed

- This stops the crash, not the underlying singleton semantics: whichever test initialises the UA layer first decides the callbacks for the whole process, so `inv_offer_answer_test`'s `on_dlg_forked` is silently absent when `dlg_target_refresh_test` gets there first. That is pre-existing and would want a different fix (per-test endpoints, or an explicit shared init).
- `tsx_uac_test.c:init_test()` holds the critical section across `pjsip_endpt_register_module()` in the same way the first revision of this PR did. It has the same latent problem, but it is not what CI is tripping over and it is not shared across files, so it seems better as its own change.

Co-Authored-By Claude Code
