### PR TITLE
pjmedia: honour CVPixelBuffer stride on the chroma plane and for packed formats

### DIFF
--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -692,8 +692,49 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
             }
         }
     } else {
-        pj_memcpy(stream->capture_buf, CVPixelBufferGetBaseAddress(img),
-                  stream->frame_size);
+        /* Packed formats (e.g. BGRA): the buffer's bytes-per-row can exceed
+         * width * bpp for alignment (Apple QA1829), so a single flat copy of
+         * frame_size reads across row boundaries and repeats the image
+         * horizontally. Copy row by row using the real strides.
+         *
+         * The destination pitch comes from the delivered buffer's own width
+         * rather than from stream->bytes_per_row. The converter reads
+         * capture_buf at orig_size -- the landscape swap of the negotiated
+         * size -- while bytes_per_row follows the negotiated orientation, so
+         * for a portrait-negotiated stream the two disagree. Deriving it here
+         * keeps an unpadded buffer byte-identical to the previous flat copy.
+         */
+        pj_size_t bpp8 = stream->size.w?
+                         (stream->bytes_per_row / stream->size.w): 0;
+        pj_size_t src_stride = CVPixelBufferGetBytesPerRow(img);
+        pj_size_t dst_stride = CVPixelBufferGetWidth(img) * bpp8;
+        pj_size_t row_bytes = (dst_stride < src_stride)? dst_stride:
+                                                         src_stride;
+        pj_size_t src_rows = CVPixelBufferGetHeight(img);
+        /* Rows the destination can hold: this is exactly what the previous
+         * single memcpy of frame_size wrote, so the copy stays within
+         * capture_buf and is byte-identical whenever the strides match.
+         */
+        pj_size_t dst_rows = dst_stride ? (stream->frame_size / dst_stride) : 0;
+        pj_size_t rows = (src_rows < dst_rows) ? src_rows : dst_rows;
+        pj_uint8_t *src = (pj_uint8_t*)CVPixelBufferGetBaseAddress(img);
+        pj_uint8_t *dst = (pj_uint8_t*)stream->capture_buf;
+        pj_size_t i;
+
+        for (i = 0; i < rows; ++i) {
+            pj_memcpy(dst, src, row_bytes);
+            dst += dst_stride;
+            src += src_stride;
+        }
+
+        /* Zero what the source could not fill, as the planar branch above
+         * does for a short buffer. capture_buf is allocated once and reused
+         * for every frame, so an unwritten region does not merely expose
+         * uninitialised memory once -- it keeps displaying the previous
+         * frame's content for as long as the shortfall lasts.
+         */
+        if (rows < dst_rows)
+            pj_bzero(dst, (dst_rows - rows) * dst_stride);
     }
     
     status = pjmedia_vid_dev_conv_resize_and_rotate(&stream->conv, 

--- a/pjmedia/src/pjmedia-videodev/darwin_dev.m
+++ b/pjmedia/src/pjmedia-videodev/darwin_dev.m
@@ -608,11 +608,18 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
              * For example, resolution 352*288 can have a stride of 384.
              */
             pj_size_t stride = CVPixelBufferGetBytesPerRowOfPlane(img, 0);
+            /* The chroma plane has its own stride and its own padding, and
+             * neither is derivable from the luma plane's (Apple QA1829: query
+             * per-plane row bytes). On the iPhone 17 front camera they differ,
+             * and walking UV with the luma stride misaligns every chroma row,
+             * which is the horizontal banding this fix is for.
+             */
+            pj_size_t stride_uv = CVPixelBufferGetBytesPerRowOfPlane(img, 1);
             /* Image height is not always equal to the video resolution.
              * For example, resolution 352*288 can have a height of 264.
              */
             pj_size_t height = CVPixelBufferGetHeight(img);
-            pj_bool_t need_clip;
+            pj_bool_t need_clip, need_clip_uv;
             
             /* Auto detect rotation */
             if ((stream->vid_size.w > stream->vid_size.h && stride < height) ||
@@ -624,6 +631,13 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
             }
             
             need_clip = (stride != stream->vid_size.w);
+            /* Gate the chroma copy on the CHROMA stride: an NV12 chroma row
+             * holds w/2 UV pairs, i.e. w bytes, so unpadded means stride_uv
+             * == w. The luma plane can be unpadded while chroma is not, so
+             * reusing need_clip here would take the strideless path on a
+             * padded chroma plane.
+             */
+            need_clip_uv = (stride_uv != stream->vid_size.w);
             
             p = (pj_uint8_t*)CVPixelBufferGetBaseAddressOfPlane(img, 0);
 
@@ -650,7 +664,7 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
             }
 
             p = (pj_uint8_t*)CVPixelBufferGetBaseAddressOfPlane(img, 1);
-            if (!need_clip) {
+            if (!need_clip_uv) {
                 p_len >>= 1;
                 p_end = p + p_len;
                 
@@ -666,7 +680,7 @@ static pj_status_t darwin_factory_default_param(pj_pool_t *pool,
                         *U++ = *p++;
                         *V++ = *p++;
                     }
-                    p += (stride - stream->vid_size.w);
+                    p += (stride_uv - stream->vid_size.w);
                 }
             }
 


### PR DESCRIPTION
Fixes #5248. The symptoms were reported and diagnosed by @mobile-sergey in #4817 — the analysis there is theirs, and this is the fix for the two parts of it that #4751 did not cover.

Two commits, one defect each, so they can be taken separately or one reverted without the other.

**`2f22ae3c` — the chroma plane's own stride.** Each plane of a `CVPixelBuffer` has its own bytes-per-row and padding on one is not derivable from another (Apple QA1829). The capture path read the luma stride once and walked both planes with it, so a differently padded chroma plane put every UV row at the wrong offset. The clip decision needed splitting for the same reason: an NV12 chroma row holds `w/2` UV pairs, i.e. `w` bytes, so "unpadded" means `stride_uv == w`, and the luma plane can be unpadded while the chroma plane is not.

**`520660f7` — packed formats copied row by row.** The non-planar path did one `pj_memcpy()` of `frame_size`, which assumes contiguous rows. Where the buffer is padded, each destination row starts part way into the next source row, so the image repeats horizontally and shears.

The row count is bounded by what the destination can hold — `frame_size / dst_stride`, which is exactly what the single `memcpy` of `frame_size` wrote — so the copy stays inside `capture_buf`, and where the two strides are equal it is byte-identical to the old behaviour. Devices that were working keep working.

## Provenance, stated narrowly

The starting point was a patch we have carried downstream since #4817 was closed. Its exact testing scope, because the earlier wording here implied more than it should have:

- Only the **previous** form of this change was exercised — the one @nanangizz has now shown uses the wrong destination pitch, not what is on this branch.
- One narrow use case, and **never with an orientation switch**.
- The corruption did not reproduce before iPhone 17; it was gone after the patch; no degradation was seen on older devices — again, without orientation switching.

That gap is worth naming rather than glossing: the pitch defect found in review only bites when the negotiated orientation is portrait, which is precisely the case never covered. Production use did not validate this fix; it validated a narrower one, on a path where the two pitches happen to agree.

So the argument for these commits is the code, not the field evidence. Hardware coverage across formats, presets, orientations and cameras is being built separately and will be reported here when it exists rather than asserted now.

## Verified

`darwin_dev.m` compiles clean with `-Wall`, zero errors and zero warnings, matching `upstream/master` exactly.

Worth stating precisely, because it is easy to overclaim here: the file is behind `PJMEDIA_HAS_VIDEO && PJMEDIA_VIDEO_DEV_HAS_DARWIN`, and a build without those defined compiles none of this — my first attempt did exactly that and proved nothing. The figures above are from a build with both defined, confirmed by checking that `stride_uv`, `need_clip_uv` and the row-copy loop survive preprocessing.

**Not verified here:** I have no iPhone 17 to re-run the original repro on, and no automated coverage exists for this path — see below. The behavioural evidence is the production use above, not a test in this PR.

## On a regression test

There is none, and I would rather say so than let it pass unmentioned. The two defects are pure arithmetic over strides, so they are testable in principle, but the arithmetic is inline in `darwin_stream_get_frame()` behind an AVFoundation callback and a real `CVPixelBuffer`. Testing it as it stands needs a device with a padded capture buffer.

Extracting the stride arithmetic into a small pure function that both the callback and a `pjmedia-test` case could call would make it testable on any host — a synthetic padded buffer, a known pattern, an assertion on the output rows. That is a larger change than this fix and I did not want to bundle it. Happy to follow up with it if you would like the coverage.

