### PR TITLE
Bug: Two pong TCP/TLS keep-alive responses from server is responded with wrong pong

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -842,6 +842,25 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
+ * Maximum age, in milliseconds, of an incomplete RFC 5626 CRLF keep-alive
+ * "ping" prefix retained from a previous read on a TCP transport, before it
+ * is discarded instead of being reassembled with the bytes that follow.
+ *
+ * A ping that is genuinely fragmented is completed by the next segment, so
+ * this only needs to be larger than the delay between two fragments of the
+ * same ping. Reassembling across a longer gap would join unrelated bytes,
+ * e.g. two "pong" replies to our own pings, into a ping the peer never sent.
+ *
+ * Only relevant when \a PJSIP_TCP_KEEP_ALIVE_RESPONSE is enabled.
+ *
+ * Default: 5000 (5 seconds)
+ */
+#ifndef PJSIP_TCP_KEEP_ALIVE_FRAGMENT_TIMEOUT
+#   define PJSIP_TCP_KEEP_ALIVE_FRAGMENT_TIMEOUT 5000
+#endif
+
+
+/**
  * The initial timeout interval for incoming TCP transports
  * (i.e. server side) in the event that no valid SIP message is received
  * following a successful connection. The value is in seconds.
@@ -900,6 +919,25 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
  */
 #ifndef PJSIP_TLS_KEEP_ALIVE_RESPONSE
 #   define PJSIP_TLS_KEEP_ALIVE_RESPONSE    1
+#endif
+
+
+/**
+ * Maximum age, in milliseconds, of an incomplete RFC 5626 CRLF keep-alive
+ * "ping" prefix retained from a previous read on a TLS transport, before it
+ * is discarded instead of being reassembled with the bytes that follow.
+ *
+ * A ping that is genuinely fragmented is completed by the next segment, so
+ * this only needs to be larger than the delay between two fragments of the
+ * same ping. Reassembling across a longer gap would join unrelated bytes,
+ * e.g. two "pong" replies to our own pings, into a ping the peer never sent.
+ *
+ * Only relevant when \a PJSIP_TLS_KEEP_ALIVE_RESPONSE is enabled.
+ *
+ * Default: 5000 (5 seconds)
+ */
+#ifndef PJSIP_TLS_KEEP_ALIVE_FRAGMENT_TIMEOUT
+#   define PJSIP_TLS_KEEP_ALIVE_FRAGMENT_TIMEOUT 5000
 #endif
 
 

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -126,6 +126,19 @@ struct tcp_transport
      */
     pjsip_tx_data_op_key     pong_op_key;
 
+    /* Set when a CRLF keep-alive "ping" of ours has been sent and nothing
+     * has been read since. The reply is a bare CRLF, which is also the first
+     * half of a ping, so this is what tells our own "pong" apart from a
+     * genuinely fragmented ping from the peer.
+     */
+    pj_bool_t                ka_ping_pending;
+
+    /* Length and arrival time of the incomplete ping prefix retained as the
+     * read remainder, so that it is not reassembled across an arbitrary gap.
+     */
+    pj_size_t                ka_partial_len;
+    pj_time_val              ka_partial_ts;
+
     /* TCP transport can only have  one rdata!
      * Otherwise chunks of incoming PDU may be received on different
      * buffer.
@@ -1436,11 +1449,22 @@ static pj_status_t tcp_shutdown(pjsip_transport *transport)
  * Callback from ioqueue that an incoming data is received from the socket.
  */
 #if PJSIP_TCP_KEEP_ALIVE_RESPONSE
-/* RFC 5626 Section 4.4.1 CRLF keep-alive patterns: the accepted "ping" and
- * the "pong" reply. Defined together in one place, with lengths derived via
- * sizeof, so both can be adjusted - or made configurable, e.g. a single CRLF
- * or a longer packet - without touching the scan/response logic. The pong
- * has static lifetime so it stays valid until the (async) send completes.
+/* RFC 5626 Section 4.4.1 CRLF keep-alive patterns: the "ping" we accept and
+ * the "pong" we reply with. These are fixed by the RFC and must NOT be
+ * changed: they are the bytes a compliant peer sends and expects back, so
+ * altering either one breaks the mechanism against every such peer. The
+ * comparison in tcp_keep_alive_timer() also relies on the ping being the RFC
+ * pattern to decide whether a pong can be expected in return.
+ *
+ * Both patterns are named here, rather than written inline, so that the
+ * scan/response logic carries no literal bytes and no literal lengths (those
+ * are derived via sizeof). The pong must not be turned into an automatic
+ * variable: the reply is sent asynchronously, so its buffer has to outlive
+ * the send call.
+ *
+ * The payload we *send* as our own keep-alive is a separate and genuinely
+ * configurable thing, PJSIP_TCP_KEEP_ALIVE_DATA; a peer will simply not answer
+ * a payload that is not the RFC ping.
  */
 static const char tcp_crlf_ka_ping[] = { '\r', '\n', '\r', '\n' };
 static const char tcp_crlf_ka_pong[] = { '\r', '\n' };
@@ -1516,8 +1540,61 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
          */
         {
             pj_size_t partial_len;
-            pj_size_t ka_len = tcp_get_crlf_ka_len((char*)data, size,
-                                                   &partial_len);
+            pj_size_t ka_len;
+            pj_bool_t ping_pending = tcp->ka_ping_pending;
+
+            /* Whatever we read now ends the window in which a bare CRLF can
+             * be attributed to a ping of ours.
+             */
+            tcp->ka_ping_pending = PJ_FALSE;
+
+            /* Discard a retained incomplete ping that has gone stale. A real
+             * fragment is completed by the next segment, not seconds later,
+             * and reassembling across such a gap would join unrelated bytes
+             * into a ping that the peer never sent.
+             */
+            if (tcp->ka_partial_len) {
+                pj_size_t stale_len = tcp->ka_partial_len;
+                pj_time_val elapsed = tcp->last_activity;
+
+                /* last_activity is the arrival time of this read, so the
+                 * gap measured here is arrival to arrival, excluding our
+                 * own processing time.
+                 */
+                PJ_TIME_VAL_SUB(elapsed, tcp->ka_partial_ts);
+                tcp->ka_partial_len = 0;
+
+                if (stale_len <= size &&
+                    PJ_TIME_VAL_MSEC(elapsed) >
+                        PJSIP_TCP_KEEP_ALIVE_FRAGMENT_TIMEOUT)
+                {
+                    pj_memmove(data, (char*)data + stale_len,
+                               size - stale_len);
+                    size -= stale_len;
+
+                    if (size == 0) {
+                        *remainder = 0;
+                        pj_pool_reset(rdata->tp_info.pool);
+                        return PJ_TRUE;
+                    }
+                }
+            }
+
+            ka_len = tcp_get_crlf_ka_len((char*)data, size, &partial_len);
+
+            /* A read consisting of nothing but a bare CRLF, while a ping of
+             * ours is outstanding, is the peer's pong to that ping, not the
+             * first half of a ping. Consume it: retaining it would let it
+             * reassemble with the next pong into a phantom ping, which we
+             * would then answer with a CRLF the peer never asked for.
+             */
+            if (ka_len == 0 && ping_pending && partial_len == size &&
+                partial_len == sizeof(tcp_crlf_ka_pong))
+            {
+                *remainder = 0;
+                pj_pool_reset(rdata->tp_info.pool);
+                return PJ_TRUE;
+            }
 
             if (ka_len) {
                 pj_ssize_t pong_len = sizeof(tcp_crlf_ka_pong);
@@ -1548,6 +1625,8 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
                 if (ka_len)
                     pj_memmove(data, (char*)data + ka_len, partial_len);
                 *remainder = partial_len;
+                tcp->ka_partial_len = partial_len;
+                tcp->ka_partial_ts = tcp->last_activity;
                 pj_pool_reset(rdata->tp_info.pool);
                 return PJ_TRUE;
             }
@@ -1756,6 +1835,19 @@ static void tcp_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
     size = tcp->ka_pkt.slen;
     status = pj_activesock_send(tcp->asock, &tcp->ka_op_key.key,
                                 tcp->ka_pkt.ptr, &size, 0);
+
+#if PJSIP_TCP_KEEP_ALIVE_RESPONSE
+    /* If what we send is the RFC 5626 ping, the peer answers it with a bare
+     * CRLF, which is also the first half of a ping. Remember that we are
+     * expecting one, so that on_data_read() can tell the two apart.
+     */
+    if (tcp->ka_pkt.slen == (pj_ssize_t)sizeof(tcp_crlf_ka_ping) &&
+        pj_memcmp(tcp->ka_pkt.ptr, tcp_crlf_ka_ping,
+                  sizeof(tcp_crlf_ka_ping)) == 0)
+    {
+        tcp->ka_ping_pending = PJ_TRUE;
+    }
+#endif
 
     if (status != PJ_SUCCESS && status != PJ_EPENDING) {
         tcp_perror(tcp->base.obj_name, 

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -120,6 +120,19 @@ struct tls_transport
      */
     pjsip_tx_data_op_key     pong_op_key;
 
+    /* Set when a CRLF keep-alive "ping" of ours has been sent and nothing
+     * has been read since. The reply is a bare CRLF, which is also the first
+     * half of a ping, so this is what tells our own "pong" apart from a
+     * genuinely fragmented ping from the peer.
+     */
+    pj_bool_t                ka_ping_pending;
+
+    /* Length and arrival time of the incomplete ping prefix retained as the
+     * read remainder, so that it is not reassembled across an arbitrary gap.
+     */
+    pj_size_t                ka_partial_len;
+    pj_time_val              ka_partial_ts;
+
     /* TLS transport can only have  one rdata!
      * Otherwise chunks of incoming PDU may be received on different
      * buffer.
@@ -2017,11 +2030,22 @@ static pj_status_t tls_shutdown(pjsip_transport *transport)
  * Callback from ioqueue that an incoming data is received from the socket.
  */
 #if PJSIP_TLS_KEEP_ALIVE_RESPONSE
-/* RFC 5626 Section 4.4.1 CRLF keep-alive patterns: the accepted "ping" and
- * the "pong" reply. Defined together in one place, with lengths derived via
- * sizeof, so both can be adjusted - or made configurable, e.g. a single CRLF
- * or a longer packet - without touching the scan/response logic. The pong
- * has static lifetime so it stays valid until the (async) send completes.
+/* RFC 5626 Section 4.4.1 CRLF keep-alive patterns: the "ping" we accept and
+ * the "pong" we reply with. These are fixed by the RFC and must NOT be
+ * changed: they are the bytes a compliant peer sends and expects back, so
+ * altering either one breaks the mechanism against every such peer. The
+ * comparison in tls_keep_alive_timer() also relies on the ping being the RFC
+ * pattern to decide whether a pong can be expected in return.
+ *
+ * Both patterns are named here, rather than written inline, so that the
+ * scan/response logic carries no literal bytes and no literal lengths (those
+ * are derived via sizeof). The pong must not be turned into an automatic
+ * variable: the reply is sent asynchronously, so its buffer has to outlive
+ * the send call.
+ *
+ * The payload we *send* as our own keep-alive is a separate and genuinely
+ * configurable thing, PJSIP_TLS_KEEP_ALIVE_DATA; a peer will simply not answer
+ * a payload that is not the RFC ping.
  */
 static const char tls_crlf_ka_ping[] = { '\r', '\n', '\r', '\n' };
 static const char tls_crlf_ka_pong[] = { '\r', '\n' };
@@ -2097,8 +2121,61 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
          */
         {
             pj_size_t partial_len;
-            pj_size_t ka_len = tls_get_crlf_ka_len((char*)data, size,
-                                                   &partial_len);
+            pj_size_t ka_len;
+            pj_bool_t ping_pending = tls->ka_ping_pending;
+
+            /* Whatever we read now ends the window in which a bare CRLF can
+             * be attributed to a ping of ours.
+             */
+            tls->ka_ping_pending = PJ_FALSE;
+
+            /* Discard a retained incomplete ping that has gone stale. A real
+             * fragment is completed by the next segment, not seconds later,
+             * and reassembling across such a gap would join unrelated bytes
+             * into a ping that the peer never sent.
+             */
+            if (tls->ka_partial_len) {
+                pj_size_t stale_len = tls->ka_partial_len;
+                pj_time_val elapsed = tls->last_activity;
+
+                /* last_activity is the arrival time of this read, so the
+                 * gap measured here is arrival to arrival, excluding our
+                 * own processing time.
+                 */
+                PJ_TIME_VAL_SUB(elapsed, tls->ka_partial_ts);
+                tls->ka_partial_len = 0;
+
+                if (stale_len <= size &&
+                    PJ_TIME_VAL_MSEC(elapsed) >
+                        PJSIP_TLS_KEEP_ALIVE_FRAGMENT_TIMEOUT)
+                {
+                    pj_memmove(data, (char*)data + stale_len,
+                               size - stale_len);
+                    size -= stale_len;
+
+                    if (size == 0) {
+                        *remainder = 0;
+                        pj_pool_reset(rdata->tp_info.pool);
+                        return PJ_TRUE;
+                    }
+                }
+            }
+
+            ka_len = tls_get_crlf_ka_len((char*)data, size, &partial_len);
+
+            /* A read consisting of nothing but a bare CRLF, while a ping of
+             * ours is outstanding, is the peer's pong to that ping, not the
+             * first half of a ping. Consume it: retaining it would let it
+             * reassemble with the next pong into a phantom ping, which we
+             * would then answer with a CRLF the peer never asked for.
+             */
+            if (ka_len == 0 && ping_pending && partial_len == size &&
+                partial_len == sizeof(tls_crlf_ka_pong))
+            {
+                *remainder = 0;
+                pj_pool_reset(rdata->tp_info.pool);
+                return PJ_TRUE;
+            }
 
             if (ka_len) {
                 pj_ssize_t pong_len = sizeof(tls_crlf_ka_pong);
@@ -2134,6 +2211,8 @@ static pj_bool_t on_data_read(pj_ssl_sock_t *ssock,
                 if (ka_len)
                     pj_memmove(data, (char*)data + ka_len, partial_len);
                 *remainder = partial_len;
+                tls->ka_partial_len = partial_len;
+                tls->ka_partial_ts = tls->last_activity;
                 pj_pool_reset(rdata->tp_info.pool);
                 return PJ_TRUE;
             }
@@ -2473,6 +2552,19 @@ static void tls_keep_alive_timer(pj_timer_heap_t *th, pj_timer_entry *e)
     size = tls->ka_pkt.slen;
     status = pj_ssl_sock_send(tls->ssock, &tls->ka_op_key.key,
                               tls->ka_pkt.ptr, &size, 0);
+
+#if PJSIP_TLS_KEEP_ALIVE_RESPONSE
+    /* If what we send is the RFC 5626 ping, the peer answers it with a bare
+     * CRLF, which is also the first half of a ping. Remember that we are
+     * expecting one, so that on_data_read() can tell the two apart.
+     */
+    if (tls->ka_pkt.slen == (pj_ssize_t)sizeof(tls_crlf_ka_ping) &&
+        pj_memcmp(tls->ka_pkt.ptr, tls_crlf_ka_ping,
+                  sizeof(tls_crlf_ka_ping)) == 0)
+    {
+        tls->ka_ping_pending = PJ_TRUE;
+    }
+#endif
 
     if (status != PJ_SUCCESS && status != PJ_EPENDING) {
         tls_perror(tls->base.obj_name, 

--- a/pjsip/src/test/transport_tcp_test.c
+++ b/pjsip/src/test/transport_tcp_test.c
@@ -462,9 +462,16 @@ int transport_tcp_keep_alive_test(void)
      * ignored by the keep-alive responder.
      */
     const char not_ping[] = { 'X', '\r', '\n', '\r', '\n' };
+    /* What a peer sends back in reply to a ping of ours. Note that it is
+     * also the first two bytes of a ping.
+     */
+    const char pong[] = { '\r', '\n' };
     char buf[8];
     pj_ssize_t len;
     pj_status_t status;
+    pj_sock_t sock2 = PJ_INVALID_SOCKET;
+    long orig_ka_interval = pjsip_cfg()->tcp.keep_alive_interval;
+    int i, j;
     int ret = 0;
 
     PJ_LOG(3,(THIS_FILE, "  testing TCP CRLF keep-alive response"));
@@ -607,16 +614,116 @@ int transport_tcp_keep_alive_test(void)
         goto on_return;
     }
 
+    /* Phase 8: a retained fragment must not be reassembled after it has
+     * gone stale. Two bare CRLFs separated by more than
+     * PJSIP_TCP_KEEP_ALIVE_FRAGMENT_TIMEOUT are not one fragmented ping, so
+     * they must not draw a pong.
+     */
+    status = ka_send_raw(sock, ping, 2);                /* "\r\n" */
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send ping fragment", status);
+        ret = -270;
+        goto on_return;
+    }
+    flush_events(PJSIP_TCP_KEEP_ALIVE_FRAGMENT_TIMEOUT + 1000);
+    status = ka_send_raw(sock, ping, 2);               /* another "\r\n" */
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to send ping fragment", status);
+        ret = -271;
+        goto on_return;
+    }
+    len = ka_recv_timeout(sock, buf, sizeof(buf), NO_PONG_WAIT_MSEC);
+    if (len != 0) {
+        PJ_LOG(3,(THIS_FILE, "   Error: got %d byte(s) for two bare CRLFs "
+                             "sent %d ms apart (expected none)", (int)len,
+                             PJSIP_TCP_KEEP_ALIVE_FRAGMENT_TIMEOUT + 1000));
+        ret = -272;
+        goto on_return;
+    }
+
+    /* Phase 9: the reply to a ping of ours is a bare CRLF, i.e. the same
+     * bytes as the first half of a ping. Two such replies must not be
+     * reassembled into a ping that the peer never sent, because we would
+     * answer that phantom ping with an unsolicited CRLF - which a server
+     * waiting for a complete message eventually gives up on and closes.
+     *
+     * Needs a connection whose transport actually pings, so use a short
+     * keep-alive interval and a fresh connection: the phases above rely on
+     * no ping of ours being outstanding, and the interval cannot be changed
+     * on a live connection (the timer reschedules with whatever it reads).
+     */
+    PJ_LOG(3,(THIS_FILE, "  testing TCP CRLF keep-alive ping/pong exchange"));
+
+    pjsip_cfg()->tcp.keep_alive_interval = 1;
+
+    status = pj_sock_socket(pj_AF_INET(), pj_SOCK_STREAM(), 0, &sock2);
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to create socket", status);
+        ret = -280;
+        goto on_return;
+    }
+    status = pj_sock_connect(sock2, &rem_addr, sizeof(rem_addr));
+    if (status != PJ_SUCCESS) {
+        app_perror("   Error: unable to connect to TCP listener", status);
+        ret = -281;
+        goto on_return;
+    }
+    flush_events(100);
+
+    for (i = 0; i < 3; ++i) {
+        /* Wait for the transport's ping, pumping the endpoint so that its
+         * keep-alive timer can fire.
+         */
+        len = 0;
+        for (j = 0; j < 40 && len == 0; ++j) {
+            flush_events(100);
+            len = ka_recv_timeout(sock2, buf, sizeof(buf), 0);
+        }
+        if (len != (pj_ssize_t)sizeof(ping) ||
+            pj_memcmp(buf, ping, sizeof(ping)) != 0)
+        {
+            PJ_LOG(3,(THIS_FILE, "   Error: expected a %d byte(s) keep-alive "
+                                 "ping on exchange %d, got %d byte(s)",
+                                 (int)sizeof(ping), i+1, (int)len));
+            ret = -282;
+            goto on_return;
+        }
+
+        /* Answer it the way a server does. */
+        status = ka_send_raw(sock2, pong, sizeof(pong));
+        if (status != PJ_SUCCESS) {
+            app_perror("   Error: unable to send keep-alive pong", status);
+            ret = -283;
+            goto on_return;
+        }
+
+        /* Our pong must not be answered: a pong is not a ping. */
+        len = ka_recv_timeout(sock2, buf, sizeof(buf), 0);
+        if (len != 0) {
+            PJ_LOG(3,(THIS_FILE, "   Error: got %d byte(s) in response to a "
+                                 "keep-alive pong on exchange %d "
+                                 "(expected none)", (int)len, i+1));
+            ret = -284;
+            goto on_return;
+        }
+    }
+
     PJ_LOG(3,(THIS_FILE, "   TCP keep-alive response test OK"));
 
 on_return:
     if (sock != PJ_INVALID_SOCKET)
         pj_sock_close(sock);
+    if (sock2 != PJ_INVALID_SOCKET)
+        pj_sock_close(sock2);
     if (tpfactory) {
         pjsip_tpmgr_unregister_tpfactory(pjsip_endpt_get_tpmgr(endpt),
                                          tpfactory);
     }
     flush_events(500);
+    /* Restore only after the transports are gone, so that no keep-alive
+     * timer is left scheduled against the restored interval.
+     */
+    pjsip_cfg()->tcp.keep_alive_interval = orig_ka_interval;
     return ret;
 #else
     PJ_LOG(3,(THIS_FILE, "  skipping TCP CRLF keep-alive response test "


### PR DESCRIPTION
# Two pong TCP/TLS keep-alive responses from server is responded with illegal pong

## The bug

The bug, tested with kamailio 5.7.4:

1. pjsip sends tcp/tls ping ("\r\n\r\n")
2. server replies with pong ("\r\n")
3. pjsip treats this as fragmented packet (as per #5062)
4. 90 secs later, pjsip send ping again
5. server replies with pong again
6. pjsip concatenates the two pong responses ("\r\n" + "\r\n") and thinks that it is an incoming ping ("\r\n\rn")
7. pjsip sends pong (as per #5059)
8. server, who didn't send ping, treats the pong as start of SIP message, and waits for the remaining message
9. 20 secs later, it still doesn't receive a message, and disconnects the transport

The whole scenario will repeat every 3.5 minutes after connection is established, which is equal to 2x90 + 20 seconds = 200 seconds.

### A second, quieter defect

Retention had no age limit at all. A peer that sends a truncated ping and never
completes it leaves us permanently two bytes out of phase: every subsequent
ping is answered, but each one also leaves a fresh 2-byte residue. Reassembling
a "fragment" across an unbounded gap — 90 seconds, in the case above — is never
correct; TCP and TLS deliver a 4-byte write essentially atomically, and a real
fragment is completed by the very next segment.

## The fix

Drop the retention of incomplete pings. `tcp_get_crlf_ka_len()` /
`tls_get_crlf_ka_len()` go back to reporting only complete leading pings, and
the caller no longer keeps a trailing prefix as the read remainder. Trailing
incomplete pings are handed to the parser, which drops them as leading
newlines (RFC 3261 Section 7.5) — the behaviour before `4fa59c672`.

This is a straight revert of the retention added in #5062, plus a comment
recording why it must not come back. 

```c
/* A trailing incomplete ping is not retained for reassembly with the next
 * read. A bare CRLF is both the first half of a ping and the "pong" a peer
 * sends in reply to a ping of ours, and the two cannot be told apart by
 * content; retaining it lets two pongs coalesce into a ping nobody sent,
 * which we would answer with a CRLF the peer never asked for. Incomplete
 * pings are therefore left to the parser, which drops them as leading
 * newlines (RFC 3261 Section 7.5), and go unanswered.
 */
```

### Why not keep the reassembly and disambiguate it

An earlier revision of this PR did that: it tracked whether a ping of ours was
outstanding, and put an age limit on the retained prefix. Review showed the
state machine to be the wrong trade. It has to be fed from every path that can
send a ping (the transport keep-alive timer is not the only one — an account
with a `Flow-Timer` registrar sends its own via `pjsip_tpmgr_send_raw()`), it
has to be published to the receive callback before the send can reach the peer
on a multi-worker endpoint, a single boolean cannot represent more than one
outstanding ping, and the age limit it needs is wall-clock and so is not
monotonic. Each of those is a defect of the disambiguation, not of the bug
being fixed.

Dropping the fragment costs the `"\r\n"`+`"\r\n"` reassembly case that #5062
added, which is worth little in practice:

* Fragmenting a 4-byte write is already unlikely on TCP or TLS.
* The retention only ever worked for a read containing *nothing but*
  keep-alive bytes. `tcp_get_crlf_ka_len()` reports a prefix only when the tail
  after the leading pings is 1..3 bytes, so a fragment that trails a message in
  the same read — `<complete message>"\r\n\r"` — was never retained;
  `pjsip_tpmgr_receive_packet()` counts those bytes into its leading-newline
  skip and drops them. Half the feature was inoperative.
* The unanswered ping it protects against is a missed liveness probe. The
  phantom pong it causes is a torn-down flow.



## What does not change

* No public API change, and no new configuration.
* No change to any default: `PJSIP_*_KEEP_ALIVE_RESPONSE` stays enabled and
  `PJSIP_*_KEEP_ALIVE_INTERVAL` stays at 90 seconds.
* `sip_config.h` is untouched.
* A complete ping in a single read is still answered, including several
  back-to-back pings and a ping that shares a read with a message — test
  phases 1-3 and 5 cover this.
* Peers that never pong see no behavioural difference at all.
* The only observable change on the wire is that we stop emitting a pong that
  no peer asked for.

## Known behaviours, unchanged by this PR

### Coalesced pongs

Two pongs that arrive coalesced *in a single read* are byte-identical to a
ping and are still answered. That needs two of our pings outstanding at once,
i.e. a keep-alive interval below the round-trip time, and it is inherent to
the RFC's choice of patterns rather than to anything here — it behaves the
same on master. Distinguishing it requires exactly the send-side state that
this revision removes.

### Asymmetric `tp_drop_data_cb` notifications

A ping and a pong are consumed by different layers, so only one of them is
reported to the application:

| Received | `tp_drop_data_cb` |
|---|---|
| `"\r\n\r\n"` (ping) | no — consumed by the keep-alive block |
| `"\r\n"` (pong) | yes, `len=2`, `PJ_EIGNORED` |
| `"\r"`, `"\r\n\r"` (incomplete ping) | yes, `len=1` / `len=3` |

A complete ping never reaches the parser: `on_data_read()` answers it and
either returns early (`ka_len == size`) or shifts it out of the buffer before
calling `pjsip_tpmgr_receive_packet()`. Anything shorter falls through to that
function, whose leading-newline skip discards it and fires the callback.

So an application that registers the callback sees one 2-byte dropped-data
notification per keep-alive cycle — with the 90 second default, one per
connection per 90 seconds, for the life of the connection — and nothing at all
for the pings it answers.

This is pre-existing: identical on master, and identical before `4fa59c672`.
The newline skip doing the dropping was added in 2008 for ticket #482 ("TCP
keep-alive packets are corrupting SIP message") precisely to absorb stray
keep-alive CRLFs; the notification was added on top of it in 2015 for ticket
#1853. Ignoring the bytes is therefore the intended behaviour and the
notification is accurate — a pong genuinely is data we did not process.

Suppressing the notification would mean recognising the pong in the keep-alive
block and consuming it there, which needs the send-side state this revision
removes, so it is deliberately left alone. Worth knowing about for anyone who
treats drop notifications as a health signal rather than as a diagnostic.


## Note on the server side

There is a case that Kamailio should not stall on this either: RFC 3261
Section 7.5 says implementations processing SIP messages over stream-oriented
transports MUST ignore any CRLF appearing before the start-line, and pjsip does
exactly that in `pjsip_tpmgr_receive_packet()`. Kamailio consumes *double*
CRLFs correctly — it answered ours — but a lone one is left pending until the
message-read timeout fires. Either way, the unsolicited pong is ours, and it is
the half worth fixing here.
