### PR TITLE
Fix use-after-free when an async auth challenge is deferred

### DIFF
--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -79,6 +79,10 @@ struct pjsip_publishc
     pjsip_endpoint              *endpt;
     pj_bool_t                    _delete_flag;
     int                          pending_tsx;
+    /* Outstanding async auth tokens. Kept separate from pending_tsx,
+     * which also gates request sending in pjsip_publishc_send().
+     */
+    int                          pending_auth_tokens;
     pj_bool_t                    in_callback;
     pj_mutex_t                  *mutex;
 
@@ -222,7 +226,7 @@ PJ_DEF(pj_status_t) pjsip_publishc_destroy(pjsip_publishc *pubc)
 {
     PJ_ASSERT_RETURN(pubc, PJ_EINVAL);
 
-    if (pubc->pending_tsx || pubc->in_callback) {
+    if (pubc->pending_tsx || pubc->in_callback || pubc->pending_auth_tokens) {
         pubc->_delete_flag = 1;
         pubc->cb = NULL;
     } else {
@@ -612,10 +616,11 @@ static void pubc_refresh_timer_cb( pj_timer_heap_t *timer_heap,
  */
 static void pubc_auth_token_release(pjsip_publishc *pubc)
 {
-    pj_assert(pubc->pending_tsx > 0);
-    --pubc->pending_tsx;
+    pj_assert(pubc->pending_auth_tokens > 0);
+    --pubc->pending_auth_tokens;
 
-    if (pubc->_delete_flag && pubc->pending_tsx == 0)
+    /* pjsip_publishc_destroy() re-defers if anything is still outstanding. */
+    if (pubc->_delete_flag)
         pjsip_publishc_destroy(pubc);
 }
 
@@ -703,7 +708,7 @@ static void tsx_callback(void *token, pjsip_event *event)
              * may defer the challenge and consume the token long after
              * pubc would otherwise have been destroyed, so hold pubc too.
              */
-            ++pubc->pending_tsx;
+            ++pubc->pending_auth_tokens;
 
             pj_bzero(&chal_param, sizeof(chal_param));
             chal_param.rdata = rdata;
@@ -713,7 +718,7 @@ static void tsx_callback(void *token, pjsip_event *event)
                                             auth_token, &chal_param);
             if (status != PJ_SUCCESS) {
                 pj_grp_lock_dec_ref(tsx->grp_lock);
-                --pubc->pending_tsx;
+                --pubc->pending_auth_tokens;
             }
         }
         if (status != PJ_SUCCESS) {

--- a/pjsip/src/pjsip-simple/publishc.c
+++ b/pjsip/src/pjsip-simple/publishc.c
@@ -563,6 +563,11 @@ static void call_callback(pjsip_publishc *pubc, pj_status_t status,
 {
     struct pjsip_publishc_cbparam cbparam;
 
+    /* The callback is cleared when the app destroys the pubc while a
+     * request or an async auth token is still outstanding.
+     */
+    if (!pubc->cb)
+        return;
 
     cbparam.pubc = pubc;
     cbparam.token = pubc->token;
@@ -602,14 +607,33 @@ static void pubc_refresh_timer_cb( pj_timer_heap_t *timer_heap,
  * user_data points to pjsip_publishc*.  No lock is held by the caller
  * (publishc does not use dialog-based locking).
  */
+/* Release the hold an async auth token took on pubc at creation,
+ * completing a destroy that was deferred while the token was outstanding.
+ */
+static void pubc_auth_token_release(pjsip_publishc *pubc)
+{
+    pj_assert(pubc->pending_tsx > 0);
+    --pubc->pending_tsx;
+
+    if (pubc->_delete_flag && pubc->pending_tsx == 0)
+        pjsip_publishc_destroy(pubc);
+}
+
 static pj_status_t pubc_async_auth_send_impl(
                                 pjsip_auth_clt_sess *auth_sess,
                                 void *user_data,
                                 pjsip_tx_data *tdata)
 {
     pjsip_publishc *pubc = (pjsip_publishc *)user_data;
+    pj_status_t status;
+
     PJ_UNUSED_ARG(auth_sess);
-    return pjsip_publishc_send(pubc, tdata);
+
+    status = pjsip_publishc_send(pubc, tdata);
+
+    pubc_auth_token_release(pubc);
+
+    return status;
 }
 
 /* Async auth abandon callback: notify the app that PUBLISH auth failed.
@@ -623,8 +647,13 @@ static void pubc_async_auth_abandon_impl(pjsip_auth_clt_sess *auth_sess,
 
     PJ_UNUSED_ARG(auth_sess);
 
+    /* The hold the token took at creation keeps pubc alive across the
+     * callback, which may destroy it.
+     */
     call_callback(pubc, PJ_ECANCELLED, PJSIP_SC_UNAUTHORIZED, &reason,
                   NULL, PJSIP_PUBC_EXPIRATION_NOT_SPECIFIED);
+
+    pubc_auth_token_release(pubc);
 }
 
 static void tsx_callback(void *token, pjsip_event *event)
@@ -670,14 +699,22 @@ static void tsx_callback(void *token, pjsip_event *event)
             auth_token->grp_lock     = tsx->grp_lock;
             pj_grp_lock_add_ref(tsx->grp_lock);
 
+            /* The grp_lock ref only keeps the transaction alive. The app
+             * may defer the challenge and consume the token long after
+             * pubc would otherwise have been destroyed, so hold pubc too.
+             */
+            ++pubc->pending_tsx;
+
             pj_bzero(&chal_param, sizeof(chal_param));
             chal_param.rdata = rdata;
             chal_param.tdata = tsx->last_tx;
             status = pjsip_auth_clt_async_impl_on_challenge(
                                             &pubc->auth_sess,
                                             auth_token, &chal_param);
-            if (status != PJ_SUCCESS)
+            if (status != PJ_SUCCESS) {
                 pj_grp_lock_dec_ref(tsx->grp_lock);
+                --pubc->pending_tsx;
+            }
         }
         if (status != PJ_SUCCESS) {
             status = pjsip_auth_clt_reinit_req(&pubc->auth_sess, rdata,

--- a/pjsip/src/pjsip-ua/sip_reg.c
+++ b/pjsip/src/pjsip-ua/sip_reg.c
@@ -1175,6 +1175,9 @@ static pj_status_t async_auth_send_impl(pjsip_auth_clt_sess *auth_sess,
                       is_unreg);
     }
 
+    /* Release the reference the token took at creation. */
+    pjsip_regc_dec_ref(regc);
+
     return status;
 }
 
@@ -1189,9 +1192,15 @@ static void async_auth_abandon_impl(pjsip_auth_clt_sess *auth_sess,
 
     PJ_UNUSED_ARG(auth_sess);
 
-    /* Called without regc->lock held (same convention as send_impl). */
+    /* Called without regc->lock held (same convention as send_impl). The
+     * reference the token took at creation keeps the regc alive across the
+     * callback, which may destroy it.
+     */
     call_callback(regc, PJ_ECANCELLED, PJSIP_SC_UNAUTHORIZED, &reason,
                   NULL, NOEXP, 0, NULL, is_unreg);
+
+    /* Release the reference the token took at creation. */
+    pjsip_regc_dec_ref(regc);
 }
 
 
@@ -1345,6 +1354,13 @@ static void regc_tsx_callback(void *token, pjsip_event *event)
             auth_token->grp_lock     = tsx->grp_lock;
             pj_grp_lock_add_ref(tsx->grp_lock);
 
+            /* The token only keeps the transaction alive, but the app may
+             * defer the challenge and consume the token long after the regc
+             * would otherwise have been destroyed. Hold a regc reference for
+             * the token's lifetime, released once it is consumed.
+             */
+            pjsip_regc_add_ref(regc);
+
             pj_bzero(&chal_param, sizeof(chal_param));
             chal_param.rdata = rdata;
             chal_param.tdata = tsx->last_tx;
@@ -1353,8 +1369,10 @@ static void regc_tsx_callback(void *token, pjsip_event *event)
                                                     &regc->auth_sess,
                                                     auth_token, &chal_param);
             pj_lock_acquire(regc->lock);
-            if (status != PJ_SUCCESS)
+            if (status != PJ_SUCCESS) {
                 pj_grp_lock_dec_ref(tsx->grp_lock);
+                pjsip_regc_dec_ref(regc);
+            }
         }
         if (status != PJ_SUCCESS) {
             /* Application does not handle the authentication, so let's

--- a/pjsip/src/pjsua2-test/auth_challenge.cpp
+++ b/pjsip/src/pjsua2-test/auth_challenge.cpp
@@ -454,25 +454,27 @@ void AuthChallengeTests::deferredAbandon()
         }
     }
     TEST_ASSERT(g_state.deferred != nullptr);
+    TEST_ASSERT(g_state.deferred->isValid() == true);
+    TEST_ASSERT(g_state.challengeReceived == true);
 
-    /* To abandon without crashing: delete the account first (which
-     * invalidates it and destroys the regc/auth token), then destroy
-     * the deferred AuthChallenge. The destructor's TRY_LOCK + is_valid
-     * guard will see the account is gone and skip the C-level abandon.
-     *
-     * We must NOT call pjsip_auth_clt_async_abandon directly because
-     * it can crash when called from outside the auth callback chain.
+    /* Abandon the challenge from the event loop. */
+    pj_status_t status = g_state.deferred->abandon();
+    TEST_ASSERT(status == PJ_SUCCESS);
+    g_state.deferred.reset();
+
+    poll_events(5000);
+
+    /* The challenge was given up, so no authenticated REGISTER may have
+     * been sent, and the registration must have failed.
      */
+    TEST_ASSERT(g_mock_auth_count == 0);
+    TEST_ASSERT(g_state.regDone == true);
+
     g_mock_enabled = PJ_FALSE;
     g_state.deferEnabled = false;
 
-    TEST_ASSERT(g_state.challengeReceived == true);
-
     acc.reset();
     pjsua_handle_events(500);
-
-    /* Now safe to destroy deferred state — account is already gone */
-    g_state.deferred.reset();
 
     std::cout << "  deferredAbandon: PASSED" << std::endl;
 }

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1181,28 +1181,17 @@ AuthChallenge::AuthChallenge()
 AuthChallenge::~AuthChallenge()
 {
     if (deferred_ && !consumed_ && auth_sess_ && token_) {
-        /* Capture sess/token under PJSUA_LOCK, then call async_abandon
-         * outside the lock to avoid lock-order inversion.
+        /* Abandon unconditionally, so the token's group lock reference and
+         * the reference it holds on its owner (regc/pubc) are released.
+         *
+         * This is safe even after the account has been deleted: no
+         * abandon_impl() reads the auth session, the only field
+         * async_abandon() itself touches is sess->parent -- always NULL for
+         * the account's shared session -- and the token's own group lock
+         * reference keeps its memory readable.  No PJSUA_LOCK is needed,
+         * which also removes any lock-order inversion.
          */
-        pjsip_auth_clt_sess *sess = NULL;
-        void *tok = NULL;
-        if (PJSUA_TRY_LOCK() == PJ_SUCCESS) {
-            if (pjsua_acc_is_valid(acc_id_)) {
-                sess = auth_sess_;
-                tok = token_;
-            }
-            PJSUA_UNLOCK();
-        } else {
-            /* Try-lock failed (e.g. GC finalizer during shutdown).
-             * Still abandon the token to release its grp_lock ref.
-             * The signature check inside async_abandon provides safety
-             * if the token was already consumed.
-             */
-            sess = auth_sess_;
-            tok = token_;
-        }
-        if (sess && tok)
-            pjsip_auth_clt_async_abandon(sess, tok);
+        pjsip_auth_clt_async_abandon(auth_sess_, token_);
     }
     if (cloned_rdata_)
         pjsip_rx_data_free_cloned(cloned_rdata_);
@@ -1343,25 +1332,13 @@ pj_status_t AuthChallenge::abandon()
     pjsip_auth_clt_sess *sess;
     void *tok;
     if (deferred_) {
-        PJSUA_LOCK();
-        if (!pjsua_acc_is_valid(acc_id_)) {
-            /* Account deleted — skip abandon.  The token's grp_lock ref
-             * will leak, but calling abandon would dereference user_data
-             * (e.g. regc) which has already been destroyed by
-             * pjsua_acc_del().  A proper fix requires pjsua_acc_del()
-             * to consume outstanding auth tokens before destruction.
-             */
-            PJSUA_UNLOCK();
-            consumed_ = true;
-            return PJ_EINVALIDOP;
-        }
-        sess = auth_sess_;  tok = token_;
-        /* Release PJSUA_LOCK before abandon to prevent lock-order
-         * inversion — abandon_impl may call regc/inv callbacks that
-         * acquire tsx grp_lock, and SIP callbacks acquire tsx grp_lock
-         * then PJSUA_LOCK (opposite order).
+        /* Safe without PJSUA_LOCK and without checking the account: the
+         * token holds a reference on its owner, no abandon_impl() reads
+         * the auth session, and taking PJSUA_LOCK here would risk
+         * lock-order inversion since abandon_impl may run regc/inv
+         * callbacks that acquire the tsx group lock.
          */
-        PJSUA_UNLOCK();
+        sess = auth_sess_;  tok = token_;
     } else {
         if (!param_) return PJ_EINVALIDOP;
         sess = param_->auth_sess;  tok = param_->token;


### PR DESCRIPTION
Fixes a use-after-free in the async authentication path: a challenge the application defers can outlive the object that owns it, so consuming the token later touches freed memory. Found while investigating why the pjsua2 `deferredAbandon` test did not actually call `abandon()`.

### `sip_reg.c` — the token holds no reference on the regc

The async auth token is allocated from `tsx->pool` and anchored with `pj_grp_lock_add_ref(tsx->grp_lock)`, but the regc is stored as a bare `user_data` pointer with no reference taken. The grp_lock ref keeps the *transaction* alive, not the regc, so a deferred challenge can be consumed long after the regc is gone — `async_auth_send_impl()` / `async_auth_abandon_impl()` then dereference freed memory.

The same gap made `abandon()` crash even with a live regc. `call_callback()` ran with `busy_ctr` at 0, so pjsua's `regc_cb()` destroyed the regc through `pjsip_regc_destroy2()`'s immediate branch and then called `pjsip_regc_get_info()` on it:

```
pj_lock_acquire: Assertion `lock != ((void *)0)' failed.
#8  pjsip_regc_get_info ()
#9  regc_cb ()
#10 async_auth_abandon_impl ()
#11 pjsip_auth_clt_async_abandon ()
#12 pj::AuthChallenge::abandon () at ../src/pjsua2/endpoint.cpp:1370
```

Every other `call_callback()` site in the file is wrapped in `pjsip_regc_add_ref()`/`dec_ref()` — `regc_refresh_timer_cb()` and `regc_tsx_callback()`, the latter commented "prevent regc from being deleted ... in the callback". These two were not. That is also why abandoning from *inside* the auth callback chain worked: `regc_tsx_callback()`'s reference was still on the stack.

Taking a regc reference for the token's lifetime covers both with one mechanism. `call_callback()` now always runs with `busy_ctr != 0`, so `pjsip_regc_destroy2()` takes its deferred branch — setting `_delete_flag` and clearing `regc->cb` rather than freeing — and the token's final `dec_ref()` completes teardown. The account-deleted case falls out for free, since `call_callback()` returns immediately on the NULL `cb`.

### `publishc.c` — same defect, plus an unguarded callback

`publishc.c` has the identical shape: raw `user_data = pubc`, anchored only to `tsx->grp_lock`. Once the challenge transaction completed, `pending_tsx` dropped to zero and `pjsip_publishc_destroy()` took its immediate branch, which calls `pjsip_auth_clt_deinit(&pubc->auth_sess)` and releases `pubc->pool`. That frees both the pubc and the `pjsip_auth_clt_sess` the token refers to, so even `pjsip_auth_clt_async_abandon()`'s first dereference of `sess` is a use-after-free.

Fixed the same way, but with a dedicated `pending_auth_tokens` counter rather than publishc's existing `pending_tsx`. Reusing `pending_tsx` was wrong, as Copilot pointed out on this PR: that counter also gates request sending in `pjsip_publishc_send()`, which queues the request (or returns `PJ_EBUSY` when queueing is disabled) whenever it is non-zero. So `pubc_async_auth_send_impl()` queued the authenticated PUBLISH instead of sending it, and with no transaction pending there was nothing left to drain the queue from `tsx_callback` — a deferred PUBLISH challenge never sent its authenticated retry. regc was unaffected because `busy_ctr` is purely a destroy-deferral refcount. The new counter is consulted only by the destroy-deferral checks.

Separately, publishc's `call_callback()` dereferenced `pubc->cb` unconditionally while the deferred branch of `pjsip_publishc_destroy()` sets it to NULL — an app destroying the pubc during an outstanding challenge and then abandoning would jump through NULL. `sip_reg.c`'s `call_callback()` has always guarded this; publishc now does too.

### `auth_challenge.cpp` — the test now abandons

`deferredAbandon`'s docblock said the event loop calls `abandon()`, but the body deleted the account instead, duplicating `accountDeleteWithPending` and leaving `AuthChallenge::abandon()` with no coverage at all. An in-code comment claimed calling it was unsafe outside the auth callback chain; the real cause was the missing reference above. The test now calls `abandon()` from the event loop and asserts no authenticated REGISTER follows.

### Modules checked and found sound

`pjsua_im.c` allocates its `im_auth_ctx` from `tsx->pool`, so the owner is already transaction-scoped. `evsub.c` and `sip_inv.c` are dialog-bound: `sip_dialog.c` takes a dialog reference for the transaction and releases it in `tsx_on_destroy()`, so a token reference on `tsx->grp_lock` defers that release. Neither needs a change.

### `endpoint.cpp` — abandon even after the account is deleted

`AuthChallenge::abandon()` and the destructor skipped the C-level abandon when `pjsua_acc_is_valid()` was false. That leaked the token's group lock reference, so `tsx_on_destroy()` never ran — and once the token also holds a reference on its owner, the regc or pubc leaked with it. Measured with `pjsip_tsx_layer_get_tsx_count()` after the pjsua2 auth suite, draining past Timer K first: **2 transactions alive indefinitely before, 0 after**.

Abandoning without the account is safe: every `abandon_impl()` declares `PJ_UNUSED_ARG(auth_sess)`, so none reads the session; the only field `pjsip_auth_clt_async_abandon()` itself reads is `sess->parent`, which is always NULL for the account's shared auth session both before and after `pjsua_acc_del()` wipes the slot; and the token's own group lock reference keeps its memory readable for the signature check. Dropping the check also removes the need for `PJSUA_LOCK` there, and with it the lock-order inversion the old comment worked around.

`respond()` keeps the gate — it calls `pjsip_auth_clt_reinit_req()`, which genuinely does read the auth session.

Note this leak is not visible to LeakSanitizer: PJSIP allocates from a caching pool factory that frees everything at `libDestroy()`, so it is runtime retention rather than a process-exit leak.

### Validation

- `make realclean && ./configure && make -j3`: clean, only pre-existing warnings.
- pjsua2-test: 8/8 runs pass on the final tree. Before the fix the suite crashed in roughly 2 of every 3 runs once `deferredAbandon` actually abandoned.
- `tests/pjsua` `scripts-recvfrom` registration and publish sets: 17/17.
- Live transaction count after the auth suite: 2 before, 0 after (see above).
- pjsip-test: `regc_test`, `auth_async_test`, `pjsua_auth_test`, `pjsua_acc_test` and `pjsua_call_test` all pass.
