### PR TITLE
Fix Coverity Scan defects reported 2026-09-08

### DIFF
--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -632,7 +632,10 @@ static pj_bool_t sess_cache_store(const pj_str_t *name, SSL_SESSION *sess)
             ossl_sess_cache_cnt--;
         }
 
-        /* Shift existing entries down and insert at front. */
+        /* Shift existing entries down and insert at front. The branches
+         * above guarantee there is room for one more entry.
+         */
+        pj_assert(ossl_sess_cache_cnt < PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE);
         for (n = ossl_sess_cache_cnt; n > 0; --n)
             ossl_sess_cache[n] = ossl_sess_cache[n - 1];
 

--- a/pjmedia/src/pjmedia/clock_thread.c
+++ b/pjmedia/src/pjmedia/clock_thread.c
@@ -183,7 +183,9 @@ static void clock_sleep(pjmedia_clock *clock, unsigned msec)
 {
 #if defined(PJ_HAS_EVENT_OBJ) && PJ_HAS_EVENT_OBJ != 0
     if (clock->quit_ev) {
-        pj_event_timedwait(clock->quit_ev, msec);
+        /* Timed out or signalled to quit, the caller handles both. */
+        pj_status_t status = pj_event_timedwait(clock->quit_ev, msec);
+        PJ_UNUSED_ARG(status);
         return;
     }
 #endif

--- a/pjsip-apps/src/pjsua/pjsua_app_legacy.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_legacy.c
@@ -732,6 +732,7 @@ static void ui_make_new_call()
         } else if (result.uri_result) {
             tmp = pj_str(result.uri_result);
         } else {
+            tmp.ptr = NULL;
             tmp.slen = 0;
         }
 


### PR DESCRIPTION
Addresses the defects from the Coverity Scan report of 2026-09-08, plus one related hardening change.

### `pjsua_app_legacy.c` — CID 1686061 (UNINIT)

In `ui_make_new_call()`, when `ui_input_url()` returns neither a buddy index nor a URI, only `tmp.slen` was set, leaving `tmp.ptr` uninitialized before `&tmp` was passed to `pjsua_call_make_call()`. Harmless in practice since `slen` is 0 and nothing dereferences `ptr`, but it is a genuine read of an uninitialized value.

### `clock_thread.c` — CID 1686060 (CHECKED_RETURN)

`clock_sleep()` ignored the return of `pj_event_timedwait()`. That is deliberate: a timeout is the normal case and a signalled event means the clock is stopping, and the caller handles both by re-checking `clock->quitting`. Made it explicit so the intent is visible and the checker is satisfied.

### `ssl_sock_ossl.c` — hardening around CID 1663961

CID 1663961 itself is a false positive: `sess_cache_find()` returns either a valid index or -1, and line 624 guards the cast with `idx >= 0 && (unsigned)idx < ossl_sess_cache_cnt`, so the shift loop stays in bounds.

While checking it, the *insert* path a few lines below looked more fragile:

```c
for (n = ossl_sess_cache_cnt; n > 0; --n)
    ossl_sess_cache[n] = ossl_sess_cache[n - 1];
```

This writes `ossl_sess_cache[cnt]`, which would be out of bounds at `cnt == PJ_SSL_SOCK_OSSL_SESS_CACHE_SIZE`. It is safe today, but only via an invariant established across all three preceding branches (found → `cnt--`; not found and full → evict + `cnt--`; not found and not full → already `< SIZE`). Added a `pj_assert()` so a future branch that forgets to decrement is caught.

### Other outstanding CIDs (past reports) — no change needed

| CID | Location | Assessment |
|---|---|---|
| 1686059 | `pjsua_stress.c:748` | False positive. `i * 2654435761u` is intentional Knuth multiplicative hashing; unsigned wraparound is well-defined and is the point. |
| 1660072 | `sdp_neg.c:2146` | False positive. `is_dynamic_pt()` constrains `pt` to `[96, 127]` and `&&` short-circuits, so `pt_change[ref_pt - START_DYNAMIC_PT]` is always in `[0, 31]`. |
| 1663961 | `ssl_sock_ossl.c:627` | False positive, see above. |
| 1645650 / 1645642 / 1645643 | `pjsua2-test/auth_challenge.cpp` | False positives (WRAPPER_ESCAPE). `Account::create()` parks `this` in pjsua's account table, and `~Account()` calls `shutdown()` → `pjsua_acc_del()`, which unregisters it first. Standard pjsua2 ownership. |

These have been marked ignored in the Coverity UI.
