### PR TITLE
pjsua2,pjsua,pjmedia: Forward the original SDP as-is during negotiation for signalling-plane B2BUA/relay use cases

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -669,6 +669,8 @@ jobs:
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-custom-sdp.xml
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-amr-sdp.xml
         python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-static-pt-no-rtpmap.xml
+        python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uac-sdp-passthrough.xml
+        python3 run.py --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua mod_sipp.py scripts-sipp/alt-pjsua-uas-sdp-passthrough.xml
     - name: upload artifacts on failure
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4

--- a/pjmedia/include/pjmedia/sdp_neg.h
+++ b/pjmedia/include/pjmedia/sdp_neg.h
@@ -720,6 +720,58 @@ PJ_DECL(pj_status_t) pjmedia_sdp_neg_negotiate( pj_pool_t *pool,
 
 
 /**
+ * Negotiate local and remote SDP without inspecting or modifying their
+ * content. Before calling this function, the SDP negotiator must be in
+ * PJMEDIA_SDP_NEG_STATE_WAIT_NEGO state. After calling this function, the
+ * negotiator state will move to PJMEDIA_SDP_NEG_STATE_DONE.
+ *
+ * Unlike #pjmedia_sdp_neg_negotiate(), this function does not run any
+ * offer/answer content negotiation (no codec/format reconciliation, no
+ * payload type reassignment, no SDP version bump): the local and remote
+ * SDP that were fed into the negotiator (via
+ * #pjmedia_sdp_neg_set_local_answer(), #pjmedia_sdp_neg_set_remote_answer(),
+ * #pjmedia_sdp_neg_modify_local_offer2(), or
+ * #pjmedia_sdp_neg_set_remote_offer()) simply become the active local and
+ * remote SDP verbatim. This is intended for applications that relay SDP
+ * on the signalling plane only (e.g. a signalling-plane B2BUA) and want
+ * the negotiator's state machine to progress normally without pjmedia
+ * altering the SDP content that has already been assembled/forwarded.
+ *
+ * Because this function skips pjmedia's internal payload-type bookkeeping
+ * (the per-negotiator dynamic payload type to codec mapping normally
+ * maintained by the negotiator to keep payload types stable across
+ * multiple offer/answer rounds), mixing calls to this function with
+ * #pjmedia_sdp_neg_negotiate() on the same negotiator instance may cause
+ * the payload types chosen by a subsequent #pjmedia_sdp_neg_negotiate()
+ * call to differ from what was actually used on the wire during a
+ * preceding passthrough round. Applications that use this function should
+ * do so for the entire lifetime of the negotiator instance.
+ *
+ * This function also skips the media-count padding that
+ * #pjmedia_sdp_neg_negotiate() normally performs (e.g. inserting a
+ * matching-but-disabled media line when the answer has fewer "m=" lines
+ * than the offer), so the resulting active local and remote SDP may end
+ * up with a different number of media lines from each other. Applications
+ * that inspect the negotiated SDP media array by index (e.g. pjsua, which
+ * assumes as many media lines as the call's configured media count) must
+ * account for this, e.g. by supplying local/remote SDP pairs with a
+ * matching media count, or by bounds-checking both SDPs' media_count
+ * before indexing.
+ *
+ * @param pool          Pool to allocate memory. The pool's lifetime needs
+ *                      to be valid for the duration of the negotiator.
+ * @param neg           The SDP negotiator instance.
+ *
+ * @return              PJ_SUCCESS on success, or the appropriate error
+ *                      code (e.g. if the negotiator is not in
+ *                      PJMEDIA_SDP_NEG_STATE_WAIT_NEGO state, or if the
+ *                      local/remote SDP to negotiate is not available).
+ */
+PJ_DECL(pj_status_t) pjmedia_sdp_neg_negotiate_passthrough(pj_pool_t *pool,
+                                                pjmedia_sdp_neg *neg);
+
+
+/**
  * Enumeration of customized SDP format matching option flags. See
  * #pjmedia_sdp_neg_register_fmt_match_cb() for more info.
  */

--- a/pjmedia/src/pjmedia/sdp_neg.c
+++ b/pjmedia/src/pjmedia/sdp_neg.c
@@ -2331,6 +2331,52 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_negotiate( pj_pool_t *pool,
 }
 
 
+/* Negotiate without inspecting/modifying offer/answer content, for
+ * signalling-plane relay (e.g. B2BUA) use cases. */
+PJ_DEF(pj_status_t) pjmedia_sdp_neg_negotiate_passthrough(pj_pool_t *pool,
+                                                          pjmedia_sdp_neg *neg)
+{
+    PJ_ASSERT_RETURN(pool && neg, PJ_EINVAL);
+
+    /* Must be in STATE_WAIT_NEGO state. */
+    PJ_ASSERT_RETURN(neg->state == PJMEDIA_SDP_NEG_STATE_WAIT_NEGO,
+                     PJMEDIA_SDPNEG_EINSTATE);
+
+    /* Must have remote and local SDP to negotiate. */
+    PJ_ASSERT_RETURN(neg->neg_remote_sdp && neg->neg_local_sdp, PJ_EBUG);
+
+    /* Promote the fed-in local/remote SDP to active. Note:
+     * assign_pt_and_update_map() is intentionally not called here.
+     */
+    neg->active_local_sdp = neg->neg_local_sdp;
+    neg->active_remote_sdp = neg->neg_remote_sdp;
+
+    /* Keep the pool used for allocating the active SDPs */
+    neg->pool_active = pool;
+
+    if (!neg->has_remote_answer) {
+        /* We are answering: this answer will be sent, so update the
+         * last sent SDP (mirrors pjmedia_sdp_neg_negotiate()), without
+         * touching its origin.version.
+         */
+        neg->last_sent = neg->neg_local_sdp;
+    }
+
+    /* State is DONE */
+    neg->state = PJMEDIA_SDP_NEG_STATE_DONE;
+
+    /* Save state */
+    neg->answer_was_remote = neg->has_remote_answer;
+
+    /* Clear temporary SDP */
+    neg->initial_sdp_tmp = NULL;
+    neg->neg_local_sdp = neg->neg_remote_sdp = NULL;
+    neg->has_remote_answer = PJ_FALSE;
+
+    return PJ_SUCCESS;
+}
+
+
 static pj_status_t custom_fmt_match(pj_pool_t *pool,
                                     const pj_str_t *fmt_name,
                                     pjmedia_sdp_media *offer,

--- a/pjmedia/src/test/sdp_neg_test.c
+++ b/pjmedia/src/test/sdp_neg_test.c
@@ -1896,6 +1896,161 @@ static int sdp_neg_static_pt_repr_test(pj_pool_t *pool)
     return 0;
 }
 
+/* Real-world SDP offer/answer pair used to verify that
+ * pjmedia_sdp_neg_negotiate_passthrough() promotes the fed-in SDP verbatim,
+ * without the fmtp reconciliation / payload-type bookkeeping that a normal
+ * pjmedia_sdp_neg_negotiate() would apply. The offer carries 6 payload
+ * types (AMR-WB/AMR/telephone-event), while the answer narrows this down
+ * to 2 with different fmtp parameters than the offer's — exactly the kind
+ * of content a normal negotiation would rewrite.
+ */
+static char pt_offer_str[] =
+    "v=0\r\n"
+    "o=- 893867431174198 4062473431 IN IP4 10.162.173.125\r\n"
+    "s=SS VOIP\r\n"
+    "c=IN IP4 10.186.99.36\r\n"
+    "t=0 0\r\n"
+    "m=audio 56832 RTP/AVP 116 107 118 96 111 110\r\n"
+    "b=AS:41\r\n"
+    "b=RS:512\r\n"
+    "b=RR:1537\r\n"
+    "a=rtpmap:116 AMR-WB/16000/1\r\n"
+    "a=fmtp:116 mode-change-capability=2;max-red=220\r\n"
+    "a=rtpmap:107 AMR-WB/16000/1\r\n"
+    "a=fmtp:107 octet-align=1;mode-change-capability=2;max-red=220\r\n"
+    "a=rtpmap:118 AMR/8000/1\r\n"
+    "a=fmtp:118 mode-change-capability=2;max-red=220\r\n"
+    "a=rtpmap:96 AMR/8000/1\r\n"
+    "a=fmtp:96 octet-align=1;mode-change-capability=2;max-red=220\r\n"
+    "a=rtpmap:111 telephone-event/16000\r\n"
+    "a=fmtp:111 0-15\r\n"
+    "a=rtpmap:110 telephone-event/8000\r\n"
+    "a=fmtp:110 0-15\r\n"
+    "a=curr:qos local none\r\n"
+    "a=curr:qos remote none\r\n"
+    "a=des:qos mandatory local sendrecv\r\n"
+    "a=des:qos optional remote sendrecv\r\n"
+    "a=sendrecv\r\n"
+    "a=ptime:20\r\n"
+    "a=maxptime:240\r\n";
+
+static char pt_answer_str[] =
+    "v=0\r\n"
+    "o=- 893867432491909 4062736973 IN IP4 10.162.173.125\r\n"
+    "s=-\r\n"
+    "t=0 0\r\n"
+    "a=msid-semantic: WMS\r\n"
+    "m=audio 56384 RTP/AVP 116 111\r\n"
+    "c=IN IP4 10.186.99.38\r\n"
+    "b=AS:41\r\n"
+    "a=rtpmap:116 AMR-WB/16000\r\n"
+    "a=fmtp:116 max-red=0; mode-change-capability=2; mode-change-neighbor=1;"
+        " mode-change-period=2\r\n"
+    "a=rtpmap:111 telephone-event/16000\r\n"
+    "a=fmtp:111 0-15\r\n"
+    "a=ptime:20\r\n"
+    "a=maxptime:40\r\n"
+    "a=msid:- 415221c9-141a-4cfa-905a-024af91d0e7c\r\n"
+    "a=ssrc:18411299 cname:NNI4WBv5F7m8JUWO\r\n"
+    "a=sendrecv\r\n";
+
+/* Verify pjmedia_sdp_neg_negotiate_passthrough() for both negotiation
+ * directions: we answer a remote offer, and remote answers our offer.
+ * In both cases, the active local/remote SDP after negotiation must be
+ * content-identical to what was fed into the negotiator, unlike
+ * pjmedia_sdp_neg_negotiate() which would reconcile/filter the answer's
+ * fmtp against the offer's and reassign payload types.
+ */
+static int sdp_neg_passthrough_test(pj_pool_t *pool)
+{
+    pjmedia_sdp_session *offer, *answer;
+    pjmedia_sdp_neg *neg;
+    const pjmedia_sdp_session *active_local, *active_remote;
+    pj_status_t status;
+    char b1[sizeof(pt_offer_str)], b2[sizeof(pt_answer_str)];
+
+    /* Case 1: we answer a remote offer (has_remote_answer == PJ_FALSE). */
+    pj_memcpy(b1, pt_offer_str, sizeof(pt_offer_str));
+    pj_memcpy(b2, pt_answer_str, sizeof(pt_answer_str));
+    if (pjmedia_sdp_parse(pool, b1, pj_ansi_strlen(b1), &offer) != PJ_SUCCESS)
+        return -3000;
+    if (pjmedia_sdp_parse(pool, b2, pj_ansi_strlen(b2), &answer) != PJ_SUCCESS)
+        return -3010;
+
+    if (pjmedia_sdp_neg_create_w_remote_offer(pool, NULL, offer, &neg) !=
+        PJ_SUCCESS)
+    {
+        return -3020;
+    }
+    if (pjmedia_sdp_neg_set_local_answer(pool, neg, answer) != PJ_SUCCESS)
+        return -3030;
+
+    status = pjmedia_sdp_neg_negotiate_passthrough(pool, neg);
+    if (status != PJ_SUCCESS) {
+        app_perror(status, "   sdp_neg_passthrough_test: negotiate failed");
+        return -3040;
+    }
+
+    if (pjmedia_sdp_neg_get_state(neg) != PJMEDIA_SDP_NEG_STATE_DONE)
+        return -3050;
+
+    if (pjmedia_sdp_neg_get_active_local(neg, &active_local) != PJ_SUCCESS)
+        return -3060;
+    if (pjmedia_sdp_neg_get_active_remote(neg, &active_remote) != PJ_SUCCESS)
+        return -3070;
+
+    if (compare_sdp_string("passthrough answer", "fed-in answer", answer,
+                           "active local", active_local, PJ_SUCCESS) != 0)
+    {
+        return -3080;
+    }
+    if (compare_sdp_string("passthrough offer", "fed-in offer", offer,
+                           "active remote", active_remote, PJ_SUCCESS) != 0)
+    {
+        return -3090;
+    }
+
+    /* Case 2: remote answers our offer (has_remote_answer == PJ_TRUE). */
+    pj_memcpy(b1, pt_offer_str, sizeof(pt_offer_str));
+    pj_memcpy(b2, pt_answer_str, sizeof(pt_answer_str));
+    if (pjmedia_sdp_parse(pool, b1, pj_ansi_strlen(b1), &offer) != PJ_SUCCESS)
+        return -3100;
+    if (pjmedia_sdp_parse(pool, b2, pj_ansi_strlen(b2), &answer) != PJ_SUCCESS)
+        return -3110;
+
+    if (pjmedia_sdp_neg_create_w_local_offer(pool, offer, &neg) != PJ_SUCCESS)
+        return -3120;
+    if (pjmedia_sdp_neg_set_remote_answer(pool, neg, answer) != PJ_SUCCESS)
+        return -3130;
+
+    status = pjmedia_sdp_neg_negotiate_passthrough(pool, neg);
+    if (status != PJ_SUCCESS) {
+        app_perror(status, "   sdp_neg_passthrough_test: negotiate failed");
+        return -3140;
+    }
+
+    if (pjmedia_sdp_neg_get_state(neg) != PJMEDIA_SDP_NEG_STATE_DONE)
+        return -3150;
+
+    if (pjmedia_sdp_neg_get_active_local(neg, &active_local) != PJ_SUCCESS)
+        return -3160;
+    if (pjmedia_sdp_neg_get_active_remote(neg, &active_remote) != PJ_SUCCESS)
+        return -3170;
+
+    if (compare_sdp_string("passthrough offer", "fed-in offer", offer,
+                           "active local", active_local, PJ_SUCCESS) != 0)
+    {
+        return -3180;
+    }
+    if (compare_sdp_string("passthrough answer", "fed-in answer", answer,
+                           "active remote", active_remote, PJ_SUCCESS) != 0)
+    {
+        return -3190;
+    }
+
+    return 0;
+}
+
 /* Regression: offer without c= on a port=0 media (passes lenient validation,
  * fails strict) must leave the negotiator in DONE state, not stuck in WAIT_NEGO. */
 static int sdp_neg_strict_validate_test(pj_pool_t *pool)
@@ -2241,6 +2396,21 @@ int sdp_neg_test()
 
         PJ_LOG(3,(THIS_FILE, "  sdp_neg_static_pt_repr_test"));
         status = sdp_neg_static_pt_repr_test(pool);
+        pj_pool_release(pool);
+
+        if (status != 0)
+            return status;
+    }
+
+    {
+        pj_pool_t *pool;
+
+        pool = pj_pool_create(mem, "sdp_neg_passthrough", 4000, 4000, NULL);
+        if (!pool)
+            return PJ_ENOMEM;
+
+        PJ_LOG(3,(THIS_FILE, "  sdp_neg_passthrough_test"));
+        status = sdp_neg_passthrough_test(pool);
         pj_pool_release(pool);
 
         if (status != 0)

--- a/pjsip-apps/src/pjsua/pjsua_app.c
+++ b/pjsip-apps/src/pjsua/pjsua_app.c
@@ -389,6 +389,9 @@ static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id,
         opt.aud_cnt = app_config.aud_cnt;
         opt.vid_cnt = app_config.vid.vid_cnt;
         opt.txt_cnt = app_config.txt_cnt;
+        if (app_config.sdp_passthrough) {
+            opt.flag |= PJSUA_CALL_SDP_PASSTHROUGH;
+        }
 
         pjsua_call_answer2(call_id, &opt, app_config.auto_answer, NULL,
                            NULL);
@@ -2255,6 +2258,9 @@ static pj_status_t app_init(void)
     call_opt.txt_cnt = app_config.txt_cnt;
     if (app_config.enable_loam) {
         call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
+    }
+    if (app_config.sdp_passthrough) {
+        call_opt.flag |= PJSUA_CALL_SDP_PASSTHROUGH;
     }
 
 #if defined(PJSIP_HAS_TLS_TRANSPORT) && PJSIP_HAS_TLS_TRANSPORT!=0

--- a/pjsip-apps/src/pjsua/pjsua_app_cli.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_cli.c
@@ -2583,6 +2583,9 @@ pj_status_t cmd_call_handler(pj_cli_cmd_val *cval)
     if (app_config.enable_loam) {
         call_opt.flag |= PJSUA_CALL_NO_SDP_OFFER;
     }
+    if (app_config.sdp_passthrough) {
+        call_opt.flag |= PJSUA_CALL_SDP_PASSTHROUGH;
+    }
 
     switch(cmd_id) {
     case CMD_CALL_NEW:

--- a/pjsip-apps/src/pjsua/pjsua_app_common.h
+++ b/pjsip-apps/src/pjsua/pjsua_app_common.h
@@ -202,6 +202,10 @@ typedef struct pjsua_app_config
      * Only available when PJSUA_MEDIA_HAS_PJMEDIA=0 (alt media backend). */
     pj_str_t                custom_sdp;
 #endif
+
+    /* Set PJSUA_CALL_SDP_PASSTHROUGH on the default call setting used for
+     * outgoing and auto-answered incoming calls (--sdp-passthrough). */
+    pj_bool_t                sdp_passthrough;
 } pjsua_app_config;
 
 /** Extern variable declaration **/

--- a/pjsip-apps/src/pjsua/pjsua_app_config.c
+++ b/pjsip-apps/src/pjsua/pjsua_app_config.c
@@ -188,6 +188,8 @@ static void usage(void)
     puts  ("  --custom-sdp=STR    Replace generated SDP with this string.");
     puts  ("                      Use \\r\\n or \\n as line separators. The full SDP is replaced as-is.");
 #endif
+    puts  ("  --sdp-passthrough  Keep and forward the local/remote SDP as-is during");
+    puts  ("                     negotiation for outgoing and auto-answered incoming calls.");
 
 #if PJSUA_HAS_VIDEO
     puts  ("");
@@ -441,7 +443,7 @@ static pj_status_t parse_args(int argc, char *argv[],
            OPT_VCAPTURE_DEV, OPT_VRENDER_DEV, OPT_PLAY_AVI, OPT_AUTO_PLAY_AVI,
            OPT_REC_AVI, OPT_REC_AVI_SIZE, OPT_REC_AVI_AUDIO, OPT_AUTO_REC_AVI,
            OPT_USE_CLI, OPT_CLI_TELNET_PORT, OPT_DISABLE_CLI_CONSOLE,
-           OPT_SERVER_AFFINITY
+           OPT_SERVER_AFFINITY, OPT_SDP_PASSTHROUGH
 #if !PJSUA_MEDIA_HAS_PJMEDIA
            , OPT_CUSTOM_SDP
 #endif
@@ -606,6 +608,7 @@ static pj_status_t parse_args(int argc, char *argv[],
         { "cli-telnet-port", 1, 0, OPT_CLI_TELNET_PORT},
         { "no-cli-console", 0, 0, OPT_DISABLE_CLI_CONSOLE},
         { "server-affinity", 2, 0, OPT_SERVER_AFFINITY},
+        { "sdp-passthrough", 0, 0, OPT_SDP_PASSTHROUGH},
 #if !PJSUA_MEDIA_HAS_PJMEDIA
         { "custom-sdp",     1, 0, OPT_CUSTOM_SDP},
 #endif
@@ -1696,6 +1699,10 @@ static pj_status_t parse_args(int argc, char *argv[],
                            "expected 'on' or 'off'", pj_optarg));
                 return PJ_EINVAL;
             }
+            break;
+
+        case OPT_SDP_PASSTHROUGH:
+            cfg->sdp_passthrough = PJ_TRUE;
             break;
 
 #if !PJSUA_MEDIA_HAS_PJMEDIA

--- a/pjsip-apps/src/swig/symbols.i
+++ b/pjsip-apps/src/swig/symbols.i
@@ -985,7 +985,8 @@ typedef enum pjsua_call_flag
     PJSUA_CALL_UPDATE_VIA = 32,
     PJSUA_CALL_UPDATE_TARGET = 64,
     PJSUA_CALL_SET_MEDIA_DIR = 128,
-    PJSUA_CALL_NO_MEDIA_SYNC = 256
+    PJSUA_CALL_NO_MEDIA_SYNC = 256,
+    PJSUA_CALL_SDP_PASSTHROUGH = 512
 } pjsua_call_flag;
 
 typedef enum pjsua_create_media_transport_flag

--- a/pjsip/include/pjsip-ua/sip_inv.h
+++ b/pjsip/include/pjsip-ua/sip_inv.h
@@ -638,6 +638,17 @@ struct pjsip_inv_session
     pj_str_t             siprec_metadata;           /**< SIPREC metadata update
                                                          pending notification,
                                                          internal.           */
+    pj_bool_t            sdp_passthrough;           /**< If PJ_TRUE, SDP
+                                                         negotiation calls
+                                                         pjmedia_sdp_neg_negotiate_passthrough()
+                                                         instead of
+                                                         pjmedia_sdp_neg_negotiate(),
+                                                         keeping the local and
+                                                         remote SDP unmodified.
+                                                         Set by the application
+                                                         (e.g. pjsua) before
+                                                         negotiation. Default
+                                                         is PJ_FALSE.        */
 };
 
 

--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -6322,7 +6322,21 @@ typedef enum pjsua_call_flag
     /**
      * Disable inter-media synchronization.
      */
-    PJSUA_CALL_NO_MEDIA_SYNC = 256
+    PJSUA_CALL_NO_MEDIA_SYNC = 256,
+
+    /**
+     * Keep and forward the original local and remote SDP as-is during
+     * negotiation, bypassing pjmedia's answer/offer content rewriting
+     * (codec/payload type reassignment, format filtering, etc). The SDP
+     * negotiator state machine still transitions normally. Intended for
+     * signalling-plane B2BUA/relay use cases where the SDP is forwarded
+     * verbatim between two call legs.
+     *
+     * Valid for #pjsua_call_make_call(), #pjsua_call_answer() /
+     * answer2(), #pjsua_call_reinvite()/reinvite2(), and
+     * #pjsua_call_update()/update2().
+     */
+    PJSUA_CALL_SDP_PASSTHROUGH = 512
 
 } pjsua_call_flag;
 

--- a/pjsip/src/pjsip-ua/sip_inv.c
+++ b/pjsip/src/pjsip-ua/sip_inv.c
@@ -2557,7 +2557,9 @@ static pj_status_t inv_negotiate_sdp( pjsip_inv_session *inv )
                      PJMEDIA_SDP_NEG_STATE_WAIT_NEGO, 
                      PJMEDIA_SDPNEG_EINSTATE);
 
-    status = pjmedia_sdp_neg_negotiate(inv->pool_prov, inv->neg, 0);
+    status = inv->sdp_passthrough?
+              pjmedia_sdp_neg_negotiate_passthrough(inv->pool_prov, inv->neg) :
+              pjmedia_sdp_neg_negotiate(inv->pool_prov, inv->neg, 0);
 
     PJ_PERROR(4,(inv->obj_name, status, "SDP negotiation done"));
 

--- a/pjsip/src/pjsua-lib/pjsua_call.c
+++ b/pjsip/src/pjsua-lib/pjsua_call.c
@@ -570,6 +570,12 @@ on_make_call_med_tp_complete(pjsua_call_id call_id,
     /* Create and associate our data in the session. */
     call->inv = inv;
 
+    /* Mirror the passthrough flag, set earlier via apply_call_setting()
+     * before call->inv existed, onto the now-created invite session.
+     */
+    call->inv->sdp_passthrough =
+                (call->opt.flag & PJSUA_CALL_SDP_PASSTHROUGH) != 0;
+
     dlg->mod_data[pjsua_var.mod.id] = call;
     inv->mod_data[pjsua_var.mod.id] = call;
 
@@ -773,6 +779,15 @@ static pj_status_t apply_call_setting(pjsua_call *call,
 #if !PJMEDIA_HAS_VIDEO
     pj_assert(call->opt.vid_cnt == 0);
 #endif
+
+    /* Mirror the passthrough flag onto the invite session so that
+     * pjsip-ua's inv_negotiate_sdp() (the primary SDP negotiation call
+     * site) can honor it without needing access to pjsua_call.
+     */
+    if (call->inv) {
+        call->inv->sdp_passthrough =
+                    (call->opt.flag & PJSUA_CALL_SDP_PASSTHROUGH) != 0;
+    }
 
     if (call->opt.flag & PJSUA_CALL_REINIT_MEDIA) {
         PJ_LOG(4, (THIS_FILE, "PJSUA_CALL_REINIT_MEDIA"));
@@ -2243,6 +2258,14 @@ pj_bool_t pjsua_call_on_incoming(pjsip_rx_data *rdata)
 
     /* Create and attach pjsua_var data to the dialog */
     call->inv = inv;
+
+    /* Mirror the passthrough flag onto the freshly created invite
+     * session (call->opt is the default at this point; pjsua_call_answer()
+     * et al re-apply it via apply_call_setting() once the application
+     * supplies its own setting).
+     */
+    call->inv->sdp_passthrough =
+                (call->opt.flag & PJSUA_CALL_SDP_PASSTHROUGH) != 0;
 
 #if PJSUA_HAS_SIPREC
     /*
@@ -4549,8 +4572,14 @@ static pj_bool_t check_lock_codec(pjsua_call *call)
             continue;
         }
 
-        /* Remote may answer with less media lines. */
-        if (i >= remote_sdp->media_count)
+        /* Remote may answer with less media lines. Also guard against
+         * local_sdp having fewer media lines than remote_sdp: this
+         * normally can't happen (process_answer()/create_answer() keep
+         * both sides' media count in sync), but with
+         * PJSUA_CALL_SDP_PASSTHROUGH the active local/remote SDPs are
+         * whatever was fed into the negotiator, unpadded.
+         */
+        if (i >= remote_sdp->media_count || i >= local_sdp->media_count)
             continue;
 
         rem_m = remote_sdp->media[i];

--- a/pjsip/src/pjsua-lib/pjsua_media.c
+++ b/pjsip/src/pjsua-lib/pjsua_media.c
@@ -4902,7 +4902,9 @@ on_check_med_status:
         if (status != PJ_SUCCESS)
             goto on_error;
 
-        status = pjmedia_sdp_neg_negotiate(tmp_pool, neg, 0);
+        status = call->inv->sdp_passthrough?
+                  pjmedia_sdp_neg_negotiate_passthrough(tmp_pool, neg) :
+                  pjmedia_sdp_neg_negotiate(tmp_pool, neg, 0);
         if (status != PJ_SUCCESS)
             goto on_error;
     }

--- a/tests/pjsua/runall.py
+++ b/tests/pjsua/runall.py
@@ -48,6 +48,8 @@ excluded_tests = [
     "alt-pjsua-uas-custom-sdp",
     "alt-pjsua-uas-amr-sdp",
     "alt-pjsua-uas-static-pt-no-rtpmap",
+    "alt-pjsua-uac-sdp-passthrough",
+    "alt-pjsua-uas-sdp-passthrough",
 ]
 
 # Exclude scripts-sipp/uac-reinvite-bad-via-branch on MacOS due to unreliable result

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uac-sdp-passthrough.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uac-sdp-passthrough.py
@@ -1,0 +1,39 @@
+#
+# Test driver for alt-pjsua-uac-sdp-passthrough.xml
+#
+# alt_pjsua acts as UAC with --sdp-passthrough. It places a call to SIPp
+# (UAS) using a real-world SDP offer (see real-world-sdp.txt: AMR-WB/AMR/
+# telephone-event, 6 payload types). SIPp answers with the real-world
+# answer verbatim (only 2 payload types, with fmtp params that differ from
+# the offer's). With PJSUA_CALL_SDP_PASSTHROUGH set, pjmedia's SDP
+# negotiator must not reconcile/rewrite this answer against the offer: the
+# 200 OK body received by alt_pjsua must show up unmodified in its log, and
+# the call should still reach STATE_CONFIRMED.
+#
+# Run with alt_pjsua:
+#   cd tests/pjsua && python3 run.py \
+#       --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua \
+#       mod_sipp.py scripts-sipp/alt-pjsua-uac-sdp-passthrough.xml
+#
+import inc_const as const
+
+# pjsua instance: UAC. No URI in args so the call is initiated via CLI
+# after cli_main() has set up the telnet log redirect.
+PJSUA = [
+    "--null-audio --max-calls=1 --no-tcp --sdp-passthrough "
+    "--custom-sdp \"v=0\\r\\no=- 893867431174198 4062473431 IN IP4 10.162.173.125\\r\\ns=SS VOIP\\r\\nc=IN IP4 10.186.99.36\\r\\nt=0 0\\r\\nm=audio 56832 RTP/AVP 116 107 118 96 111 110\\r\\nb=AS:41\\r\\nb=RS:512\\r\\nb=RR:1537\\r\\na=rtpmap:116 AMR-WB/16000/1\\r\\na=fmtp:116 mode-change-capability=2;max-red=220\\r\\na=rtpmap:107 AMR-WB/16000/1\\r\\na=fmtp:107 octet-align=1;mode-change-capability=2;max-red=220\\r\\na=rtpmap:118 AMR/8000/1\\r\\na=fmtp:118 mode-change-capability=2;max-red=220\\r\\na=rtpmap:96 AMR/8000/1\\r\\na=fmtp:96 octet-align=1;mode-change-capability=2;max-red=220\\r\\na=rtpmap:111 telephone-event/16000\\r\\na=fmtp:111 0-15\\r\\na=rtpmap:110 telephone-event/8000\\r\\na=fmtp:110 0-15\\r\\na=curr:qos local none\\r\\na=curr:qos remote none\\r\\na=des:qos mandatory local sendrecv\\r\\na=des:qos optional remote sendrecv\\r\\na=sendrecv\\r\\na=ptime:20\\r\\na=maxptime:240\""
+]
+
+PJSUA_CLI_EXPECTS = [
+    [0, "", "call new $SIPP_URI"],
+    # Verify the real-world answer SIPp sends in its 200 OK is received by
+    # alt_pjsua unmodified: the negotiated fmtp params and codec set stay
+    # exactly as SIPp sent them (only 116/111, fmtp diverging from the
+    # offer), instead of being reconciled against the 6-codec offer.
+    [0, r"m=audio 56384 RTP/AVP 116 111", ""],
+    [0, r"a=rtpmap:116 AMR-WB/16000", ""],
+    [0, r"a=fmtp:116 max-red=0; mode-change-capability=2; "
+        r"mode-change-neighbor=1; mode-change-period=2", ""],
+    [0, r"a=rtpmap:111 telephone-event/16000", ""],
+    [0, const.STATE_CONFIRMED, "call hangup"],
+]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uac-sdp-passthrough.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uac-sdp-passthrough.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- SIPp acts as UAS. alt_pjsua (with the "sdp-passthrough" option) sends an INVITE
+     carrying the real-world SDP offer from real-world-sdp.txt (AMR-WB/AMR/
+     telephone-event, 6 payload types). SIPp verifies the offer's codecs
+     appear, then answers 200 OK with the real-world answer verbatim (only
+     2 payload types, with fmtp params that would normally be reconciled/
+     filtered against the offer by pjmedia's SDP negotiator). alt_pjsua
+     must accept this answer as-is (passthrough) and reach CONFIRMED. -->
+
+<scenario name="alt_pjsua UAC SDP passthrough: SIPp as UAS">
+
+  <recv request="INVITE" crlf="true">
+    <action>
+      <!-- Verify the INVITE carries the real-world offer injected by
+           alt_pjsua via the "custom-sdp" option. search_in="msg" searches
+           the entire SIP message. The condexec nops avoid SIPp 3.7 exiting
+           on "referenced 1 times" warning. -->
+      <ereg regexp="m=audio 56832 RTP/AVP 116 107 118 96 111 110"
+            search_in="msg" check_it="true" assign_to="1"/>
+      <ereg regexp="a=rtpmap:116 AMR-WB/16000/1" search_in="msg"
+            check_it="true" assign_to="2"/>
+      <ereg regexp="a=fmtp:116 mode-change-capability=2;max-red=220"
+            search_in="msg" check_it="true" assign_to="3"/>
+    </action>
+  </recv>
+  <nop condexec="1"></nop>
+  <nop condexec="2"></nop>
+  <nop condexec="3"></nop>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 100 Trying
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+v=0
+o=- 893867432491909 4062736973 IN IP4 10.162.173.125
+s=-
+t=0 0
+a=msid-semantic: WMS
+m=audio 56384 RTP/AVP 116 111
+c=IN IP4 10.186.99.38
+b=AS:41
+a=rtpmap:116 AMR-WB/16000
+a=fmtp:116 max-red=0; mode-change-capability=2; mode-change-neighbor=1; mode-change-period=2
+a=rtpmap:111 telephone-event/16000
+a=fmtp:111 0-15
+a=ptime:20
+a=maxptime:40
+a=msid:- 415221c9-141a-4cfa-905a-024af91d0e7c
+a=ssrc:18411299 cname:NNI4WBv5F7m8JUWO
+a=sendrecv
+
+    ]]>
+  </send>
+
+  <recv request="ACK" crlf="true">
+  </recv>
+
+  <recv request="BYE" crlf="true">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-sdp-passthrough.py
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-sdp-passthrough.py
@@ -1,0 +1,34 @@
+#
+# Test driver for alt-pjsua-uas-sdp-passthrough.xml
+#
+# alt_pjsua acts as UAS with --sdp-passthrough and --auto-answer=200. SIPp
+# sends an INVITE with the real-world SDP offer from real-world-sdp.txt
+# (AMR-WB/AMR/telephone-event, 6 payload types). alt_pjsua answers with the
+# real-world answer (via --custom-sdp), which only has 2 payload types and
+# fmtp params that would normally be reconciled/filtered against the offer
+# by pjmedia's SDP negotiator. With PJSUA_CALL_SDP_PASSTHROUGH set, the
+# 200 OK body must carry this answer unmodified, and the call should still
+# reach STATE_CONFIRMED.
+#
+# Run with alt_pjsua:
+#   cd tests/pjsua && python3 run.py \
+#       --exe ../../pjsip-apps/src/3rdparty_media_sample/alt_pjsua \
+#       mod_sipp.py scripts-sipp/alt-pjsua-uas-sdp-passthrough.xml
+#
+import inc_const as const
+
+# pjsua instance: UAS, auto-answers with the real-world answer verbatim.
+PJSUA = [
+    "--null-audio --max-calls=1 --no-tcp --sdp-passthrough "
+    "--auto-answer=200 "
+    "--custom-sdp \"v=0\\r\\no=- 893867432491909 4062736973 IN IP4 10.162.173.125\\r\\ns=-\\r\\nt=0 0\\r\\na=msid-semantic: WMS\\r\\nm=audio 56384 RTP/AVP 116 111\\r\\nc=IN IP4 10.186.99.38\\r\\nb=AS:41\\r\\na=rtpmap:116 AMR-WB/16000\\r\\na=fmtp:116 max-red=0; mode-change-capability=2; mode-change-neighbor=1; mode-change-period=2\\r\\na=rtpmap:111 telephone-event/16000\\r\\na=fmtp:111 0-15\\r\\na=ptime:20\\r\\na=maxptime:40\\r\\na=msid:- 415221c9-141a-4cfa-905a-024af91d0e7c\\r\\na=ssrc:18411299 cname:NNI4WBv5F7m8JUWO\\r\\na=sendrecv\""
+]
+
+PJSUA_CLI_EXPECTS = [
+    # Verify the real-world offer SIPp sends in its INVITE is received by
+    # alt_pjsua unmodified.
+    [0, r"m=audio 56832 RTP/AVP 116 107 118 96 111 110", ""],
+    [0, r"a=rtpmap:116 AMR-WB/16000/1", ""],
+    [0, r"a=fmtp:116 mode-change-capability=2;max-red=220", ""],
+    [0, const.STATE_CONFIRMED, ""],
+]

--- a/tests/pjsua/scripts-sipp/alt-pjsua-uas-sdp-passthrough.xml
+++ b/tests/pjsua/scripts-sipp/alt-pjsua-uas-sdp-passthrough.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- SIPp acts as UAC and sends an INVITE with the real-world SDP offer
+     from real-world-sdp.txt (AMR-WB/AMR/telephone-event, 6 payload types).
+     alt_pjsua (with the "sdp-passthrough" and "auto-answer=200" options)
+     answers with the real-world answer (via the "custom-sdp" option),
+     which only has 2 payload types and fmtp params that would normally be
+     reconciled/filtered against the offer by pjmedia's SDP negotiator.
+     SIPp verifies the 200 OK body carries this answer unmodified, sends
+     ACK, waits briefly, then sends BYE. -->
+
+<scenario name="alt_pjsua UAS SDP passthrough: SIPp as UAC">
+
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: alt_pjsua UAS SDP passthrough test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+v=0
+o=- 893867431174198 4062473431 IN IP4 10.162.173.125
+s=SS VOIP
+c=IN IP4 10.186.99.36
+t=0 0
+m=audio 56832 RTP/AVP 116 107 118 96 111 110
+b=AS:41
+b=RS:512
+b=RR:1537
+a=rtpmap:116 AMR-WB/16000/1
+a=fmtp:116 mode-change-capability=2;max-red=220
+a=rtpmap:107 AMR-WB/16000/1
+a=fmtp:107 octet-align=1;mode-change-capability=2;max-red=220
+a=rtpmap:118 AMR/8000/1
+a=fmtp:118 mode-change-capability=2;max-red=220
+a=rtpmap:96 AMR/8000/1
+a=fmtp:96 octet-align=1;mode-change-capability=2;max-red=220
+a=rtpmap:111 telephone-event/16000
+a=fmtp:111 0-15
+a=rtpmap:110 telephone-event/8000
+a=fmtp:110 0-15
+a=curr:qos local none
+a=curr:qos remote none
+a=des:qos mandatory local sendrecv
+a=des:qos optional remote sendrecv
+a=sendrecv
+a=ptime:20
+a=maxptime:240
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true">
+  </recv>
+
+  <recv response="180" optional="true">
+  </recv>
+
+  <recv response="200" rtd="true">
+    <action>
+      <!-- Verify the 200 OK carries the real-world answer injected by
+           alt_pjsua via the "custom-sdp" option, unmodified: only 2
+           payload types (not reconciled against the offer's 6), and the
+           answer's own fmtp params (not the offer's). search_in="msg"
+           searches the entire SIP message. The condexec nops avoid SIPp
+           3.7 exiting on "referenced 1 times" warning. -->
+      <ereg regexp="m=audio 56384 RTP/AVP 116 111" search_in="msg"
+            check_it="true" assign_to="1"/>
+      <ereg regexp="a=rtpmap:116 AMR-WB/16000" search_in="msg"
+            check_it="true" assign_to="2"/>
+      <ereg regexp="a=fmtp:116 max-red=0; mode-change-capability=2; mode-change-neighbor=1; mode-change-period=2"
+            search_in="msg" check_it="true" assign_to="3"/>
+      <ereg regexp="a=rtpmap:111 telephone-event/16000" search_in="msg"
+            check_it="true" assign_to="4"/>
+    </action>
+  </recv>
+  <nop condexec="1"></nop>
+  <nop condexec="2"></nop>
+  <nop condexec="3"></nop>
+  <nop condexec="4"></nop>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <pause milliseconds="500"/>
+
+  <send retrans="500">
+    <![CDATA[
+
+      BYE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[call_number]
+      To: sut <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 2 BYE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <recv response="200" crlf="true">
+  </recv>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>


### PR DESCRIPTION
This extension is intended for signalling-plane B2BUA/relay use cases where the SDP is forwarded verbatim between two call legs.

If call option `PJSUA_CALL_SDP_PASSTHROUGH`  is set, PJSUA(2) keeps and forwards the original local and remote SDP as-is during negotiation, bypassing pjmedia's answer/offer content rewriting  (codec/payload type reassignment, format filtering, etc). The SDP negotiator state machine still transitions normally. 

New integration and unit tests are in place.

Note that this commit is related to, but gets far beyond PR #5143 (see comment https://github.com/pjsip/pjproject/pull/5143#issuecomment-5188666789).

