### PR TITLE
pjsua: skip the IPv6 TURN transports when the TURN server is an IPv4 literal

### DIFF
--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -1290,18 +1290,45 @@ static pj_status_t create_ice_media_transport(
     /* Configure TURN settings */
     if (acc_cfg->turn_cfg.enable_turn) {
         unsigned i, idx = 0;
-        
-        if (use_ipv6 && !use_nat64 && PJ_ICE_MAX_TURN >= 3) {
+        pj_bool_t turn_ipv6 = (use_ipv6 || use_nat64);
+        pj_str_t turn_server;
+        pj_uint16_t turn_port = 0;
+        pj_in_addr turn_addr;
+
+        /* Configure TURN server */
+
+        /* Parse the server entry into host:port */
+        status = pj_sockaddr_parse2(pj_AF_UNSPEC(), 0,
+                                    &acc_cfg->turn_cfg.turn_server,
+                                    &turn_server, &turn_port, NULL);
+        if (status != PJ_SUCCESS || turn_server.slen == 0) {
+            PJ_LOG(1,(THIS_FILE, "Invalid TURN server setting"));
+            return PJ_EINVAL;
+        }
+
+        if (turn_port == 0)
+            turn_port = 3479;
+
+        /* No IPv6 TURN transport when the server is an IPv4 address literal,
+         * as resolving it as IPv6 will always fail.
+         */
+        if (turn_ipv6 && !use_nat64 &&
+            pj_inet_pton(pj_AF_INET(), &turn_server, &turn_addr)==PJ_SUCCESS)
+        {
+            turn_ipv6 = PJ_FALSE;
+        }
+
+        if (turn_ipv6 && !use_nat64 && PJ_ICE_MAX_TURN >= 3) {
             ice_cfg.turn_tp_cnt = 3;
             idx = 1;
         } else {
             ice_cfg.turn_tp_cnt = 1;
         }
-        
+
         for (i = 0; i < ice_cfg.turn_tp_cnt; i++)
             pj_ice_strans_turn_cfg_default(&ice_cfg.turn_tp[i]);
 
-        if (use_ipv6 || use_nat64) {
+        if (turn_ipv6) {
             if (!use_nat64)
                 ice_cfg.turn_tp[idx++].af = pj_AF_INET6();
 
@@ -1310,28 +1337,12 @@ static pj_status_t create_ice_media_transport(
             ice_cfg.turn_tp[idx].alloc_param.af = pj_AF_INET();
         }
 
-        /* Configure TURN server */
-
-        /* Parse the server entry into host:port */
-        status = pj_sockaddr_parse2(pj_AF_UNSPEC(), 0,
-                                    &acc_cfg->turn_cfg.turn_server,
-                                    &ice_cfg.turn_tp[0].server,
-                                    &ice_cfg.turn_tp[0].port,
-                                    NULL);
-        if (status != PJ_SUCCESS || ice_cfg.turn_tp[0].server.slen == 0) {
-            PJ_LOG(1,(THIS_FILE, "Invalid TURN server setting"));
-            return PJ_EINVAL;
-        }
-
-        if (ice_cfg.turn_tp[0].port == 0)
-            ice_cfg.turn_tp[0].port = 3479;
-
         for (i = 0; i < ice_cfg.turn_tp_cnt; i++) {
             pj_str_t IN6_ADDR_ANY = {"0", 1};
 
             /* Configure TURN connection settings and credential */
-            ice_cfg.turn_tp[i].server    = ice_cfg.turn_tp[0].server;
-            ice_cfg.turn_tp[i].port      = ice_cfg.turn_tp[0].port;
+            ice_cfg.turn_tp[i].server    = turn_server;
+            ice_cfg.turn_tp[i].port      = turn_port;
             ice_cfg.turn_tp[i].conn_type = acc_cfg->turn_cfg.turn_conn_type;
             pj_memcpy(&ice_cfg.turn_tp[i].auth_cred, 
                       &acc_cfg->turn_cfg.turn_auth_cred,


### PR DESCRIPTION
When ICE selects IPv6 for a call, `create_ice_media_transport()` configures three TURN transports — IPv4, IPv6, and IPv6 requesting an IPv4 relay allocation:

```c
if (use_ipv6 && !use_nat64 && PJ_ICE_MAX_TURN >= 3) {
    ice_cfg.turn_tp_cnt = 3;
    idx = 1;
}
```

If the configured TURN server is an IPv4 address literal, the two IPv6 transports can never work — resolving an IPv4 literal as IPv6 always fails — so every ICE component reports two `PJ_ERESOLVE` failures before falling back to the IPv4 transport. With RTP and RTCP components that is four failed resolutions per call, purely from a configuration the code can inspect up front.

This detects that case and configures the single IPv4 transport only.

### Notes

The check uses `pj_inet_pton()` rather than the address family `pj_sockaddr_parse2()` reports through its `raf` argument. That output is derived from counting colons, so it reports `AF_INET` for host names as well, which would wrongly drop IPv6 TURN whenever the server is configured by name:

```
1.2.3.4                    host='1.2.3.4'            port=3479 raf=AF_INET  v4-literal=YES -> skip IPv6 TURN
1.2.3.4:3478               host='1.2.3.4'            port=3478 raf=AF_INET  v4-literal=YES -> skip IPv6 TURN
turn.example.com           host='turn.example.com'   port=3479 raf=AF_INET  v4-literal=no  -> keep IPv6 TURN
turn.example.com:3478      host='turn.example.com'   port=3478 raf=AF_INET  v4-literal=no  -> keep IPv6 TURN
2001:db8::1                host='2001:db8::1'        port=3479 raf=AF_INET6 v4-literal=no  -> keep IPv6 TURN
[2001:db8::1]:3478         host='2001:db8::1'        port=3478 raf=AF_INET6 v4-literal=no  -> keep IPv6 TURN
```

`pj_inet_pton()` is safe to hand a host name — it copies into a null-terminated buffer and returns `PJ_ENAMETOOLONG` rather than succeeding on anything over `PJ_INET6_ADDRSTRLEN`, and the header documents this exact "is it an IP literal" use.

Parsing the server entry has to move ahead of the transport count decision, which the entry now feeds. While there, the parsed host and port go into locals rather than being staged in `turn_tp[0]` and copied out of it in the following loop.

NAT64 is unaffected: it needs the IPv6 transport regardless of the server's address family, so the new check is gated on `!use_nat64` like the existing count decision.

### Scope

Only the IPv4-literal case is handled, because it is decidable without a resolver. Two related sources of the same noise are left alone:

- A **host name with no AAAA record** produces identical failures. Avoiding those means resolving the TURN host up front, which needs a per-call blocking `pj_getaddrinfo()` plus a cache and would regress the async DNS SRV path used when a nameserver is configured.
- An **IPv6 literal** leaves the IPv4 transport failing instead, the mirror image of this bug. It is rarer and the fix is less contained, since the transport count and `idx` bookkeeping both assume the IPv4 transport is `turn_tp[0]`.

### Testing

Builds clean with `-Wall` (no new warnings; only the intentional `PJ_TODO` unused-label ones). `tests/pjsua` `100_simple.py` passes.

The IPv4-literal decision itself was verified directly with the table above. I could not exercise the full call path — that needs a globally routable IPv6 address and a TURN server, neither available in my environment — so the three-transport path is unchanged-by-inspection rather than by test.

Co-Authored-By Claude Code

https://claude.ai/code/session_01KmbXd2yQE42J4GHaASgBFh
